### PR TITLE
fix(sentry): filter injected jQuery errors on the marketing surface

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -187,6 +187,40 @@ export const MARKETING_IGNORE_ERRORS: RegExp[] = [
   // separate Sentry clients, so the marketing copy was the gap that let
   // WORLDMONITOR-108 through.
   /webkit\.messageHandlers/,
+  // A bare `jQuery` global reference from an injected script.
+  // WORLDMONITOR-11F is the shape: `ReferenceError: jQuery is not defined` on
+  // Firefox 148 / Linux, sent by `sentry.javascript.react` with a null release,
+  // whose single frame is the prerendered welcome document itself
+  // (`https://www.worldmonitor.app/` line 1, column 445).
+  //
+  // The licence is the IDENTIFIER, not the frame — deliberately, because on
+  // this surface the document frame proves nothing (see
+  // MARKETING_DOCUMENT_FRAME: welcome.html's WebMCP bootstrap and
+  // prerender.mjs's DEFERRED_STYLES_SCRIPT are executable inline script the
+  // browser attributes to the same URL). A `ReferenceError: <name> is not
+  // defined` can only be thrown by code that reads `<name>` as a BARE
+  // identifier, and no first-party source on this surface — `pro-test/src`, the
+  // `shared/` leaves it imports, or either inline script — contains one for
+  // `jQuery`. The one `jQuery` token in the shipped marketing output is
+  // UAParser's optional-plugin hookup inside the bundled Clerk chunk,
+  // `i.jQuery || i.Zepto`: a guarded PROPERTY read on the global object, which
+  // evaluates to `undefined` and cannot raise a ReferenceError. So the throw is
+  // third-party by construction, which is what makes a frame-blind
+  // `ignoreErrors` entry safe here where `marketingBeforeSend`'s frame gates —
+  // handed one document frame — could not act at all.
+  //
+  // Already suppressed on the dashboard (`/jQuery is not defined/` in
+  // `src/bootstrap/sentry-init.ts`); the two surfaces run separate Sentry
+  // clients, which is the same gap that let WORLDMONITOR-15/-102/-107/-108/
+  // -10N/-10T/-117 through.
+  //
+  // Anchored to the whole message rather than copying the dashboard's bare
+  // substring, for the reason the `Error invoking` entry above spells out:
+  // `ignoreErrors` is frame-blind, so an unanchored pattern would also drop a
+  // first-party message that merely CONTAINS the phrase, even riding a
+  // `/pro/assets/*.js` frame. `tests/pro-sentry-filter-policy.test.mts` pins
+  // both the suppression and the bare-identifier scan that licenses it.
+  /^jQuery is not defined$/,
 ];
 
 /** Sentry's own hashed SDK chunk — infrastructure, never evidence of our code. */

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -148,6 +148,40 @@ describe('marketing ignoreErrors', () => {
     assert.equal(isIgnored('ReferenceError', "Can't find variable: zaloJSV2Extended"), false);
   });
 
+  it('drops the injected bare-jQuery ReferenceError (WORLDMONITOR-11F)', () => {
+    // Verbatim production value. Firefox 148 / Linux, single frame on the
+    // prerendered welcome document, `sentry.javascript.react` with a null
+    // release — a marketing-bundle event, so the dashboard's own
+    // `/jQuery is not defined/` entry never ran on it.
+    assert.equal(isIgnored('ReferenceError', 'jQuery is not defined'), true);
+  });
+
+  // Positive control for the anchors. `ignoreErrors` is frame-blind, so an
+  // unanchored copy of the dashboard's pattern would also swallow a
+  // first-party message that merely contains the phrase. Drop the `^`/`$` and
+  // this goes red.
+  it('keeps a first-party message that merely contains the jQuery phrase', () => {
+    assert.equal(
+      isIgnored('Error', 'Checkout aborted: jQuery is not defined on the host page'),
+      false,
+    );
+    assert.equal(isIgnored('ReferenceError', 'jQueryUI is not defined'), false);
+  });
+
+  it('pins the marketing surface as bare-jQuery-free, which is what licenses the rule', () => {
+    // The WORLDMONITOR-11F suppression is licensed by the identifier, not by
+    // the frame: a `ReferenceError: jQuery is not defined` can only come from
+    // code that reads `jQuery` as a bare identifier, and no first-party source
+    // on this surface holds one. If that changes, the entry must move behind a
+    // frame gate — fail loudly here rather than silently hide a real bug.
+    const offenders = marketingFirstPartySources()
+      .filter((f) => !f.rel.includes('sentry-filter-policy'))
+      .filter((f) => /\bjQuery\b/.test(f.code))
+      .map((f) => f.rel);
+    assert.deepEqual(offenders, [],
+      'the marketing surface now references jQuery — re-derive the WORLDMONITOR-11F rule');
+  });
+
   // Positive control: the array must not have grown a pattern broad enough to
   // swallow an ordinary marketing-bundle bug.
   it('keeps a genuine first-party error message', () => {


### PR DESCRIPTION
## Summary

An injected script's `ReferenceError: jQuery is not defined` now stops at the marketing surface's Sentry client instead of filing as a production `error` (WORLDMONITOR-11F, Firefox 148 / Linux). The dashboard has dropped that exact message for months — `/` and `/pro` just run a **separate** `@sentry/react` client with its own vetted policy, so `src/bootstrap/sentry-init.ts` never saw the event. Same split that let WORLDMONITOR-15/-102/-107/-108/-10N/-10T/-117 through.

The part worth reviewing is *why this is safe in the frame-blind array* rather than behind `marketingBeforeSend`'s frame gate. On this surface a document frame proves nothing — `welcome.html`'s WebMCP bootstrap and `prerender.mjs`'s `DEFERRED_STYLES_SCRIPT` are executable inline script the browser attributes to the same URL — so the gate could not act on the single document frame this event carried. The licence is the **identifier**: a `ReferenceError` for `jQuery` can only be thrown by code reading `jQuery` as a *bare* identifier, and no first-party source on this surface holds one.

One trap for a reviewer who greps: the shipped marketing output **does** contain a `jQuery` token — UAParser's `i.jQuery || i.Zepto` inside the bundled Clerk chunk. That is a guarded *property* read on the global; it evaluates to `undefined` and cannot raise a `ReferenceError`, so it does not weaken the argument.

Anchored `^…$` rather than copying the dashboard's bare `/jQuery is not defined/`: `ignoreErrors` is frame-blind, so an unanchored pattern would also swallow a first-party message that merely *contains* the phrase.

## Test plan

`tests/pro-sentry-filter-policy.test.mts` — **71 pass / 0 fail**. Each new test was proven to have teeth by mutating the source and watching it go red:

| Mutation applied | Test that fails |
|---|---|
| Delete the new pattern | `drops the injected bare-jQuery ReferenceError (WORLDMONITOR-11F)` |
| Unanchor it to `/jQuery is not defined/` | `keeps a first-party message that merely contains the jQuery phrase` |

The third test, `pins the marketing surface as bare-jQuery-free`, is the standing guard: it scans `pro-test/src`, the `shared/` leaves it imports, and both inline-script entrypoints, and fails if a bare `jQuery` reference ever appears — at which point this entry must move behind a frame gate instead of silently hiding a real bug.

`tsc --noEmit` exit 0, biome clean, full pre-push gate green.

WORLDMONITOR-11F is resolved in Sentry with a **plain** resolve (no `inNextRelease` pin, `statusDetails: {}` verified), so a post-deploy recurrence regresses it visibly rather than muting permanently.

## Related

Prior repairs to this same client split: #7241, #7354, #7356.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Opus 5](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
