### PR TITLE
fix(docker): keep source-attribution off generated build JS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,13 @@ RUN npm ci --ignore-scripts
 # Copy full source
 COPY . .
 
+# The crawlable-corpus step runs the source-attribution drift gate against
+# scripts/, server/, api/, and src/. generate-inventory-facts and
+# build-handlers write untracked .js into those same roots, so the gate must
+# run on the pristine checkout first (#7435). tsc + vite stay later: they
+# need the generated inventory assets and compiled handlers.
+RUN npm run build:crawlable-corpus && npm run build:sitemap
+
 # Generated inventory modules are intentionally untracked. Recreate them in
 # the clean image context before handlers import or bundle them.
 RUN node scripts/generate-inventory-facts.mjs
@@ -36,9 +43,9 @@ RUN node docker/build-handlers.mjs
 # build:pro installs pro-test's own lockfile.
 RUN npm run build:pro
 
-# Build the crawlable static corpus and Vite frontend (outputs to dist/)
+# Build the Vite frontend (outputs to dist/)
 # Skip blog build — blog-site has its own deps not installed here
-RUN npm run build:crawlable-corpus && npm run build:sitemap && npx tsc && npx vite build
+RUN npx tsc && npx vite build
 # Assert the /pro pages survived the public/ -> dist/ copy (#6898). build:pro
 # succeeding proves public/pro/ exists; it does NOT prove Vite copied it, and
 # docker/nginx.conf's SPA fallback would serve the dashboard shell at 200 for a

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,12 @@ ARG VITE_WS_API_URL=https://api.worldmonitor.app
 ENV VITE_VARIANT=${VITE_VARIANT}
 ENV VITE_WS_API_URL=${VITE_WS_API_URL}
 
+# The crawlable-corpus step runs the source-attribution drift gate. Inventory
+# facts write untracked .js into api/, so the gate must see the pristine
+# checkout first (#7435). tsc + vite stay later so they copy the generated
+# assets into dist/.
+RUN npm run build:crawlable-corpus && npm run build:sitemap
+
 # Generated inventory assets are intentionally untracked. Recreate them in the
 # clean release image before Vite copies public/ into dist/.
 RUN node scripts/generate-inventory-facts.mjs
@@ -36,11 +42,10 @@ RUN node scripts/generate-inventory-facts.mjs
 # serves a 404 behind a live route. build:pro installs pro-test's own lockfile.
 RUN npm run build:pro
 
-# Build the crawlable static corpus, then tsc + vite build directly like the
-# sidecar image's builder. `npm run build` would chain build:blog
-# (blog-site has its own lockfile, not installed here) and the prebuild
-# openapi/agent-skills generators.
-RUN npm run build:crawlable-corpus && npm run build:sitemap && npx tsc && npx vite build
+# tsc + vite build directly like the sidecar image's builder. `npm run build`
+# would chain build:blog (blog-site has its own lockfile, not installed here)
+# and the prebuild openapi/agent-skills generators.
+RUN npx tsc && npx vite build
 RUN test -s dist/product-facts.json
 # Assert the /pro pages survived the public/ -> dist/ copy. build:pro succeeding
 # proves public/pro/ exists; it does NOT prove Vite copied it, and nginx routes

--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -987,8 +987,11 @@ function isGeneratedSourcePath(rootDir, relativePath) {
   if (/\.generated\./.test(base)) return true;
   // docker/build-handlers.mjs emits a .js sibling next to each api/**/*.ts
   // handler. The TypeScript source is the authority; the bundle just repeats
-  // its URLs (and any inlined deps).
+  // its URLs (and any inlined deps). Restrict the sibling skip to api/:
+  // authored JS under scripts/, server/, or src/ stays in the inventory even
+  // when a same-stem .ts/.tsx sibling exists.
   if (extname(base) !== '.js') return false;
+  if (!relativePath.startsWith('api/')) return false;
   const stem = relativePath.slice(0, -'.js'.length);
   return existsSync(join(rootDir, `${stem}.ts`)) || existsSync(join(rootDir, `${stem}.tsx`));
 }

--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -979,6 +979,20 @@ function readdirPresentSync(absoluteDir) {
   }
 }
 
+function isGeneratedSourcePath(rootDir, relativePath) {
+  const base = relativePath.split('/').pop() ?? relativePath;
+  // Inventory facts and other generator outputs use `*.generated.*` and are
+  // gitignored. Scanning them after a Docker/local generate step invents
+  // references the committed manifest was never built against (#7435).
+  if (/\.generated\./.test(base)) return true;
+  // docker/build-handlers.mjs emits a .js sibling next to each api/**/*.ts
+  // handler. The TypeScript source is the authority; the bundle just repeats
+  // its URLs (and any inlined deps).
+  if (extname(base) !== '.js') return false;
+  const stem = relativePath.slice(0, -'.js'.length);
+  return existsSync(join(rootDir, `${stem}.ts`)) || existsSync(join(rootDir, `${stem}.tsx`));
+}
+
 function walkSourceFiles(rootDir) {
   const files = [];
   const visit = (relativeDir) => {
@@ -988,7 +1002,11 @@ function walkSourceFiles(rootDir) {
       if (entry.isDirectory()) {
         if (['node_modules', '.git', 'generated', 'e2e', 'fixtures', '__fixtures__', 'test', 'tests'].includes(entry.name)) continue;
         visit(relativePath);
-      } else if (SOURCE_EXTENSIONS.has(extname(entry.name)) && !/\.(test|spec)\./.test(entry.name)) {
+      } else if (
+        SOURCE_EXTENSIONS.has(extname(entry.name))
+        && !/\.(test|spec)\./.test(entry.name)
+        && !isGeneratedSourcePath(rootDir, relativePath)
+      ) {
         files.push(relativePath);
       }
     }

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -480,10 +480,21 @@ describe('crawlable content corpus deployment contracts', () => {
         source.indexOf('node scripts/generate-inventory-facts.mjs') < source.indexOf('npx vite build'),
         name + ' must generate ignored inventory assets in a clean build context before Vite runs',
       );
+      // generate-inventory-facts and build-handlers write untracked .js into
+      // SOURCE_ROOTS. The corpus step runs the attribution drift gate against
+      // those same roots, so it must see the pristine tree (#7435).
+      assert.ok(
+        source.indexOf('npm run build:crawlable-corpus') < source.indexOf('node scripts/generate-inventory-facts.mjs'),
+        name + ' must run the attribution gate before inventory-facts writes untracked JS into api/',
+      );
     }
     assert.ok(
       dockerfileSource.indexOf('node scripts/generate-inventory-facts.mjs') < dockerfileSource.indexOf('node docker/build-handlers.mjs'),
       'the self-host image must generate the Edge inventory module before handler bundling',
+    );
+    assert.ok(
+      dockerfileSource.indexOf('npm run build:crawlable-corpus') < dockerfileSource.indexOf('node docker/build-handlers.mjs'),
+      'the self-host image must run the attribution gate before build-handlers writes compiled .js into api/',
     );
     assert.match(frontendDockerfileSource, /RUN test -s dist\/product-facts\.json/);
     assert.ok(!packageJson.scripts['build:full'].includes('npm run build:blog &&'), 'build:full must not regenerate inventory facts inside build:blog');

--- a/tests/source-attribution.test.mjs
+++ b/tests/source-attribution.test.mjs
@@ -549,13 +549,15 @@ test('the source walk ignores generated inventory modules and compiled handler s
     writeUrlModule(join(fixture.dir, 'api/worldmonitor/probe/v1/list-probe.ts'), 'authored-ts.example');
     writeUrlModule(join(fixture.dir, 'api/worldmonitor/probe/v1/list-probe.js'), 'pollution-compiled.example');
     writeUrlModule(join(fixture.dir, 'api/authored-handler.js'), 'authored-js.example');
+    writeUrlModule(join(fixture.dir, 'scripts/legacy-probe.js'), 'scripts-js.example');
+    writeUrlModule(join(fixture.dir, 'scripts/legacy-probe.ts'), 'scripts-ts.example');
 
     const inventory = scanUpstreamHosts(fixture.dir);
     const hosts = inventory.map((entry) => entry.host).sort();
     assert.deepEqual(
       hosts,
-      ['authored-js.example', 'authored-ts.example', 'fixture.example'],
-      'generated *.generated.* files and compiled .js siblings of .ts handlers must not enter the inventory',
+      ['authored-js.example', 'authored-ts.example', 'fixture.example', 'scripts-js.example', 'scripts-ts.example'],
+      'generated *.generated.* files and compiled api/ .js siblings of .ts handlers must not enter the inventory',
     );
     assert.equal(
       inventory.find((entry) => entry.host === 'authored-ts.example')?.references[0]?.path,
@@ -565,11 +567,23 @@ test('the source walk ignores generated inventory modules and compiled handler s
       inventory.find((entry) => entry.host === 'authored-js.example')?.references[0]?.path,
       'api/authored-handler.js',
     );
+    assert.equal(
+      inventory.find((entry) => entry.host === 'scripts-js.example')?.references[0]?.path,
+      'scripts/legacy-probe.js',
+    );
+    assert.equal(
+      inventory.find((entry) => entry.host === 'scripts-ts.example')?.references[0]?.path,
+      'scripts/legacy-probe.ts',
+    );
 
     const { errors } = checkSourceAttribution(fixture.dir);
     assert.ok(
       errors.some((error) => error.includes('missing manifest entry for authored-js.example')),
       `authored JS without a sibling .ts must remain visible: ${JSON.stringify(errors)}`,
+    );
+    assert.ok(
+      errors.some((error) => error.includes('missing manifest entry for scripts-js.example')),
+      `authored scripts/ JS with a sibling .ts must remain visible: ${JSON.stringify(errors)}`,
     );
     assert.equal(
       errors.some((error) => /pollution-(?:generated|compiled)\.example/.test(error)),

--- a/tests/source-attribution.test.mjs
+++ b/tests/source-attribution.test.mjs
@@ -537,6 +537,71 @@ test('scanUpstreamHosts does not crash on empty leftover api/[domain]/v1 trees',
   }
 });
 
+function writeUrlModule(path, host) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `const SOURCE_URL = 'https://${host}/v1/data';\nexport const url = SOURCE_URL;\n`);
+}
+
+test('the source walk ignores generated inventory modules and compiled handler siblings', () => {
+  const fixture = makeFixtureCheckout();
+  try {
+    writeUrlModule(join(fixture.dir, 'api/_inventory-facts.generated.js'), 'pollution-generated.example');
+    writeUrlModule(join(fixture.dir, 'api/worldmonitor/probe/v1/list-probe.ts'), 'authored-ts.example');
+    writeUrlModule(join(fixture.dir, 'api/worldmonitor/probe/v1/list-probe.js'), 'pollution-compiled.example');
+    writeUrlModule(join(fixture.dir, 'api/authored-handler.js'), 'authored-js.example');
+
+    const inventory = scanUpstreamHosts(fixture.dir);
+    const hosts = inventory.map((entry) => entry.host).sort();
+    assert.deepEqual(
+      hosts,
+      ['authored-js.example', 'authored-ts.example', 'fixture.example'],
+      'generated *.generated.* files and compiled .js siblings of .ts handlers must not enter the inventory',
+    );
+    assert.equal(
+      inventory.find((entry) => entry.host === 'authored-ts.example')?.references[0]?.path,
+      'api/worldmonitor/probe/v1/list-probe.ts',
+    );
+    assert.equal(
+      inventory.find((entry) => entry.host === 'authored-js.example')?.references[0]?.path,
+      'api/authored-handler.js',
+    );
+
+    const { errors } = checkSourceAttribution(fixture.dir);
+    assert.ok(
+      errors.some((error) => error.includes('missing manifest entry for authored-js.example')),
+      `authored JS without a sibling .ts must remain visible: ${JSON.stringify(errors)}`,
+    );
+    assert.equal(
+      errors.some((error) => /pollution-(?:generated|compiled)\.example/.test(error)),
+      false,
+      `generated pollution must not create attribution drift: ${JSON.stringify(errors)}`,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('the check gate stays green when Docker generators write untracked JS into scanned roots', () => {
+  const fixture = makeFixtureCheckout();
+  try {
+    // Same pollution the self-host Dockerfile creates: inventory-facts plus a
+    // compiled handler sibling that re-embeds the authored URL. Today the
+    // walk treats those as new references and the gate reports stale kinds.
+    writeUrlModule(join(fixture.dir, 'api/_inventory-facts.generated.js'), 'fixture.example');
+    writeFileSync(join(fixture.dir, 'api/probe.ts'), 'export const ready = true;\n');
+    writeUrlModule(join(fixture.dir, 'api/probe.js'), 'fixture.example');
+
+    const { errors } = checkSourceAttribution(fixture.dir);
+    assert.deepEqual(
+      errors,
+      [],
+      `untracked generator output must not fail the attribution gate: ${JSON.stringify(errors)}`,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
 test('ledger stats match validated stats when the committed manifest is current', () => {
   const inventory = scanUpstreamHosts(rootDir);
   const manifest = loadManifest(rootDir);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Self-host `docker compose build worldmonitor` dies in `build:crawlable-corpus` with ~472 `stale manifest entry` errors. The source-attribution gate scans `scripts/`, `server/`, `api/`, and `src/` for `.js` (among other extensions). By the time that gate runs, `generate-inventory-facts.mjs` and `docker/build-handlers.mjs` have already written untracked `.js` into those same roots, so the scan no longer matches the committed manifest. Regenerating with `--write` would commit the pollution.

This PR does both of the remedies from #7435:

- The walk skips `*.generated.*` files and compiled `.js` siblings of `.ts`/`.tsx` handlers **under `api/` only** (the tree `build-handlers` actually writes), so the gate only sees authored sources.
- Root `Dockerfile` and `docker/Dockerfile` run `build:crawlable-corpus` + `build:sitemap` immediately after `COPY . .`, before those generators. `tsc` / `vite` stay later so they still consume generated inventory assets.

Review follow-up (`0149d70a4`): Codex asked to keep authored JS+TS pairs outside `api/` in the inventory. The sibling skip is now `api/`-scoped, and the fixture asserts a `scripts/` JS+TS pair remains visible.

Closes #7435.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: self-host Docker builder + source-attribution scan

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`) — CI typecheck required check is green on the first head
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked — N/A
- [ ] All required Audit Council role signoffs attached — N/A
- [ ] Generated docs regenerated from proto where applicable — N/A
- [ ] Fixture-backed examples recomputed — N/A
- [ ] Redis writers/readers enumerated for every documented key — N/A

## Local verification

- New fixture tests fail on current `main` (generated hosts enter the inventory; gate reports `stale manifest entry for fixture.example: references`) and pass after the skip.
- Dockerfile ordering contract now requires corpus before `generate-inventory-facts` and `build-handlers`.
- `node scripts/source-attribution.mjs --check` stays green after `generate-inventory-facts` plus a compiled `api/ask.js` sibling (the Docker pollution pattern).
- Full `tests/source-attribution.test.mjs`: 46 pass, including a `scripts/` JS+TS pair that must remain visible.
- CI on `27af88a0d`: required typecheck, unit, biome, and `gate` were green. Review-fix head is `0149d70a4`; CI for that commit is still running.

A full `docker compose build worldmonitor` was not run in this environment.

## Known Residuals

- `*.generated.*` also skips committed catalog modules (`api/_product-catalog.generated.js`, `src/config/products.generated.ts`). That matches #7435, and `--check` on the live tree still passes because those hosts are also declared in authored sources. A URL that existed only in generated output would stay invisible by design.
- A `.js` file under `api/` is treated as compiled when a same-stem `.ts`/`.tsx` exists. There are currently zero `api/**` JS+TS pairs, and Docker cannot consult git (`.git` is dockerignored), so the sibling heuristic is the only reliable detector for `build-handlers` output.
- `build-handlers` pass 2 rebundles authored root `api/*.js` in place after the gate. Docker is safe because corpus runs first. A later local `--check` after `node docker/build-handlers.mjs` could still see inlined-dep URLs. Teaching `--write` to refuse a polluted tree is follow-up, not this bug.
- Dockerfile order is pinned with `indexOf` string contracts, not an image build. End-to-end proof remains the first self-host rebuild after merge.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This change only affects image-build ordering and the source-attribution file walk; it does not alter runtime API, dashboard, or data-source behavior.

Healthy signal: self-host `docker compose build worldmonitor` completes the crawlable-corpus step without `stale manifest entry` errors.

Failure signal: corpus step exits 1 with attribution drift. Roll back the image build to the previous Dockerfile / scanner if a self-host rebuild is blocked.

Validation window: first self-host image rebuild after merge. Owner: the operator who runs `docker compose build`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0559a-def0-78df-9681-7b06725fada0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0559a-def0-78df-9681-7b06725fada0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

