### PR TITLE
fix(relay): fetch Classify digest from the local API_BASE_URL

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -57,6 +57,8 @@ COPY scripts/lib/poll-generation-guard.cjs ./scripts/lib/poll-generation-guard.c
 COPY scripts/lib/x-poll-cycle.cjs ./scripts/lib/x-poll-cycle.cjs
 # Stale-digest alert gate required by ais-relay.cjs (#7084).
 COPY scripts/lib/digest-stale-gate.cjs ./scripts/lib/digest-stale-gate.cjs
+# Classify digest URL/auth/transport helper required by ais-relay.cjs (#7437).
+COPY scripts/lib/classify-digest-request.cjs ./scripts/lib/classify-digest-request.cjs
 COPY scripts/shared/country-name-to-iso2.cjs ./scripts/shared/country-name-to-iso2.cjs
 # country-names.json backs the full name→ISO2 map (#5359 uniform country
 # scoping); required by country-name-to-iso2.cjs at startup.

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -106,10 +106,16 @@ services:
       LLM_API_URL: ""             # e.g. http://localhost:11434/v1/chat/completions
       LLM_API_KEY: ""
       LLM_MODEL: ""
+      # Same value as ais-relay — gateway accepts it on list-feed-digest (#7437).
+      WORLDMONITOR_RELAY_KEY: ""
 
   ais-relay:
     environment:
       AISSTREAM_API_KEY: ""       # same key as above — relay needs it too
+      # Classify fetches the local digest (compose defaults API_BASE_URL to
+      # http://worldmonitor:8080). Set the same WORLDMONITOR_RELAY_KEY on
+      # worldmonitor so the digest GET is not a silent 401.
+      WORLDMONITOR_RELAY_KEY: ""
 ```
 
 ### 💰 Free vs Paid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       WM_TRUSTED_PROXY_CIDRS: "${WM_TRUSTED_PROXY_CIDRS:-}"
       WS_RELAY_URL: "http://ais-relay:3004"
       RELAY_SHARED_SECRET: "${RELAY_SHARED_SECRET:?RELAY_SHARED_SECRET required — generate with: openssl rand -hex 32}"
+      WORLDMONITOR_RELAY_KEY: "${WORLDMONITOR_RELAY_KEY:-}"
       # LLM provider (any OpenAI-compatible endpoint)
       LLM_API_URL: "${LLM_API_URL:-}"
       LLM_API_KEY: "${LLM_API_KEY:-}"
@@ -80,6 +81,9 @@ services:
       UPSTASH_REDIS_REST_TOKEN: "${REDIS_TOKEN:?REDIS_TOKEN required — generate with: openssl rand -hex 32}"
       UPSTASH_ALLOW_INSECURE_HTTP: "true"
       UCDP_ACCESS_TOKEN: "${UCDP_ACCESS_TOKEN:-}"
+      # Classify reads list-feed-digest from this install, not production (#7437).
+      API_BASE_URL: "${API_BASE_URL:-http://worldmonitor:8080}"
+      WORLDMONITOR_RELAY_KEY: "${WORLDMONITOR_RELAY_KEY:-}"
       PORT: "3004"
     depends_on:
       redis-rest:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       UPSTASH_ALLOW_INSECURE_HTTP: "true"
       UCDP_ACCESS_TOKEN: "${UCDP_ACCESS_TOKEN:-}"
       # Classify reads list-feed-digest from this install, not production (#7437).
+      # Do not depends_on worldmonitor here — the app already depends_on ais-relay.
+      # Transient connection retries cover the compose boot race instead.
       API_BASE_URL: "${API_BASE_URL:-http://worldmonitor:8080}"
       WORLDMONITOR_RELAY_KEY: "${WORLDMONITOR_RELAY_KEY:-}"
       PORT: "3004"

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -57,6 +57,7 @@ const {
   classifyDigestTransport,
   buildClassifyDigestHeaders,
   formatClassifyDigestFetchFailure,
+  shouldWriteClassifySeedMeta,
 } = require('./lib/classify-digest-request.cjs');
 const {
   YahooQuoteSummaryClient,
@@ -4845,7 +4846,7 @@ async function seedClassifyForVariant(variant, seenTitles) {
     if (resp.statusCode !== 200) {
       resp.resume();
       console.warn(formatClassifyDigestFetchFailure(resp.statusCode, RELAY_API_KEY));
-      return { total: 0, classified: 0, skipped: 0 };
+      return { total: 0, classified: 0, skipped: 0, fetchFailed: true };
     }
     const body = await new Promise((resolve) => {
       let d = '';
@@ -4855,7 +4856,7 @@ async function seedClassifyForVariant(variant, seenTitles) {
     digest = JSON.parse(body);
   } catch (e) {
     console.warn('[Classify] digest fetch error:', e?.message || e);
-    return { total: 0, classified: 0, skipped: 0 };
+    return { total: 0, classified: 0, skipped: 0, fetchFailed: true };
   }
 
   // #7084: stale RSS titles already had their alert pass when served fresh.
@@ -5021,12 +5022,16 @@ async function seedClassify() {
 
     let totalClassified = 0;
     let totalSkipped = 0;
+    let fetchOk = 0;
+    let fetchFailed = 0;
     const mergedByCountry = {};
     const seenTitles = new Set();
     for (let v = 0; v < CLASSIFY_VARIANTS.length; v++) {
       if (v > 0) await new Promise((r) => setTimeout(r, CLASSIFY_VARIANT_STAGGER_MS));
       try {
         const stats = await seedClassifyForVariant(CLASSIFY_VARIANTS[v], seenTitles);
+        if (stats.fetchFailed) fetchFailed += 1;
+        else fetchOk += 1;
         totalClassified += stats.classified;
         totalSkipped += stats.skipped;
         console.log(`[Classify] ${CLASSIFY_VARIANTS[v]}: ${stats.total} titles, ${stats.classified} classified, ${stats.skipped} skipped`);
@@ -5039,6 +5044,11 @@ async function seedClassify() {
       } catch (e) {
         console.warn(`[Classify] ${CLASSIFY_VARIANTS[v]} error:`, e?.message || e);
       }
+    }
+
+    if (!shouldWriteClassifySeedMeta({ fetchOk, fetchFailed })) {
+      console.warn('[Classify] Digest fetch failed for every variant — not writing seed-meta:classify');
+      return;
     }
 
     await upstashSet('seed-meta:news:threat-summary', { fetchedAt: Date.now(), recordCount: Object.keys(mergedByCountry).length }, 604800);

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -53,6 +53,12 @@ const { createPollGenerationGuard } = require('./lib/poll-generation-guard.cjs')
 const { createXPollCycle } = require('./lib/x-poll-cycle.cjs');
 const { buildClassifyCandidateMap, isStaleDigestReplay } = require('./lib/digest-stale-gate.cjs');
 const {
+  buildClassifyDigestUrl,
+  classifyDigestTransport,
+  buildClassifyDigestHeaders,
+  formatClassifyDigestFetchFailure,
+} = require('./lib/classify-digest-request.cjs');
+const {
   YahooQuoteSummaryClient,
   buildSectorSeedMeta,
   buildSectorValuationCoverage,
@@ -4821,25 +4827,34 @@ async function classifyFetchLlm(titles) {
 let classifyInFlight = false;
 
 async function seedClassifyForVariant(variant, seenTitles) {
-  const digestUrl = `https://api.worldmonitor.app/api/news/v1/list-feed-digest?variant=${variant}&lang=en`;
+  const digestUrl = buildClassifyDigestUrl(variant);
+  const transport = classifyDigestTransport(digestUrl) === 'http' ? http : https;
   let digest;
   try {
     const resp = await new Promise((resolve, reject) => {
-      const req = https.get(digestUrl, {
-        headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+      const req = transport.get(digestUrl, {
+        headers: buildClassifyDigestHeaders({
+          userAgent: CHROME_UA,
+          relayKey: RELAY_API_KEY,
+        }),
         timeout: 15000,
       }, resolve);
       req.on('error', reject);
       req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
     });
-    if (resp.statusCode !== 200) { resp.resume(); return { total: 0, classified: 0, skipped: 0 }; }
+    if (resp.statusCode !== 200) {
+      resp.resume();
+      console.warn(formatClassifyDigestFetchFailure(resp.statusCode, RELAY_API_KEY));
+      return { total: 0, classified: 0, skipped: 0 };
+    }
     const body = await new Promise((resolve) => {
       let d = '';
       resp.on('data', (c) => { d += c; });
       resp.on('end', () => resolve(d));
     });
     digest = JSON.parse(body);
-  } catch {
+  } catch (e) {
+    console.warn('[Classify] digest fetch error:', e?.message || e);
     return { total: 0, classified: 0, skipped: 0 };
   }
 

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -58,6 +58,8 @@ const {
   buildClassifyDigestHeaders,
   formatClassifyDigestFetchFailure,
   shouldWriteClassifySeedMeta,
+  CLASSIFY_DIGEST_RETRY_DELAYS_MS,
+  classifyDigestRetryDecision,
 } = require('./lib/classify-digest-request.cjs');
 const {
   YahooQuoteSummaryClient,
@@ -4831,31 +4833,51 @@ async function seedClassifyForVariant(variant, seenTitles) {
   const digestUrl = buildClassifyDigestUrl(variant);
   const transport = classifyDigestTransport(digestUrl) === 'http' ? http : https;
   let digest;
-  try {
-    const resp = await new Promise((resolve, reject) => {
-      const req = transport.get(digestUrl, {
-        headers: buildClassifyDigestHeaders({
-          userAgent: CHROME_UA,
-          relayKey: RELAY_API_KEY,
-        }),
-        timeout: 15000,
-      }, resolve);
-      req.on('error', reject);
-      req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
-    });
-    if (resp.statusCode !== 200) {
-      resp.resume();
-      console.warn(formatClassifyDigestFetchFailure(resp.statusCode, RELAY_API_KEY));
+  const maxDigestAttempts = CLASSIFY_DIGEST_RETRY_DELAYS_MS.length + 1;
+  for (let attempt = 0; attempt < maxDigestAttempts; attempt++) {
+    try {
+      const resp = await new Promise((resolve, reject) => {
+        const req = transport.get(digestUrl, {
+          headers: buildClassifyDigestHeaders({
+            userAgent: CHROME_UA,
+            relayKey: RELAY_API_KEY,
+          }),
+          timeout: 15000,
+        }, resolve);
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+      });
+      if (resp.statusCode !== 200) {
+        resp.resume();
+        const retry = classifyDigestRetryDecision({ attempt, status: resp.statusCode });
+        if (retry.retry) {
+          console.warn(`[Classify] digest fetch HTTP ${resp.statusCode}; retrying in ${retry.delayMs}ms`);
+          await new Promise((r) => setTimeout(r, retry.delayMs));
+          continue;
+        }
+        console.warn(formatClassifyDigestFetchFailure(resp.statusCode, RELAY_API_KEY));
+        return { total: 0, classified: 0, skipped: 0, fetchFailed: true };
+      }
+      const body = await new Promise((resolve) => {
+        let d = '';
+        resp.on('data', (c) => { d += c; });
+        resp.on('end', () => resolve(d));
+      });
+      digest = JSON.parse(body);
+      break;
+    } catch (e) {
+      const retry = classifyDigestRetryDecision({ attempt, error: e });
+      if (retry.retry) {
+        console.warn(`[Classify] digest fetch error: ${e?.message || e}; retrying in ${retry.delayMs}ms`);
+        await new Promise((r) => setTimeout(r, retry.delayMs));
+        continue;
+      }
+      console.warn('[Classify] digest fetch error:', e?.message || e);
       return { total: 0, classified: 0, skipped: 0, fetchFailed: true };
     }
-    const body = await new Promise((resolve) => {
-      let d = '';
-      resp.on('data', (c) => { d += c; });
-      resp.on('end', () => resolve(d));
-    });
-    digest = JSON.parse(body);
-  } catch (e) {
-    console.warn('[Classify] digest fetch error:', e?.message || e);
+  }
+  if (!digest) {
+    console.warn('[Classify] digest fetch error: exhausted retries');
     return { total: 0, classified: 0, skipped: 0, fetchFailed: true };
   }
 

--- a/scripts/lib/classify-digest-request.cjs
+++ b/scripts/lib/classify-digest-request.cjs
@@ -37,10 +37,15 @@ function buildClassifyDigestHeaders({ userAgent, relayKey } = {}) {
 }
 
 function formatClassifyDigestFetchFailure(status, relayKey) {
-  const keyNote = relayKey
-    ? ''
-    : ' (WORLDMONITOR_RELAY_KEY not set — 401 expected; set it on the relay AND the API host)';
+  const authFailure = status === 401 || status === 403;
+  const keyNote = !relayKey && authFailure
+    ? ' (WORLDMONITOR_RELAY_KEY not set — 401 expected; set it on the relay AND the API host)'
+    : '';
   return `[Classify] digest fetch failed: HTTP ${status}${keyNote}`;
+}
+
+function shouldWriteClassifySeedMeta({ fetchOk = 0, fetchFailed = 0 } = {}) {
+  return fetchOk > 0 || fetchFailed === 0;
 }
 
 module.exports = {
@@ -51,4 +56,5 @@ module.exports = {
   classifyDigestTransport,
   buildClassifyDigestHeaders,
   formatClassifyDigestFetchFailure,
+  shouldWriteClassifySeedMeta,
 };

--- a/scripts/lib/classify-digest-request.cjs
+++ b/scripts/lib/classify-digest-request.cjs
@@ -48,13 +48,50 @@ function shouldWriteClassifySeedMeta({ fetchOk = 0, fetchFailed = 0 } = {}) {
   return fetchOk > 0 || fetchFailed === 0;
 }
 
+// Compose starts ais-relay before worldmonitor (the app already depends_on the
+// relay; reversing that would cycle). A refused first `full` fetch would
+// otherwise sit until the 15-minute interval. Bounded retries cover the
+// seconds between relay listen and app listen without waiting on HTTP 4xx.
+const CLASSIFY_DIGEST_RETRY_DELAYS_MS = Object.freeze([2000, 4000, 8000, 8000, 8000]);
+const CLASSIFY_DIGEST_TRANSIENT_ERROR = /ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ENETUNREACH|EHOSTUNREACH|timeout|socket hang up/i;
+
+function isTransientClassifyDigestFetchError(error) {
+  if (error == null) return false;
+  const code = typeof error === 'object' && error.code ? String(error.code) : '';
+  const message = typeof error === 'object' && error.message ? String(error.message) : String(error);
+  return CLASSIFY_DIGEST_TRANSIENT_ERROR.test(code) || CLASSIFY_DIGEST_TRANSIENT_ERROR.test(message);
+}
+
+function isRetryableClassifyDigestStatus(status) {
+  return status === 502 || status === 503 || status === 504;
+}
+
+function classifyDigestRetryDelayMs(attempt) {
+  const delay = CLASSIFY_DIGEST_RETRY_DELAYS_MS[attempt];
+  return typeof delay === 'number' ? delay : 0;
+}
+
+function classifyDigestRetryDecision({ attempt = 0, error, status } = {}) {
+  const maxAttempts = CLASSIFY_DIGEST_RETRY_DELAYS_MS.length + 1;
+  if (attempt >= maxAttempts - 1) return { retry: false, delayMs: 0 };
+  if (isTransientClassifyDigestFetchError(error) || isRetryableClassifyDigestStatus(status)) {
+    return { retry: true, delayMs: classifyDigestRetryDelayMs(attempt) };
+  }
+  return { retry: false, delayMs: 0 };
+}
+
 module.exports = {
   DEFAULT_CLASSIFY_API_HOST,
   DEFAULT_CLASSIFY_API_BASE,
+  CLASSIFY_DIGEST_RETRY_DELAYS_MS,
   resolveClassifyApiBase,
   buildClassifyDigestUrl,
   classifyDigestTransport,
   buildClassifyDigestHeaders,
   formatClassifyDigestFetchFailure,
   shouldWriteClassifySeedMeta,
+  isTransientClassifyDigestFetchError,
+  isRetryableClassifyDigestStatus,
+  classifyDigestRetryDelayMs,
+  classifyDigestRetryDecision,
 };

--- a/scripts/lib/classify-digest-request.cjs
+++ b/scripts/lib/classify-digest-request.cjs
@@ -1,0 +1,54 @@
+'use strict';
+
+// #7437: where should Classify fetch list-feed-digest from, and with which
+// auth/transport? The previous inline https.get against the hardcoded
+// production API host silently classified 0 titles on every self-host install.
+//
+// Lives in scripts/lib rather than inline in ais-relay.cjs so the URL, scheme,
+// and header contract can execute in tests without importing the boot-on-require
+// relay — same reason as digest-stale-gate.cjs.
+
+const DEFAULT_CLASSIFY_API_HOST = 'api.worldmonitor.app';
+const DEFAULT_CLASSIFY_API_BASE = `https://${DEFAULT_CLASSIFY_API_HOST}`;
+
+function resolveClassifyApiBase(env = process.env) {
+  const raw = typeof env.API_BASE_URL === 'string' ? env.API_BASE_URL.trim() : '';
+  return (raw || DEFAULT_CLASSIFY_API_BASE).replace(/\/+$/, '');
+}
+
+function buildClassifyDigestUrl(variant, env = process.env) {
+  const encodedVariant = encodeURIComponent(String(variant ?? ''));
+  return `${resolveClassifyApiBase(env)}/api/news/v1/list-feed-digest?variant=${encodedVariant}&lang=en`;
+}
+
+function classifyDigestTransport(url) {
+  try {
+    return new URL(url).protocol === 'http:' ? 'http' : 'https';
+  } catch {
+    return 'https';
+  }
+}
+
+function buildClassifyDigestHeaders({ userAgent, relayKey } = {}) {
+  const headers = { Accept: 'application/json' };
+  if (userAgent) headers['User-Agent'] = userAgent;
+  if (relayKey) headers['X-WorldMonitor-Key'] = relayKey;
+  return headers;
+}
+
+function formatClassifyDigestFetchFailure(status, relayKey) {
+  const keyNote = relayKey
+    ? ''
+    : ' (WORLDMONITOR_RELAY_KEY not set — 401 expected; set it on the relay AND the API host)';
+  return `[Classify] digest fetch failed: HTTP ${status}${keyNote}`;
+}
+
+module.exports = {
+  DEFAULT_CLASSIFY_API_HOST,
+  DEFAULT_CLASSIFY_API_BASE,
+  resolveClassifyApiBase,
+  buildClassifyDigestUrl,
+  classifyDigestTransport,
+  buildClassifyDigestHeaders,
+  formatClassifyDigestFetchFailure,
+};

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -27,6 +27,7 @@
       "scripts/ais-relay.cjs",
       "scripts/docs-stats.mjs",
       "scripts/generate-inventory-facts.mjs",
+      "scripts/lib/classify-digest-request.cjs",
       "scripts/lib/digest-stale-gate.cjs",
       "scripts/lib/llm-model-policy.cjs",
       "scripts/lib/llm-telemetry.cjs",

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -507,6 +507,10 @@ export const RELAY_WARM_PING_PATHS = new Set<string>([
   '/api/infrastructure/v1/list-temporal-anomalies',
   '/api/intelligence/v1/get-risk-scores',
   '/api/supply-chain/v1/get-chokepoint-status',
+  // Classify reads the same public digest a session holder can already trigger
+  // so self-host / Railway can send WORLDMONITOR_RELAY_KEY instead of an
+  // enterprise key (#7437).
+  '/api/news/v1/list-feed-digest',
 ]);
 
 /**

--- a/tests/classify-digest-request.test.mjs
+++ b/tests/classify-digest-request.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * #7437: Classify must read the digest from the install it belongs to.
+ *
+ * seedClassifyForVariant used to hardcode the production API host and
+ * https.get, so a self-hosted relay asked production (non-200, swallowed)
+ * and an in-network http:// API_BASE_URL threw. The request builder lives
+ * in scripts/lib so these cases execute without importing the boot-on-require
+ * relay — same reason as digest-stale-gate.cjs.
+ *
+ * Run: node --test tests/classify-digest-request.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const {
+  DEFAULT_CLASSIFY_API_HOST,
+  DEFAULT_CLASSIFY_API_BASE,
+  resolveClassifyApiBase,
+  buildClassifyDigestUrl,
+  classifyDigestTransport,
+  buildClassifyDigestHeaders,
+  formatClassifyDigestFetchFailure,
+} = require('../scripts/lib/classify-digest-request.cjs');
+
+const relaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'), 'utf8');
+const dockerfileSrc = readFileSync(resolve(__dirname, '..', 'Dockerfile.relay'), 'utf8');
+
+function classifyFnSrc() {
+  const start = relaySrc.indexOf('async function seedClassifyForVariant');
+  const end = relaySrc.indexOf('\nasync function seedClassify()', start);
+  assert.ok(start >= 0 && end > start, 'seedClassifyForVariant not found');
+  return relaySrc.slice(start, end);
+}
+
+describe('classify digest request builder (#7437)', () => {
+  it('defaults to the production API host when API_BASE_URL is unset', () => {
+    assert.equal(DEFAULT_CLASSIFY_API_HOST, 'api.worldmonitor.app');
+    assert.equal(DEFAULT_CLASSIFY_API_BASE, `https://${DEFAULT_CLASSIFY_API_HOST}`);
+    assert.equal(resolveClassifyApiBase({}), DEFAULT_CLASSIFY_API_BASE);
+    assert.equal(resolveClassifyApiBase({ API_BASE_URL: '   ' }), DEFAULT_CLASSIFY_API_BASE);
+    assert.equal(
+      buildClassifyDigestUrl('full', {}),
+      `${DEFAULT_CLASSIFY_API_BASE}/api/news/v1/list-feed-digest?variant=full&lang=en`,
+    );
+  });
+
+  it('honors API_BASE_URL, including an in-network http base with a trailing slash', () => {
+    const env = { API_BASE_URL: 'http://worldmonitor:8080/' };
+    assert.equal(resolveClassifyApiBase(env), 'http://worldmonitor:8080');
+    assert.equal(
+      buildClassifyDigestUrl('tech', env),
+      'http://worldmonitor:8080/api/news/v1/list-feed-digest?variant=tech&lang=en',
+    );
+    assert.equal(classifyDigestTransport(buildClassifyDigestUrl('tech', env)), 'http');
+  });
+
+  it('selects https for the production default and encodes the variant', () => {
+    const url = buildClassifyDigestUrl('happy go', { API_BASE_URL: 'https://api.example.test' });
+    assert.equal(
+      url,
+      'https://api.example.test/api/news/v1/list-feed-digest?variant=happy%20go&lang=en',
+    );
+    assert.equal(classifyDigestTransport(url), 'https');
+  });
+
+  it('sends X-WorldMonitor-Key only when WORLDMONITOR_RELAY_KEY is set', () => {
+    assert.deepEqual(
+      buildClassifyDigestHeaders({ userAgent: 'WM-Test/1', relayKey: '' }),
+      { Accept: 'application/json', 'User-Agent': 'WM-Test/1' },
+    );
+    assert.deepEqual(
+      buildClassifyDigestHeaders({ userAgent: 'WM-Test/1', relayKey: 'relay-secret' }),
+      {
+        Accept: 'application/json',
+        'User-Agent': 'WM-Test/1',
+        'X-WorldMonitor-Key': 'relay-secret',
+      },
+    );
+  });
+
+  it('names the HTTP status so a failed digest fetch is not silent zeros', () => {
+    assert.match(
+      formatClassifyDigestFetchFailure(401, ''),
+      /HTTP 401.*WORLDMONITOR_RELAY_KEY not set/,
+    );
+    assert.equal(
+      formatClassifyDigestFetchFailure(403, 'set'),
+      '[Classify] digest fetch failed: HTTP 403',
+    );
+  });
+});
+
+describe('ais-relay Classify wiring (#7437)', () => {
+  it('builds the digest request from the executable helper, not a hardcoded host', () => {
+    const classifyFn = classifyFnSrc();
+    assert.match(classifyFn, /buildClassifyDigestUrl\(variant\)/);
+    assert.match(classifyFn, /classifyDigestTransport\(digestUrl\)/);
+    assert.match(classifyFn, /buildClassifyDigestHeaders\(/);
+    assert.doesNotMatch(classifyFn, /list-feed-digest\?variant=/);
+    assert.doesNotMatch(classifyFn, /https\.get\(digestUrl/);
+  });
+
+  it('logs non-200 digest status and fetch errors instead of returning zeros silently', () => {
+    const classifyFn = classifyFnSrc();
+    assert.match(classifyFn, /formatClassifyDigestFetchFailure\(/);
+    assert.match(classifyFn, /\[Classify\] digest fetch error:/);
+  });
+
+  it('copies the helper into the relay image next to digest-stale-gate.cjs', () => {
+    assert.match(
+      dockerfileSrc,
+      /COPY scripts\/lib\/classify-digest-request\.cjs \.\/scripts\/lib\/classify-digest-request\.cjs/,
+    );
+  });
+});

--- a/tests/classify-digest-request.test.mjs
+++ b/tests/classify-digest-request.test.mjs
@@ -27,6 +27,7 @@ const {
   classifyDigestTransport,
   buildClassifyDigestHeaders,
   formatClassifyDigestFetchFailure,
+  shouldWriteClassifySeedMeta,
 } = require('../scripts/lib/classify-digest-request.cjs');
 
 const relaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'), 'utf8');
@@ -90,10 +91,24 @@ describe('classify digest request builder (#7437)', () => {
       formatClassifyDigestFetchFailure(401, ''),
       /HTTP 401.*WORLDMONITOR_RELAY_KEY not set/,
     );
+    assert.match(
+      formatClassifyDigestFetchFailure(403, ''),
+      /HTTP 403.*WORLDMONITOR_RELAY_KEY not set/,
+    );
+    assert.equal(
+      formatClassifyDigestFetchFailure(502, ''),
+      '[Classify] digest fetch failed: HTTP 502',
+    );
     assert.equal(
       formatClassifyDigestFetchFailure(403, 'set'),
       '[Classify] digest fetch failed: HTTP 403',
     );
+  });
+
+  it('withholds seed-meta after an all-variant digest fetch failure', () => {
+    assert.equal(shouldWriteClassifySeedMeta({ fetchOk: 0, fetchFailed: 5 }), false);
+    assert.equal(shouldWriteClassifySeedMeta({ fetchOk: 1, fetchFailed: 4 }), true);
+    assert.equal(shouldWriteClassifySeedMeta({ fetchOk: 0, fetchFailed: 0 }), true);
   });
 });
 
@@ -111,6 +126,8 @@ describe('ais-relay Classify wiring (#7437)', () => {
     const classifyFn = classifyFnSrc();
     assert.match(classifyFn, /formatClassifyDigestFetchFailure\(/);
     assert.match(classifyFn, /\[Classify\] digest fetch error:/);
+    assert.match(classifyFn, /fetchFailed:\s*true/);
+    assert.match(relaySrc, /shouldWriteClassifySeedMeta\(\{ fetchOk, fetchFailed \}\)/);
   });
 
   it('copies the helper into the relay image next to digest-stale-gate.cjs', () => {

--- a/tests/classify-digest-request.test.mjs
+++ b/tests/classify-digest-request.test.mjs
@@ -28,6 +28,10 @@ const {
   buildClassifyDigestHeaders,
   formatClassifyDigestFetchFailure,
   shouldWriteClassifySeedMeta,
+  CLASSIFY_DIGEST_RETRY_DELAYS_MS,
+  isTransientClassifyDigestFetchError,
+  isRetryableClassifyDigestStatus,
+  classifyDigestRetryDecision,
 } = require('../scripts/lib/classify-digest-request.cjs');
 
 const relaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'), 'utf8');
@@ -110,6 +114,39 @@ describe('classify digest request builder (#7437)', () => {
     assert.equal(shouldWriteClassifySeedMeta({ fetchOk: 1, fetchFailed: 4 }), true);
     assert.equal(shouldWriteClassifySeedMeta({ fetchOk: 0, fetchFailed: 0 }), true);
   });
+
+  it('retries connection refusals and 502/503/504, not auth failures', () => {
+    assert.equal(isTransientClassifyDigestFetchError({ code: 'ECONNREFUSED' }), true);
+    assert.equal(isTransientClassifyDigestFetchError(new Error('timeout')), true);
+    assert.equal(isTransientClassifyDigestFetchError(new Error('socket hang up')), true);
+    assert.equal(isTransientClassifyDigestFetchError(new Error('certificate has expired')), false);
+    assert.equal(isRetryableClassifyDigestStatus(502), true);
+    assert.equal(isRetryableClassifyDigestStatus(503), true);
+    assert.equal(isRetryableClassifyDigestStatus(504), true);
+    assert.equal(isRetryableClassifyDigestStatus(401), false);
+    assert.equal(isRetryableClassifyDigestStatus(403), false);
+    assert.equal(isRetryableClassifyDigestStatus(200), false);
+
+    assert.deepEqual(
+      classifyDigestRetryDecision({ attempt: 0, error: { code: 'ECONNREFUSED' } }),
+      { retry: true, delayMs: 2000 },
+    );
+    assert.deepEqual(
+      classifyDigestRetryDecision({ attempt: 1, status: 503 }),
+      { retry: true, delayMs: 4000 },
+    );
+    assert.deepEqual(
+      classifyDigestRetryDecision({ attempt: 0, status: 401 }),
+      { retry: false, delayMs: 0 },
+    );
+    assert.deepEqual(
+      classifyDigestRetryDecision({
+        attempt: CLASSIFY_DIGEST_RETRY_DELAYS_MS.length,
+        error: { code: 'ECONNREFUSED' },
+      }),
+      { retry: false, delayMs: 0 },
+    );
+  });
 });
 
 describe('ais-relay Classify wiring (#7437)', () => {
@@ -128,6 +165,8 @@ describe('ais-relay Classify wiring (#7437)', () => {
     assert.match(classifyFn, /\[Classify\] digest fetch error:/);
     assert.match(classifyFn, /fetchFailed:\s*true/);
     assert.match(relaySrc, /shouldWriteClassifySeedMeta\(\{ fetchOk, fetchFailed \}\)/);
+    assert.match(classifyFn, /classifyDigestRetryDecision\(/);
+    assert.match(classifyFn, /CLASSIFY_DIGEST_RETRY_DELAYS_MS\.length \+ 1/);
   });
 
   it('copies the helper into the relay image next to digest-stale-gate.cjs', () => {

--- a/tests/docker-compose-no-default-secrets.test.mts
+++ b/tests/docker-compose-no-default-secrets.test.mts
@@ -199,6 +199,28 @@ describe('docker self-hosting — no default credentials (#3804)', () => {
     );
   });
 
+  it('docker-compose.yml points ais-relay Classify at the in-network app (#7437)', async () => {
+    const compose = await read('docker-compose.yml');
+    const relay = serviceBlock(compose, 'ais-relay');
+    const worldmonitor = serviceBlock(compose, 'worldmonitor');
+
+    assert.match(
+      relay,
+      /API_BASE_URL:\s*"\$\{API_BASE_URL:-http:\/\/worldmonitor:8080\}"/,
+      'ais-relay must default API_BASE_URL to the compose-network worldmonitor service',
+    );
+    assert.match(
+      relay,
+      /WORLDMONITOR_RELAY_KEY:\s*"\$\{WORLDMONITOR_RELAY_KEY:-\}"/,
+      'ais-relay must receive WORLDMONITOR_RELAY_KEY so Classify can send X-WorldMonitor-Key',
+    );
+    assert.match(
+      worldmonitor,
+      /WORLDMONITOR_RELAY_KEY:\s*"\$\{WORLDMONITOR_RELAY_KEY:-\}"/,
+      'worldmonitor must receive the same WORLDMONITOR_RELAY_KEY so the gateway can accept the Classify digest fetch',
+    );
+  });
+
   it('docker-compose.yml bounds redis-rest memory against its per-request body buffer (#7099)', async () => {
     const compose = await read('docker-compose.yml');
     const redisRest = serviceBlock(compose, 'redis-rest');

--- a/tests/docker-compose-no-default-secrets.test.mts
+++ b/tests/docker-compose-no-default-secrets.test.mts
@@ -219,6 +219,11 @@ describe('docker self-hosting — no default credentials (#3804)', () => {
       /WORLDMONITOR_RELAY_KEY:\s*"\$\{WORLDMONITOR_RELAY_KEY:-\}"/,
       'worldmonitor must receive the same WORLDMONITOR_RELAY_KEY so the gateway can accept the Classify digest fetch',
     );
+    assert.doesNotMatch(
+      relay,
+      /depends_on:[\s\S]*worldmonitor/,
+      'ais-relay must not depend_on worldmonitor — that would cycle with the app depends_on',
+    );
   });
 
   it('docker-compose.yml bounds redis-rest memory against its per-request body buffer (#7099)', async () => {

--- a/tests/relay-warm-ping-auth.test.mts
+++ b/tests/relay-warm-ping-auth.test.mts
@@ -44,6 +44,7 @@ describe('relay warm-ping internal auth', () => {
         '/api/infrastructure/v1/list-service-statuses',
         '/api/infrastructure/v1/list-temporal-anomalies',
         '/api/intelligence/v1/get-risk-scores',
+        '/api/news/v1/list-feed-digest',
         '/api/supply-chain/v1/get-chokepoint-status',
       ],
     );

--- a/tests/telegram-trust-registry.test.mjs
+++ b/tests/telegram-trust-registry.test.mjs
@@ -164,7 +164,7 @@ describe('Telegram alert-tier policy (#6600)', () => {
     const classifyEnd = aisRelaySrc.indexOf('\nasync function seedClassify()', classifyStart);
     assert.ok(classifyStart >= 0 && classifyEnd > classifyStart);
     const classifyFn = aisRelaySrc.slice(classifyStart, classifyEnd);
-    assert.match(classifyFn, /list-feed-digest/);
+    assert.match(classifyFn, /buildClassifyDigestUrl\(variant\)/);
     assert.doesNotMatch(classifyFn, /telegramState\.items/);
 
     // BEFORE: generic platform source and unlisted labels default to 4 for


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`seedClassifyForVariant` in `scripts/ais-relay.cjs` hardcoded the production digest URL and always used `https.get`. On a self-hosted compose stack that silently 401'd against production (or threw on `http://worldmonitor:8080`), every Classify cycle logged `0 titles, 0 classified` and importance ranking stayed on keyword fallback.

This change mirrors `seed-insights.mjs` `warmDigestCache`:

- Honor `API_BASE_URL` (compose defaults to `http://worldmonitor:8080`)
- Send `X-WorldMonitor-Key` when `WORLDMONITOR_RELAY_KEY` is set
- Pick `http`/`https` from the URL scheme
- Log non-200 digest status instead of returning zeros silently
- Allow the dedicated relay key on `/api/news/v1/list-feed-digest` so the same least-privilege secret used by warm-pings can authorize Classify
- Do not write `seed-meta:classify` when every variant's digest fetch failed
- Retry transient connection errors and 502/503/504 for ~30s so a compose boot race does not wait the full 15-minute interval for `full`
- Watch `scripts/lib/classify-digest-request.cjs` on the ais-relay Railway service

Fixes #7437

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [x] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: ais-relay Classify seeder, self-host compose

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

`npm run typecheck:api` passed (gateway change). Browser `typecheck` is not required for this surface.

## Documentation Alignment Checklist

N/A — no methodology/API contract docs changed beyond `SELF_HOSTING.md` operator notes.

## Screenshots

N/A — relay/seeder fix. Verification is the focused test suite.

## Post-Deploy Monitoring & Validation

- **Self-host:** recreate `ais-relay` with `API_BASE_URL=http://worldmonitor:8080` and the same `WORLDMONITOR_RELAY_KEY` on `worldmonitor` + `ais-relay`. First healthy cycle should log `[Classify] full: N titles, … classified` with N > 0 (not `0 titles, 0 classified`).
- **Logs to watch:** `[Classify] digest fetch failed: HTTP`, `[Classify] digest fetch error:`, `[Classify] digest fetch HTTP …; retrying`, `[Classify] Digest fetch failed for every variant`, `[Classify] full:`
- **Healthy:** per-variant title counts > 0 when the digest has stories; digest importance logs `llm=` > 0 after cache fills.
- **Failure:** persistent `HTTP 401` (key missing on one side), `ECONNREFUSED` after the retry budget (app still not reachable), or `0 classified` with a successful title count (LLM provider issue, out of scope).
- **Rollback:** revert this PR so Classify again targets the production host (previous behavior). Self-host remains broken until re-applied.
- **Window / owner:** one Classify interval (15 min) after relay recreate; reporter on #7437 can confirm the self-host cycle.

## Known Residuals

- First Classify pass can still miss `worldmonitor:8080` if the app takes longer than the ~30s transient-retry budget. Failures do not write `seed-meta:classify`, so the next 15-minute interval retries. Compose cannot `depends_on worldmonitor` without cycling with the app.
- `WORLDMONITOR_RELAY_KEY` is still untrimmed at the relay (same latent mismatch as other warm-pings).
- Sending the key to a mis-set `API_BASE_URL` would forward the dedicated relay secret; the host is operator-controlled env, same as other seeders.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0559b-2ee1-721c-af2c-84e78ab1eaa5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0559b-2ee1-721c-af2c-84e78ab1eaa5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

