### PR TITLE
test(convex-auth): drive the bounded wait and rebind retry with injected timers

### DIFF
--- a/src/services/convex-client.ts
+++ b/src/services/convex-client.ts
@@ -289,6 +289,31 @@ async function callEnsureRecord(c: ConvexClient): Promise<void> {
 }
 
 /**
+ * Timer seam for the auth-wait and retry paths (#5841).
+ *
+ * The bounded auth wait and the transient-rebind retry delay used to run on
+ * real timers only, so their unit tests could only be driven by elapsed wall
+ * time — 1 ms retry hops and 5 ms bounded waits racing setImmediate flushes
+ * and a 1 s polling deadline, which is exactly the profile that reds the
+ * merge-blocking `unit` job under CI scheduling stalls. Production keeps real
+ * timers; tests install a manual scheduler and fire these deterministically.
+ */
+export type ConvexAuthTimers = {
+  setTimeout: (fn: () => void, ms: number) => unknown;
+  clearTimeout: (id: unknown) => void;
+};
+const REAL_AUTH_TIMERS: ConvexAuthTimers = {
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (id) => clearTimeout(id as ReturnType<typeof setTimeout>),
+};
+let authTimers: ConvexAuthTimers = REAL_AUTH_TIMERS;
+
+/** Test-only: install a manual scheduler; pass null to restore real timers. */
+export function __setConvexAuthTimersForTests(timers: ConvexAuthTimers | null): void {
+  authTimers = timers ?? REAL_AUTH_TIMERS;
+}
+
+/**
  * Wait for ConvexClient auth to be established.
  * Resolves when the server confirms the client is authenticated.
  * Times out after 10s to prevent indefinite hangs for unauthenticated users.
@@ -334,12 +359,12 @@ async function waitForAuthBarrier(
   barrier: ConvexAuthBarrier,
   timeoutMs: number,
 ): Promise<boolean> {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let timeoutId: unknown = null;
   const timeout = new Promise<boolean>((resolve) => {
-    timeoutId = setTimeout(() => resolve(false), timeoutMs);
+    timeoutId = authTimers.setTimeout(() => resolve(false), timeoutMs);
   });
   const ready = await Promise.race([barrier.promise, timeout]);
-  if (timeoutId !== null) clearTimeout(timeoutId);
+  if (timeoutId !== null) authTimers.clearTimeout(timeoutId);
   return (
     ready &&
     barrier.generation === authGeneration &&
@@ -431,7 +456,7 @@ export async function rebindConvexAuthForWatchHandoff(
     const retryDelayMs = retryDelaysMs[attempt];
     if (retryDelayMs === undefined) return false;
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, retryDelayMs);
+      authTimers.setTimeout(resolve, retryDelayMs);
     });
     if (attached) return true;
   }

--- a/tests/convex-auth-handoff.test.mts
+++ b/tests/convex-auth-handoff.test.mts
@@ -10,6 +10,7 @@ import { readFile } from 'node:fs/promises';
 import { afterEach, describe, it } from 'node:test';
 
 import {
+  __setConvexAuthTimersForTests,
   __setConvexClientFactoryForTests,
   __setConvexClientForTests,
   getConvexClient,
@@ -129,6 +130,42 @@ function deferred<T>(): {
   return { promise, resolve: resolvePromise, reject: rejectPromise };
 }
 
+/**
+ * Manual scheduler for convex-client's auth timers (#5841). The bounded auth
+ * wait and the transient-rebind retry delay fire ONLY when a test fires them,
+ * so these paths are driven deterministically instead of by elapsed wall time
+ * — the two timing-shaped cases below used to red the merge-blocking `unit`
+ * job whenever CI scheduling latency starved a real 1 ms retry hop, a real
+ * 5 ms bounded wait, or the 1 s polling deadline that watched them.
+ */
+function installManualAuthTimers(): {
+  pending: () => Array<{ ms: number }>;
+  fireNext: () => void;
+} {
+  type ManualTimer = { fn: () => void; ms: number; cancelled: boolean; fired: boolean };
+  const timers: ManualTimer[] = [];
+  __setConvexAuthTimersForTests({
+    setTimeout: (fn, ms) => {
+      const timer: ManualTimer = { fn, ms, cancelled: false, fired: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeout: (id) => {
+      const timer = id as ManualTimer | null;
+      if (timer) timer.cancelled = true;
+    },
+  });
+  return {
+    pending: () => timers.filter((t) => !t.cancelled && !t.fired).map((t) => ({ ms: t.ms })),
+    fireNext: () => {
+      const timer = timers.find((t) => !t.cancelled && !t.fired);
+      assert.ok(timer, 'expected a live auth timer to fire');
+      timer.fired = true;
+      timer.fn();
+    },
+  };
+}
+
 function installFakeClient(): FakeConvexClient {
   const fake = new FakeConvexClient();
   __setConvexClientForTests(fake);
@@ -142,6 +179,7 @@ afterEach(() => {
   __setConvexClientFactoryForTests(null);
   __setConvexClientForTests(null);
   __setClerkInstanceForTests(null);
+  __setConvexAuthTimersForTests(null);
 });
 
 describe('generation-scoped Convex auth handoff', () => {
@@ -244,6 +282,7 @@ describe('generation-scoped Convex auth handoff', () => {
 
   it('retries a transient terminal token failure for the current identity', async () => {
     const fake = installFakeClient();
+    const timers = installManualAuthTimers();
     const attached: string[] = [];
     let current = true;
     const handoff = rebindConvexAuthForWatchHandoff(
@@ -256,11 +295,15 @@ describe('generation-scoped Convex auth handoff', () => {
       await flushMicrotasks();
 
       fake.authConfigs[1].onChange(false);
-      await waitForCondition(
-        () => fake.authConfigs.length === 3,
-        'current B should install one bounded retry config',
-      );
+      await flushMicrotasks();
 
+      // The terminal failure settles the barrier, so the bounded wait resolves
+      // without its timeout; what remains live is exactly the retry delay.
+      assert.deepEqual(timers.pending(), [{ ms: 1 }], 'one live retry-delay timer');
+      timers.fireNext();
+      await flushMicrotasks();
+
+      assert.equal(fake.authConfigs.length, 3, 'current B installs one bounded retry config');
       fake.authConfigs[2].onChange(true);
       assert.equal(await handoff, true);
       assert.deepEqual(attached, ['B']);
@@ -273,6 +316,7 @@ describe('generation-scoped Convex auth handoff', () => {
 
   it('recovers current-user watches after a bounded wait times out', async () => {
     const fake = installFakeClient();
+    const timers = installManualAuthTimers();
     const attached: string[] = [];
     const handoff = rebindConvexAuthForWatchHandoff(
       () => true,
@@ -281,6 +325,11 @@ describe('generation-scoped Convex auth handoff', () => {
       [],
     );
     await flushMicrotasks();
+
+    // The bounded wait expires only when the TEST fires it — never by
+    // elapsed wall time.
+    assert.deepEqual(timers.pending(), [{ ms: 5 }], 'one live bounded-wait timer');
+    timers.fireNext();
 
     assert.equal(await handoff, false);
     assert.deepEqual(attached, []);


### PR DESCRIPTION
Fixes #5841

## The racing boundaries, named

The two cases were sensitive to three real-timer boundaries at once:
1. the **1 ms rebind retry hop** (`retryDelaysMs: [1]` → real `setTimeout` inside `rebindConvexAuthForWatchHandoff`),
2. the **5 ms bounded auth wait** (`waitForAuthBarrier`'s real timeout timer),
3. the test's own **1 s wall-clock polling deadline** (`waitForCondition` looping on `Date.now()` with real 1 ms hops).

A CI scheduling stall at any of them flips the outcome — e.g. the poll deadline expiring before the retry chain (barrier settle → microtask → 1 ms timer → `startConvexAuthRebind`) gets scheduled. That matches the issue's observed profile: red on one run, green on the rerun, no relevant code delta, passes 25/0 locally.

## Fix (the issue's suggested starting point, verbatim)

- `src/services/convex-client.ts`: the auth-wait timeout and the rebind retry delay now route through an injectable `ConvexAuthTimers` seam (`__setConvexAuthTimersForTests`). Production behaviour unchanged — the default is real timers.
- `tests/convex-auth-handoff.test.mts`: the two cases install a manual scheduler and **fire** the timers explicitly, asserting exactly which timer is live at each step (`[{ms: 1}]` retry delay after the terminal failure; `[{ms: 5}]` bounded wait). The `waitForCondition` poll is replaced by a direct assertion after the fired retry — no path in either case depends on elapsed wall time any more. Seam reset in `afterEach`.

## Verification

- 26/26, stable across 10 consecutive runs.
- Mutation check: dropping `attachWatches()` from the handoff turns 5 cases red — the rewrite kept its detection power. (A second mutation, inverting the retry-exhaustion guard, reds case A immediately and hangs case B in an infinite retry loop — also caught, loudly.)
- `npm run typecheck` and biome clean; the suite's other 24 cases are untouched and keep real timers.