### PR TITLE
fix(git): identity gate fails closed on an unresolvable commit range

### DIFF
--- a/scripts/prepush-identity-gate.sh
+++ b/scripts/prepush-identity-gate.sh
@@ -34,7 +34,16 @@ report_commit() {
 }
 
 check_range() {
-  # $@ = git rev-list selector for the new commits of one pushed ref
+  # $@ = git rev-list selector for the new commits of one pushed ref.
+  # Returns 1 when the selector itself cannot be resolved (e.g. a force-push
+  # whose advertised remote tip was never fetched, so the SHA is not in the
+  # local object database) — the caller MUST fall back to another scan rather
+  # than treat "no output" as "no commits": a swallowed resolution error here
+  # is exactly the vacuous pass this gate exists to prevent.
+  local log_output
+  if ! log_output=$(git log --format='%H%x09%an <%ae>%x09%cn <%ce>' "$@" 2>/dev/null); then
+    return 1
+  fi
   while IFS=$'\t' read -r sha author committer; do
     [ -z "${sha:-}" ] && continue
     local blocked=0
@@ -47,16 +56,29 @@ check_range() {
       report_commit "$sha" "$author" "$committer"
       fail=1
     fi
-  done < <(git log --format='%H%x09%an <%ae>%x09%cn <%ce>' "$@" 2>/dev/null || true)
+  done <<< "$log_output"
+  return 0
 }
 
 while read -r _local_ref local_sha _remote_ref remote_sha; do
   [ -z "${local_sha:-}" ] && continue
   if printf '%s' "$local_sha" | grep -qE "$ZERO_RE"; then continue; fi # deletion
   if [ -n "${remote_sha:-}" ] && ! printf '%s' "$remote_sha" | grep -qE "$ZERO_RE"; then
-    check_range "$remote_sha..$local_sha"
+    if ! check_range "$remote_sha..$local_sha"; then
+      # Advertised remote tip is not in the local object database (unfetched
+      # force-push target). Fail closed: scan everything locally reachable
+      # that origin does not already have; if even that cannot resolve,
+      # block outright rather than pass unverified.
+      if ! check_range "$local_sha" --not --remotes=origin; then
+        echo "IDENTITY GATE: could not resolve the outgoing commit range for $local_sha; refusing to push unverified."
+        fail=1
+      fi
+    fi
   else
-    check_range "$local_sha" --not --remotes=origin
+    if ! check_range "$local_sha" --not --remotes=origin; then
+      echo "IDENTITY GATE: could not resolve the outgoing commit range for $local_sha; refusing to push unverified."
+      fail=1
+    fi
   fi
 done
 

--- a/tests/prepush-identity-gate.test.mts
+++ b/tests/prepush-identity-gate.test.mts
@@ -117,6 +117,20 @@ describe('prepush-identity-gate.sh', () => {
     assert.equal(status, 0);
   });
 
+  it('fails closed on an unfetched remote tip instead of passing vacuously', () => {
+    // Force-push contract: the advertised remote SHA may be absent from the
+    // local object database. git log <absent>..<local> errors — and a
+    // swallowed error must not read as "no new commits" (the reviewer-
+    // reproduced vacuous pass). The gate must fall back to scanning what
+    // origin does not have, which here finds the fixture-authored commit.
+    const repo = makeRepo({ name: 'Fixture', email: 'fixture@example.invalid' });
+    const sha = git(repo, ['rev-parse', 'HEAD']);
+    const absent = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const { status, out } = runGate(repo, [`refs/heads/main ${sha} refs/heads/main ${absent}`]);
+    assert.equal(status, 1, `unresolvable range must not pass the gate; output:\n${out}`);
+    assert.match(out, /fixture@example\.invalid/);
+  });
+
   it('blocks when the shared config is currently poisoned, even with clean commits', () => {
     const repo = makeRepo({ name: 'Real Person', email: 'real@worldmonitor.dev' });
     const sha = git(repo, ['rev-parse', 'HEAD']);


### PR DESCRIPTION
Follow-up to #7432, addressing its post-merge Codex review finding (P1, reviewer-reproduced).

**Hole:** on a force-push whose advertised remote tip was never fetched, `git log <absent-sha>..<local>` errors; the `|| true` swallowed it and produced zero commits — so a fixture-authored commit passed the gate vacuously.

**Fix:** `check_range` now propagates range-resolution failure; the caller falls back to scanning everything origin does not already have, and blocks outright ("refusing to push unverified") if even that cannot resolve. Fail closed, never silent.

**Testing:** new red-first test simulating the unfetched-tip contract (absent 40-hex remote SHA) — the gate must block via the fallback scan; identity-gate suite 9/9 green.

https://claude.ai/code/session_01WrkDCXFv9iHNdtu8PgvbFZ