### PR TITLE
fix(pro): let Tailwind utilities outrank the critical-CSS reset

### DIFF
--- a/pro-test/prerender.mjs
+++ b/pro-test/prerender.mjs
@@ -22,9 +22,13 @@ const DASHBOARD_SCREENSHOT_ASSETS = [
   { filenamePrefix: DASHBOARD_SCREENSHOT_BASENAME + '-1280', extension: '.webp' },
 ];
 
-// This inline critical CSS is UNLAYERED, so it wins the cascade over the
-// full Tailwind stylesheet (which lives in @layer utilities) regardless of
-// specificity/media -- even after the deferred sheet loads. That means any
+// The region-scoped rules in this inline critical CSS are UNLAYERED, so they
+// win the cascade over the full Tailwind stylesheet (which lives in @layer
+// utilities) regardless of specificity/media -- even after the deferred sheet
+// loads. The preflight-equivalent reset is the ONE exception: it sits in
+// @layer base so element-level defaults like `a{color:inherit}` lose to the
+// utilities that are supposed to override them (an unlayered reset held the
+// nav CTA at 1.58:1 contrast). That means any
 // `hidden <bp>:<display>` reveal (e.g. `hidden lg:flex` / `hidden md:block`
 // nav rows, `hidden sm:block`) must ALSO be re-shown here in the matching
 // @media block, or the
@@ -36,8 +40,20 @@ const DASHBOARD_SCREENSHOT_ASSETS = [
 // `nav[data-wm-nav]`, the sticky header's marker — never to a bare element that
 // a landmark added elsewhere on the page can also match (#6983).
 const CRITICAL_CSS = [
+  // Declare Tailwind's cascade-layer order up front. This inline block loads
+  // BEFORE the external sheet, so whatever it names first fixes the order the
+  // external sheet's @layer blocks slot into. Without it the reset below is
+  // unlayered — and unlayered CSS outranks EVERY layer, so Tailwind's
+  // `@layer utilities` text-colour utilities lost to `a{color:inherit}` on
+  // every anchor. That painted the nav's "Upgrade to Pro" CTA #f3f4f6 on
+  // #4ade80: 1.58:1, against a 4.5:1 requirement.
+  '@layer properties,theme,base,components,utilities;',
   ':root{--font-sans:system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;--font-mono:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;--font-display:system-ui,sans-serif;--color-wm-bg:#050505;--color-wm-card:#111;--color-wm-border:#222;--color-wm-green:#4ade80;--color-wm-blue:#60a5fa;--color-wm-text:#f3f4f6;--color-wm-muted:#9ca3af}',
-  '*,::before,::after{box-sizing:border-box;border:0 solid #222}html{background:#050505;color:#f3f4f6;-webkit-text-size-adjust:100%;tab-size:4}body{margin:0;background:#050505;color:#f3f4f6;font-family:var(--font-sans);line-height:1.5;-webkit-font-smoothing:antialiased}a{color:inherit;text-decoration:none}img,svg{display:block;vertical-align:middle}img{max-width:100%;height:auto}h1,h2,h3,p{margin:0}',
+  // Preflight-equivalent reset, layered so utilities outrank it once the
+  // external sheet lands. The region-scoped mirrors below stay UNLAYERED on
+  // purpose: they must win during the pre-stylesheet window, and they carry
+  // the same values Tailwind resolves to afterwards.
+  '@layer base{*,::before,::after{box-sizing:border-box;border:0 solid #222}html{background:#050505;color:#f3f4f6;-webkit-text-size-adjust:100%;tab-size:4}body{margin:0;background:#050505;color:#f3f4f6;font-family:var(--font-sans);line-height:1.5;-webkit-font-smoothing:antialiased}a{color:inherit;text-decoration:none}img,svg{display:block;vertical-align:middle}img{max-width:100%;height:auto}h1,h2,h3,p{margin:0}}',
   '#root,#root>div{min-height:100vh}.glass-panel{background:rgba(17,17,17,.7);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border:1px solid #222}.text-glow{text-shadow:0 0 20px rgba(74,222,128,.3)}.border-glow{box-shadow:0 0 20px rgba(74,222,128,.1)}',
   // Every rule here is scoped to `nav[data-wm-nav]` — the sticky header — and
   // never to the bare `nav` element. This CSS is unlayered, so a bare type
@@ -46,7 +62,7 @@ const CRITICAL_CSS = [
   // legal footer row (#6982) shipped exactly that, painted across the header
   // and over the Launch CTA on both / and /pro. deploy-config.test.mjs proves
   // the containment against the prerendered welcome page.
-  'nav[data-wm-nav]{position:fixed;top:0;left:0;right:0;z-index:50;background:rgba(17,17,17,.7);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border:1px solid #222;border-inline-width:0;border-bottom-width:0}nav[data-wm-nav]>div{max-width:80rem;margin-inline:auto;padding-inline:1rem;height:4rem;display:flex;align-items:center;justify-content:space-between;gap:.75rem}nav[data-wm-nav] a{display:flex;align-items:center;gap:.5rem}nav[data-wm-nav] a[aria-label*="Launch"]{flex-shrink:0;background:#4ade80;color:#050505;padding:.5rem .75rem;border-radius:.25rem;font:700 .75rem/1 ui-monospace,SFMono-Regular,monospace;text-transform:uppercase;letter-spacing:.025em}nav[data-wm-nav] .hidden{display:none}nav[data-wm-nav] [class~=font-display]{font-family:var(--font-display);font-weight:700}nav[data-wm-nav] [class~=text-wm-muted],main [class~=text-wm-muted]{color:#9ca3af}nav[data-wm-nav] [class~=text-wm-green],main [class~=text-wm-green]{color:#4ade80}nav[data-wm-nav] [class~=text-wm-blue]{color:#60a5fa}',
+  'nav[data-wm-nav]{position:fixed;top:0;left:0;right:0;z-index:50;background:rgba(17,17,17,.7);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border:1px solid #222;border-inline-width:0;border-bottom-width:0}nav[data-wm-nav]>div{max-width:80rem;margin-inline:auto;padding-inline:1rem;height:4rem;display:flex;align-items:center;justify-content:space-between;gap:.75rem}nav[data-wm-nav] a{display:flex;align-items:center;gap:.5rem}nav[data-wm-nav] a[aria-label*="Launch"]{flex-shrink:0;background:#4ade80;color:#050505;padding:.5rem .75rem;border-radius:.25rem;font:700 .75rem/1 ui-monospace,SFMono-Regular,monospace;text-transform:uppercase;letter-spacing:.025em}nav[data-wm-nav] .hidden{display:none}nav[data-wm-nav] [class~=font-display]{font-family:var(--font-display);font-weight:700}nav[data-wm-nav] [class~=text-wm-muted],main [class~=text-wm-muted]{color:#9ca3af}nav[data-wm-nav] [class~=text-wm-green],main [class~=text-wm-green]{color:#4ade80}nav[data-wm-nav] [class~=text-wm-blue]{color:#60a5fa}nav[data-wm-nav] [class~=text-wm-bg]{color:#050505}',
   'main>section:first-child{position:relative;overflow:hidden;padding:7rem 1rem 4rem}main>section:first-child>div:first-child{position:absolute;inset:0;background:radial-gradient(circle at 50% 0%,rgba(74,222,128,.10) 0%,transparent 55%);pointer-events:none}main>section:first-child>div:nth-child(2){position:relative;z-index:10;max-width:64rem;margin-inline:auto;text-align:center}main h1{font-family:var(--font-display);font-weight:700;font-size:2.25rem;line-height:1.08;letter-spacing:-.025em}main p{margin:1.5rem auto 0;max-width:42rem;color:#9ca3af;font-size:1rem;line-height:1.5}',
   'main [class~=relative]{position:relative}main [class~=absolute]{position:absolute}main [class~=inset-0]{inset:0}main [class~=z-10]{z-index:10}main [class~=pointer-events-none]{pointer-events:none}main [class~=flex]{display:flex}main [class~=inline-flex]{display:inline-flex}main [class~=grid]{display:grid}main [class~=block]{display:block}main .hidden{display:none}main [class~=items-center]{align-items:center}main [class~=items-stretch]{align-items:stretch}main [class~=justify-center]{justify-content:center}main [class~=justify-between]{justify-content:space-between}main [class~=flex-col]{flex-direction:column}main [class~=flex-wrap]{flex-wrap:wrap}main [class~=grid-cols-2]{grid-template-columns:repeat(2,minmax(0,1fr))}',
   'main [class~=mx-auto]{margin-inline:auto}main [class~=mt-1]{margin-top:.25rem}main [class~=mt-3]{margin-top:.75rem}main [class~=mt-6]{margin-top:1.5rem}main [class~=mt-8]{margin-top:2rem}main [class~=mt-9]{margin-top:2.25rem}main [class~=mt-10]{margin-top:2.5rem}main [class~=mb-5]{margin-bottom:1.25rem}main [class~=gap-1]{gap:.25rem}main [class~=gap-2]{gap:.5rem}main [class~=gap-3]{gap:.75rem}main [class~=gap-4]{gap:1rem}main [class~=gap-x-6]{column-gap:1.5rem}main [class~=gap-y-3]{row-gap:.75rem}',

--- a/tests/pro-critical-css.test.mjs
+++ b/tests/pro-critical-css.test.mjs
@@ -101,6 +101,10 @@ function layerBlock(css, name) {
   return null;
 }
 
+function hasBareAnchorColorRule(css) {
+  return /(?:^|[;{}])\s*a\s*\{[^}]*\bcolor\s*:/.test(css);
+}
+
 /** The inline critical CSS, stripped of its <style> wrapper. */
 function criticalStyleText(html) {
   const firstPreload = deferredStylePreloadTags(html)[0];
@@ -132,6 +136,17 @@ describe('pro critical CSS parser', () => {
       `),
       ['/assets/main.css', '/assets/screen.css'],
     );
+  });
+
+  it('detects spaced bare-anchor colour rules left outside the base layer', () => {
+    for (const css of [
+      '@layer base{a{color:inherit}}a { color: inherit }',
+      '@layer base{a{color:inherit}}@media(min-width:640px){a { color: inherit }}',
+    ]) {
+      const base = layerBlock(css, 'base');
+      assert.ok(base);
+      assert.equal(hasBareAnchorColorRule(css.replace(base.whole, '')), true);
+    }
   });
 });
 
@@ -285,9 +300,9 @@ describe('pro built HTML critical CSS contract', { skip: shouldSkipProBuiltOutpu
         assert.match(base.body, /a\{color:inherit/, 'the anchor reset belongs in @layer base');
         // Outside the base block there must be no unlayered bare-`a` colour
         // rule left to outrank the utilities again.
-        assert.doesNotMatch(
-          critical.replace(base.whole, ''),
-          /(?:^|[;}])a\{[^}]*color:/,
+        assert.equal(
+          hasBareAnchorColorRule(critical.replace(base.whole, '')),
+          false,
           'no unlayered bare-anchor colour rule may survive',
         );
       });

--- a/tests/pro-critical-css.test.mjs
+++ b/tests/pro-critical-css.test.mjs
@@ -82,6 +82,34 @@ function inlineStyleTags(html) {
   return [...html.matchAll(/<style\b[^>]*>[\s\S]*?<\/style>/gi)].map((match) => match[0]);
 }
 
+/**
+ * Body of the first `@layer <name> {…}` block, brace-balanced. A non-greedy
+ * `[\s\S]*?}` stops at the first nested rule's closing brace, which silently
+ * returns an empty-looking block and makes the assertion below unfalsifiable.
+ */
+function layerBlock(css, name) {
+  const open = css.indexOf(`@layer ${name}{`);
+  if (open === -1) return null;
+  const start = css.indexOf('{', open);
+  let depth = 0;
+  for (let i = start; i < css.length; i++) {
+    if (css[i] === '{') depth += 1;
+    if (css[i] === '}' && --depth === 0) {
+      return { body: css.slice(start + 1, i), whole: css.slice(open, i + 1) };
+    }
+  }
+  return null;
+}
+
+/** The inline critical CSS, stripped of its <style> wrapper. */
+function criticalStyleText(html) {
+  const firstPreload = deferredStylePreloadTags(html)[0];
+  return inlineStyleTags(html)
+    .filter((tag) => html.indexOf(tag) < html.indexOf(firstPreload))
+    .map((tag) => tag.replace(/^<style\b[^>]*>/i, '').replace(/<\/style>$/i, ''))
+    .join('\n');
+}
+
 describe('pro critical CSS parser', () => {
   it('detects stylesheet links regardless of attribute order', () => {
     assert.deepEqual(
@@ -227,5 +255,51 @@ describe('pro built HTML critical CSS contract', { skip: shouldSkipProBuiltOutpu
     assert.doesNotMatch(html, /html\.js #seo-prerender/);
     assert.match(html, /<h1\b/);
     assert.match(html, /fetchPriority="high"/);
+  });
+
+  // The reset's `a{color:inherit}` used to sit unlayered, and unlayered CSS
+  // outranks every @layer. Tailwind v4 emits utilities into @layer utilities,
+  // so `text-wm-bg` lost to the reset on every anchor and the nav's "Upgrade
+  // to Pro" CTA painted #f3f4f6 on #4ade80 — 1.58:1 where 4.5:1 is required.
+  describe('critical-CSS reset loses to Tailwind utilities (cascade layers)', () => {
+    for (const { relPath, label } of PRO_PAGES) {
+      it(`${label} declares the Tailwind layer order before any rule`, () => {
+        const critical = criticalStyleText(builtSrc(relPath));
+        const order = critical.match(/@layer\s+([a-z,\s]+);/);
+        assert.ok(order, 'critical CSS must declare a cascade-layer order');
+        assert.deepEqual(
+          order[1].split(',').map((name) => name.trim()),
+          ['properties', 'theme', 'base', 'components', 'utilities'],
+          'layer order must match the order Tailwind emits in the external sheet',
+        );
+        assert.ok(
+          order.index < critical.indexOf('{'),
+          'the layer statement must precede every rule so later @layer blocks slot into it',
+        );
+      });
+
+      it(`${label} keeps the anchor reset inside @layer base`, () => {
+        const critical = criticalStyleText(builtSrc(relPath));
+        const base = layerBlock(critical, 'base');
+        assert.ok(base, 'critical CSS must ship an @layer base block');
+        assert.match(base.body, /a\{color:inherit/, 'the anchor reset belongs in @layer base');
+        // Outside the base block there must be no unlayered bare-`a` colour
+        // rule left to outrank the utilities again.
+        assert.doesNotMatch(
+          critical.replace(base.whole, ''),
+          /(?:^|[;}])a\{[^}]*color:/,
+          'no unlayered bare-anchor colour rule may survive',
+        );
+      });
+
+      it(`${label} mirrors text-wm-bg for the nav, not just main`, () => {
+        const critical = criticalStyleText(builtSrc(relPath));
+        assert.match(
+          critical,
+          /nav\[data-wm-nav\][^{]*\[class~=text-wm-bg\]\{color:#050505\}/,
+          'the nav CTA needs the dark-on-green colour during the pre-stylesheet window',
+        );
+      });
+    }
   });
 });


### PR DESCRIPTION
## The bug

The nav's **"Upgrade to Pro"** CTA on `/pro` renders near-white on green. Lighthouse:

```
Element has insufficient color contrast of 1.58
(foreground #f3f4f6, background #4ade80, 12px bold). Expected 4.5:1
```

It is marked `class="bg-wm-green text-wm-bg …"`, so it is *supposed* to be `#050505` on `#4ade80` — 11.7:1. The utility never applied.

## Root cause: an unlayered reset outranks the whole utility layer

`pro-test/prerender.mjs` injects `CRITICAL_CSS` inline, and that block was **unlayered**. Unlayered CSS wins over every `@layer`, regardless of specificity or source order. Tailwind v4 emits all utilities into `@layer utilities`, so:

```css
/* inline, unlayered — always wins */
a { color: inherit; text-decoration: none }

/* external sheet, @layer utilities — always loses on an <a> */
.text-wm-bg { color: var(--color-wm-bg) }
```

Every anchor on the marketing surface therefore inherited its colour instead of taking its Tailwind text-colour utility.

Only the nav CTA was *visibly* broken, because the critical CSS already mirrors the needed colours per region and `main` had one (`main [class~=bg-wm-green]{…color:#050505}`) while `nav[data-wm-nav]` did not. The rest were latent.

The tell that this was worked around rather than diagnosed: the same inline block hard-codes `color:#050505` for `nav[data-wm-nav] a[aria-label*="Launch"]` — #6990 patched exactly one CTA past this same cascade problem.

## Fix

1. **Declare Tailwind's layer order first**, so the external sheet's `@layer` blocks slot into a known order:
   `@layer properties,theme,base,components,utilities;`
2. **Move the preflight-equivalent reset into `@layer base`**, so element defaults like `a{color:inherit}` lose to the utilities meant to override them.
3. **Add the missing nav mirror** `nav[data-wm-nav] [class~=text-wm-bg]{color:#050505}`, so the CTA is also correct during the pre-stylesheet window.

The region-scoped mirrors stay deliberately **unlayered** — they must win before the deferred sheet lands, and they carry the values Tailwind resolves to anyway. The file's header comment asserted the block was unlayered wholesale; it is updated to record the one exception and why, so the next reader does not undo it.

## Verification

Measured in a real browser against the rebuilt `public/pro/index.html`:

| CTA | before | after |
|---|---|---|
| Upgrade to Pro (nav) | `#f3f4f6` on `#4ade80` — **1.58:1** | `#050505` on `#4ade80` — **11.7:1** |
| Choose Your Plan ×2, Try the Live Dashboard, Talk to Sales | 11.7:1 (already covered by the `main` mirror) | 11.7:1 |

Six new assertions in `tests/pro-critical-css.test.mjs` cover the layer statement, the reset's placement in `@layer base`, and the nav mirror, on both built pages.

**Mutation-checked:** my first `@layer base{…}` extractor used a non-greedy `[\s\S]*?}`, which stops at the first *nested* rule's closing brace and made the assertion unfalsifiable. Replaced with a brace-balanced reader, then re-run against `origin/main`'s `prerender.mjs`: all 6 go red. The reason is recorded in a comment above the helper.

`npm run typecheck`, `npm run lint` and the full `WM_EXPECT_BUILT_OUTPUT=1 npm run test:data` suite pass.

## Scope

Pre-existing since #6140 introduced `prerender.mjs`; unrelated to the #7382 touch-target regression fixed in #7443. Independent branch off `main`, so the two can land in either order.

https://claude.ai/code/session_01BkadGoomHWUSS5etmQkZC5
