### PR TITLE
fix(a11y): restore the marketing lockup to one home link (#7382)

### DIFF
--- a/blog-site/src/layouts/Base.astro
+++ b/blog-site/src/layouts/Base.astro
@@ -1,6 +1,5 @@
 ---
 import productFacts from '../../../shared/product-facts.generated.json';
-import { SOMEONE_CEO_URL } from '../../../shared/press';
 import TrackedProductLink from '../components/TrackedProductLink.astro';
 
 interface Props {
@@ -108,10 +107,7 @@ function stringifyJsonLd(value: Record<string, unknown>): string {
           <a href="/blog/" class="logo-mark" aria-label="World Monitor Blog — Home">
             <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" class="logo-icon-img" />
           </a>
-          <div class="logo-text">
-            <a href="/blog/" class="logo-name">WORLD MONITOR</a>
-            <a href={SOMEONE_CEO_URL} class="logo-sub" rel="noopener noreferrer">by Someone.ceo</a>
-          </div>
+          <a href="/blog/" class="logo-name">WORLD MONITOR</a>
         </div>
         <ul class="nav-links">
           <li><a href="/blog/">Blog</a></li>
@@ -149,10 +145,7 @@ function stringifyJsonLd(value: Record<string, unknown>): string {
       <div class="footer-inner">
         <div class="footer-brand">
           <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" class="footer-icon-img" />
-          <div class="footer-brand-text">
-            <span class="footer-name">WORLD MONITOR</span>
-            <a href={SOMEONE_CEO_URL} class="footer-sub" rel="noopener noreferrer">by Someone.ceo</a>
-          </div>
+          <span class="footer-name">WORLD MONITOR</span>
         </div>
         <div class="footer-links">
           <a href="/blog/authors/elie-habib/">About</a>

--- a/blog-site/src/styles/global.css
+++ b/blog-site/src/styles/global.css
@@ -90,11 +90,6 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   border-radius: 50%;
 }
 
-.site-header .logo .logo-text {
-  display: flex;
-  flex-direction: column;
-}
-
 .site-header .logo .logo-name {
   font-family: var(--font-display);
   font-weight: 700;
@@ -105,18 +100,6 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   transition: opacity 0.2s;
 }
 .site-header .logo .logo-name:hover { opacity: 0.8; }
-
-.site-header .logo .logo-sub {
-  font-family: var(--font-mono);
-  font-size: 0.5625rem;
-  color: var(--wm-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  line-height: 1;
-  margin-top: 3px;
-  transition: color 0.2s;
-}
-.site-header .logo .logo-sub:hover { color: var(--wm-text); }
 
 .site-header .nav-links {
   display: flex;
@@ -175,11 +158,6 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   border-radius: 50%;
 }
 
-.site-footer .footer-brand-text {
-  display: flex;
-  flex-direction: column;
-}
-
 .site-footer .footer-name {
   font-family: var(--font-display);
   font-weight: 700;
@@ -187,16 +165,6 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   color: var(--wm-text);
   letter-spacing: 0.02em;
 }
-
-.site-footer .footer-sub {
-  font-family: var(--font-mono);
-  font-size: 0.5625rem;
-  color: var(--wm-muted);
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  transition: color 0.2s;
-}
-.site-footer .footer-sub:hover { color: var(--wm-text); }
 
 .site-footer .footer-links {
   display: flex;

--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -1168,7 +1168,7 @@ const EnterprisePage = () => (
   <div className="min-h-screen selection:bg-wm-green/30 selection:text-wm-green">
     <nav data-wm-nav="primary" className="fixed top-0 left-0 right-0 z-50 glass-panel border-b-0 border-x-0 rounded-none" aria-label="Main navigation">
       <div className="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-        <Logo />
+        <Logo href="#" onClick={(e) => { e.preventDefault(); window.location.hash = ''; }} />
         <div className="hidden md:flex items-center gap-8 text-sm font-mono text-wm-muted">
           <a href="#" onClick={(e) => { e.preventDefault(); window.location.hash = ''; }} className="hover:text-wm-text transition-colors">{t('nav.pro')}</a>
           <a href="#enterprise" onClick={(e) => { e.preventDefault(); document.getElementById('features')?.scrollIntoView({ behavior: 'smooth' }); }} className="hover:text-wm-text transition-colors">{t('nav.enterprise')}</a>

--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -41,7 +41,7 @@ import { isInternalSourceTag } from '../../shared/referral-namespaces';
 import { readMcpAttributionFromSearch } from '../../shared/mcp-attribution';
 import { LegalFooterNav } from './components/LegalFooterNav';
 import { PressFooterNav } from './components/PressFooterNav';
-import { ABOUT_DOCS_PATH, SOMEONE_CEO_URL } from '../../shared/press';
+import { ABOUT_DOCS_PATH } from '../../shared/press';
 
 const API_BASE = 'https://api.worldmonitor.app/api';
 const TURNSTILE_SITE_KEY = '0x4AAAAAACnaYgHIyxclu8Tj';
@@ -1168,7 +1168,7 @@ const EnterprisePage = () => (
   <div className="min-h-screen selection:bg-wm-green/30 selection:text-wm-green">
     <nav data-wm-nav="primary" className="fixed top-0 left-0 right-0 z-50 glass-panel border-b-0 border-x-0 rounded-none" aria-label="Main navigation">
       <div className="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-        <a href="#" onClick={(e) => { e.preventDefault(); window.location.hash = ''; }}><Logo /></a>
+        <Logo />
         <div className="hidden md:flex items-center gap-8 text-sm font-mono text-wm-muted">
           <a href="#" onClick={(e) => { e.preventDefault(); window.location.hash = ''; }} className="hover:text-wm-text transition-colors">{t('nav.pro')}</a>
           <a href="#enterprise" onClick={(e) => { e.preventDefault(); document.getElementById('features')?.scrollIntoView({ behavior: 'smooth' }); }} className="hover:text-wm-text transition-colors">{t('nav.enterprise')}</a>
@@ -1357,16 +1357,7 @@ const EnterprisePage = () => (
       <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto text-xs text-wm-muted font-mono">
         <div className="flex items-center gap-3 mb-4 md:mb-0">
           <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" loading="lazy" className="rounded-full" />
-          <div className="flex flex-col text-left">
-            <span className="font-display font-bold text-sm leading-none tracking-tight text-wm-text">WORLD MONITOR</span>
-            <a
-              href={SOMEONE_CEO_URL}
-              className="text-[9px] uppercase tracking-[2px] opacity-60 mt-0.5 hover:opacity-100 hover:text-wm-text transition-colors"
-              rel="noopener noreferrer"
-            >
-              by Someone.ceo
-            </a>
-          </div>
+          <span className="font-display font-bold text-sm leading-none tracking-tight text-wm-text">WORLD MONITOR</span>
         </div>
         <div className="flex items-center gap-6">
           <a href={DASHBOARD_PATH} className="hover:text-wm-text transition-colors">Dashboard</a>

--- a/pro-test/src/components/Footer.tsx
+++ b/pro-test/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { DASHBOARD_PATH } from '../routes';
-import { ABOUT_DOCS_PATH, SOMEONE_CEO_URL } from '../../../shared/press';
+import { ABOUT_DOCS_PATH } from '../../../shared/press';
 import { LegalFooterNav } from './LegalFooterNav';
 import { PressFooterNav } from './PressFooterNav';
 
@@ -8,16 +8,7 @@ export const Footer = () => (
     <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto text-xs text-wm-muted font-mono">
       <div className="flex items-center gap-3 mb-4 md:mb-0">
         <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" loading="lazy" className="rounded-full" />
-        <div className="flex flex-col text-left">
-          <span className="font-display font-bold text-sm leading-none tracking-tight text-wm-text">WORLD MONITOR</span>
-          <a
-            href={SOMEONE_CEO_URL}
-            className="text-[10px] uppercase tracking-[2px] text-wm-muted mt-0.5 hover:text-wm-text transition-colors"
-            rel="noopener noreferrer"
-          >
-            by Someone.ceo
-          </a>
-        </div>
+        <span className="font-display font-bold text-sm leading-none tracking-tight text-wm-text">WORLD MONITOR</span>
       </div>
       <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
         <a href={DASHBOARD_PATH} className="hover:text-wm-text transition-colors">Dashboard</a>

--- a/pro-test/src/components/Logo.tsx
+++ b/pro-test/src/components/Logo.tsx
@@ -1,8 +1,19 @@
 import { Globe, Activity } from 'lucide-react';
-import { SOMEONE_CEO_URL } from '../../../shared/press';
 
+/**
+ * Home lockup for the marketing chrome.
+ *
+ * One anchor wrapping the whole lockup on purpose: the 32px glyph gives the
+ * link a target that clears the 24x24 minimum, and the accessible name comes
+ * from the visible WORLD MONITOR text rather than a mismatched aria-label.
+ * Splitting this into stacked 14px/10px text links scored 0 on axe
+ * target-size (#7382).
+ */
 export const Logo = () => (
-  <div className="flex items-center gap-2">
+  <a
+    href="https://worldmonitor.app"
+    className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+  >
     <span
       className="relative w-8 h-8 rounded-full bg-wm-card border border-wm-border flex items-center justify-center overflow-hidden"
       aria-hidden="true"
@@ -10,17 +21,8 @@ export const Logo = () => (
       <Globe className="w-5 h-5 text-wm-blue opacity-50 absolute" />
       <Activity className="w-6 h-6 text-wm-green absolute z-10" />
     </span>
-    <div className="flex flex-col">
-      <a href="https://worldmonitor.app" className="font-display font-bold text-sm leading-none tracking-tight hover:opacity-80 transition-opacity">
-        WORLD MONITOR
-      </a>
-      <a
-        href={SOMEONE_CEO_URL}
-        className="text-[10px] text-wm-muted font-mono uppercase tracking-widest leading-none mt-1 hover:text-wm-text transition-colors"
-        rel="noopener noreferrer"
-      >
-        by Someone.ceo
-      </a>
-    </div>
-  </div>
+    <span className="font-display font-bold text-sm leading-none tracking-tight">
+      WORLD MONITOR
+    </span>
+  </a>
 );

--- a/pro-test/src/components/Logo.tsx
+++ b/pro-test/src/components/Logo.tsx
@@ -1,4 +1,12 @@
+import type { MouseEventHandler } from 'react';
 import { Globe, Activity } from 'lucide-react';
+
+interface LogoProps {
+  /** Destination for the lockup. Defaults to the marketing home. */
+  href?: string;
+  /** Intercept the click — e.g. the Enterprise view clearing its hash route. */
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+}
 
 /**
  * Home lockup for the marketing chrome.
@@ -8,10 +16,17 @@ import { Globe, Activity } from 'lucide-react';
  * from the visible WORLD MONITOR text rather than a mismatched aria-label.
  * Splitting this into stacked 14px/10px text links scored 0 on axe
  * target-size (#7382).
+ *
+ * Call sites needing an in-page destination pass `href`/`onClick` instead of
+ * wrapping this in another anchor: nesting is invalid HTML, and the outer
+ * handler's preventDefault() silently cancelled the inner link's navigation
+ * too, so unwrapping without forwarding the handler changes where the logo
+ * goes.
  */
-export const Logo = () => (
+export const Logo = ({ href = 'https://worldmonitor.app', onClick }: LogoProps = {}) => (
   <a
-    href="https://worldmonitor.app"
+    href={href}
+    onClick={onClick}
     className="flex items-center gap-2 hover:opacity-80 transition-opacity"
   >
     <span

--- a/pro-test/src/components/PressFooterNav.tsx
+++ b/pro-test/src/components/PressFooterNav.tsx
@@ -12,7 +12,7 @@ export const PressFooterNav = () => (
     aria-label="In the press"
     className="max-w-7xl mx-auto mt-4 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[11px] text-wm-muted font-mono"
   >
-    <span className="uppercase tracking-[2px] opacity-60">In the press</span>
+    <span className="uppercase tracking-[2px] text-wm-muted">In the press</span>
     {PRESS_LINKS.map(link => (
       <a
         key={link.url}

--- a/shared/press.ts
+++ b/shared/press.ts
@@ -6,9 +6,6 @@
  * Silicon Canals 2M cite, the WIRED feature, or the country-reach figure.
  */
 
-/** Studio lockup target — resolves (301) onto www.worldmonitor.app. */
-export const SOMEONE_CEO_URL = 'https://someone.ceo';
-
 export const WIRED_FEATURE_URL =
   'https://www.wired.com/story/world-monitor-elie-habib/';
 

--- a/tests/a11y-issue-7382-welcome-invariants.test.mjs
+++ b/tests/a11y-issue-7382-welcome-invariants.test.mjs
@@ -7,9 +7,22 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '..');
 
-const footer = readFileSync(resolve(root, 'pro-test/src/components/Footer.tsx'), 'utf8');
-const logo = readFileSync(resolve(root, 'pro-test/src/components/Logo.tsx'), 'utf8');
-const nav = readFileSync(resolve(root, 'pro-test/src/welcome/Nav.tsx'), 'utf8');
+const read = (path) => readFileSync(resolve(root, path), 'utf8');
+
+const footer = read('pro-test/src/components/Footer.tsx');
+const logo = read('pro-test/src/components/Logo.tsx');
+const nav = read('pro-test/src/welcome/Nav.tsx');
+const pressNav = read('pro-test/src/components/PressFooterNav.tsx');
+const app = read('pro-test/src/App.tsx');
+const blogBase = read('blog-site/src/layouts/Base.astro');
+
+/** Marketing chrome that renders the WORLD MONITOR lockup. */
+const LOCKUP_SOURCES = Object.entries({
+  'pro-test/src/components/Logo.tsx': logo,
+  'pro-test/src/components/Footer.tsx': footer,
+  'pro-test/src/App.tsx': app,
+  'blog-site/src/layouts/Base.astro': blogBase,
+});
 
 describe('welcome a11y invariants (#7382)', () => {
   it('keeps footer copyright and byline at solid muted contrast (no opacity fade)', () => {
@@ -19,10 +32,45 @@ describe('welcome a11y invariants (#7382)', () => {
     assert.match(footer, /text-\[10px\] text-wm-muted/);
   });
 
+  it('keeps the press-row label at solid muted contrast (no opacity fade)', () => {
+    // #7383 added this row with the same opacity-60 fade #7414 swept out of
+    // Footer/Logo, so it kept color-contrast red at 3.42:1 against #020202.
+    assert.doesNotMatch(pressNav, /opacity-\d+/);
+    assert.match(pressNav, /text-wm-muted/);
+  });
+
   it('names the home control from visible WORLD MONITOR text (no mismatched aria-label)', () => {
     assert.doesNotMatch(logo, /aria-label=/);
     assert.match(logo, /WORLD MONITOR/);
     assert.match(logo, /aria-hidden="true"/);
+  });
+
+  it('exposes the lockup as ONE home link, not stacked sub-24px targets', () => {
+    // #7383 split the single 32px-tall lockup anchor into a 14px wordmark
+    // link plus a 10px byline link 16px apart, which axe target-size scores
+    // as "safe clickable space has a diameter of 8px instead of 24px".
+    const anchors = logo.match(/<a[\s>]/g) ?? [];
+    assert.equal(anchors.length, 1, 'Logo must render exactly one anchor');
+    assert.match(logo, /className="flex items-center gap-2/);
+  });
+
+  it('never nests an interactive control around the lockup', () => {
+    // <a href="#"><Logo /></a> on the Enterprise page put an anchor inside an
+    // anchor: invalid HTML, and the inner href silently wins the click.
+    // Matched line-wise on purpose — an `onClick={(e) => ...}` attribute
+    // contains a bare `>`, so a `<a[^>]*>` pattern stops short and can never
+    // see the <Logo /> that follows.
+    const wrapped = app
+      .split('\n')
+      .filter((line) => line.includes('<Logo') && /<a[\s>]/.test(line));
+    assert.deepEqual(wrapped, [], 'Logo must not be wrapped in an anchor');
+  });
+
+  it('carries no Someone.ceo studio byline in marketing chrome', () => {
+    for (const [path, source] of LOCKUP_SOURCES) {
+      assert.doesNotMatch(source, /Someone\.ceo/i, `${path} must not render the studio byline`);
+      assert.doesNotMatch(source, /SOMEONE_CEO_URL/, `${path} must not import the studio URL`);
+    }
   });
 
   it('keeps Launch CTA aria-label matching visible copy (critical CSS + a11y)', () => {

--- a/tests/a11y-issue-7382-welcome-invariants.test.mjs
+++ b/tests/a11y-issue-7382-welcome-invariants.test.mjs
@@ -56,7 +56,7 @@ describe('welcome a11y invariants (#7382)', () => {
 
   it('never nests an interactive control around the lockup', () => {
     // <a href="#"><Logo /></a> on the Enterprise page put an anchor inside an
-    // anchor: invalid HTML, and the inner href silently wins the click.
+    // anchor: invalid HTML.
     // Matched line-wise on purpose — an `onClick={(e) => ...}` attribute
     // contains a bare `>`, so a `<a[^>]*>` pattern stops short and can never
     // see the <Logo /> that follows.
@@ -64,6 +64,23 @@ describe('welcome a11y invariants (#7382)', () => {
       .split('\n')
       .filter((line) => line.includes('<Logo') && /<a[\s>]/.test(line));
     assert.deepEqual(wrapped, [], 'Logo must not be wrapped in an anchor');
+  });
+
+  it('keeps the Enterprise lockup returning to the Pro page, not leaving the site', () => {
+    // The removed wrapper was not inert. It caught the click bubbling up from
+    // the whole lockup and called preventDefault(), so the inner anchor's
+    // href never navigated — clicking the wordmark on /pro#enterprise cleared
+    // the hash and stayed on /pro (confirmed against production).
+    // Unwrapping without forwarding the handler would silently send that
+    // click off-site to worldmonitor.app, so Logo takes the destination.
+    assert.match(logo, /href = 'https:\/\/worldmonitor\.app'/, 'Logo keeps the home default');
+    assert.match(logo, /href=\{href\}/);
+    assert.match(logo, /onClick=\{onClick\}/);
+    assert.match(
+      app,
+      /<Logo\s+href="#"\s+onClick=\{\(e\) => \{ e\.preventDefault\(\); window\.location\.hash = ''; \}\}\s*\/>/,
+      'the Enterprise nav lockup must still clear the hash instead of leaving the site',
+    );
   });
 
   it('carries no Someone.ceo studio byline in marketing chrome', () => {

--- a/tests/geo-content-credibility-7377.test.mjs
+++ b/tests/geo-content-credibility-7377.test.mjs
@@ -14,7 +14,6 @@ import {
   GITHUB_STARS_BADGE_URL,
   PRESS_LINKS,
   SILICON_CANALS_2M_URL,
-  SOMEONE_CEO_URL,
   WIRED_FEATURE_URL,
 } from '../shared/press.ts';
 
@@ -139,18 +138,10 @@ describe('issue #7377 GEO content credibility', () => {
     assert.match(pressNav, /In the press/);
   });
 
-  it('(d) links the Someone.ceo studio lockup to a resolvable URL', () => {
-    for (const path of [
-      'pro-test/src/components/Logo.tsx',
-      'pro-test/src/components/Footer.tsx',
-      'blog-site/src/layouts/Base.astro',
-    ]) {
-      const source = read(path);
-      assert.ok(
-        source.includes('SOMEONE_CEO_URL') || source.includes(SOMEONE_CEO_URL),
-        `${path} must link Someone.ceo via SOMEONE_CEO_URL`,
-      );
-      assert.match(source, /by Someone\.ceo/);
-    }
-  });
+  // (d) pinned a "by Someone.ceo" studio byline into the header/footer lockups.
+  // Dropped deliberately: stacking it under the wordmark made two sub-24px
+  // links 16px apart and scored 0 on axe target-size (#7382). The byline
+  // carried no product information, so it was removed rather than resized.
+  // The removal invariant now lives in
+  // tests/a11y-issue-7382-welcome-invariants.test.mjs.
 });


### PR DESCRIPTION
## What DebugBear caught

A change alert on `www.worldmonitor.app` reported **Lighthouse accessibility 95 → 90** on the landing page, with `Touch targets do not have sufficient size or spacing: 100 → 0`.

Reproduced live before touching anything — Lighthouse returns **accessibility 90** on both `/` and `/pro`, with two failing nodes:

```
Target has insufficient size (119px by 14px, should be at least 24px by 24px)
Target has insufficient space to its closest neighbors.
Safe clickable space has a diameter of 8px instead of at least 24px.
```

## Root cause

Both regressions come from the #7377/#7383 credibility pass:

1. **`Logo.tsx`** — #7383 replaced one 32px-tall lockup anchor with two stacked text links: a 14px wordmark and a 10px `by Someone.ceo` byline, centres 16px apart. Neither clears 24×24, and they are too close to pass on spacing instead. Also reproduced at 390px on `/pro`, which is the truncated "Pro (Mobile)" section of the same alert.

2. **`PressFooterNav.tsx`** — #7383 added this row carrying the same `opacity-60` fade that #7414 later swept out of `Footer.tsx` and `Logo.tsx` but missed here. It renders `#5e636a` on `#020202` = **3.42:1**, under the required 4.5:1. DebugBear did not flag it as a *change* because the audit was already failing before, so it showed 0 → 0.

## Why the byline is removed rather than resized

Two non-overlapping 24px targets need 48px; the lockup has 28px. Padding them to size makes their hit areas overlap, so clicks on the byline would land on the wordmark — an audit pass that introduces a real bug. The byline carried no product information, so it is dropped from the welcome nav, both marketing footers and the blog chrome, along with the now-dead `SOMEONE_CEO_URL` constant and its CSS. The wordmark alone gives the home link a **159×32** target.

## Also fixed

`pro-test/src/App.tsx:1171` wrapped `<Logo />` in `<a href="#">`. `Logo` has always contained an anchor, so this was nested interactive content — invalid HTML.

**Corrected after review** (thanks @chatgpt-codex-connector): this PR originally claimed the unwrap was behaviour-neutral because "the inner `href` already won the click." That was wrong. The outer handler caught the click bubbling up from the whole lockup and called `preventDefault()`, which cancels the default action for the entire dispatch — the inner anchor's navigation included. Verified against production, which still runs the old markup: clicking the wordmark on `/pro#enterprise` lands on `/pro#`, not `worldmonitor.app`.

`Logo` now takes optional `href`/`onClick` so the Enterprise call site keeps its hash-clearing destination without nesting anchors. The default stays the marketing home, so every other call site is untouched.

## Verification

Measured in a real browser against the built `public/pro/welcome.html`:

| | before | after |
|---|---|---|
| axe `target-size` failures | 2 | **0** |
| nested anchors (`a a`) | 2 | **0** |
| "In the press" contrast | 3.42:1 | **8.17:1** |
| logo target | 119×14 + 119×10 | **159×32** |
| `/pro#enterprise` logo click | → `/pro#` | → `/pro#` (preserved) |

New assertions land in `tests/a11y-issue-7382-welcome-invariants.test.mjs` and were confirmed red against the pre-fix tree before any source changed. One of them initially passed vacuously — `<a[^>]*>` cannot cross the bare `>` inside an `onClick={(e) => …}` attribute — so it is matched line-wise instead, with a comment recording why.

`geo-content-credibility-7377` test (d) pinned the byline into the lockups; it is removed with a comment pointing at the replacement invariant.

`npm run typecheck`, `npm run lint` and the full `WM_EXPECT_BUILT_OUTPUT=1 npm run test:data` suite all pass.

## Known gap, not addressed here

`e2e/a11y-axe-scan.spec.ts` only scans the dashboard and the settings dialog. The marketing surface has **zero** axe coverage, which is why this shipped unnoticed. Worth a follow-up issue rather than widening this PR.

Refs #7382

https://claude.ai/code/session_01BkadGoomHWUSS5etmQkZC5
