### PR TITLE
fix(git): stop test fixtures from poisoning the shared repo identity

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -40,6 +40,22 @@ if [ -z "${WM_ALLOW_FOREIGN_HOOKS:-}" ] && [ -n "${BASH_SOURCE[0]:-}" ]; then
   fi
 fi
 
+# --- Git-env hygiene + identity gate (the "Fixture author" incident class) ---
+# During a push git exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE to this hook,
+# and those OVERRIDE cwd for every child process. A test fixture run below that
+# shells out to `git config user.name` without stripping them writes its fake
+# identity into the SHARED .git/config — poisoning every worktree's future
+# commits (2026-08-30 "Fixture <fixture@example.invalid>" incident; also
+# "test@example.com", "WorldMonitor Test", "e@e.co" before it). The hook needs
+# none of these vars: cwd-based discovery works in every worktree. Capture the
+# push stdin first (the gate consumes it), then strip the list git publishes.
+WM_PUSH_STDIN=$(cat || true)
+printf '%s\n' "$WM_PUSH_STDIN" | bash scripts/prepush-identity-gate.sh || exit 1
+for _git_env in $(git rev-parse --local-env-vars 2>/dev/null); do
+  unset "$_git_env" 2>/dev/null || true
+done
+unset _git_env
+
 echo "Checking for local environment dumps..."
 node scripts/check-local-secret-dumps.mjs --pre-push "${1:-}" || exit 1
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -388,6 +388,12 @@ A gate failure caused by an external service being unavailable or answering unus
 
 Two properties keep the soft path from becoming a hole. It may fire only when the external system produced no usable result at all, never when a result exists and reports a genuine problem; and the skip must be annotated with what went unchecked, because an unannounced skip is indistinguishable from a pass. The diagnostic corollary matters as much as the split: because the tree is not the variable, the same commit can pass and then fail with nothing changed, so a gate that reddens repo-wide is diagnosed by comparing *when* each run executed rather than by reading pass/fail — sibling branches showing green are often stale runs from before the outage. See also: Tiered Gate, Vacuous Guard.
 
+### Identity Gate
+
+The state-dependent pre-push check that refuses to publish commits whose author or committer email matches a known test-fixture pattern, and fails a push outright while the shared repository configuration itself still carries such an identity. It exists because git hands its repository-location environment down to hook children, overriding their working directory — so an un-isolated test fixture run by the hook writes its fake identity into configuration that every linked worktree inherits.
+
+The gate checks the state that will actually be published rather than trusting upstream hardening: outgoing commits and the shared configuration are examined at push time, so a leak produced by a stale worktree running an old hook is still caught at the boundary even when the current tree is fully isolated. On failure it prints the repair recipe rather than only refusing, because the pusher is usually not the party that poisoned the configuration. See also: Tiered Gate.
+
 ### Baselined Advisory
 
 A dependency advisory the security gate knowingly tolerates, recorded per-lockfile with written reasoning for why the vulnerable path is unreachable in this project — typically a build-time-only or dev-tooling chain, or a fix that is semver-major on a parent the project cannot yet move.

--- a/docs/solutions/logic-errors/prepush-hook-env-override-poisons-shared-git-identity.md
+++ b/docs/solutions/logic-errors/prepush-hook-env-override-poisons-shared-git-identity.md
@@ -1,0 +1,255 @@
+---
+title: "Git-exported hook env vars override cwd, letting un-isolated test fixtures poison the shared git identity"
+date: 2026-08-30
+category: logic-errors
+module: pre-push-identity-gate
+problem_type: logic_error
+component: development_workflow
+severity: high
+symptoms:
+  - "Commits land on main and PR branches authored/committed as test <test@example.com>, Fixture <fixture@example.invalid>, WorldMonitor Test, or e <e@e.co> -- none of them real contributors"
+  - "git config --global user.name always shows the correct identity while the poisoned value lives in the repo-local SHARED .git/config"
+  - "A commit carries a fixture's fake identity even from a worktree that never ran a git-fixture test (the poison is in config every linked worktree shares)"
+  - "A fixture's cd <tempdir> && git init && git config user.name writes into the real repo whenever it executes as a child of the pre-push hook"
+root_cause: test_isolation
+resolution_type: workflow_improvement
+related_components:
+  - tooling
+  - testing_framework
+tags:
+  - pre-push
+  - husky
+  - git-identity
+  - env-var-leak
+  - shared-git-config
+  - test-isolation
+  - worktree
+  - fixture-authorship
+---
+
+# Git-exported hook env vars override cwd, letting un-isolated test fixtures poison the shared git identity
+
+## Problem
+
+Commits were repeatedly landing under fake test-fixture identities instead of the real
+contributor — "Fixture <fixture@example.invalid>" (2026-08-30), "test <test@example.com>"
+(2026-08-29/30, this one reached `main`), "WorldMonitor Test <test@worldmonitor.app>", and
+"e <e@e.co>". The identities didn't come from a misconfigured `git config --global`; they came
+from git itself.
+
+**Root cause.** During a push, git exports `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` into
+the environment of the pre-push hook's child processes. Those three variables **override a
+child's `cwd`** for the purposes of git repo discovery — a process can `cd` into an unrelated
+temp directory and still have every git command it runs resolve back to the *original* repo
+because the env vars win.
+
+WorldMonitor's `.husky/pre-push` hook runs the tests touched by the push
+(`scripts/prepush-changed-tests.sh`, invoked at `.husky/pre-push:576` and `:583`). Several of
+those test files spin up throwaway git fixtures — `git init` in a tempdir, then
+`git config user.name <fixture>` to give the fixture repo an identity — as ordinary test setup.
+Under a normal `npm test` invocation this is harmless: the fixture's `cwd` is honored and the
+config write lands in the fixture's own `.git/config`. Run the *same* fixture code from inside a
+git hook, though, and the inherited `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` redirect that
+`git config user.name` write straight into the **real, shared `.git/config`** of the repository
+being pushed — the common config that every linked worktree reads. From that point on, every
+commit made from *any* worktree of that repo silently carries the fixture's fake author until
+someone notices.
+
+This is a shared-worktree amplifier: WorldMonitor runs on the order of a hundred linked
+worktrees off one common `.git` directory (113 at the time of this incident), so one hook run in one worktree poisons identity for all of them.
+
+## Symptoms
+
+- Commits landing on `main` and PR branches authored/committed as `test <test@example.com>`,
+  `Fixture <fixture@example.invalid>`, `WorldMonitor Test <test@worldmonitor.app>`, or
+  `e <e@e.co>` — none of them real contributors.
+- `git config --global user.name`/`user.email` always showed the correct identity, which is
+  misleading and delayed diagnosis — the poison lives in the **repo-local shared config**
+  (`.git/config` in the common git dir), not the global one. `git config --show-origin
+  user.name` (and `user.email`) attributes the value to its source file instantly and would
+  have shortened the hunt.
+- The bad identity could appear on a commit made in a worktree that had never itself run a git
+  fixture test — because the poison sits in config shared across every worktree, not in any one
+  worktree's state.
+
+## What Didn't Work
+
+1. **Suspecting the currently-checked-out tests.** Every test file at HEAD was already isolated
+   from git's hook-exported env — running canaries for the 6 suspect test files under a forced
+   `GIT_DIR` all came back clean. The actual leak was coming from **stale worktrees** (the repo
+   carries them by the dozen) still running an old copy of the pre-push hook against an
+   un-hardened, older copy of the test files. Auditing only the live tree's code missed it
+   entirely; the offending code no longer existed at HEAD but was still being executed elsewhere.
+
+2. **Grepping for the isolation pattern by regex.** A search for `local-env-vars|GIT_DIR`
+   produced false "unhardened" positives, because tests use several different, equally valid
+   isolation idioms — filtering by a `GIT_` prefix, or hand-deleting a fixed list of override
+   vars — not just the `--local-env-vars` idiom. One file that the grep flagged as having "NO
+   ISOLATION" was actually a false negative caused by a missing file being read behind
+   `2>/dev/null`; the absence of output was misread as evidence of a gap rather than as a
+   swallowed error.
+
+3. **Checking only `git config --global user.name`.** This was always correct and led away from
+   the bug. The poisoned value lives in the repo-local **shared** config (the common `.git/config`
+   used by every linked worktree), which `--global` never touches.
+   `git config --show-origin user.name` (and the same for `user.email`) surfaces the poisoned
+   value and its source file in one call and should be the first diagnostic run, not the last.
+
+## Solution
+
+PR #7432 (`fix/prepush-git-env-identity-leak`; open as of this writing) adds three pieces:
+
+### 1. `.husky/pre-push` — strip git's exported env before anything runs
+
+`.husky/pre-push:43-57` (the "Git-env hygiene + identity gate" block):
+
+```bash
+# --- Git-env hygiene + identity gate (the "Fixture author" incident class) ---
+# During a push git exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE to this hook,
+# and those OVERRIDE cwd for every child process. A test fixture run below that
+# shells out to `git config user.name` without stripping them writes its fake
+# identity into the SHARED .git/config — poisoning every worktree's future
+# commits (2026-08-30 "Fixture <fixture@example.invalid>" incident; also
+# "test@example.com", "WorldMonitor Test", "e@e.co" before it). The hook needs
+# none of these vars: cwd-based discovery works in every worktree. Capture the
+# push stdin first (the gate consumes it), then strip the list git publishes.
+WM_PUSH_STDIN=$(cat || true)
+printf '%s\n' "$WM_PUSH_STDIN" | bash scripts/prepush-identity-gate.sh || exit 1
+for _git_env in $(git rev-parse --local-env-vars 2>/dev/null); do
+  unset "$_git_env" 2>/dev/null || true
+done
+unset _git_env
+```
+
+The push's stdin (`<local ref> <local sha> <remote ref> <remote sha>` lines) is captured into
+`WM_PUSH_STDIN` first, since the identity gate needs to read it, then the env strip runs
+**before** the hook does anything else — critically, before `scripts/prepush-changed-tests.sh`
+is invoked at `.husky/pre-push:576` and `:583`, which is what selects and runs the test files
+that create git fixtures. Because every later child process (including the changed-test runner)
+inherits an environment with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/etc. already removed, an
+un-isolated fixture that does `cd <tempdir> && git init && git config user.name ...` now
+correctly resolves `<tempdir>` as its repo, because there's no override left to redirect it back
+to the real one.
+
+### 2. `scripts/prepush-identity-gate.sh` — a backstop that catches whatever the strip misses
+
+New file, `scripts/prepush-identity-gate.sh:1-87`. Two independent checks:
+
+- **Outgoing-commit check** (`scripts/prepush-identity-gate.sh:36-61`): for each pushed ref, walks
+  the new commits (`remote_sha..local_sha` for updates, `local_sha --not --remotes=origin` for new
+  branches) and blocks the push if any author or committer email matches the fixture pattern
+  defined at `scripts/prepush-identity-gate.sh:25`:
+
+  ```bash
+  BAD_EMAIL_RE='@example\.(invalid|test|com)$|^e@e\.co$|^fixture@|^test@worldmonitor\.app$'
+  ```
+
+- **Shared-config check** (`scripts/prepush-identity-gate.sh:63-73`): reads
+  `user.email` directly out of the **common** git config
+  (`git rev-parse --path-format=absolute --git-common-dir`) and fails the push if it currently
+  holds a fixture-pattern address — even when the commits being pushed are themselves clean —
+  because the *next* commit made from any worktree would silently inherit the poison.
+
+This is deliberately a second, independent layer: the env-strip in the hook prevents the write at
+current SHAs, but the gate is what stops a leak from a **stale worktree** running old, un-hardened
+test code (exactly the failure mode from "What Didn't Work" item 1) from ever reaching GitHub.
+
+On failure it prints the exact repair recipe (`scripts/prepush-identity-gate.sh:75-86`).
+
+### 3. `tests/prepush-identity-gate.test.mts` — 8 tests, including a policy test
+
+`tests/prepush-identity-gate.test.mts` (169 lines) covers:
+
+- 5 behavioral tests on `prepush-identity-gate.sh` (`:82-127`): blocks a fixture-authored new
+  branch, blocks a fixture-authored commit inside an update range, passes a clean push, ignores
+  branch deletions, and blocks when the shared config is currently poisoned even with clean
+  commits.
+- 2 wiring tests on the hook itself (`:130-145`): asserts `.husky/pre-push` unsets
+  `$(git rev-parse --local-env-vars)` **before** any test invocation (`hook.indexOf('--local-env-vars')` must precede the index of `npx tsx --test|prepush-changed-tests`), and asserts the
+  gate script is wired on the push stdin.
+- 1 **policy test** (`:147-169`): scans every `tests/*.test.m[jt]s` file, flags any that write a
+  git identity (`git config user.name` or equivalent) via a `git` invocation, and asserts each one
+  carries a recognized isolation idiom — `--local-env-vars`, a `GIT_` prefix filter, explicit
+  `GIT_CONFIG_GLOBAL`, or the hand-listed `GIT_DIR` delete idiom. This is what prevents the class
+  of bug from being reintroduced by a future fixture that forgets to isolate itself, closing
+  exactly the gap that let the original leak happen in the first place.
+
+The test file also documents (`:35-48`) that it is itself a git-identity-writing fixture and
+practices what the policy test enforces — using `--local-env-vars` to build an `isolatedEnv()`
+helper for its own git spawns.
+
+## Why This Works
+
+The bug had one true cause with two exposure surfaces, so the fix addresses both:
+
+- **Prevention at the source** — stripping `git rev-parse --local-env-vars` in the hook, before
+  any test runs, removes the actual mechanism (`GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`
+  overriding a child's `cwd`). Once those vars are gone, a fixture's `git config user.name` call
+  can only ever write into the fixture's own tempdir repo, because plain `cwd`-based discovery is
+  all that's left, and that's exactly what a hook needs anyway (per the comment at
+  `.husky/pre-push:49-50`: "The hook needs none of these vars: cwd-based discovery works in every
+  worktree").
+- **Detection at the boundary** — the identity gate doesn't assume the strip is sufficient. It
+  independently re-checks both the outgoing commits *and* the shared config's current state right
+  before the push leaves the machine. This is what makes the fix robust against the actual failure
+  mode diagnosed in "What Didn't Work": code at HEAD can be perfectly hardened while a stale
+  worktree's stale hook still runs stale, unhardened test code. The gate catches that leak
+  regardless of which worktree or which version of the hook produced it, because it checks the
+  state that matters (the config that will be read, the commits that will be published) rather
+  than trusting that every code path upstream was isolated correctly.
+- **Regression-proofing** — the policy test converts "isolate your git fixture" from a convention
+  someone has to remember into something CI enforces on every new test file that touches git
+  identity, so the next fixture author can't reintroduce the same class of bug undetected.
+
+## Prevention
+
+- **Diagnose git-identity leaks with `git config --show-origin`, not `--global`.** A poisoned
+  shared config is invisible to a `--global` check; `--show-origin` attributes the value to its
+  actual config file (worktree-common vs. global) in one call.
+- **Any process that shells out to `git config user.name`/`user.email` as test scaffolding must
+  isolate itself from git's hook-exported environment** — strip `$(git rev-parse
+  --local-env-vars)`, filter to a `GIT_` prefix, or set `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to
+  `/dev/null` plus an explicit local-only config. `tests/prepush-identity-gate.test.mts`'s policy
+  test (`:147-169`) now enforces this for every git-identity-writing file under `tests/`.
+  Understand this as a repo-wide pattern, not a one-file fix: any hook, script, or CI job that
+  spawns children while inside a git hook context inherits the same `GIT_DIR`/`GIT_WORK_TREE`/
+  `GIT_INDEX_FILE` override risk, not just test fixtures.
+- **Reproduction recipe for this class of bug** — a minimal canary that reliably reproduces the
+  leak without needing a real hook run, useful for verifying any future fix or new isolation
+  idiom:
+
+  ```bash
+  # Poisons <canary>/.git/config from inside an unrelated tempdir, simulating
+  # what an un-isolated fixture does when run as a hook child:
+  GIT_DIR=<canary>/.git bash -c 'cd <tempfixture> && git init && git config user.name LeakyFixture'
+
+  # The strip neutralizes it — it must run INSIDE the child that inherited the
+  # override (stripping in the parent and re-exporting GIT_DIR would still leak):
+  GIT_DIR=<canary>/.git bash -c '
+    for v in $(git rev-parse --local-env-vars); do unset "$v"; done
+    cd <tempfixture> && git init && git config user.name LeakyFixture'
+  # -> canary stays clean; the write lands in <tempfixture>/.git/config
+  ```
+
+- **When a leak does land** (a stale worktree, an unpatched hook elsewhere, or before this fix
+  existed), the repair recipe — verified live against a real leaked commit on PR #7431 — is
+  printed directly by the gate (`scripts/prepush-identity-gate.sh:75-86`):
+
+  ```bash
+  git config --file <main>/.git/config --unset user.name
+  git config --file <main>/.git/config --unset user.email
+  git rebase origin/main --exec 'git commit --amend --reset-author --no-edit'
+  git push --force-with-lease
+  ```
+
+- **Stale worktrees are a standing risk, not just a diagnostic red herring.** They can keep
+  running an old, un-hardened hook and old, un-isolated test copies indefinitely, silently
+  reintroducing a class of bug that was already fixed at HEAD. Periodic worktree hygiene (prune or
+  update stale worktrees) reduces this surface independent of any single code fix.
+
+## References
+
+- Fix: PR #7432 (`.husky/pre-push` env strip + `scripts/prepush-identity-gate.sh` + `tests/prepush-identity-gate.test.mts`)
+- Incident that surfaced it: PR #7431's original commits published as `Fixture <fixture@example.invalid>` (2026-08-30); repaired live with the recipe above
+- Same shared-`.git`-state-poisoning family, different key/mechanism: [git-push-timeout-stale-core-hookspath](../performance-issues/git-push-timeout-stale-core-hookspath.md) (stale absolute `core.hooksPath` welds every worktree's push to one checkout's hook; issues #5810, #6104)
+- Same file, different silent pre-push defect: [pre-push-green-tree-cache-attested-a-tree-the-gates-never-ran](./pre-push-green-tree-cache-attested-a-tree-the-gates-never-ran.md)

--- a/scripts/prepush-identity-gate.sh
+++ b/scripts/prepush-identity-gate.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Pre-push identity gate: refuse to publish commits carrying a leaked
+# test-fixture identity, and fail fast when the SHARED repo config currently
+# holds one (the next commit would be poisoned).
+#
+# Why this exists: test fixtures shell out to `git config user.name/email`.
+# When such a test runs UNDER A GIT HOOK, git exports GIT_DIR/GIT_WORK_TREE/
+# GIT_INDEX_FILE to the hook's children, and those OVERRIDE the fixture's cwd —
+# the identity write lands in the SHARED .git/config, and every later commit
+# from ANY worktree silently carries the fake author. Observed incidents:
+# "Fixture <fixture@example.invalid>" (2026-08-30), "test <test@example.com>"
+# (2026-08-29/30), "WorldMonitor Test <test@worldmonitor.app>", "e <e@e.co>".
+# The hook-side env strip prevents the write at current SHAs; THIS gate is the
+# boundary that keeps any residual leak (e.g. a stale worktree's old tests)
+# from ever reaching GitHub.
+#
+# Input: the pre-push stdin, one line per ref:
+#   <local ref> <local sha> <remote ref> <remote sha>
+# New branches (all-zero remote sha) are checked as "commits not on any
+# origin ref"; deletions (all-zero local sha) are skipped.
+set -euo pipefail
+
+# Fixture-pattern emails only — names are too ambiguous to block on.
+# example.com/.invalid/.test are RFC-reserved and never a real contributor.
+BAD_EMAIL_RE='@example\.(invalid|test|com)$|^e@e\.co$|^fixture@|^test@worldmonitor\.app$'
+
+ZERO_RE='^0+$'
+fail=0
+
+report_commit() {
+  echo "IDENTITY GATE: refusing to push commit $1"
+  echo "  author:    $2"
+  echo "  committer: $3"
+}
+
+check_range() {
+  # $@ = git rev-list selector for the new commits of one pushed ref
+  while IFS=$'\t' read -r sha author committer; do
+    [ -z "${sha:-}" ] && continue
+    local blocked=0
+    for who in "$author" "$committer"; do
+      email=${who##*<}
+      email=${email%>}
+      if printf '%s' "$email" | grep -qiE "$BAD_EMAIL_RE"; then blocked=1; fi
+    done
+    if [ "$blocked" -eq 1 ]; then
+      report_commit "$sha" "$author" "$committer"
+      fail=1
+    fi
+  done < <(git log --format='%H%x09%an <%ae>%x09%cn <%ce>' "$@" 2>/dev/null || true)
+}
+
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ -z "${local_sha:-}" ] && continue
+  if printf '%s' "$local_sha" | grep -qE "$ZERO_RE"; then continue; fi # deletion
+  if [ -n "${remote_sha:-}" ] && ! printf '%s' "$remote_sha" | grep -qE "$ZERO_RE"; then
+    check_range "$remote_sha..$local_sha"
+  else
+    check_range "$local_sha" --not --remotes=origin
+  fi
+done
+
+# Shared-config check: a poisoned identity in the COMMON config poisons the
+# next commit from every worktree even when the outgoing commits are clean.
+common_config="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)/config"
+if [ -f "$common_config" ]; then
+  current_email=$(git config --file "$common_config" --get user.email 2>/dev/null || true)
+  if [ -n "$current_email" ] && printf '%s' "$current_email" | grep -qiE "$BAD_EMAIL_RE"; then
+    echo "IDENTITY GATE: the SHARED repo config carries a test-fixture identity:"
+    echo "  user.email = $current_email (in $common_config)"
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo ""
+  echo "A test fixture leaked its git identity into the shared repo config"
+  echo "(GIT_DIR from a git hook overrides a fixture's cwd). Repair:"
+  echo "  1. Inspect:  git config --show-origin user.name user.email"
+  echo "  2. Clean up: git config --file \"$common_config\" --unset user.name"
+  echo "               git config --file \"$common_config\" --unset user.email"
+  echo "  3. Rewrite the branch authors:"
+  echo "     git rebase origin/main --exec 'git commit --amend --reset-author --no-edit'"
+  echo "  4. Push again."
+  exit 1
+fi
+exit 0

--- a/tests/prepush-admission.test.mjs
+++ b/tests/prepush-admission.test.mjs
@@ -82,7 +82,7 @@ describe('pre-push heavy-phase admission', () => {
     const gitEnv = isolatedGitEnv();
     mkdirSync(repo);
     execFileSync('git', ['init', '--quiet', '--initial-branch=main', '.'], { cwd: repo, env: gitEnv });
-    execFileSync('git', ['config', 'user.email', 'prepush-admission@example.invalid'], { cwd: repo, env: gitEnv });
+    execFileSync('git', ['config', 'user.email', 'prepush-admission@wm-fixture.localhost'], { cwd: repo, env: gitEnv });
     execFileSync('git', ['config', 'user.name', 'Prepush Admission Fixture'], { cwd: repo, env: gitEnv });
     execFileSync('git', ['commit', '--quiet', '--allow-empty', '-m', 'base'], { cwd: repo, env: gitEnv });
     const worktrees = Array.from({ length: 5 }, (_, index) => join(dir, `worktree-${index + 1}`));

--- a/tests/prepush-attest.test.mjs
+++ b/tests/prepush-attest.test.mjs
@@ -71,7 +71,7 @@ function makeRepo({ baseFiles = { 'README.md': 'base\n' }, branchFiles = {} } = 
   const root = mkdtempSync(join(tmpdir(), 'wm-prepush-attest-'));
   fixtures.push(root);
   git(root, ['init', '--quiet', '--initial-branch=main', '.']);
-  git(root, ['config', 'user.email', 'prepush-attest@example.invalid']);
+  git(root, ['config', 'user.email', 'prepush-attest@wm-fixture.localhost']);
   git(root, ['config', 'user.name', 'Prepush Attest Fixture']);
   for (const [path, contents] of Object.entries(baseFiles)) write(root, path, contents);
   git(root, ['add', '-A']);
@@ -511,7 +511,7 @@ describe('base-guard fetches lazily and only to disprove a violation (#6764)', (
     const clone = join(root, 'clone');
     execFileSync('git', ['init', '--quiet', '--bare', '--initial-branch=main', origin], { env: isolatedGitEnv(), encoding: 'utf8' });
     execFileSync('git', ['clone', '--quiet', origin, clone], { env: isolatedGitEnv(), encoding: 'utf8' });
-    git(clone, ['config', 'user.email', 'base-guard@example.invalid']);
+    git(clone, ['config', 'user.email', 'base-guard@wm-fixture.localhost']);
     git(clone, ['config', 'user.name', 'Base Guard Fixture']);
     write(clone, 'README.md', 'base\n');
     git(clone, ['add', '-A']);

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -109,7 +109,7 @@ function makeFixture({
   // node_modules/ is gitignored above so this stays invisible to `dirty`.
   writeFileSync(join(root, 'node_modules', '.package-lock.json'), '{}\n');
   copyFileSync(HOOK, join(root, '.husky', 'pre-push'));
-  for (const script of ['prepush-admission.mjs', 'prepush-attest.sh', 'prepush-changed-tests.sh']) {
+  for (const script of ['prepush-admission.mjs', 'prepush-attest.sh', 'prepush-changed-tests.sh', 'prepush-identity-gate.sh']) {
     copyFileSync(join(REPO_ROOT, 'scripts', script), join(root, 'scripts', script));
   }
   copyFileSync(
@@ -166,7 +166,7 @@ function makeFixture({
   }
 
   git(['init', '--quiet', '--initial-branch=main', '.']);
-  git(['config', 'user.email', 'prepush-hook@example.invalid']);
+  git(['config', 'user.email', 'prepush-hook@wm-fixture.localhost']);
   git(['config', 'user.name', 'Prepush Hook Fixture']);
   git(['add', '-A']);
   git(['commit', '--quiet', '-m', 'base']);
@@ -245,7 +245,7 @@ function pushWithPoisonedSharedHooksPath() {
   mkdirSync(main, { recursive: true });
   execFileSync('git', ['init', '--quiet', '--bare', remote], { env });
   git(main, ['init', '--quiet', '--initial-branch=main', '.']);
-  git(main, ['config', 'user.email', 'prepush-hook@example.invalid']);
+  git(main, ['config', 'user.email', 'prepush-hook@wm-fixture.localhost']);
   git(main, ['config', 'user.name', 'Prepush Hook Fixture']);
   git(main, ['remote', 'add', 'origin', remote]);
 
@@ -259,6 +259,7 @@ function pushWithPoisonedSharedHooksPath() {
     'prepush-admission.mjs',
     'prepush-attest.sh',
     'prepush-changed-tests.sh',
+    'prepush-identity-gate.sh',
   ]) {
     copyFileSync(join(REPO_ROOT, 'scripts', script), join(main, 'scripts', script));
   }

--- a/tests/prepush-identity-gate.test.mts
+++ b/tests/prepush-identity-gate.test.mts
@@ -1,0 +1,169 @@
+/**
+ * Pre-push identity gate + git-env hygiene (the "Fixture author" incident class).
+ *
+ * Mechanism being defended against: test fixtures shell out to
+ * `git config user.name/email`; when such a test runs UNDER A GIT HOOK, git
+ * exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE to the hook's children and
+ * those OVERRIDE the fixture's cwd — the identity write lands in the SHARED
+ * .git/config, and every later commit from ANY worktree silently carries the
+ * fake author (observed: "Fixture <fixture@example.invalid>" 2026-08-30,
+ * "test <test@example.com>" 2026-08-29/30, "WorldMonitor Test", "e <e@e.co>").
+ *
+ * Contract under test:
+ *  1. scripts/prepush-identity-gate.sh blocks a push whose outgoing commits
+ *     carry a fixture-pattern author/committer email, and passes clean ones.
+ *  2. It also blocks when the SHARED repo config currently holds a
+ *     fixture-pattern user.email (the next commit would be poisoned), with a
+ *     repair hint.
+ *  3. .husky/pre-push strips git's exported local env vars before running
+ *     anything, and wires the gate on the push stdin.
+ *  4. Policy: every test file that writes a git identity must isolate its
+ *     git spawns from hook-exported env (one of the recognized idioms).
+ */
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const GATE = join(REPO_ROOT, 'scripts', 'prepush-identity-gate.sh');
+const ZERO = '0'.repeat(40);
+
+// This test is itself a git-writing fixture — practice what it preaches.
+const GIT_LOCAL_ENV_VARS = execFileSync('git', ['rev-parse', '--local-env-vars'], { encoding: 'utf8' })
+  .trim().split('\n').filter(Boolean);
+
+function isolatedEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...overrides,
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_CONFIG_SYSTEM: '/dev/null',
+  };
+  for (const name of GIT_LOCAL_ENV_VARS) delete env[name];
+  return env;
+}
+
+const fixtures: string[] = [];
+process.on('exit', () => {
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, env: isolatedEnv(), encoding: 'utf8' }).trim();
+}
+
+function makeRepo(identity: { name: string; email: string }): string {
+  const root = mkdtempSync(join(tmpdir(), 'wm-identity-gate-'));
+  fixtures.push(root);
+  git(root, ['init', '--quiet', '--initial-branch=main']);
+  git(root, ['config', 'user.name', identity.name]);
+  git(root, ['config', 'user.email', identity.email]);
+  writeFileSync(join(root, 'README.md'), 'fixture\n');
+  git(root, ['add', 'README.md']);
+  git(root, ['commit', '--quiet', '-m', 'base']);
+  return root;
+}
+
+function runGate(cwd: string, stdinLines: string[]): { status: number | null; out: string } {
+  const result = spawnSync('bash', [GATE], {
+    cwd,
+    input: stdinLines.map((line) => `${line}\n`).join(''),
+    encoding: 'utf8',
+    env: isolatedEnv(),
+  });
+  return { status: result.status, out: `${result.stdout}\n${result.stderr}` };
+}
+
+describe('prepush-identity-gate.sh', () => {
+  it('blocks a new-branch push whose commit is fixture-authored', () => {
+    const repo = makeRepo({ name: 'Fixture', email: 'fixture@example.invalid' });
+    const sha = git(repo, ['rev-parse', 'HEAD']);
+    const { status, out } = runGate(repo, [`refs/heads/main ${sha} refs/heads/main ${ZERO}`]);
+    assert.equal(status, 1, `gate must block a fixture-authored push; output:\n${out}`);
+    assert.match(out, /fixture@example\.invalid/);
+    assert.match(out, /--reset-author/, 'block message must include the rewrite recipe');
+  });
+
+  it('blocks an update push when a NEW commit in the range is fixture-authored', () => {
+    const repo = makeRepo({ name: 'Real Person', email: 'real@worldmonitor.dev' });
+    const base = git(repo, ['rev-parse', 'HEAD']);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    writeFileSync(join(repo, 'x.txt'), 'x\n');
+    git(repo, ['add', 'x.txt']);
+    git(repo, ['commit', '--quiet', '-m', 'leaked-identity commit']);
+    const head = git(repo, ['rev-parse', 'HEAD']);
+    // Restore a clean config so only the commit range triggers.
+    git(repo, ['config', 'user.email', 'real@worldmonitor.dev']);
+    const { status, out } = runGate(repo, [`refs/heads/main ${head} refs/heads/main ${base}`]);
+    assert.equal(status, 1, `gate must block; output:\n${out}`);
+    assert.match(out, /test@example\.com/);
+  });
+
+  it('passes a clean push', () => {
+    const repo = makeRepo({ name: 'Real Person', email: 'real@worldmonitor.dev' });
+    const sha = git(repo, ['rev-parse', 'HEAD']);
+    const { status, out } = runGate(repo, [`refs/heads/main ${sha} refs/heads/main ${ZERO}`]);
+    assert.equal(status, 0, `gate must pass clean pushes; output:\n${out}`);
+  });
+
+  it('ignores branch deletions (all-zero local sha)', () => {
+    const repo = makeRepo({ name: 'Real Person', email: 'real@worldmonitor.dev' });
+    const sha = git(repo, ['rev-parse', 'HEAD']);
+    const { status } = runGate(repo, [`(delete) ${ZERO} refs/heads/old ${sha}`]);
+    assert.equal(status, 0);
+  });
+
+  it('blocks when the shared config is currently poisoned, even with clean commits', () => {
+    const repo = makeRepo({ name: 'Real Person', email: 'real@worldmonitor.dev' });
+    const sha = git(repo, ['rev-parse', 'HEAD']);
+    git(repo, ['config', 'user.email', 'fixture@example.invalid']);
+    const { status, out } = runGate(repo, [`refs/heads/main ${sha} refs/heads/main ${ZERO}`]);
+    assert.equal(status, 1, `poisoned shared config must fail the push; output:\n${out}`);
+    assert.match(out, /--unset/, 'block message must include the config repair hint');
+  });
+});
+
+describe('pre-push hook hygiene wiring', () => {
+  const hook = readFileSync(join(REPO_ROOT, '.husky', 'pre-push'), 'utf8');
+
+  it('strips git-exported local env vars before running anything test-shaped', () => {
+    assert.match(hook, /--local-env-vars/,
+      'pre-push must unset $(git rev-parse --local-env-vars) so hook-run test fixtures cannot write into the real repo');
+    const stripIdx = hook.indexOf('--local-env-vars');
+    const firstTestIdx = hook.search(/npx tsx --test|prepush-changed-tests/);
+    assert.ok(stripIdx >= 0 && firstTestIdx > stripIdx,
+      'the env strip must come before any test invocation');
+  });
+
+  it('wires the identity gate on the push stdin', () => {
+    assert.match(hook, /prepush-identity-gate\.sh/,
+      'pre-push must run the identity gate so a leaked fixture author fails loudly instead of reaching GitHub');
+  });
+});
+
+describe('policy: git-identity-writing test fixtures must isolate their git env', () => {
+  it('every test that sets user.name via git carries a recognized isolation idiom', () => {
+    const testsDir = join(REPO_ROOT, 'tests');
+    const offenders: string[] = [];
+    for (const name of readdirSync(testsDir)) {
+      if (!/\.test\.m[jt]s$/.test(name)) continue;
+      const path = join(testsDir, name);
+      const src = readFileSync(path, 'utf8');
+      const writesIdentity = /['"]config['"],\s*['"]user\.name['"]|['"]user\.name['"],/.test(src)
+        && /\bgit\b/i.test(src);
+      if (!writesIdentity) continue;
+      const isolated = src.includes('--local-env-vars')
+        || src.includes("startsWith('GIT_')")
+        || src.includes('GIT_CONFIG_GLOBAL')
+        // hand-listed delete of the override vars (deploy-config idiom)
+        || (src.includes("'GIT_DIR'") && src.includes('delete '));
+      if (!isolated) offenders.push(name);
+    }
+    assert.deepEqual(offenders, [],
+      `these tests write a git identity without isolating git's hook-exported env (GIT_DIR overrides cwd under a hook): ${offenders.join(', ')}`);
+  });
+});

--- a/tests/prepush-proto-freshness-inputs.test.mjs
+++ b/tests/prepush-proto-freshness-inputs.test.mjs
@@ -109,7 +109,7 @@ function makeProtoInputRepo() {
     writeFileSync(target, contents);
   };
   git(['init', '--quiet', '--initial-branch=main', '.']);
-  git(['config', 'user.email', 'proto-freshness@example.invalid']);
+  git(['config', 'user.email', 'proto-freshness@wm-fixture.localhost']);
   git(['config', 'user.name', 'Proto Freshness Fixture']);
   write('proto/service.proto', 'syntax = "proto3";\n');
   write('Makefile', 'generate:\n\t@true\n');


### PR DESCRIPTION
## Problem

Commits have repeatedly been published under fake test-fixture identities — `Fixture <fixture@example.invalid>` (2026-08-30, PR #7431's original commits), `test <test@example.com>` (2026-08-29/30, on main), `WorldMonitor Test <test@worldmonitor.app>` (259 commits historically), `e <e@e.co>` (369 commits).

## Root cause (reproduced with a canary repo)

During a push, git exports `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` to the pre-push hook's children, and **those override a child's `cwd`**. The hook runs changed tests; any test fixture that shells out to `git config user.name` without stripping that env writes its fake identity into the **shared** `.git/config` — which every worktree inherits for all future commits. Current HEAD's fixtures are all isolated, but stale worktrees run old hooks with old un-isolated tests, so the poisoning recurs.

## Fix — three layers

1. **`.husky/pre-push` strips `$(git rev-parse --local-env-vars)`** before running anything, so no hook-run fixture can see the real repo (proven: canary poisoned without the strip, contained with it).
2. **`scripts/prepush-identity-gate.sh`**, wired on the push stdin: refuses to push commits whose author/committer email matches fixture patterns (`@example.invalid|test|com`, `e@e.co`, `fixture@*`, `test@worldmonitor.app`), and fails fast when the shared config is *currently* poisoned — printing the exact repair recipe (`--unset` + `--reset-author` rebase). This also catches leaks originating from stale worktrees.
3. **Policy test**: any test that writes a git identity must carry a recognized env-isolation idiom (`--local-env-vars` strip, `GIT_` prefix filter, `GIT_CONFIG_GLOBAL`, or a hand-listed `GIT_DIR` delete) — a new leaky fixture cannot ship.

Contract-test fixtures move off the banned `@example.invalid` domain to `@wm-fixture.localhost`.

## Testing

- `tests/prepush-identity-gate.test.mts` (new, 8 tests, written red-first): gate blocks fixture-authored new-branch and update pushes, passes clean pushes, ignores deletions, blocks on poisoned shared config; hook wiring pins; fixture-isolation policy.
- 132 hook-contract tests green (`prepush-hook-gate`, `prepush-admission`, `prepush-attest`, `prepush-proto-freshness-inputs`, `prepush-changed-tests`).
- Full `test:data`: 28,800 tests, 0 failures.
- This PR's own push ran the new hook end to end (gate + strip) successfully.

https://claude.ai/code/session_01WrkDCXFv9iHNdtu8PgvbFZ