### PR TITLE
fix(mcp): publish the registry manifest on a cadence that actually fires

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,6 +1,33 @@
 name: Publish MCP Registry
 
+# Publishes server.json (description derived from the server card's live tool
+# inventory) to registry.modelcontextprotocol.io under app.worldmonitor.
+#
+# Triggers — the release-only wiring this replaces logged zero runs: the last
+# GitHub release predated it by ~6 months and tracks the desktop app, not
+# SERVER_VERSION, so the registry stayed at 1.13.0/39 tools against a live
+# 1.17.0/72 (#7372). Publication now follows the cadence that exists:
+#   - push to main touching a manifest input: republish the moment the payload
+#     the registry serves can change. Same shape as desktop-release-train.yml.
+#   - schedule (daily): self-healing backstop. GitHub keeps one pending run per
+#     concurrency group, so a merge burst can drop a queued publish; the next
+#     scheduled run re-attempts it from current main.
+#   - release published + workflow_dispatch: retained for manual and tagged runs.
+# Re-running is safe: scripts/publish-mcp-registry.mjs looks the version up
+# first, skips an identical published payload, and fails closed on a differing
+# one rather than silently diverging.
 on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/publish-mcp-registry.yml'
+      - 'public/.well-known/mcp/server-card.json'
+      - 'scripts/mcp-registry-published-versions.json'
+      - 'scripts/prepare-mcp-registry-manifest.mjs'
+      - 'scripts/publish-mcp-registry.mjs'
+      - 'server.json'
+  schedule:
+    - cron: '41 5 * * *'
   release:
     types: [published]
   workflow_dispatch:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -409,7 +409,7 @@ Runs before every `git push`:
 | `publish-python.yml` | `py-v*` tag, manual | Tests and publishes the `worldmonitor-sdk` PyPI package (`sdk/python/`) via OIDC trusted publishing (no token) with attestations |
 | `publish-ruby.yml` | `gem-v*` tag, manual | Tests and publishes the `worldmonitor` gem (`sdk/ruby/`) via RubyGems OIDC trusted publishing (no token) |
 | `publish-go.yml` | `sdk/go/v*` tag, manual | Vets/tests the Go SDK module (`sdk/go/`) at the tag and warms proxy.golang.org so the version is go-gettable and indexed on pkg.go.dev |
-| `publish-mcp-registry.yml` | Published release, manual on main | Derives the public MCP Registry manifest from the server card, validates it with the pinned publisher, and publishes it through the protected `mcp-registry-publish` environment |
+| `publish-mcp-registry.yml` | Push to main (manifest inputs), daily cron, published release, manual | Derives the public MCP Registry manifest from the server card, validates it with the pinned publisher, and publishes it through the `mcp-registry-publish` environment; publication is idempotent and fails closed when a published version's payload changed |
 | `test-linux-app.yml` | Twice-weekly schedule (Mon/Thu 05:23 UTC), manual | Desktop Canary (Linux): installed-app build + launch, hard-fails on crashed app, unreachable sidecar, or blank render (#5902) |
 
 The Railway `umami` runtime is built from `Dockerfile.umami`, which pins the

--- a/scripts/mcp-registry-published-versions.json
+++ b/scripts/mcp-registry-published-versions.json
@@ -1,0 +1,6 @@
+{
+  "$comment": "The MCP registry description carries the tool count and the registry rejects a changed payload for an already-published version. server-card.json::tools tracks the code registry, so adding a tool moves that count on its own — 68, 69, 71 and 72 tools all shipped under SERVER_VERSION 1.17.0 while the registry still advertised 1.13.0/39 (#7372). Each version pins the inventory it publishes: changing the tool set means bumping SERVER_VERSION (api/mcp/constants.ts), server-card.json::serverInfo.version and server.json, then adding a new entry here — never editing an existing one.",
+  "versions": {
+    "1.17.0": 72
+  }
+}

--- a/scripts/mcp-registry-published-versions.json
+++ b/scripts/mcp-registry-published-versions.json
@@ -1,6 +1,9 @@
 {
-  "$comment": "The MCP registry description carries the tool count and the registry rejects a changed payload for an already-published version. server-card.json::tools tracks the code registry, so adding a tool moves that count on its own — 68, 69, 71 and 72 tools all shipped under SERVER_VERSION 1.17.0 while the registry still advertised 1.13.0/39 (#7372). Each version pins the inventory it publishes: changing the tool set means bumping SERVER_VERSION (api/mcp/constants.ts), server-card.json::serverInfo.version and server.json, then adding a new entry here — never editing an existing one.",
+  "$comment": "The official MCP registry refuses to republish a version whose payload changed, and publish-mcp-registry.mjs compares the WHOLE canonicalized manifest. Nothing forces SERVER_VERSION to move with that payload: server-card.json::tools tracks the code registry, so 68, 69, 71 and 72 tools all shipped under 1.17.0 while the published description sat frozen at 39 (#7372), and a copy edit to server.json::description does the same with even less of a version-bump smell. Each version therefore pins the exact payload it publishes — `tools` for a legible error, `manifestSha256` over the derived manifest for every other field. Changing what is published means bumping SERVER_VERSION (api/mcp/constants.ts) plus `version` and `serverInfo.version` in server-card.json and server.json, then adding a NEW entry here. Editing a published entry in place does not un-publish it: the registry still holds the old payload, so the publish job fails closed on every run until the version is bumped.",
   "versions": {
-    "1.17.0": 72
+    "1.17.0": {
+      "tools": 72,
+      "manifestSha256": "28c51a2caeb612865d404056e4936e048955ae9d63673b4e9294469c459aac87"
+    }
   }
 }

--- a/scripts/prepare-mcp-registry-manifest.mjs
+++ b/scripts/prepare-mcp-registry-manifest.mjs
@@ -6,7 +6,43 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-export function buildMcpRegistryManifest(server, serverCard) {
+// The published description carries the tool count, and the official registry
+// rejects a changed payload for an already-published version. server-card.json
+// ::tools is held in lockstep with the code registry, so every added tool moves
+// that count on its own — 68, 69, 71 and 72 tools all shipped under 1.17.0
+// while the registry still advertised 1.13.0/39 (#7372). Pinning the count per
+// version makes the tool-addition PR fail here, with the version bump named,
+// instead of the post-merge publish job failing closed against the registry.
+export function assertPinnedToolInventory(serverCard, ledger) {
+  const publishedVersions = ledger?.versions;
+  if (!publishedVersions || typeof publishedVersions !== 'object') {
+    throw new Error('published-version ledger must expose a `versions` map');
+  }
+  if (!Array.isArray(serverCard.tools)) {
+    throw new Error('server card must contain a tools array to pin');
+  }
+  const version = serverCard.version;
+  if (typeof version !== 'string' || version.trim() === '') {
+    throw new Error('server card must declare a version');
+  }
+  const pinned = publishedVersions[version];
+  if (pinned === undefined) {
+    throw new Error(
+      `server card version ${version} is not pinned in scripts/mcp-registry-published-versions.json; `
+        + `add "${version}": ${serverCard.tools.length} so the published tool inventory is reviewed`,
+    );
+  }
+  if (pinned !== serverCard.tools.length) {
+    throw new Error(
+      `server card declares ${serverCard.tools.length} tools but SERVER_VERSION ${version} is pinned to ${pinned}. `
+        + 'The registry refuses a changed payload for an existing version — bump SERVER_VERSION '
+        + '(api/mcp/constants.ts), public/.well-known/mcp/server-card.json::serverInfo.version and server.json, '
+        + 'then add the new version to scripts/mcp-registry-published-versions.json.',
+    );
+  }
+}
+
+export function buildMcpRegistryManifest(server, serverCard, publishedVersions) {
   if (!Array.isArray(serverCard.tools) || serverCard.tools.length === 0) {
     throw new Error('server card must contain a non-empty tools array');
   }
@@ -16,6 +52,7 @@ export function buildMcpRegistryManifest(server, serverCard) {
   if (/\b\d+ tools\b/i.test(server.description)) {
     throw new Error('server.json description must not contain a hand-authored tool count');
   }
+  assertPinnedToolInventory(serverCard, publishedVersions);
 
   const description = `${server.description.trim()} ${serverCard.tools.length} tools.`;
   if (description.length > 100) {
@@ -28,13 +65,15 @@ export function buildMcpRegistryManifest(server, serverCard) {
 export function prepareMcpRegistryManifest({
   serverPath = resolve(ROOT, 'server.json'),
   serverCardPath = resolve(ROOT, 'public/.well-known/mcp/server-card.json'),
+  publishedVersionsPath = resolve(ROOT, 'scripts/mcp-registry-published-versions.json'),
   outputPath,
 } = {}) {
   if (!outputPath) throw new Error('outputPath is required');
 
   const server = JSON.parse(readFileSync(serverPath, 'utf-8'));
   const serverCard = JSON.parse(readFileSync(serverCardPath, 'utf-8'));
-  const manifest = buildMcpRegistryManifest(server, serverCard);
+  const publishedVersions = JSON.parse(readFileSync(publishedVersionsPath, 'utf-8'));
+  const manifest = buildMcpRegistryManifest(server, serverCard, publishedVersions);
   writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
   return manifest;
 }

--- a/scripts/prepare-mcp-registry-manifest.mjs
+++ b/scripts/prepare-mcp-registry-manifest.mjs
@@ -1,48 +1,84 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { stableMcpRegistryStringify } from './publish-mcp-registry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-// The published description carries the tool count, and the official registry
-// rejects a changed payload for an already-published version. server-card.json
-// ::tools is held in lockstep with the code registry, so every added tool moves
-// that count on its own — 68, 69, 71 and 72 tools all shipped under 1.17.0
-// while the registry still advertised 1.13.0/39 (#7372). Pinning the count per
-// version makes the tool-addition PR fail here, with the version bump named,
-// instead of the post-merge publish job failing closed against the registry.
-export function assertPinnedToolInventory(serverCard, ledger) {
+// The official registry refuses to republish a version whose payload changed —
+// publish-mcp-registry.mjs compares the WHOLE canonicalized manifest and fails
+// closed on any differing key. Nothing forces the version to move with it:
+// server-card.json::tools tracks the code registry, so 68, 69, 71 and 72 tools
+// all shipped under SERVER_VERSION 1.17.0 while the published description sat
+// frozen at 39 (#7372), and a plain copy edit to server.json::description does
+// the same with even less of a version-bump smell. So each version pins the
+// exact payload it publishes: the tool count for a legible message, and a
+// fingerprint over the derived manifest for everything else. The drift then
+// fails on the PR that causes it, naming the bump, instead of reding the
+// post-merge publish job every day until someone reads the logs.
+export function mcpRegistryManifestFingerprint(manifest) {
+  return createHash('sha256').update(stableMcpRegistryStringify(manifest)).digest('hex');
+}
+
+function pinnedEntry(version, ledger) {
   const publishedVersions = ledger?.versions;
   if (!publishedVersions || typeof publishedVersions !== 'object') {
     throw new Error('published-version ledger must expose a `versions` map');
   }
-  if (!Array.isArray(serverCard.tools)) {
+  if (typeof version !== 'string' || version.trim() === '') {
+    throw new Error('a non-empty version is required to look up its pin');
+  }
+  if (!Object.hasOwn(publishedVersions, version)) return null;
+  const pinned = publishedVersions[version];
+  if (!pinned || typeof pinned !== 'object') {
+    throw new Error(`ledger entry for ${version} must be an object with tools and manifestSha256`);
+  }
+  return pinned;
+}
+
+const BUMP_INSTRUCTIONS = 'bump SERVER_VERSION (api/mcp/constants.ts) plus the matching '
+  + '`version` and `serverInfo.version` in public/.well-known/mcp/server-card.json and '
+  + 'server.json, then add the new version to scripts/mcp-registry-published-versions.json';
+
+export function assertPinnedToolInventory(serverCard, ledger) {
+  if (!serverCard || !Array.isArray(serverCard.tools)) {
     throw new Error('server card must contain a tools array to pin');
   }
   const version = serverCard.version;
-  if (typeof version !== 'string' || version.trim() === '') {
-    throw new Error('server card must declare a version');
-  }
-  const pinned = publishedVersions[version];
-  if (pinned === undefined) {
+  const pinned = pinnedEntry(version, ledger);
+  if (pinned === null) {
     throw new Error(
       `server card version ${version} is not pinned in scripts/mcp-registry-published-versions.json; `
-        + `add "${version}": ${serverCard.tools.length} so the published tool inventory is reviewed`,
+        + `add an entry with "tools": ${serverCard.tools.length} so the published inventory is reviewed`,
     );
   }
-  if (pinned !== serverCard.tools.length) {
+  if (pinned.tools !== serverCard.tools.length) {
     throw new Error(
-      `server card declares ${serverCard.tools.length} tools but SERVER_VERSION ${version} is pinned to ${pinned}. `
-        + 'The registry refuses a changed payload for an existing version — bump SERVER_VERSION '
-        + '(api/mcp/constants.ts), public/.well-known/mcp/server-card.json::serverInfo.version and server.json, '
-        + 'then add the new version to scripts/mcp-registry-published-versions.json.',
+      `server card declares ${serverCard.tools.length} tools but version ${version} is pinned to ${pinned.tools}. `
+        + `The registry refuses a changed payload for an existing version — ${BUMP_INSTRUCTIONS}.`,
     );
   }
 }
 
-export function buildMcpRegistryManifest(server, serverCard, publishedVersions) {
+export function assertPinnedManifestPayload(manifest, ledger) {
+  const pinned = pinnedEntry(manifest?.version, ledger);
+  if (pinned === null) {
+    throw new Error(`manifest version ${manifest?.version} is not pinned in the published-version ledger`);
+  }
+  const fingerprint = mcpRegistryManifestFingerprint(manifest);
+  if (pinned.manifestSha256 !== fingerprint) {
+    throw new Error(
+      `the published payload for version ${manifest.version} changed (pinned ${pinned.manifestSha256}, built ${fingerprint}). `
+        + `The registry refuses a changed payload for an existing version — ${BUMP_INSTRUCTIONS}. `
+        + `For a new version, pin "manifestSha256": "${fingerprint}".`,
+    );
+  }
+}
+
+export function buildMcpRegistryManifest(server, serverCard, ledger) {
   if (!Array.isArray(serverCard.tools) || serverCard.tools.length === 0) {
     throw new Error('server card must contain a non-empty tools array');
   }
@@ -52,14 +88,25 @@ export function buildMcpRegistryManifest(server, serverCard, publishedVersions) 
   if (/\b\d+ tools\b/i.test(server.description)) {
     throw new Error('server.json description must not contain a hand-authored tool count');
   }
-  assertPinnedToolInventory(serverCard, publishedVersions);
+  // The pin is keyed on the server card, but the manifest publishes
+  // server.json's version. Left unchecked, a card at 1.17.0 and a server.json
+  // at 1.16.0 would publish 1.16.0 carrying a 1.17.0 inventory.
+  if (server.version !== serverCard.version) {
+    throw new Error(
+      `server.json version ${server.version} does not match server card version ${serverCard.version}; `
+        + 'the published version and the pinned inventory must be the same version',
+    );
+  }
+  assertPinnedToolInventory(serverCard, ledger);
 
   const description = `${server.description.trim()} ${serverCard.tools.length} tools.`;
   if (description.length > 100) {
     throw new Error(`published description exceeds 100 characters: ${description.length}`);
   }
 
-  return { ...server, description };
+  const manifest = { ...server, description };
+  assertPinnedManifestPayload(manifest, ledger);
+  return manifest;
 }
 
 export function prepareMcpRegistryManifest({
@@ -72,8 +119,8 @@ export function prepareMcpRegistryManifest({
 
   const server = JSON.parse(readFileSync(serverPath, 'utf-8'));
   const serverCard = JSON.parse(readFileSync(serverCardPath, 'utf-8'));
-  const publishedVersions = JSON.parse(readFileSync(publishedVersionsPath, 'utf-8'));
-  const manifest = buildMcpRegistryManifest(server, serverCard, publishedVersions);
+  const ledger = JSON.parse(readFileSync(publishedVersionsPath, 'utf-8'));
+  const manifest = buildMcpRegistryManifest(server, serverCard, ledger);
   writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
   return manifest;
 }

--- a/tests/mcp-registry-artifacts.test.mjs
+++ b/tests/mcp-registry-artifacts.test.mjs
@@ -7,8 +7,10 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { load as loadYaml } from 'js-yaml';
 import {
+  assertPinnedManifestPayload,
   assertPinnedToolInventory,
   buildMcpRegistryManifest,
+  mcpRegistryManifestFingerprint,
 } from '../scripts/prepare-mcp-registry-manifest.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -87,11 +89,16 @@ describe('mcp registry publication artifacts', () => {
     const versions = Object.keys(publishedVersions ?? {});
     assert.ok(versions.length > 0, 'the published-version ledger must not be empty');
     assert.match(ledger.$comment ?? '', /SERVER_VERSION/, 'the ledger must document why it exists');
-    for (const [version, count] of Object.entries(publishedVersions)) {
+    for (const [version, pinned] of Object.entries(publishedVersions)) {
       assert.match(version, /^\d+\.\d+\.\d+$/, `${version} is not a semver version`);
       assert.ok(
-        Number.isInteger(count) && count > 0,
+        Number.isInteger(pinned.tools) && pinned.tools > 0,
         `${version} must pin a positive integer tool count`,
+      );
+      assert.match(
+        pinned.manifestSha256 ?? '',
+        /^[a-f0-9]{64}$/,
+        `${version} must pin a sha256 over the manifest it published`,
       );
     }
     assert.deepEqual(
@@ -105,7 +112,7 @@ describe('mcp registry publication artifacts', () => {
       'the newest ledger entry must be the version the server card declares',
     );
     assert.equal(
-      publishedVersions[serverCard.version],
+      publishedVersions[serverCard.version].tools,
       serverCard.tools.length,
       'adding or removing an MCP tool changes the published registry description; '
         + 'bump SERVER_VERSION and add a ledger entry instead of editing the pinned count',
@@ -137,6 +144,43 @@ describe('mcp registry publication artifacts', () => {
       () => buildMcpRegistryManifest(serverJson, serverCard, undefined),
       /versions/,
       'omitting the ledger must fail closed rather than build an unpinned manifest',
+    );
+  });
+
+  it('refuses a payload edit under a published version, not just a tool-count change', () => {
+    // The tool count is one field of a payload the registry stores whole and
+    // refuses to replace. A copy edit to the description under a frozen
+    // version reproduces the same permanently-red publish job, with none of
+    // the version-bump smell — and server.json is in the workflow's push paths.
+    const reworded = { ...serverJson, description: 'Live markets, conflicts, and country risk.' };
+    assert.throws(
+      () => buildMcpRegistryManifest(reworded, serverCard, ledger),
+      /published payload for version .* changed/,
+      'a reworded description under a published version must fail in the PR, not in the publish job',
+    );
+    assert.throws(
+      () => buildMcpRegistryManifest({ ...serverJson, title: 'World Monitor MCP' }, serverCard, ledger),
+      /published payload for version .* changed/,
+      'every published field is pinned, not only the derived tool count',
+    );
+    assert.throws(
+      () => buildMcpRegistryManifest({ ...serverJson, version: '1.16.0' }, serverCard, ledger),
+      /does not match server card version/,
+      'publishing a version other than the pinned one must fail closed',
+    );
+  });
+
+  it('pins the fingerprint of the manifest actually published', () => {
+    const manifest = buildMcpRegistryManifest(serverJson, serverCard, ledger);
+    assert.equal(
+      mcpRegistryManifestFingerprint(manifest),
+      publishedVersions[serverCard.version].manifestSha256,
+      'the pinned sha256 must be the fingerprint of the manifest the generator emits',
+    );
+    assert.doesNotThrow(() => assertPinnedManifestPayload(manifest, ledger));
+    assert.throws(
+      () => assertPinnedManifestPayload({ ...manifest, websiteUrl: 'https://example.test' }, ledger),
+      /published payload for version .* changed/,
     );
   });
 
@@ -196,9 +240,12 @@ describe('mcp registry publication artifacts', () => {
       Array.isArray(triggers.schedule) && triggers.schedule.length > 0,
       'a scheduled backstop must re-attempt publication when a merge-time run is lost',
     );
-    for (const entry of triggers.schedule) {
-      assert.match(entry.cron, /^[\d*,\-/ ]+$/, `unexpected cron expression: ${entry.cron}`);
-    }
+    assert.equal(triggers.schedule.length, 1, 'one daily backstop, not a cadence guess');
+    assert.match(
+      triggers.schedule[0].cron,
+      /^([0-9]|[1-5][0-9]) ([0-9]|1[0-9]|2[0-3]) \* \* \*$/,
+      `the backstop must be a valid daily cron, got: ${triggers.schedule[0].cron}`,
+    );
     assert.equal(
       workflow.concurrency['cancel-in-progress'],
       false,

--- a/tests/mcp-registry-artifacts.test.mjs
+++ b/tests/mcp-registry-artifacts.test.mjs
@@ -6,7 +6,10 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { load as loadYaml } from 'js-yaml';
-import { buildMcpRegistryManifest } from '../scripts/prepare-mcp-registry-manifest.mjs';
+import {
+  assertPinnedToolInventory,
+  buildMcpRegistryManifest,
+} from '../scripts/prepare-mcp-registry-manifest.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = resolve(dirname(__filename), '..');
@@ -17,14 +20,30 @@ const ROOT = resolve(dirname(__filename), '..');
 //   surface. If it 404s or its format drifts, every future `mcp-publisher
 //   login http` fails and the namespace is unrecoverable without DNS access.
 // - server.json is the source registry entry. The publish workflow derives
-//   its tool count from the server card, then uses the protected domain key
-//   when a release is published.
+//   its tool count from the server card, then uses the protected domain key.
+// - The workflow must fire on the cadence this repo actually has. #7372
+//   published on `release: published` only; the last GitHub release predated
+//   that wiring by ~6 months, the workflow logged zero runs, and the registry
+//   sat at 1.13.0/39 tools against a live 1.17.0/72. Publication is driven by
+//   pushes that change the manifest inputs, with a daily self-healing
+//   backstop, mirroring desktop-release-train.yml.
+// - scripts/mcp-registry-published-versions.json pins the tool count each
+//   SERVER_VERSION declares. server-card.json::tools is held in lockstep with
+//   the code registry (tests/public-product-facts.test.mjs), so every added
+//   tool changes the published description while SERVER_VERSION stays put —
+//   68 -> 69 -> 71 -> 72 all shipped under 1.17.0. The registry refuses a
+//   changed payload for an existing version, so that drift is what turns the
+//   publish job permanently red. Changing the inventory must bump the version.
 describe('mcp registry publication artifacts', () => {
   const authFile = readFileSync(join(ROOT, 'public/.well-known/mcp-registry-auth'), 'utf-8');
   const serverJson = JSON.parse(readFileSync(join(ROOT, 'server.json'), 'utf-8'));
   const serverCard = JSON.parse(
     readFileSync(join(ROOT, 'public/.well-known/mcp/server-card.json'), 'utf-8'),
   );
+  const ledger = JSON.parse(
+    readFileSync(join(ROOT, 'scripts/mcp-registry-published-versions.json'), 'utf-8'),
+  );
+  const publishedVersions = ledger.versions;
 
   it('mcp-registry-auth carries a single MCPv1 ed25519 key line', () => {
     assert.match(
@@ -55,13 +74,70 @@ describe('mcp registry publication artifacts', () => {
   });
 
   it('builds the published registry description from the live MCP tool count', () => {
-    const published = buildMcpRegistryManifest(serverJson, serverCard);
+    const published = buildMcpRegistryManifest(serverJson, serverCard, ledger);
     assert.match(
       published.description,
       new RegExp(`\\b${serverCard.tools.length} tools\\b`),
       'registry description must report the tool inventory in the server card',
     );
     assert.ok(published.description.length <= 100, 'registry description must fit the official limit');
+  });
+
+  it('pins each SERVER_VERSION to the tool inventory it published', () => {
+    const versions = Object.keys(publishedVersions ?? {});
+    assert.ok(versions.length > 0, 'the published-version ledger must not be empty');
+    assert.match(ledger.$comment ?? '', /SERVER_VERSION/, 'the ledger must document why it exists');
+    for (const [version, count] of Object.entries(publishedVersions)) {
+      assert.match(version, /^\d+\.\d+\.\d+$/, `${version} is not a semver version`);
+      assert.ok(
+        Number.isInteger(count) && count > 0,
+        `${version} must pin a positive integer tool count`,
+      );
+    }
+    assert.deepEqual(
+      versions,
+      [...versions].sort((a, b) => a.localeCompare(b, 'en', { numeric: true })),
+      'ledger entries must stay in ascending version order',
+    );
+    assert.equal(
+      versions.at(-1),
+      serverCard.version,
+      'the newest ledger entry must be the version the server card declares',
+    );
+    assert.equal(
+      publishedVersions[serverCard.version],
+      serverCard.tools.length,
+      'adding or removing an MCP tool changes the published registry description; '
+        + 'bump SERVER_VERSION and add a ledger entry instead of editing the pinned count',
+    );
+  });
+
+  it('refuses to build a manifest whose tool count contradicts its pinned version', () => {
+    const drifted = {
+      ...serverCard,
+      tools: [...serverCard.tools, { name: 'get_unpinned_tool' }],
+    };
+    assert.throws(
+      () => assertPinnedToolInventory(drifted, ledger),
+      /SERVER_VERSION/,
+      'a tool added without a version bump must fail the manifest generator, not the publish job',
+    );
+    assert.throws(
+      () => assertPinnedToolInventory({ ...serverCard, version: '9.9.9' }, ledger),
+      /9\.9\.9/,
+      'an unpinned version must fail closed rather than publish an unreviewed inventory',
+    );
+    assert.doesNotThrow(() => assertPinnedToolInventory(serverCard, ledger));
+    assert.throws(
+      () => assertPinnedToolInventory(serverCard, {}),
+      /versions/,
+      'a ledger without a versions map must fail closed, not skip the pin',
+    );
+    assert.throws(
+      () => buildMcpRegistryManifest(serverJson, serverCard, undefined),
+      /versions/,
+      'omitting the ledger must fail closed rather than build an unpinned manifest',
+    );
   });
 
   it('runs the publication CLI and writes the derived manifest', () => {
@@ -81,7 +157,7 @@ describe('mcp registry publication artifacts', () => {
     }
   });
 
-  it('publishes registry metadata on release with protected HTTP credentials', () => {
+  it('publishes registry metadata on manifest changes with protected HTTP credentials', () => {
     const workflowPath = join(ROOT, '.github/workflows/publish-mcp-registry.yml');
     assert.equal(existsSync(workflowPath), true, 'missing MCP registry publish workflow');
 
@@ -96,9 +172,38 @@ describe('mcp registry publication artifacts', () => {
     };
 
     assert.deepEqual(triggers.release.types, ['published']);
-    assert.equal(Object.hasOwn(triggers, 'push'), false);
     assert.ok(Object.hasOwn(triggers, 'workflow_dispatch'));
     assert.equal(Object.hasOwn(triggers, 'pull_request'), false);
+    assert.deepEqual(
+      triggers.push?.branches,
+      ['main'],
+      'publication must follow merges to main — `release: published` alone logged zero runs (#7372)',
+    );
+    for (const manifestInput of [
+      '.github/workflows/publish-mcp-registry.yml',
+      'public/.well-known/mcp/server-card.json',
+      'scripts/mcp-registry-published-versions.json',
+      'scripts/prepare-mcp-registry-manifest.mjs',
+      'scripts/publish-mcp-registry.mjs',
+      'server.json',
+    ]) {
+      assert.ok(
+        triggers.push?.paths?.includes(manifestInput),
+        `${manifestInput} changes the published manifest and must trigger publication`,
+      );
+    }
+    assert.ok(
+      Array.isArray(triggers.schedule) && triggers.schedule.length > 0,
+      'a scheduled backstop must re-attempt publication when a merge-time run is lost',
+    );
+    for (const entry of triggers.schedule) {
+      assert.match(entry.cron, /^[\d*,\-/ ]+$/, `unexpected cron expression: ${entry.cron}`);
+    }
+    assert.equal(
+      workflow.concurrency['cancel-in-progress'],
+      false,
+      'a publish in flight must not be cancelled by a following merge',
+    );
     assert.deepEqual(workflow.permissions, { contents: 'read' });
     assert.equal(workflow.jobs.publish.environment, 'mcp-registry-publish');
     assert.equal(workflow.jobs.publish['timeout-minutes'], 10);


### PR DESCRIPTION
## Why

#7372 (c) is the one acceptance criterion still unmet. The official MCP registry advertises `version 1.13.0`, `"39 tools"`, `updatedAt 2026-07-05` against a live 1.17.0 / 72 tools — a 46% understatement, verified just now:

```
$ curl https://registry.modelcontextprotocol.io/v0.1/servers?search=app.worldmonitor
"description":"Live global intelligence: ... 39 tools.","version":"1.13.0"
```

#7393 wired a publish workflow, but on `release: published` only. That trigger has not fired: the last GitHub release is **v2.5.23 (2026-03-01)**, six months old, and it tracks the desktop app rather than `SERVER_VERSION`. `Publish MCP Registry` is registered and `active` with **zero runs**. So the manifest was correct and simply never shipped.

## What changed

**Publish on the cadence this repo actually has.** Push to main touching a manifest input, plus a daily backstop, keeping `release: published` and `workflow_dispatch`. Same shape as `desktop-release-train.yml`. Re-running is already safe — `publish-mcp-registry.mjs` looks the version up first, skips an identical payload, and fails closed on a differing one.

**Pin the payload each version publishes.** `server-card.json::tools` is held in lockstep with the code registry (`public-product-facts.test.mjs:450`), so the count moves on its own: **68 → 69 → 71 → 72 all shipped under `SERVER_VERSION` 1.17.0** while the published description stayed frozen. The registry refuses a changed payload for an existing version, so the next added tool would have red-lined the publish job daily instead. `scripts/mcp-registry-published-versions.json` pins `tools` plus a sha256 over the derived manifest; the drift now fails on the PR that causes it, naming the bump to make.

## Review findings fixed in the second commit

Two independent reviewers converged on the same hole, so it is fixed rather than noted:

| Finding | Fix |
|---|---|
| The ledger pinned one derived field, but the registry stores and refuses to replace the **whole** server object. A copy edit to `server.json::description` under a frozen version reproduced the same permanent red, with no version-bump smell — and `server.json` is in the push paths | Pin `sha256(stableMcpRegistryStringify(manifest))` per version. This also closes the shortest path to green on the count guard: editing the pinned count in place no longer passes, because the fingerprint moves with the description it derives |
| The pin was keyed on `serverCard.version`, but the manifest publishes `server.version` | A 1.16.0 `server.json` with a 1.17.0 card now fails closed instead of publishing 1.16.0 carrying a 1.17.0 inventory |
| `ARCHITECTURE.md:412` still documented the release-only trigger; `docs-stats` only checks the workflow is *listed*, never the trigger column | Row corrected |
| The cron assertion was a charset check accepting `"0"` and `"0 0 31 2 *"` (Feb 31 — never fires), guarding the only recovery path for a concurrency-dropped run | Pins a valid daily cadence |
| `publishedVersions[version]` was a prototype-chain lookup; the exported pin dereferenced `serverCard.tools` undefended | `Object.hasOwn`; argument guarded |

## Verification

- Test-first: the new assertions were written against the old code and observed red (missing export + missing ledger) before implementation.
- Mutation-tested both drift vectors against the real generator — a 73rd tool and an in-place ledger edit each throw with the version bump named; the working tree was restored from a copy, not `git checkout`.
- Live dry-run against the registry: `lookup found: false` for 1.17.0 → `{"action":"publish","reason":"version-absent"}`. On merge this publishes `1.17.0` with `"72 tools"`.
- `tests/mcp-registry-artifacts.test.mjs` 10/10; registry + workflow + deploy-config + agent-readiness suites **725 pass, 0 fail**; `docs:check` OK; biome clean; all pre-push gates passed.
- Re-verified the other three acceptance criteria live (35 probes, 5 UAs x 7 URLs): all Tier-2 crawlers get `200 application/json`, `llms.txt` carries `Version: 2.10.0 · Last updated: 2026-08-30`, and its OpenAPI byte annotation (2,792,285) is byte-exact against production.

## Operator notes

- **The `mcp-registry-publish` environment does not exist** (`gh api .../environments` lists 19, none matching). GitHub creates it on first run with no protection rules, and `MCP_REGISTRY_PRIVATE_KEY` is repo-level, so publication works either way — but the test asserts a control that is not configured. Worth creating with a `main`-only deployment-branch policy. Do **not** add required reviewers: with `cancel-in-progress: false` a waiting run would hold the concurrency group and queue every later publish behind it.
- Within ~15 min of merge, `registry.modelcontextprotocol.io` should report 1.17.0 with a description ending `72 tools.` If it still says 1.13.0/39, read the `Publish MCP Registry` run.

## Residual

`scripts/check-postmerge-deploys.mjs` now describes this workflow ("a push-to-main deployer that the deploy gate cannot see") but its enrollment list is hard-coded to three files. Enrolling this one needs a `deployedTagRef` and `skipProofPaths` contract that does not fit a registry publish; left out deliberately. The daily scheduled run fails loudly on its own, which is the property that enrollment would buy.

Refs #7372

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
