### PR TITLE
fix(agent-readiness): align leftover discovery copy with repository-package contract (#7372)

### DIFF
--- a/public/agent.txt
+++ b/public/agent.txt
@@ -38,7 +38,8 @@ across live layers, a plain LLM is cheaper and faster.
 - REST API: https://api.worldmonitor.app — OpenAPI at
   https://worldmonitor.app/openapi.yaml
 - Agent skills: https://worldmonitor.app/.well-known/agent-skills/index.json
-- Agent plugin: https://worldmonitor.app/plugin.json
+- Agent plugin metadata: https://worldmonitor.app/plugin.json — repository
+  package at https://github.com/koala73/worldmonitor (not sibling HTTP files)
 - Auth walkthrough: https://worldmonitor.app/auth.md (anonymous discovery and
   get_sources need no credentials; get_sources is daily-quota-free with a
   fail-closed 10/min/IP ceiling; all other data calls take

--- a/public/agents.md
+++ b/public/agents.md
@@ -12,7 +12,7 @@ World Monitor is a real-time global intelligence dashboard: curated news feeds, 
 - **REST API:** base `https://api.worldmonitor.app` — OpenAPI spec: https://worldmonitor.app/openapi.yaml (JSON: /openapi.json) · API catalog: https://worldmonitor.app/.well-known/api-catalog
 - **NLWeb:** `POST https://www.worldmonitor.app/ask` (supports SSE) for natural-language questions; machine-readable dashboard view at `https://www.worldmonitor.app/?mode=agent`
 - **Agent Skills:** discovery index at https://worldmonitor.app/.well-known/agent-skills/index.json · install via `npx skills add koala73/worldmonitor` (https://skills.sh/koala73/worldmonitor)
-- **Agent Plugin:** https://worldmonitor.app/plugin.json — Agent Plugins 1.0.0 manifest (`plugin.json` + `mcp.json` + `skills/`) for clients that load https://agent-plugins.org packages
+- **Agent Plugin metadata:** https://worldmonitor.app/plugin.json — public metadata for the Agent Plugins 1.0.0 repository package. Install the package from https://github.com/koala73/worldmonitor (root `plugin.json`, `mcp.json`, and `skills/*/SKILL.md` live in the repository, not as sibling HTTP files)
 - **CLI:** `npx worldmonitor tools` lists every tool (public, no key) — https://www.npmjs.com/package/worldmonitor
 - **SDKs:** Python `pip install worldmonitor-sdk` · Ruby `gem install worldmonitor` · Go `go get github.com/koala73/worldmonitor/sdk/go` · JavaScript npm `worldmonitor` — guide: https://www.worldmonitor.app/docs/sdks
 - **Sandbox / test environment:** https://www.worldmonitor.app/sandbox/index.json — deterministic, schema-valid sample responses for representative REST operations; no auth, no quota, safe for CI. Guide: https://www.worldmonitor.app/docs/sandbox

--- a/public/developers.md
+++ b/public/developers.md
@@ -1,6 +1,6 @@
 # World Monitor Developer Portal
 
-Last updated: August 19, 2026
+Last updated: August 30, 2026
 
 The World Monitor Developer Portal is the single entry point for building on World Monitor — the real-time global-intelligence platform that correlates geopolitics, markets, commodities, shipping, aviation, infrastructure, cyber threats, weather, and live news as source-attributed structured JSON. The hosted MCP, REST, CLI, and SDK surfaces share the platform authentication model and underlying data contracts, so you can start with the MCP server and drop down to the REST API or an SDK without relearning the platform. WebMCP is different: it reuses the current browser session and exposes a smaller, page-local inventory for the visible website UI.
 
@@ -15,7 +15,7 @@ This page names and links every developer resource type. For the machine-readabl
 - **[World Monitor SDKs](https://worldmonitor.app/sdks.md):** official zero-dependency client libraries for Python, Ruby, Go, and JavaScript. Details: [sdks.md](https://worldmonitor.app/sdks.md) · [SDK guide](https://www.worldmonitor.app/docs/sdks)
 - **World Monitor CLI:** `npx worldmonitor tools` scripts every tool from a shell — [npm `worldmonitor`](https://www.npmjs.com/package/worldmonitor) · [CLI guide](https://www.worldmonitor.app/docs/cli)
 - **World Monitor Agent Skills:** installable skills for agent frameworks — discovery index at https://worldmonitor.app/.well-known/agent-skills/index.json · `npx skills add koala73/worldmonitor`
-- **World Monitor Agent Plugin:** Agent Plugins 1.0.0 package at https://worldmonitor.app/plugin.json (`plugin.json` + `mcp.json` + `skills/`)
+- **World Monitor Agent Plugin metadata:** public metadata at https://worldmonitor.app/plugin.json for the Agent Plugins 1.0.0 repository package. Install from https://github.com/koala73/worldmonitor (root `plugin.json`, `mcp.json`, and `skills/*/SKILL.md` live in the repository, not as sibling HTTP files)
 - **World Monitor API documentation:** the full developer documentation site at [/docs](https://www.worldmonitor.app/docs/documentation), including the [MCP Quickstart](https://www.worldmonitor.app/docs/mcp-quickstart), [tool reference](https://www.worldmonitor.app/docs/mcp-tools-reference), and [JMESPath projection guide](https://www.worldmonitor.app/docs/mcp-jmespath).
 - **World Monitor authentication:** the agent auth walkthrough at [auth.md](https://worldmonitor.app/auth.md) — API keys (`X-WorldMonitor-Key: wm_<40-hex>`) and OAuth 2.1 (`scope=mcp`) with dynamic client registration.
 - **World Monitor sandbox:** deterministic, schema-valid sample responses for representative REST operations — no key, no quota, safe for CI. Index: https://www.worldmonitor.app/sandbox/index.json · [Sandbox guide](https://www.worldmonitor.app/docs/sandbox) · scoped context: [developers/llms.txt](https://worldmonitor.app/developers/llms.txt)

--- a/public/developers/llms.txt
+++ b/public/developers/llms.txt
@@ -12,7 +12,7 @@ All developer surfaces share one tool inventory and one subscription auth model 
 - [CLI](https://www.npmjs.com/package/worldmonitor): `npx worldmonitor tools` lists every tool with no key; `npm install -g worldmonitor` installs the command
 - [SDKs](https://worldmonitor.app/sdks.md): Python `pip install worldmonitor-sdk` · Ruby `gem install worldmonitor` · Go `go get github.com/koala73/worldmonitor/sdk/go` · JavaScript (npm `worldmonitor`)
 - [Agent Skills](https://worldmonitor.app/.well-known/agent-skills/index.json): installable skills manifest — `npx skills add koala73/worldmonitor`
-- [Agent Plugin](https://worldmonitor.app/plugin.json): Agent Plugins 1.0.0 package (`plugin.json` + `mcp.json` + `skills/`)
+- [Agent Plugin metadata](https://worldmonitor.app/plugin.json): public metadata for the Agent Plugins 1.0.0 repository package. Install from https://github.com/koala73/worldmonitor (root `plugin.json`, `mcp.json`, and `skills/*/SKILL.md` live in the repository, not as sibling HTTP files)
 
 ## Test Without a Key
 

--- a/public/home.md
+++ b/public/home.md
@@ -66,7 +66,7 @@ Start with the short [llms.txt briefing](https://worldmonitor.app/llms.txt), the
 - [REST API](https://api.worldmonitor.app): structured endpoints described by the [OpenAPI contract](https://worldmonitor.app/openapi.yaml).
 - [Agent-mode homepage](https://www.worldmonitor.app/?mode=agent): a compact JSON summary of endpoints, authentication, capabilities, and discovery files.
 - [Agent Skills](https://worldmonitor.app/.well-known/agent-skills/index.json): task-focused instructions for common country, resilience, and intelligence workflows.
-- [Agent Plugin](https://worldmonitor.app/plugin.json): Agent Plugins 1.0.0 manifest that packages the MCP servers and agent skills.
+- [Agent Plugin metadata](https://worldmonitor.app/plugin.json): public metadata for the Agent Plugins 1.0.0 repository package. Install from https://github.com/koala73/worldmonitor (root `plugin.json`, `mcp.json`, and `skills/*/SKILL.md` live in the repository, not as sibling HTTP files).
 - [A2A agent card](https://worldmonitor.app/.well-known/agent-card.json): service identity and protocol discovery for agent-to-agent clients.
 - [SDK guide](https://www.worldmonitor.app/docs/sdks) and [worldmonitor CLI](https://www.npmjs.com/package/worldmonitor): supported clients for applications and shell workflows.
 

--- a/tests/agent-plugins-manifest.test.mjs
+++ b/tests/agent-plugins-manifest.test.mjs
@@ -141,11 +141,18 @@ describe('agent readiness: Agent Plugins manifest', () => {
       );
     }
     assert.match(publicLlms, /repository package/i);
-    for (const relativePath of ['public/agents.md', 'public/developers.md', 'public/developers/llms.txt']) {
+    const repositoryPackage = /repository\s+package/i;
+    for (const relativePath of [
+      'public/agents.md',
+      'public/developers.md',
+      'public/developers/llms.txt',
+      'public/home.md',
+      'public/agent.txt',
+    ]) {
       const body = readFileSync(join(ROOT, relativePath), 'utf-8');
       assert.match(
         body,
-        /repository package/i,
+        repositoryPackage,
         `${relativePath} must describe the Agent Plugin as a repository package`,
       );
     }

--- a/tests/agent-plugins-manifest.test.mjs
+++ b/tests/agent-plugins-manifest.test.mjs
@@ -128,12 +128,27 @@ describe('agent readiness: Agent Plugins manifest', () => {
     assert.equal(existsSync(join(ROOT, 'public/mcp.json')), false);
     const mcpRoute = (vercelConfig.headers ?? []).find((rule) => rule.source === '/mcp.json');
     assert.equal(mcpRoute, undefined, 'vercel.json must not serve /mcp.json as a static Agent Plugin file');
-    assert.doesNotMatch(
-      publicLlms,
-      /\[Agent Plugin\][^\n]*`plugin\.json` \+ `mcp\.json` \+ `skills\/`/,
-      'the public /plugin.json link must not promise sibling HTTP files that only exist in the repository package',
-    );
+    // The backtick trio implies sibling HTTP files next to /plugin.json. Those files
+    // only exist in the GitHub package; every discovery surface must say so explicitly
+    // (or omit the trio) rather than listing them as if they were fetchable URLs.
+    const httpSiblingPromise = /`plugin\.json` \+ `mcp\.json` \+ `skills\//;
+    for (const relativePath of DISCOVERY_SURFACES) {
+      const body = readFileSync(join(ROOT, relativePath), 'utf-8');
+      assert.doesNotMatch(
+        body,
+        httpSiblingPromise,
+        `${relativePath} must not promise HTTP siblings that only exist in the repository package`,
+      );
+    }
     assert.match(publicLlms, /repository package/i);
+    for (const relativePath of ['public/agents.md', 'public/developers.md', 'public/developers/llms.txt']) {
+      const body = readFileSync(join(ROOT, relativePath), 'utf-8');
+      assert.match(
+        body,
+        /repository package/i,
+        `${relativePath} must describe the Agent Plugin as a repository package`,
+      );
+    }
   });
 
   it('every well-known agent skill has a plugin skills/ SKILL.md inside the plugin root', () => {

--- a/tests/agent-plugins-manifest.test.mjs
+++ b/tests/agent-plugins-manifest.test.mjs
@@ -46,7 +46,6 @@ const DISCOVERY_SURFACES = [
 const plugin = JSON.parse(readFileSync(join(ROOT, 'plugin.json'), 'utf-8'));
 const publicPlugin = readFileSync(join(ROOT, 'public/plugin.json'));
 const mcp = JSON.parse(readFileSync(join(ROOT, 'mcp.json'), 'utf-8'));
-const publicLlms = readFileSync(join(ROOT, 'public/llms.txt'), 'utf-8');
 const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
 const vercelConfig = JSON.parse(readFileSync(join(ROOT, 'vercel.json'), 'utf-8'));
 const serverCard = JSON.parse(
@@ -126,12 +125,28 @@ describe('agent readiness: Agent Plugins manifest', () => {
 
   it('describes mcp.json as part of the repository package, not the HTTP manifest', () => {
     assert.equal(existsSync(join(ROOT, 'public/mcp.json')), false);
+    // The pages claim skills/*/SKILL.md lives in the repository too, so pin that half of
+    // the sentence the same way. public/.well-known/agent-skills/ is a different surface
+    // and is genuinely served; only a sibling public/skills/ would make the copy false.
+    assert.equal(
+      existsSync(join(ROOT, 'public/skills')),
+      false,
+      'public/skills/ must not be served as sibling HTTP files',
+    );
     const mcpRoute = (vercelConfig.headers ?? []).find((rule) => rule.source === '/mcp.json');
     assert.equal(mcpRoute, undefined, 'vercel.json must not serve /mcp.json as a static Agent Plugin file');
     // The backtick trio implies sibling HTTP files next to /plugin.json. Those files
     // only exist in the GitHub package; every discovery surface must say so explicitly
     // (or omit the trio) rather than listing them as if they were fetchable URLs.
     const httpSiblingPromise = /`plugin\.json` \+ `mcp\.json` \+ `skills\//;
+    // Positive control. Once the copy is correct this regex matches nothing in the tree,
+    // so every doesNotMatch below passes vacuously and an escaping slip would silently
+    // neuter all of them at once. Pin it against a known-bad string so it stays able to red.
+    assert.match('(`plugin.json` + `mcp.json` + `skills/`)', httpSiblingPromise);
+    // httpSiblingPromise only catches one literal phrasing (a comma list, a reordered trio
+    // or a bare URL all evade it), so reject the sibling URLs themselves regardless of how
+    // the surrounding prose is written.
+    const httpSiblingUrl = /worldmonitor\.app\/(?:mcp\.json|skills\/)/;
     for (const relativePath of DISCOVERY_SURFACES) {
       const body = readFileSync(join(ROOT, relativePath), 'utf-8');
       assert.doesNotMatch(
@@ -139,16 +154,25 @@ describe('agent readiness: Agent Plugins manifest', () => {
         httpSiblingPromise,
         `${relativePath} must not promise HTTP siblings that only exist in the repository package`,
       );
+      assert.doesNotMatch(
+        body,
+        httpSiblingUrl,
+        `${relativePath} must not link /mcp.json or /skills/ as fetchable URLs`,
+      );
     }
-    assert.match(publicLlms, /repository package/i);
+    // Derived from DISCOVERY_SURFACES so a newly added surface is enrolled by default
+    // rather than silently exempt. The docs/*.mdx pages are excluded because they state the
+    // same contract as "The GitHub repository is the plugin package" (and its Chinese
+    // translation), which this regex cannot match; they keep their own SKILL.md assertion.
     const repositoryPackage = /repository\s+package/i;
-    for (const relativePath of [
-      'public/agents.md',
-      'public/developers.md',
-      'public/developers/llms.txt',
-      'public/home.md',
-      'public/agent.txt',
-    ]) {
+    const repositoryPackageSurfaces = DISCOVERY_SURFACES.filter(
+      (relativePath) => !relativePath.startsWith('docs/'),
+    );
+    assert.ok(
+      repositoryPackageSurfaces.length >= 8,
+      'repository-package coverage shrank; every non-docs discovery surface must stay enrolled',
+    );
+    for (const relativePath of repositoryPackageSurfaces) {
       const body = readFileSync(join(ROOT, relativePath), 'utf-8');
       assert.match(
         body,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the last in-repo residual from #7372 after #7393 / #7416.

`public/llms.txt` already describes the Agent Plugin as a **repository package** and does not promise HTTP siblings. Several other discovery surfaces still advertised packaging language that implied `/mcp.json` (and skills) were fetchable next to `/plugin.json`, which 404s.

- Reword `agents.md`, `developers.md`, `developers/llms.txt`, `home.md`, and `agent.txt` to match the repository-package contract
- Strengthen `tests/agent-plugins-manifest.test.mjs` so every discovery surface is locked against the HTTP-sibling promise, and the residual entrypoints assert repository-package wording

### Issue #7372 acceptance status

| Criterion | Status |
|---|---|
| (a) Tier-2 UAs get JSON on URLs `llms.txt` links | Done on main via sandbox reroute (#7393). Verified live: GPTBot → `200 application/json` on sandbox sample. Live `/api/...` still Cloudflare-403s crawlers (external WAF; out of repo). |
| (b) `/mcp.json` serves or claim removed | Claim removed from `llms.txt` on main; this PR removes leftover claims on sibling discovery pages. `/mcp.json` intentionally 404s. |
| (c) Registry republish + 69+ tools | Live registry reports **1.17.0 / 72 tools** as `isLatest` (#7416). |
| (d) `llms.txt` version + date + OpenAPI size | Done on main (#7393). |

## Type of change

- [x] Bug fix
- [x] Documentation

## Affected areas

- [x] Other: agent discovery surfaces (`agents.md`, `developers.md`, `developers/llms.txt`, `home.md`, `agent.txt`)

## Checklist

- [x] Focused unit tests pass (`tests/agent-plugins-manifest.test.mjs`, `tests/llms-txt-mcp-tools.test.mjs`, `tests/brand-identity-page.test.mjs`)
- [x] No API keys or secrets committed
- [x] TypeScript / health-probe items — N/A (markdown + test only)

## Documentation Alignment Checklist

- N/A — discovery copy alignment only; no methodology/API contract change

## Code review

- Roster: correctness, project-standards, testing, agent-native, learnings
- Actionable findings: none
- Residuals addressed in-PR: `home.md` / `agent.txt` install copy (from review residual risks)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — static discovery markdown and a unit-test guard only; no runtime API, Worker, or registry publish path changes in this PR.

After deploy, spot-check that `https://worldmonitor.app/agents.md`, `/developers.md`, `/developers/llms.txt`, `/home.md`, and `/agent.txt` contain “repository package” and no `` `plugin.json` + `mcp.json` + `skills/` `` trio. Failure signal: those pages reintroduce the HTTP-sibling promise (rollback this PR).

## Screenshots

N/A — static markdown discovery surfaces.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63c06156-4c19-459b-9f63-fcc093b7c432?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63c06156-4c19-459b-9f63-fcc093b7c432&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

