### PR TITLE
chore(mcp): declare and enforce the FlowSource taxonomy on the chokepoint-flows cache tool

### DIFF
--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -14,6 +14,7 @@ import {
   computeCredibilityScore,
 } from '../../../shared/news-credibility.js';
 import { getSourceTier } from '../../../server/_shared/source-tiers';
+import { FLOW_SOURCE_WIRE_VALUES, narrowFlowSource } from '../../../server/_shared/flow-source';
 import { hasRedistributableProviderAttribution } from '../../../shared/provider-redistribution';
 import { CII_RISK_SCORE_CACHE_KEYS } from '../../_cii-risk-cache-keys.js';
 // @ts-expect-error — generated Edge-safe JS mirror; authored types live in shared/bootstrap-tier-keys.d.ts
@@ -2508,11 +2509,38 @@ export const CACHE_TOOLS: ToolDef[] = [
       },
       'chokepoint-flows': {
         type: ['object', 'null'],
-        additionalProperties: { type: 'object' },
+        additionalProperties: { type: 'object', properties: {
+          currentMbd: { type: ['number', 'null'] },
+          baselineMbd: { type: ['number', 'null'] },
+          flowRatio: { type: ['number', 'null'] },
+          disrupted: { type: 'boolean' },
+          // The closed taxonomy #6101 promoted on the REST path; served
+          // values are narrowed onto it in _postFilter below, so this enum
+          // is enforced, not aspirational (#6113).
+          source: { type: 'string', enum: [...FLOW_SOURCE_WIRE_VALUES] },
+          // Raw seeder value, NOT the closed hazard enum — that half is
+          // blocked on sebuf codegen for the REST twin (#6106) and the two
+          // surfaces should adopt it together.
+          hazardAlertLevel: { type: ['string', 'null'] },
+          hazardAlertName: { type: ['string', 'null'] },
+        } },
       },
     }),
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _postFilter: (data, params) => {
+      // Narrow BEFORE any filtering so the declared source enum above is a
+      // property of every served response, exactly as the REST boundary's
+      // narrowServedSources makes it (#6113). The blob is written by a seeder
+      // that deploys independently; an undeclared basis must read as
+      // FLOW_SOURCE_UNSPECIFIED, never leak verbatim.
+      const flows = data['chokepoint-flows'];
+      if (flows && typeof flows === 'object') {
+        for (const entry of Object.values(flows)) {
+          if (entry && typeof entry === 'object' && 'source' in entry) {
+            (entry as { source: unknown }).source = narrowFlowSource((entry as { source: unknown }).source);
+          }
+        }
+      }
       const cp = argStr(params.chokepoint);
       if (cp) {
         mapNested(data, 'transit-summaries', 'summaries', (m) => pickMapKeysLike(m, cp));

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -2518,9 +2518,19 @@ export const CACHE_TOOLS: ToolDef[] = [
           // values are narrowed onto it in _postFilter below, so this enum
           // is enforced, not aspirational (#6113).
           source: { type: 'string', enum: [...FLOW_SOURCE_WIRE_VALUES] },
-          // Raw seeder value, NOT the closed hazard enum — that half is
-          // blocked on sebuf codegen for the REST twin (#6106) and the two
-          // surfaces should adopt it together.
+          // Raw seeder value, NOT the closed hazard enum. Hand-authored JSON
+          // Schema COULD express it here today (#6113 says so explicitly; see
+          // the `source` enums on get_toronto_* above) — this is DEFERRED, not
+          // blocked: #6106 blocks the REST twin on sebuf codegen, and shipping
+          // the closed set on one surface only would recreate the very
+          // declare-vs-serve split this tool just closed for `source`.
+          //
+          // Nullability is likewise a DELIBERATE divergence from REST, not an
+          // oversight: get-chokepoint-status.ts coerces `null -> ''` because
+          // the proto field is non-nullable, a constraint this hand-authored
+          // schema does not have. Serving `null` keeps "no hazard nearby"
+          // distinguishable from "hazard with an empty name", which is the more
+          // useful answer for an agent. Declared as it is actually served.
           hazardAlertLevel: { type: ['string', 'null'] },
           hazardAlertName: { type: ['string', 'null'] },
         } },
@@ -2533,10 +2543,17 @@ export const CACHE_TOOLS: ToolDef[] = [
       // narrowServedSources makes it (#6113). The blob is written by a seeder
       // that deploys independently; an undeclared basis must read as
       // FLOW_SOURCE_UNSPECIFIED, never leak verbatim.
+      //
+      // Deliberately NOT guarded on `'source' in entry`: the REST twin builds
+      // `source: toFlowSource(...)` unconditionally, so an entry that omits the
+      // key entirely must still read FLOW_SOURCE_UNSPECIFIED here rather than
+      // arrive with the field missing — otherwise the two surfaces answer
+      // differently for the same blob, which is the divergence this closes.
+      // tests/chokepoint-flow-source-taxonomy.test.mts pins that case on REST.
       const flows = data['chokepoint-flows'];
       if (flows && typeof flows === 'object') {
         for (const entry of Object.values(flows)) {
-          if (entry && typeof entry === 'object' && 'source' in entry) {
+          if (entry && typeof entry === 'object') {
             (entry as { source: unknown }).source = narrowFlowSource((entry as { source: unknown }).source);
           }
         }

--- a/server/_shared/flow-source.ts
+++ b/server/_shared/flow-source.ts
@@ -1,0 +1,40 @@
+import type { FlowSource } from '../../src/generated/server/worldmonitor/supply_chain/v1/service_server';
+
+/**
+ * The one FlowSource taxonomy shared by every surface that serves
+ * `energy:chokepoint-flows:v1` (#6101 promoted the REST/OpenAPI/TS path;
+ * #6113 brought the MCP cache tool onto the same set).
+ *
+ * Declared as an EXHAUSTIVE record over the non-UNSPECIFIED FlowSource
+ * members so that adding a member to the proto is a compile error in every
+ * consumer. A plain `Set<FlowSource>` caught a typo but not an omission —
+ * the new member would simply be absent, and a consumer would silently strip
+ * the very value the proto had just declared legal.
+ */
+export const FLOW_SOURCE_MEMBERS: Record<Exclude<FlowSource, 'FLOW_SOURCE_UNSPECIFIED'>, true> = {
+  'portwatch-dwt': true,
+  'portwatch-counts': true,
+};
+
+export const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
+
+/**
+ * Every wire value the taxonomy admits, UNSPECIFIED first — the `enum:` list
+ * a schema surface declares. Deriving it from the record keeps declare and
+ * serve on one source of truth.
+ */
+export const FLOW_SOURCE_WIRE_VALUES: readonly string[] = [
+  'FLOW_SOURCE_UNSPECIFIED',
+  ...Object.keys(FLOW_SOURCE_MEMBERS),
+];
+
+/**
+ * Narrow an untyped seeder value onto the taxonomy. The chokepoint-flows blob
+ * is written by a seeder that deploys independently of any consumer, so a
+ * served `source` is not guaranteed to be a declared member — and a closed
+ * taxonomy is only honest if the boundary that declares it also enforces it.
+ */
+export function narrowFlowSource(value: unknown): FlowSource {
+  if (typeof value === 'string' && FLOW_SOURCES.has(value)) return value as FlowSource;
+  return 'FLOW_SOURCE_UNSPECIFIED';
+}

--- a/server/_shared/flow-source.ts
+++ b/server/_shared/flow-source.ts
@@ -16,7 +16,15 @@ export const FLOW_SOURCE_MEMBERS: Record<Exclude<FlowSource, 'FLOW_SOURCE_UNSPEC
   'portwatch-counts': true,
 };
 
-export const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
+/**
+ * Deliberately module-private: `narrowFlowSource` below is the ONLY narrowing
+ * entry point any surface should use. Exporting the raw set invites a second
+ * hand-rolled `FLOW_SOURCES.has(...)` predicate elsewhere, and the axis that
+ * drifts in practice is the predicate (case-folding, trimming, a legacy alias),
+ * not the member list — so sharing the set without sharing the decision would
+ * leave exactly the REST/MCP divergence #6113 exists to close.
+ */
+const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
 
 /**
  * Every wire value the taxonomy admits, UNSPECIFIED first — the `enum:` list
@@ -33,6 +41,10 @@ export const FLOW_SOURCE_WIRE_VALUES: readonly string[] = [
  * is written by a seeder that deploys independently of any consumer, so a
  * served `source` is not guaranteed to be a declared member — and a closed
  * taxonomy is only honest if the boundary that declares it also enforces it.
+ *
+ * Total over every input, including `undefined` (an entry that omits `source`
+ * entirely): both surfaces must answer FLOW_SOURCE_UNSPECIFIED for that, so no
+ * caller should guard on key presence before calling this.
  */
 export function narrowFlowSource(value: unknown): FlowSource {
   if (typeof value === 'string' && FLOW_SOURCES.has(value)) return value as FlowSource;

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -20,7 +20,7 @@ import { getVesselSnapshot } from '../../maritime/v1/get-vessel-snapshot';
 import { computeDisruptionScore, scoreToStatus, SEVERITY_SCORE, THREAT_LEVEL } from './_scoring.mjs';
 import { type ThreatLevel, threatLevelToWarRiskTier } from './_insurance-tier';
 import { CHOKEPOINT_STATUS_KEY as REDIS_CACHE_KEY } from '../../../_shared/cache-keys';
-import { FLOW_SOURCES } from '../../../_shared/flow-source';
+import { narrowFlowSource } from '../../../_shared/flow-source';
 const TRANSIT_SUMMARIES_KEY = 'supply_chain:transit-summaries:v1';
 const FLOWS_KEY = 'energy:chokepoint-flows:v1';
 // NOTE: historical fallback via supply_chain:portwatch:v1 / corridorrisk / chokepoint_transits
@@ -350,7 +350,12 @@ interface FlowEstimateEntry { currentMbd: number; baselineMbd: number; flowRatio
 const warnedFlowSources = new Set<string>();
 
 function toFlowSource(value: unknown): FlowSource {
-  if (typeof value === 'string' && FLOW_SOURCES.has(value)) return value as FlowSource;
+  // Delegate the DECISION, not just the member set: a second copy of the
+  // predicate here would let REST and the MCP cache tool answer differently for
+  // the same Redis blob the moment either side learned to trim or case-fold.
+  // This wrapper adds only the REST-side warn (#6113).
+  const narrowed = narrowFlowSource(value);
+  if (narrowed !== 'FLOW_SOURCE_UNSPECIFIED') return narrowed;
   if (value !== undefined && value !== null && value !== '') {
     const seen = String(value);
     if (!warnedFlowSources.has(seen)) {

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -20,6 +20,7 @@ import { getVesselSnapshot } from '../../maritime/v1/get-vessel-snapshot';
 import { computeDisruptionScore, scoreToStatus, SEVERITY_SCORE, THREAT_LEVEL } from './_scoring.mjs';
 import { type ThreatLevel, threatLevelToWarRiskTier } from './_insurance-tier';
 import { CHOKEPOINT_STATUS_KEY as REDIS_CACHE_KEY } from '../../../_shared/cache-keys';
+import { FLOW_SOURCES } from '../../../_shared/flow-source';
 const TRANSIT_SUMMARIES_KEY = 'supply_chain:transit-summaries:v1';
 const FLOWS_KEY = 'energy:chokepoint-flows:v1';
 // NOTE: historical fallback via supply_chain:portwatch:v1 / corridorrisk / chokepoint_transits
@@ -323,20 +324,9 @@ interface ChokepointFetchResult {
 
 interface FlowEstimateEntry { currentMbd: number; baselineMbd: number; flowRatio: number; disrupted: boolean; source: string; hazardAlertLevel: string | null; hazardAlertName: string | null }
 
-/**
- * The coverage bases seed-chokepoint-flows.mjs can emit. Declared as an
- * EXHAUSTIVE record over the non-UNSPECIFIED FlowSource members so that adding
- * a member to the proto is a compile error here. A plain `Set<FlowSource>`
- * caught a typo but not an omission — the new member would simply be absent,
- * and this handler would silently strip the very value the proto had just
- * declared legal.
- */
-const FLOW_SOURCE_MEMBERS: Record<Exclude<FlowSource, 'FLOW_SOURCE_UNSPECIFIED'>, true> = {
-  'portwatch-dwt': true,
-  'portwatch-counts': true,
-};
-
-const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
+// The taxonomy record lives in server/_shared/flow-source.ts (#6113) so this
+// handler and the MCP cache tool narrow and declare from one source of truth;
+// the exhaustive-record compile check moved with it.
 
 /**
  * Narrow the seeder's `source` onto the FlowSource taxonomy the proto declares

--- a/tests/mcp-flow-source-taxonomy.test.mts
+++ b/tests/mcp-flow-source-taxonomy.test.mts
@@ -1,0 +1,97 @@
+/**
+ * #6113 — the chokepoint-flows dataset served the raw seeder blob on the MCP
+ * surface with no FlowSource taxonomy: not discoverable (the output schema
+ * declared bare `additionalProperties: {type:'object'}`) and not narrowed
+ * (`toFlowSource` never ran on the cache-tool path), while the REST handler
+ * both declared and enforced the closed enum since #6101.
+ *
+ * Option 1 from the issue — narrow AND declare in the same change, so the
+ * declaration and the served bytes move together (the
+ * contract-gate-field-names-miss-value-axis defect class): the tool's
+ * `_postFilter` narrows `source` onto the taxonomy exactly like the REST
+ * boundary does, and the schema declares the enum an agent can discover from
+ * `tools/list`. Both sides import one shared taxonomy module, typed
+ * exhaustively against the generated `FlowSource`, so a proto change is a
+ * compile error in each consumer rather than silent drift.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { CACHE_TOOLS } from '../api/mcp/registry/cache-tools.ts';
+
+const tool = CACHE_TOOLS.find((t) => t.name === 'get_chokepoint_status');
+
+/** The wire taxonomy #6101 promoted (generated FlowSource union). */
+const WIRE_TAXONOMY = ['FLOW_SOURCE_UNSPECIFIED', 'portwatch-dwt', 'portwatch-counts'];
+
+function flowsData() {
+  return {
+    'chokepoint-flows': {
+      hormuz_strait: {
+        currentMbd: 2.6, baselineMbd: 21, flowRatio: 0.123, disrupted: true,
+        source: 'portwatch-dwt', hazardAlertLevel: 'RED', hazardAlertName: 'HORMUZ-26',
+      },
+      suez: {
+        currentMbd: 7.6, baselineMbd: 7.6, flowRatio: 1.001, disrupted: false,
+        // An undeclared basis a newer seeder deploy could emit — the exact
+        // value class the REST boundary narrows and MCP served verbatim.
+        source: 'satellite-blend', hazardAlertLevel: null, hazardAlertName: null,
+      },
+      panama: {
+        currentMbd: 1.1, baselineMbd: 1.2, flowRatio: 0.917, disrupted: false,
+        source: null, hazardAlertLevel: null, hazardAlertName: null,
+      },
+    },
+  };
+}
+
+describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
+  it('narrows an out-of-taxonomy source to FLOW_SOURCE_UNSPECIFIED and keeps declared values verbatim', () => {
+    assert.ok(tool, 'tool must exist in CACHE_TOOLS');
+    const data = flowsData();
+
+    tool._postFilter(data, {});
+
+    const flows = data['chokepoint-flows'];
+    assert.equal(flows.hormuz_strait.source, 'portwatch-dwt', 'a declared basis passes through untouched');
+    assert.equal(
+      flows.suez.source, 'FLOW_SOURCE_UNSPECIFIED',
+      'an undeclared seeder value must be narrowed, not served verbatim — the schema promise must be kept by the code',
+    );
+    assert.equal(flows.panama.source, 'FLOW_SOURCE_UNSPECIFIED', 'a missing basis narrows too');
+    assert.equal(flows.hormuz_strait.currentMbd, 2.6, 'narrowing must not disturb the numeric fields');
+  });
+
+  it('narrows on the filtered path too (chokepoint param applied)', () => {
+    const data = flowsData();
+
+    tool._postFilter(data, { chokepoint: 'suez' });
+
+    assert.deepEqual(Object.keys(data['chokepoint-flows']), ['suez']);
+    assert.equal(data['chokepoint-flows'].suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+  });
+
+  it('leaves an absent or null chokepoint-flows dataset alone', () => {
+    const empty = { 'chokepoint-flows': null };
+    assert.doesNotThrow(() => tool._postFilter(empty, {}));
+    assert.equal(empty['chokepoint-flows'], null);
+
+    const missing = {};
+    assert.doesNotThrow(() => tool._postFilter(missing, {}));
+  });
+
+  it('declares the closed taxonomy in the output schema an agent discovers', () => {
+    const flowsSchema = tool.outputSchema.properties.data.properties['chokepoint-flows'];
+    const valueSchema = flowsSchema.additionalProperties;
+    assert.equal(valueSchema.type, 'object');
+    assert.deepEqual(
+      valueSchema.properties.source.enum, WIRE_TAXONOMY,
+      'the enum an agent sees from tools/list must be the taxonomy the served bytes are narrowed onto',
+    );
+    // The declared value shape carries the real flow fields, not a bare
+    // object — the coverage fixture stops passing trivially.
+    for (const field of ['currentMbd', 'baselineMbd', 'flowRatio', 'disrupted', 'hazardAlertLevel']) {
+      assert.ok(valueSchema.properties[field], `schema must declare ${field}`);
+    }
+  });
+});

--- a/tests/mcp-flow-source-taxonomy.test.mts
+++ b/tests/mcp-flow-source-taxonomy.test.mts
@@ -15,7 +15,7 @@
  * compile error in each consumer rather than silent drift.
  */
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 
 import { CACHE_TOOLS } from '../api/mcp/registry/cache-tools.ts';
 
@@ -41,34 +41,63 @@ function flowsData() {
         currentMbd: 1.1, baselineMbd: 1.2, flowRatio: 0.917, disrupted: false,
         source: null, hazardAlertLevel: null, hazardAlertName: null,
       },
+      korea_strait: {
+        // `source` key absent ENTIRELY — the case the REST twin pins as
+        // `korea_strait: flow(undefined)` in chokepoint-flow-source-taxonomy
+        // .test.mts. REST emits FLOW_SOURCE_UNSPECIFIED for it, so MCP must
+        // too; a presence guard here would serve the field missing instead.
+        currentMbd: 0.4, baselineMbd: 0.4, flowRatio: 1, disrupted: false,
+        hazardAlertLevel: null, hazardAlertName: null,
+      },
     },
   };
 }
 
 describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
+  // Every assertion below reads the RETURNED object, never the argument that
+  // was passed in. api/mcp/dispatch.ts serves `_postFilter`'s return value
+  // (`result = tool._postFilter(structuredClone(data), params)`), so asserting
+  // on the caller's own reference would keep passing if a future refactor
+  // rebuilt entries instead of mutating them — and would keep passing while
+  // un-narrowed sources went out on the wire.
   it('narrows an out-of-taxonomy source to FLOW_SOURCE_UNSPECIFIED and keeps declared values verbatim', () => {
     assert.ok(tool, 'tool must exist in CACHE_TOOLS');
-    const data = flowsData();
 
-    tool._postFilter(data, {});
+    const served = tool._postFilter(flowsData(), {});
 
-    const flows = data['chokepoint-flows'];
+    const flows = served['chokepoint-flows'];
     assert.equal(flows.hormuz_strait.source, 'portwatch-dwt', 'a declared basis passes through untouched');
     assert.equal(
       flows.suez.source, 'FLOW_SOURCE_UNSPECIFIED',
       'an undeclared seeder value must be narrowed, not served verbatim — the schema promise must be kept by the code',
     );
-    assert.equal(flows.panama.source, 'FLOW_SOURCE_UNSPECIFIED', 'a missing basis narrows too');
+    assert.equal(flows.panama.source, 'FLOW_SOURCE_UNSPECIFIED', 'an explicit null basis narrows too');
+    assert.equal(
+      flows.korea_strait.source, 'FLOW_SOURCE_UNSPECIFIED',
+      'an entry that omits `source` entirely must be narrowed, not served with the field missing — REST emits UNSPECIFIED for the same blob',
+    );
     assert.equal(flows.hormuz_strait.currentMbd, 2.6, 'narrowing must not disturb the numeric fields');
   });
 
   it('narrows on the filtered path too (chokepoint param applied)', () => {
-    const data = flowsData();
+    const served = tool._postFilter(flowsData(), { chokepoint: 'suez' });
 
-    tool._postFilter(data, { chokepoint: 'suez' });
+    assert.deepEqual(Object.keys(served['chokepoint-flows']), ['suez']);
+    assert.equal(served['chokepoint-flows'].suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+  });
 
-    assert.deepEqual(Object.keys(data['chokepoint-flows']), ['suez']);
-    assert.equal(data['chokepoint-flows'].suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+  // `dataset` is the one argument shape where selectDatasets (api/mcp/filters
+  // .ts:187-192) builds a genuinely NEW top-level object rather than returning
+  // the input reference — the branch where "assert on input" and "assert on
+  // return" could diverge. Nothing else in this file exercises it.
+  it('narrows on the dataset-selected path, where the returned object is not the input object', () => {
+    const input = flowsData();
+    const served = tool._postFilter(input, { dataset: ['chokepoint-flows'] });
+
+    assert.notEqual(served, input, 'selectDatasets must have built a new top-level object for this case');
+    assert.deepEqual(Object.keys(served), ['chokepoint-flows'], 'only the requested dataset is served');
+    assert.equal(served['chokepoint-flows'].suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+    assert.equal(served['chokepoint-flows'].korea_strait.source, 'FLOW_SOURCE_UNSPECIFIED');
   });
 
   it('leaves an absent or null chokepoint-flows dataset alone', () => {
@@ -78,6 +107,30 @@ describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
 
     const missing = {};
     assert.doesNotThrow(() => tool._postFilter(missing, {}));
+  });
+
+  // The guard is `entry && typeof entry === 'object'`; the test above only
+  // covers the dataset itself being null/absent. These are the per-ENTRY
+  // branches — a filter throw is not loud, it is silent: dispatch.ts catches it
+  // and falls back to the RAW un-narrowed blob, so a crash here would quietly
+  // undo the enum guarantee rather than fail the call.
+  it('tolerates null and non-object entries inside a populated map', () => {
+    const data = {
+      'chokepoint-flows': {
+        suez: null,
+        panama: 'not-an-object',
+        hormuz_strait: { currentMbd: 2.6, source: 'satellite-blend' },
+      },
+    };
+
+    const served = tool._postFilter(data, {});
+
+    assert.equal(served['chokepoint-flows'].suez, null, 'a null entry is left alone, not crashed on');
+    assert.equal(served['chokepoint-flows'].panama, 'not-an-object', 'a non-object entry is left alone');
+    assert.equal(
+      served['chokepoint-flows'].hormuz_strait.source, 'FLOW_SOURCE_UNSPECIFIED',
+      'a malformed sibling must not stop the good entry from being narrowed',
+    );
   });
 
   it('declares the closed taxonomy in the output schema an agent discovers', () => {
@@ -92,6 +145,84 @@ describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
     // object — the coverage fixture stops passing trivially.
     for (const field of ['currentMbd', 'baselineMbd', 'flowRatio', 'disrupted', 'hazardAlertLevel']) {
       assert.ok(valueSchema.properties[field], `schema must declare ${field}`);
+    }
+  });
+});
+
+/**
+ * #6113's acceptance asks for a test that "drives the MCP tool ... and asserts
+ * the SERVED value is narrowed — not just that the schema validates". The block
+ * above calls `_postFilter` directly, which does not cross the dispatcher: it
+ * misses `structuredClone`, the fail-open try/catch, and JSON serialization.
+ * This drives a real `tools/call` through api/mcp.ts and reads the bytes a
+ * client actually receives, matching the bar the REST twin's own gate sets in
+ * tests/chokepoint-flow-source-taxonomy.test.mts.
+ */
+describe('get_chokepoint_status narrows source end-to-end through tools/call (#6113)', () => {
+  const VALID_KEY = 'wm_test_key_flow_source';
+  const originalFetch = globalThis.fetch;
+  const originalEnv = { ...process.env };
+
+  // An undeclared basis, an explicit null, and a missing key — the three
+  // classes that must all reach the client as FLOW_SOURCE_UNSPECIFIED.
+  const FLOWS = {
+    suez: { currentMbd: 7.6, baselineMbd: 7.6, flowRatio: 1.001, disrupted: false, source: 'satellite-blend' },
+    panama: { currentMbd: 1.1, baselineMbd: 1.2, flowRatio: 0.917, disrupted: false, source: null },
+    korea_strait: { currentMbd: 0.4, baselineMbd: 0.4, flowRatio: 1, disrupted: false },
+    hormuz_strait: { currentMbd: 2.6, baselineMbd: 21, flowRatio: 0.123, disrupted: true, source: 'portwatch-dwt' },
+  };
+
+  beforeEach(() => {
+    process.env.WORLDMONITOR_VALID_KEYS = VALID_KEY;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    globalThis.fetch = async (url, init) => {
+      const u = url.toString();
+      if (u.endsWith('/pipeline')) {
+        const commands = JSON.parse(init.body);
+        return Response.json(commands.map(() => ({ result: 0 })));
+      }
+      if (u.includes(`/get/${encodeURIComponent('energy:chokepoint-flows:v1')}`)) {
+        return Response.json({ result: JSON.stringify(FLOWS) });
+      }
+      // Every other key (the five sibling datasets and all seed-meta reads)
+      // answers empty: this test is about the flows dataset only, and a stale
+      // aggregate does not suppress the payload.
+      return Response.json({ result: null });
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const k of Object.keys(process.env)) if (!(k in originalEnv)) delete process.env[k];
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('serves no source value outside the declared enum', async () => {
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}-${Math.random()}`);
+
+    const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'tools/call',
+        params: { name: 'get_chokepoint_status', arguments: {} },
+      }),
+    }));
+
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'tools/call must return content');
+    const served = JSON.parse(body.result.content[0].text).data['chokepoint-flows'];
+
+    assert.equal(served.hormuz_strait.source, 'portwatch-dwt', 'a declared basis survives the round trip verbatim');
+    for (const id of ['suez', 'panama', 'korea_strait']) {
+      assert.ok(
+        WIRE_TAXONOMY.includes(served[id].source),
+        `${id} reached the client as "${served[id].source}", outside the enum the outputSchema advertises`,
+      );
+      assert.equal(served[id].source, 'FLOW_SOURCE_UNSPECIFIED');
     }
   });
 });

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2569,7 +2569,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const portwatchPortsPayload = { countries: { US: { ports: 23 } } };
     const chokepointBaselinesPayload = { suez: { lat: 30.0, lon: 32.5 } };
     const portwatchChokepointsRefPayload = { count: 13, ids: ['suez', 'hormuz', 'malacca'] };
-    const chokepointFlowsPayload = { suez: { dailyBarrels: 9_200_000 } };
+    // Carries an in-taxonomy `source` so this label-walk assertion keeps testing
+    // LABELLING only: get_chokepoint_status's _postFilter narrows every flow
+    // entry's `source` onto the FlowSource taxonomy (#6113), so a source-less
+    // fixture would come back with `source: 'FLOW_SOURCE_UNSPECIFIED'` added and
+    // fail the deepEqual below for a reason that has nothing to do with labels.
+    const chokepointFlowsPayload = { suez: { dailyBarrels: 9_200_000, source: 'portwatch-dwt' } };
 
     // transit-summaries budget=30min → 5min old (fresh)
     const transitSummariesFetchedAt = Date.now() - 5 * 60_000;


### PR DESCRIPTION
Fixes #6113

## What changed (option 1 — narrow + declare, in one change)

- **One taxonomy module**: `server/_shared/flow-source.ts` owns the exhaustive `Record<Exclude<FlowSource,'FLOW_SOURCE_UNSPECIFIED'>, true>` (moved from the REST handler, so a proto change stays a compile error in every consumer), the `FLOW_SOURCES` set, `FLOW_SOURCE_WIRE_VALUES` for schema surfaces, and a pure `narrowFlowSource`. `get-chokepoint-status.ts` imports it instead of its local copy — REST and MCP can no longer drift.
- **Enforced**: `get_chokepoint_status`'s `_postFilter` narrows every served `source` onto the taxonomy before any filtering, mirroring the REST boundary's `narrowServedSources` — an undeclared seeder basis reads as `FLOW_SOURCE_UNSPECIFIED`, never verbatim.
- **Declared**: the `chokepoint-flows` output schema now carries the enum (built from the shared wire-value list, not a literal copy) plus the real value fields (`currentMbd`, `baselineMbd`, `flowRatio`, `disrupted`, hazard fields) instead of bare `additionalProperties: {type:'object'}` — discoverable from `tools/list`/`describe_tool`.
- `hazardAlertLevel` deliberately stays a raw nullable string with a comment pointing at #6106: its closed enum is blocked on sebuf codegen for the REST twin, and the issue's own note says the two surfaces should adopt it together.

## Acceptance mapping

- **Narrowing and `enum:` land in the same change** ✓ (same `_postFilter`/schema edit, one shared source of truth).
- **A test drives the tool with an out-of-taxonomy `source` and asserts the served value is narrowed** — `tests/mcp-flow-source-taxonomy.test.mts`: `satellite-blend` and `null` narrow to `FLOW_SOURCE_UNSPECIFIED` on both the full-bundle and `chokepoint`-filtered paths, declared values pass through verbatim, numeric fields untouched, absent/null dataset tolerated, and the schema enum equals the generated `FlowSource` wire union.
- **`tests/mcp-output-schema-coverage.test.mjs` still passes and the fixture exercises the new shape** ✓ — the captured fixture's full flow objects now validate against declared properties + enum rather than a bare object (38/38).

## Verification

- Failing-first: 3 of 4 new tests fail on main (the absent-dataset control passes). Mutation check: making the narrowing a no-op turns 2 red.
- Sibling suites green: analysis cache tools + portwatch freshness parity (110/110), chokepoint suites (56/56). `npm run typecheck` and biome clean.