### PR TITLE
fix(billing): swallow SecurityError when opening the customer portal

### DIFF
--- a/src/components/payment-failure-banner.ts
+++ b/src/components/payment-failure-banner.ts
@@ -121,7 +121,10 @@ export function initPaymentFailureBanner(): () => void {
       updateBtn.addEventListener('click', () => {
         // Pre-reserve portal tab synchronously to survive popup blocker.
         const reservedWin = prereserveBillingPortalTab();
-        void openBillingPortal(reservedWin);
+        // openBillingPortal is specified never to reject for recoverable nav
+        // failures; this catch is belt-and-suspenders so a future throw cannot
+        // become an unhandledrejection on the billing CTA (WORLDMONITOR-11C).
+        void openBillingPortal(reservedWin).catch(() => {});
       });
     }
 

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -58,9 +58,15 @@ let unsubscribeConvex: (() => void) | null = null;
 // and as `cause` (for Sentry's structured display) so events remain debuggable (WORLDMONITOR-ND).
 function normalizeCaughtError(action: string, err: unknown): Error {
   if (err instanceof Error) return err;
-  // Chrome iOS / WKWebView: DOMException is not always `instanceof Error`.
+  // Chrome iOS / WKWebView: DOMException is not always `instanceof Error`, so
+  // a SecurityError from window.open / location assignment fell through to the
+  // synthetic "threw non-Error: …" branch below and titled its Sentry issue
+  // after the wrapper rather than the fault (WORLDMONITOR-11D). Keep the
+  // `[billing] <action>:` prefix every other error from this module carries —
+  // without it the same fault produces two differently-shaped titles depending
+  // on which branch caught it, and neither says where it happened.
   if (typeof DOMException !== 'undefined' && err instanceof DOMException) {
-    const wrapped = new Error(`${err.name}: ${err.message}`);
+    const wrapped = new Error(`[billing] ${action}: ${err.name}: ${err.message}`);
     (wrapped as Error & { cause?: unknown }).cause = err;
     return wrapped;
   }

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -58,6 +58,12 @@ let unsubscribeConvex: (() => void) | null = null;
 // and as `cause` (for Sentry's structured display) so events remain debuggable (WORLDMONITOR-ND).
 function normalizeCaughtError(action: string, err: unknown): Error {
   if (err instanceof Error) return err;
+  // Chrome iOS / WKWebView: DOMException is not always `instanceof Error`.
+  if (typeof DOMException !== 'undefined' && err instanceof DOMException) {
+    const wrapped = new Error(`${err.name}: ${err.message}`);
+    (wrapped as Error & { cause?: unknown }).cause = err;
+    return wrapped;
+  }
   const rendered = err === undefined ? 'undefined' : String(err);
   const wrapped = new Error(`[billing] ${action} threw non-Error: ${rendered}`);
   // Attach the original thrown value as `cause` so Sentry shows it as structured data.
@@ -378,10 +384,18 @@ export async function openBillingPortal(
     // documents this as its contract: a swallowed failure that still claims
     // "opened" is worse than no message, because the caller then tells the
     // user to look at a window that does not exist.
-    const navOutcome = await openExternalUrl(url, reservedWin);
-    return navOutcome === 'failed'
-      ? { outcome: 'open-failed', url }
-      : { outcome: 'opened', url };
+    //
+    // Never let a recoverable nav throw reject this promise: two CTA
+    // callers invoke `void openBillingPortal(...)` with no .catch, and a
+    // SecurityError on a reserved blank tab became WORLDMONITOR-11C.
+    try {
+      const navOutcome = await openExternalUrl(url, reservedWin);
+      return navOutcome === 'failed'
+        ? { outcome: 'open-failed', url }
+        : { outcome: 'opened', url };
+    } catch {
+      return { outcome: 'open-failed', url };
+    }
   };
 
   // NO_CUSTOMER means the user is entitled (comp grant, recently-restored
@@ -395,11 +409,20 @@ export async function openBillingPortal(
   // pre-reserved tab — still better UX than landing in a stranger's
   // portal. WORLDMONITOR-R5.
   const closeReserved = (): void => {
-    if (reservedWin && !reservedWin.closed) reservedWin.close();
+    if (!reservedWin) return;
+    try {
+      if (!reservedWin.closed) reservedWin.close();
+    } catch {
+      try {
+        reservedWin.close();
+      } catch {
+        // Chrome iOS can throw SecurityError on both `.closed` and `.close()`.
+      }
+    }
   };
 
   const userId = getCurrentClerkUser()?.id;
-  if (!userId) return navigate(DODO_PORTAL_FALLBACK_URL);
+  if (!userId) return await navigate(DODO_PORTAL_FALLBACK_URL);
 
   try {
     const client = await getConvexClient();
@@ -456,7 +479,10 @@ export async function openBillingPortal(
       closeReserved();
       return { outcome: 'no-customer' };
     }
-    return navigate(DODO_PORTAL_FALLBACK_URL);
+    // Same load-bearing `return await` as the try path: without it a throw
+    // from navigate rejects openBillingPortal, and two callers use bare
+    // `void openBillingPortal(...)` (WORLDMONITOR-11C).
+    return await navigate(DODO_PORTAL_FALLBACK_URL);
   }
 }
 

--- a/src/services/external-navigation.ts
+++ b/src/services/external-navigation.ts
@@ -243,11 +243,15 @@ export async function openExternalUrl(
       }
     } catch {
       // Chrome Mobile iOS / WKWebView: assigning href on a blank tab reserved
-      // via window.open('') throws SecurityError (DOMException 18). Close the
-      // orphan and fall through to a fresh open / same-tab assign so a normal
-      // https portal URL never rejects (WORLDMONITOR-11C).
-      closeWindowQuietly(preopened);
+      // via window.open('') throws SecurityError (DOMException 18). Fall
+      // through to a fresh open / same-tab assign so a normal https portal
+      // URL never rejects (WORLDMONITOR-11C).
     }
+    // Close whenever we did not navigate the reserved handle — including
+    // when `.closed` itself threw (isWindowStillOpen returns false and the
+    // try above does not catch). An orphaned blank tab plus same-tab
+    // fallback is the WORLDMONITOR-11C user-visible failure mode.
+    closeWindowQuietly(preopened);
   }
   const fresh = openWindowWithHandle(targetUrl);
   if (fresh) return 'popup';

--- a/src/services/external-navigation.ts
+++ b/src/services/external-navigation.ts
@@ -123,7 +123,19 @@ async function invokeOpenUrlBounded(url: string): Promise<void> {
  * (`strict-origin-when-cross-origin`) for cross-origin targets.
  */
 function openWindowWithHandle(url: string): Window | null {
-  const win = window.open(url, '_blank');
+  // `window.open` does not always merely RETURN null when refused: Chrome
+  // Mobile iOS / WebKit can throw SecurityError (DOMException 18) instead —
+  // notably once the user-gesture window is spent, which is exactly the state
+  // this module reaches after awaiting a portal-session round-trip. A throw
+  // here escapes every caller, including the fresh-open fallback the reserved
+  // tab drops into, so normalize refusal to the null this function already
+  // documents as its "did it open?" answer.
+  let win: Window | null;
+  try {
+    win = window.open(url, '_blank');
+  } catch {
+    return null;
+  }
   if (win) {
     try {
       win.opener = null;

--- a/src/services/external-navigation.ts
+++ b/src/services/external-navigation.ts
@@ -136,6 +136,32 @@ function openWindowWithHandle(url: string): Window | null {
 }
 
 /**
+ * `Window.closed` can itself throw SecurityError on Chrome Mobile iOS /
+ * WKWebView after `window.open('', '_blank')`. Treat that as "unusable".
+ */
+function isWindowStillOpen(win: Window): boolean {
+  try {
+    return !win.closed;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Close a reserved blank tab without letting SecurityError escape. Used when
+ * the handle cannot be navigated (scheme reject, desktop handoff, or a
+ * thrown `location.href` assignment — WORLDMONITOR-11C).
+ */
+function closeWindowQuietly(win: Window | null | undefined): void {
+  if (!win) return;
+  try {
+    win.close();
+  } catch {
+    // Blank-tab close can throw the same SecurityError as navigating it.
+  }
+}
+
+/**
  * Reserve a blank tab SYNCHRONOUSLY inside a click handler so an async
  * external navigation can land in it without tripping the popup blocker.
  * Callers must call this before awaiting anything, then pass the handle to
@@ -178,7 +204,7 @@ export async function openExternalUrl(
   const targetUrl = typeof url === 'string' ? url : url.toString();
   if (!isOpenableExternalUrl(targetUrl)) {
     reportOpenFailure(targetUrl, 'rejected-scheme');
-    if (preopened && !preopened.closed) preopened.close();
+    closeWindowQuietly(preopened);
     return 'failed';
   }
 
@@ -186,7 +212,7 @@ export async function openExternalUrl(
     // A pre-reserved tab is a web-only workaround. Close any handle a caller
     // reserved before it knew the runtime, so the OS browser doesn't come
     // forward over an orphaned blank WebView window.
-    if (preopened && !preopened.closed) preopened.close();
+    closeWindowQuietly(preopened);
     try {
       await invokeOpenUrlBounded(targetUrl);
       return 'native';
@@ -209,9 +235,19 @@ export async function openExternalUrl(
     }
   }
 
-  if (preopened && !preopened.closed) {
-    preopened.location.href = targetUrl;
-    return 'popup';
+  if (preopened) {
+    try {
+      if (isWindowStillOpen(preopened)) {
+        preopened.location.href = targetUrl;
+        return 'popup';
+      }
+    } catch {
+      // Chrome Mobile iOS / WKWebView: assigning href on a blank tab reserved
+      // via window.open('') throws SecurityError (DOMException 18). Close the
+      // orphan and fall through to a fresh open / same-tab assign so a normal
+      // https portal URL never rejects (WORLDMONITOR-11C).
+      closeWindowQuietly(preopened);
+    }
   }
   const fresh = openWindowWithHandle(targetUrl);
   if (fresh) return 'popup';
@@ -222,6 +258,11 @@ export async function openExternalUrl(
     reportOpenFailure(targetUrl, 'popup-blocked');
     return 'failed';
   }
-  window.location.assign(targetUrl);
-  return 'same-tab';
+  try {
+    window.location.assign(targetUrl);
+    return 'same-tab';
+  } catch {
+    reportOpenFailure(targetUrl, 'same-tab-assign-failed');
+    return 'failed';
+  }
 }

--- a/tests/desktop-external-handoff.test.mts
+++ b/tests/desktop-external-handoff.test.mts
@@ -43,6 +43,14 @@ interface WindowProbe {
   invokeHangs: boolean;
   /** Simulates a popup blocker: window.open returns null. */
   popupBlocked: boolean;
+  /**
+   * Chrome Mobile iOS / WebKit THROWS SecurityError from `window.open` rather
+   * than returning null once the user-gesture window is spent. Distinct from
+   * `popupBlocked`, which is the well-behaved refusal.
+   */
+  openThrowsSecurityError: boolean;
+  /** Same-tab `location.assign` throws — the last fallback can refuse too. */
+  assignThrowsSecurityError: boolean;
 }
 
 let probe: WindowProbe;
@@ -121,6 +129,8 @@ function installWindow(kind: 'desktop' | 'web'): void {
     invokeRejects: false,
     invokeHangs: false,
     popupBlocked: false,
+    openThrowsSecurityError: false,
+    assignThrowsSecurityError: false,
   };
 
   const desktop = kind === 'desktop';
@@ -131,6 +141,7 @@ function installWindow(kind: 'desktop' | 'web'): void {
     origin: desktop ? 'tauri://localhost' : 'https://worldmonitor.app',
     href: desktop ? 'tauri://localhost/index.html' : 'https://worldmonitor.app/dashboard',
     assign: (url: string) => {
+      if (probe.assignThrowsSecurityError) throw makeSecurityError();
       probe.assigned.push(url);
     },
   };
@@ -146,6 +157,7 @@ function installWindow(kind: 'desktop' | 'web'): void {
     // the tab present in the tab list.
     open: (url: string, target?: string, features?: string) => {
       probe.opened.push([url, target, features]);
+      if (probe.openThrowsSecurityError) throw makeSecurityError();
       if (probe.popupBlocked) return null;
       // The tab opens either way; only the HANDLE is withheld. Recording it
       // in `handedOutTabs` would be wrong — nothing can sever an opener it
@@ -441,6 +453,37 @@ describe('openExternalUrl — web', () => {
     assert.equal(outcome, 'popup');
     assert.equal(probe.closedTabs, 1, 'an unreadable reserved handle must still be closed');
     assert.deepEqual(probe.opened, [[PORTAL_URL, '_blank', undefined]]);
+  });
+
+  // `window.open` itself can THROW rather than return null once the gesture
+  // window is spent — which is the state the fresh-open fallback runs in,
+  // after the reserved tab has already been found unusable. Without the guard
+  // the recovery path throws on the way out of the recovery.
+  it('treats a SecurityError from window.open like a blocked popup', async () => {
+    installWindow('web');
+    probe.openThrowsSecurityError = true;
+
+    assert.equal(await openExternalUrl(PORTAL_URL), 'same-tab');
+    assert.deepEqual(probe.assigned, [PORTAL_URL]);
+  });
+
+  it('recovers when the reserved tab AND window.open both refuse', async () => {
+    // The full iOS shape: the handle is poison, and re-opening is refused too.
+    installWindow('web');
+    const reserved = makeTab({ hrefAssignThrows: true });
+    probe.openThrowsSecurityError = true;
+
+    assert.equal(await openExternalUrl(PORTAL_URL, reserved), 'same-tab');
+    assert.deepEqual(probe.assigned, [PORTAL_URL]);
+  });
+
+  it('returns failed, without throwing, when even same-tab assign refuses', async () => {
+    installWindow('web');
+    probe.popupBlocked = true;
+    probe.assignThrowsSecurityError = true;
+
+    assert.equal(await openExternalUrl(PORTAL_URL), 'failed');
+    assert.deepEqual(probe.assigned, []);
   });
 });
 

--- a/tests/desktop-external-handoff.test.mts
+++ b/tests/desktop-external-handoff.test.mts
@@ -47,7 +47,26 @@ interface WindowProbe {
 
 let probe: WindowProbe;
 
-function makeTab(): {
+/**
+ * Chrome Mobile iOS / WKWebView throws this when a blank `window.open`
+ * handle later has `location.href` assigned (WORLDMONITOR-11C). Built as a
+ * DOMException when the runtime has one, otherwise an Error-like object
+ * whose `instanceof Error` is false — the same quirk that made billing
+ * log "threw non-Error".
+ */
+function makeSecurityError(): unknown {
+  if (typeof DOMException === 'function') {
+    return new DOMException('The operation is insecure.', 'SecurityError');
+  }
+  const err = { name: 'SecurityError', message: 'The operation is insecure.' };
+  Object.setPrototypeOf(err, null);
+  return err;
+}
+
+function makeTab(options?: {
+  hrefAssignThrows?: boolean;
+  closedAccessThrows?: boolean;
+}): {
   closed: boolean;
   location: { href: string };
   close: () => void;
@@ -65,6 +84,23 @@ function makeTab(): {
       probe.closedTabs += 1;
     },
   };
+  if (options?.hrefAssignThrows) {
+    Object.defineProperty(tab.location, 'href', {
+      configurable: true,
+      get: () => '',
+      set: () => {
+        throw makeSecurityError();
+      },
+    });
+  }
+  if (options?.closedAccessThrows) {
+    Object.defineProperty(tab, 'closed', {
+      configurable: true,
+      get: () => {
+        throw makeSecurityError();
+      },
+    });
+  }
   probe.handedOutTabs.push(tab);
   return tab;
 }
@@ -350,6 +386,62 @@ describe('openExternalUrl — web', () => {
       'a settings panel with staged secrets must not be navigated out from under the user',
     );
   });
+
+  // WORLDMONITOR-11C: Chrome Mobile iOS throws SecurityError (DOMException 18)
+  // when assigning location.href on a blank tab reserved via window.open('').
+  // The helper must swallow that, close the blank tab, and fall through the
+  // same popup / same-tab / failed policy — never reject.
+  it('falls back when assigning location.href on a reserved tab throws SecurityError', async () => {
+    installWindow('web');
+    const reserved = makeTab({ hrefAssignThrows: true });
+
+    let outcome: Awaited<ReturnType<typeof openExternalUrl>> | undefined;
+    await assert.doesNotReject(async () => {
+      outcome = await openExternalUrl(PORTAL_URL, reserved);
+    });
+    assert.ok(outcome !== undefined);
+
+    assert.ok(
+      outcome === 'popup' || outcome === 'same-tab' || outcome === 'failed',
+      `expected a settled nav outcome, got ${outcome}`,
+    );
+    assert.equal(outcome, 'popup', 'fresh window.open after the reserved tab is unusable');
+    assert.equal(reserved.closed, true, 'the blank reserved tab must be closed when it cannot be navigated');
+    assert.deepEqual(probe.opened, [[PORTAL_URL, '_blank', undefined]]);
+    assert.deepEqual(probe.assigned, []);
+  });
+
+  it('falls back to same-tab when reserved-tab SecurityError and the fresh popup are both blocked', async () => {
+    installWindow('web');
+    probe.popupBlocked = true;
+    const reserved = makeTab({ hrefAssignThrows: true });
+
+    const outcome = await openExternalUrl(PORTAL_URL, reserved);
+
+    assert.equal(outcome, 'same-tab');
+    assert.deepEqual(probe.assigned, [PORTAL_URL]);
+  });
+
+  it('returns failed, without rejecting, when reserved-tab SecurityError meets sameTabFallback:false', async () => {
+    installWindow('web');
+    probe.popupBlocked = true;
+    const reserved = makeTab({ hrefAssignThrows: true });
+
+    const outcome = await openExternalUrl(PORTAL_URL, reserved, { sameTabFallback: false });
+
+    assert.equal(outcome, 'failed');
+    assert.deepEqual(probe.assigned, []);
+  });
+
+  it('treats SecurityError on reserved-tab .closed as an unusable handle', async () => {
+    installWindow('web');
+    const reserved = makeTab({ closedAccessThrows: true });
+
+    const outcome = await openExternalUrl(PORTAL_URL, reserved);
+
+    assert.equal(outcome, 'popup');
+    assert.deepEqual(probe.opened, [[PORTAL_URL, '_blank', undefined]]);
+  });
 });
 
 /**
@@ -482,5 +574,31 @@ describe('openBillingPortal — web', () => {
 
     assert.equal(reserved?.location.href, PORTAL_URL);
     assert.deepEqual(probe.invocations, []);
+  });
+
+  it('does not label a reserved-tab SecurityError as a portal-URL fetch failure', async () => {
+    installWindow('web');
+    installSignedInPortalUser();
+    const reserved = makeTab({ hrefAssignThrows: true });
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    };
+
+    let result: Awaited<ReturnType<typeof openBillingPortal>>;
+    try {
+      result = await openBillingPortal(reserved);
+    } finally {
+      console.error = originalError;
+    }
+
+    assert.equal(result.outcome, 'opened');
+    if (result.outcome === 'opened') assert.equal(result.url, PORTAL_URL);
+    assert.equal(
+      errors.some((line) => line.includes('Failed to get customer portal URL')),
+      false,
+      'navigation SecurityError after a successful portal URL fetch must not be logged as a Convex/URL failure',
+    );
   });
 });

--- a/tests/desktop-external-handoff.test.mts
+++ b/tests/desktop-external-handoff.test.mts
@@ -72,15 +72,22 @@ function makeTab(options?: {
   close: () => void;
   opener: unknown;
 } {
+  let closedState = false;
   const tab = {
-    closed: false,
+    get closed() {
+      if (options?.closedAccessThrows) throw makeSecurityError();
+      return closedState;
+    },
+    set closed(value: boolean) {
+      closedState = value;
+    },
     location: { href: '' },
     // Starts non-null so `opener === null` proves the code severed it, rather
     // than passing because the fake never had one. This is the property that
     // replaced `noopener` in the feature string.
     opener: {} as unknown,
     close(): void {
-      tab.closed = true;
+      closedState = true;
       probe.closedTabs += 1;
     },
   };
@@ -89,14 +96,6 @@ function makeTab(options?: {
       configurable: true,
       get: () => '',
       set: () => {
-        throw makeSecurityError();
-      },
-    });
-  }
-  if (options?.closedAccessThrows) {
-    Object.defineProperty(tab, 'closed', {
-      configurable: true,
-      get: () => {
         throw makeSecurityError();
       },
     });
@@ -440,6 +439,7 @@ describe('openExternalUrl — web', () => {
     const outcome = await openExternalUrl(PORTAL_URL, reserved);
 
     assert.equal(outcome, 'popup');
+    assert.equal(probe.closedTabs, 1, 'an unreadable reserved handle must still be closed');
     assert.deepEqual(probe.opened, [[PORTAL_URL, '_blank', undefined]]);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes WORLDMONITOR-11C: Chrome Mobile iOS throws `SecurityError` (`DOMException` code 18) when assigning `location.href` on a blank tab reserved via `window.open('')`. That rejected `openExternalUrl`, the billing catch mislabeled it as a Convex/portal-URL failure, and a missing `await` plus a bare `void openBillingPortal()` turned the fallback throw into an unhandled rejection.

Sentry: https://elie-habib.sentry.io/issues/7700594597/

This does **not** add an `ignoreErrors` filter for `SecurityError` — first-party billing UX owns the failure.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: billing portal navigation (web, Chrome Mobile iOS)

## What changed

1. **`openExternalUrl`** — wrap `preopened.closed` and `preopened.location.href = …` in try/catch. On SecurityError (or any throw), close the blank tab if possible and fall back to a fresh `window.open`, then same-tab `assign` per the existing `sameTabFallback` policy. A normal https portal URL no longer rejects.
2. **`openBillingPortal`** — `navigate()` swallows recoverable nav throws and returns `{ outcome: 'open-failed', url }`. Catch-path fallback uses `return await navigate(...)`. A reserved-tab SecurityError after a successful portal-URL fetch is no longer logged as `Failed to get customer portal URL`.
3. **Payment-failure banner** — `.catch(() => {})` on the existing `void` call so a future throw cannot become `onunhandledrejection`.

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [x] N/A — this PR does not publish or change documentation claims

## Verification

- `npm run typecheck` (`tsc --noEmit`) passed
- `tests/desktop-external-handoff.test.mts` — 27/27, including:
  - SecurityError on reserved-tab `location.href` assignment → `'popup'` fallback, never rejects
  - same error + blocked popup → `'same-tab'`
  - same error + `sameTabFallback: false` → `'failed'`, no reject
  - SecurityError on `.closed` access → `'popup'` fallback
  - `openBillingPortal` does not log `Failed to get customer portal URL` for a reserved-tab SecurityError after a successful portal URL fetch
- Related: `tests/convex-auth-handoff.test.mts`, `tests/billing-state-wiring.test.mts`, `tests/external-navigation-call-sites.test.mjs` — all passed

Not verified: production Chrome Mobile iOS / WKWebView (no device). Do not merge until review.

## Screenshots

N/A — service-layer navigation fallback; no UI change beyond swallowing a rejection on the existing billing CTA.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3e28666-a739-4b9a-bf84-a26954157cd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3e28666-a739-4b9a-bf84-a26954157cd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

