### PR TITLE
fix(billing): fall back when reserved portal tab throws SecurityError

### DIFF
--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -56,8 +56,16 @@ let unsubscribeConvex: (() => void) | null = null;
 // Sentry serializes those as synthetic `Error: undefined` with zero frames — uninvestigable.
 // Normalize to a real Error carrying the offending value both in the message (for log/search)
 // and as `cause` (for Sentry's structured display) so events remain debuggable (WORLDMONITOR-ND).
+function isErrorValue(err: unknown): err is Error {
+  if (err instanceof Error) return true;
+  // Chrome Mobile iOS / WKWebKit can throw a host DOMException that fails
+  // `instanceof Error` (WORLDMONITOR-11D). Treat it as a normal Error so
+  // Sentry keeps the original name/message instead of "threw non-Error".
+  return typeof DOMException !== 'undefined' && err instanceof DOMException;
+}
+
 function normalizeCaughtError(action: string, err: unknown): Error {
-  if (err instanceof Error) return err;
+  if (isErrorValue(err)) return err;
   const rendered = err === undefined ? 'undefined' : String(err);
   const wrapped = new Error(`[billing] ${action} threw non-Error: ${rendered}`);
   // Attach the original thrown value as `cause` so Sentry shows it as structured data.
@@ -395,7 +403,13 @@ export async function openBillingPortal(
   // pre-reserved tab — still better UX than landing in a stranger's
   // portal. WORLDMONITOR-R5.
   const closeReserved = (): void => {
-    if (reservedWin && !reservedWin.closed) reservedWin.close();
+    if (!reservedWin) return;
+    try {
+      if (!reservedWin.closed) reservedWin.close();
+    } catch {
+      // WKWebKit can throw SecurityError inspecting a reserved popup after
+      // an await (WORLDMONITOR-11D). The tab is already unusable.
+    }
   };
 
   const userId = getCurrentClerkUser()?.id;

--- a/src/services/external-navigation.ts
+++ b/src/services/external-navigation.ts
@@ -136,6 +136,38 @@ function openWindowWithHandle(url: string): Window | null {
 }
 
 /**
+ * Close a click-reserved popup without letting a WebKit SecurityError escape.
+ *
+ * Chrome Mobile iOS / WKWebKit can throw `SecurityError: The operation is
+ * insecure` when a caller inspects or closes an about:blank tab after an
+ * await (WORLDMONITOR-11D). The handle is already unusable; swallowing here
+ * lets the caller fall through to a fresh `window.open` or same-tab assign.
+ */
+function closeReservedWindow(win: Window | null | undefined): void {
+  if (!win) return;
+  try {
+    if (!win.closed) win.close();
+  } catch {
+    // Reserved-tab inspection/close is best-effort. See WORLDMONITOR-11D.
+  }
+}
+
+/**
+ * Navigate a click-reserved popup. Returns false when the handle is gone or
+ * WebKit refuses the assignment, so the caller can fall back without throwing.
+ */
+function navigateReservedWindow(win: Window, url: string): boolean {
+  try {
+    if (win.closed) return false;
+    win.location.href = url;
+    return true;
+  } catch {
+    closeReservedWindow(win);
+    return false;
+  }
+}
+
+/**
  * Reserve a blank tab SYNCHRONOUSLY inside a click handler so an async
  * external navigation can land in it without tripping the popup blocker.
  * Callers must call this before awaiting anything, then pass the handle to
@@ -178,7 +210,7 @@ export async function openExternalUrl(
   const targetUrl = typeof url === 'string' ? url : url.toString();
   if (!isOpenableExternalUrl(targetUrl)) {
     reportOpenFailure(targetUrl, 'rejected-scheme');
-    if (preopened && !preopened.closed) preopened.close();
+    closeReservedWindow(preopened);
     return 'failed';
   }
 
@@ -186,7 +218,7 @@ export async function openExternalUrl(
     // A pre-reserved tab is a web-only workaround. Close any handle a caller
     // reserved before it knew the runtime, so the OS browser doesn't come
     // forward over an orphaned blank WebView window.
-    if (preopened && !preopened.closed) preopened.close();
+    closeReservedWindow(preopened);
     try {
       await invokeOpenUrlBounded(targetUrl);
       return 'native';
@@ -209,8 +241,7 @@ export async function openExternalUrl(
     }
   }
 
-  if (preopened && !preopened.closed) {
-    preopened.location.href = targetUrl;
+  if (preopened && navigateReservedWindow(preopened, targetUrl)) {
     return 'popup';
   }
   const fresh = openWindowWithHandle(targetUrl);
@@ -222,6 +253,11 @@ export async function openExternalUrl(
     reportOpenFailure(targetUrl, 'popup-blocked');
     return 'failed';
   }
-  window.location.assign(targetUrl);
-  return 'same-tab';
+  try {
+    window.location.assign(targetUrl);
+    return 'same-tab';
+  } catch {
+    reportOpenFailure(targetUrl, 'same-tab-assign-failed');
+    return 'failed';
+  }
 }

--- a/tests/desktop-external-handoff.test.mts
+++ b/tests/desktop-external-handoff.test.mts
@@ -43,25 +43,52 @@ interface WindowProbe {
   invokeHangs: boolean;
   /** Simulates a popup blocker: window.open returns null. */
   popupBlocked: boolean;
+  /** Simulates same-tab assign throwing (WKWebKit / locked navigation). */
+  assignThrows: boolean;
 }
 
 let probe: WindowProbe;
 
-function makeTab(): {
+function makeTab(opts?: {
+  /** WKWebKit after an await: reading `.closed` throws SecurityError. */
+  closedThrows?: boolean;
+  /** WKWebKit after an await: assigning `location.href` throws SecurityError. */
+  navigateThrows?: boolean;
+}): {
   closed: boolean;
   location: { href: string };
   close: () => void;
   opener: unknown;
 } {
+  let closed = false;
+  let href = '';
   const tab = {
-    closed: false,
-    location: { href: '' },
+    get closed(): boolean {
+      if (opts?.closedThrows) {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      }
+      return closed;
+    },
+    set closed(value: boolean) {
+      closed = value;
+    },
+    location: {
+      get href() {
+        return href;
+      },
+      set href(value: string) {
+        if (opts?.navigateThrows) {
+          throw new DOMException('The operation is insecure.', 'SecurityError');
+        }
+        href = value;
+      },
+    },
     // Starts non-null so `opener === null` proves the code severed it, rather
     // than passing because the fake never had one. This is the property that
     // replaced `noopener` in the feature string.
     opener: {} as unknown,
     close(): void {
-      tab.closed = true;
+      closed = true;
       probe.closedTabs += 1;
     },
   };
@@ -86,6 +113,7 @@ function installWindow(kind: 'desktop' | 'web'): void {
     invokeRejects: false,
     invokeHangs: false,
     popupBlocked: false,
+    assignThrows: false,
   };
 
   const desktop = kind === 'desktop';
@@ -96,6 +124,9 @@ function installWindow(kind: 'desktop' | 'web'): void {
     origin: desktop ? 'tauri://localhost' : 'https://worldmonitor.app',
     href: desktop ? 'tauri://localhost/index.html' : 'https://worldmonitor.app/dashboard',
     assign: (url: string) => {
+      if (probe.assignThrows) {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      }
       probe.assigned.push(url);
     },
   };
@@ -216,6 +247,15 @@ describe('openExternalUrl — desktop', () => {
     assert.equal(stray.closed, true, 'a blank WebView window must not be left behind the browser');
     assert.equal(stray.location.href, '', 'the reserved tab must never be navigated on desktop');
     assert.equal(probe.invocations.length, 1);
+  });
+
+  it('still hands off natively when closing the reserved tab throws SecurityError', async () => {
+    installWindow('desktop');
+    const stray = makeTab({ closedThrows: true });
+
+    assert.equal(await openExternalUrl('https://worldmonitor.app/pro', stray), 'native');
+    assert.equal(probe.invocations.length, 1);
+    assert.deepEqual(probe.assigned, []);
   });
 
   // Bounded so a regression that drops the timeout fails fast here instead of
@@ -350,6 +390,59 @@ describe('openExternalUrl — web', () => {
       'a settings panel with staged secrets must not be navigated out from under the user',
     );
   });
+
+  // WORLDMONITOR-11D: Chrome Mobile iOS / WKWebKit throws SecurityError when
+  // a click-reserved about:blank popup is inspected or navigated after an
+  // await. That used to escape openExternalUrl into billing's catch, so
+  // Manage Billing reported a failure and never opened the portal.
+  it('falls back to a fresh tab when reserved-window navigation throws SecurityError', async () => {
+    installWindow('web');
+    const reserved = makeTab({ navigateThrows: true });
+
+    assert.equal(await openExternalUrl(PORTAL_URL, reserved), 'popup');
+
+    assert.deepEqual(probe.opened, [[PORTAL_URL, '_blank', undefined]]);
+    assert.deepEqual(probe.assigned, []);
+  });
+
+  it('falls back to same-tab when reserved navigation AND a fresh popup both fail', async () => {
+    installWindow('web');
+    probe.popupBlocked = true;
+    const reserved = makeTab({ navigateThrows: true });
+
+    assert.equal(await openExternalUrl(PORTAL_URL, reserved), 'same-tab');
+
+    assert.deepEqual(probe.assigned, [PORTAL_URL]);
+  });
+
+  it('does not throw when inspecting a reserved window .closed raises SecurityError', async () => {
+    installWindow('web');
+    const reserved = makeTab({ closedThrows: true });
+
+    assert.equal(await openExternalUrl(PORTAL_URL, reserved), 'popup');
+
+    assert.deepEqual(probe.opened, [[PORTAL_URL, '_blank', undefined]]);
+  });
+
+  it('returns failed instead of throwing when same-tab assign also raises SecurityError', async () => {
+    installWindow('web');
+    probe.popupBlocked = true;
+    probe.assignThrows = true;
+    const reserved = makeTab({ navigateThrows: true });
+
+    assert.equal(await openExternalUrl(PORTAL_URL, reserved), 'failed');
+  });
+
+  it('still refuses same-tab fallback after a reserved-window SecurityError', async () => {
+    installWindow('web');
+    probe.popupBlocked = true;
+    const reserved = makeTab({ navigateThrows: true });
+
+    const outcome = await openExternalUrl(PORTAL_URL, reserved, { sameTabFallback: false });
+
+    assert.equal(outcome, 'failed');
+    assert.deepEqual(probe.assigned, []);
+  });
 });
 
 /**
@@ -481,6 +574,20 @@ describe('openBillingPortal — web', () => {
     });
 
     assert.equal(reserved?.location.href, PORTAL_URL);
+    assert.deepEqual(probe.invocations, []);
+  });
+
+  it('still opens the portal when reserved-tab navigation throws SecurityError', async () => {
+    installWindow('web');
+    installSignedInPortalUser();
+    const reserved = makeTab({ navigateThrows: true });
+
+    assert.deepEqual(await openBillingPortal(reserved as never), {
+      outcome: 'opened',
+      url: PORTAL_URL,
+    });
+
+    assert.deepEqual(probe.opened, [[PORTAL_URL, '_blank', undefined]]);
     assert.deepEqual(probe.invocations, []);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes WORLDMONITOR-11D. On Chrome Mobile iOS / WKWebKit, navigating a click-reserved billing-portal popup after the Convex `getCustomerPortalUrl` await throws `SecurityError: The operation is insecure`. That escaped `openExternalUrl` into `openBillingPortal`'s catch, so Manage Billing (including `#pf-update-btn` on the payment-failure banner) reported a failure and never opened the Dodo customer portal.

`openExternalUrl` now treats reserved-window `.closed` / `location.href` / same-tab `assign` failures as a dead handle and falls through to a fresh `window.open`, then same-tab `location.assign` under the existing `sameTabFallback` policy. The desktop Tauri `open_url` path and the click-handler `prereserveBillingPortalTab` contract are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: billing portal / external navigation (web WKWebKit)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [x] N/A — this PR does not publish or change documentation claims

## What changed

- `src/services/external-navigation.ts`: try/catch around reserved-window inspect/navigate/close and same-tab assign; fall back instead of throwing
- `src/services/billing.ts`: swallow the same SecurityError when closing an unused reserved tab; treat `DOMException` as a normal Error in `normalizeCaughtError` so a future wrap is not titled "threw non-Error"
- `tests/desktop-external-handoff.test.mts`: reserved-tab SecurityError now falls back to a fresh popup / same-tab / `failed` without escaping `openExternalUrl` or `openBillingPortal`

## Verification

- `npx tsx --test tests/desktop-external-handoff.test.mts` — 29/29 pass (including the new SecurityError cases)
- Neighboring handoff suites: `tests/convex-auth-handoff.test.mts`, `tests/desktop-checkout-handoff.test.mts`, `tests/external-navigation-call-sites.test.mjs` — 37/37 pass
- `npm run typecheck` (`tsc --noEmit`) — pass

Production iOS Chrome behavior remains unproved until this ships and WORLDMONITOR-11D stops receiving events. Sentry was not resolved from this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caeef778-9645-4d0e-93d9-676e62932bf5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caeef778-9645-4d0e-93d9-676e62932bf5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

