### PR TITLE
test(panel-layout): drive the tab-cap guarantees on a live PanelLayoutManager

### DIFF
--- a/tests/dom/panel-layout-tab-cap.test.mts
+++ b/tests/dom/panel-layout-tab-cap.test.mts
@@ -30,7 +30,7 @@ const entitlementListeners: Array<(state: EntitlementState | null) => void> = []
 const subscriptionListeners: Array<() => void> = [];
 
 const trackGateHit = vi.fn();
-const saveTabsState = vi.fn(() => ({ persisted: true }));
+const saveTabsState = vi.fn((..._args: unknown[]) => ({ persisted: true }));
 const showToast = vi.fn();
 
 const capEvaluations = vi.hoisted(() => ({ count: 0 }));

--- a/tests/dom/panel-layout-tab-cap.test.mts
+++ b/tests/dom/panel-layout-tab-cap.test.mts
@@ -1,0 +1,301 @@
+/**
+ * #5892 — the tab-cap guarantees, driven on a live PanelLayoutManager.
+ *
+ * `tests/tab-cap.test.mts`'s `tab-cap wiring` block guarded three real
+ * guarantees with `assert.match` over panel-layout.ts SOURCE TEXT — the
+ * grep-shape the repo has been burned by before (a grep proves a name exists
+ * in a file; it never drives the decision — see docs/solutions/logic-errors/
+ * playback-control-gated-on-a-clerk-role-field-with-no-writer.md). Nothing
+ * mounted the class because its constructor runs checkout-return handling and
+ * the Pro-activation controller on the way up; this harness stubs exactly
+ * those boot side effects and asserts the guarantees behaviourally:
+ *
+ *   - a blocked addTab() leaves tabsState.tabs byte-identical, fires
+ *     trackGateHit('dashboard-tab') exactly once, and persists nothing
+ *   - an allowed addTab() appends exactly one tab and never reorders or
+ *     drops an existing one
+ *   - an auth emission and an entitlement emission each re-run the cap
+ *     (the auth-only-subscription bug the guard was written for)
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AuthSession } from '@/services/auth-state';
+import type { EntitlementState } from '@/services/entitlements';
+
+let authState: AuthSession;
+let entitlement: EntitlementState | null = null;
+
+const authListeners: Array<(state: AuthSession) => void> = [];
+const entitlementListeners: Array<(state: EntitlementState | null) => void> = [];
+const subscriptionListeners: Array<() => void> = [];
+
+const trackGateHit = vi.fn();
+const saveTabsState = vi.fn(() => ({ persisted: true }));
+const showToast = vi.fn();
+
+const capEvaluations = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock('@/services/auth-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/auth-state')>()),
+  getAuthState: () => authState,
+  subscribeAuthState: (listener: (state: AuthSession) => void) => {
+    authListeners.push(listener);
+    return () => {};
+  },
+}));
+
+vi.mock('@/services/entitlements', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/entitlements')>()),
+  getEntitlementState: () => entitlement,
+  onEntitlementChange: (listener: (state: EntitlementState | null) => void) => {
+    entitlementListeners.push(listener);
+    return () => {};
+  },
+  initEntitlementSubscription: async () => {},
+  destroyEntitlementSubscription: () => {},
+}));
+
+vi.mock('@/services/billing', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/billing')>()),
+  getSubscription: () => null,
+  onSubscriptionChange: (listener: () => void) => {
+    subscriptionListeners.push(listener);
+    return () => {};
+  },
+  initSubscriptionWatch: async () => {},
+  destroySubscriptionWatch: () => {},
+}));
+
+// The catalog probe would go to the network; the gate itself stays active so
+// cap verdicts are real.
+vi.mock('@/services/gates/export-resolver', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/gates/export-resolver')>()),
+  isExportGateActive: () => true,
+  primeExportGateActivation: async () => false,
+}));
+
+// Count every cap resolution while keeping the REAL resolver — the counter is
+// what proves an emission re-ran the cap; the verdict logic stays untouched.
+vi.mock('@/services/gates/export', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/gates/export')>();
+  return {
+    ...actual,
+    evaluateTabCap: (...args: Parameters<typeof actual.evaluateTabCap>) => {
+      capEvaluations.count += 1;
+      return actual.evaluateTabCap(...args);
+    },
+  };
+});
+
+vi.mock('@/services/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/analytics')>()),
+  trackGateHit: (...args: unknown[]) => trackGateHit(...args),
+  trackCheckoutSuccess: () => {},
+  trackCheckoutFailed: () => {},
+  replayPendingCheckoutSuccess: () => {},
+  replayPendingProFunnelEvents: () => {},
+  replayPendingConversionEvents: () => {},
+}));
+
+vi.mock('@/services/tab-store', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/tab-store')>()),
+  loadTabsState: () => null,
+  saveTabsState: (...args: unknown[]) => saveTabsState(...args),
+}));
+
+vi.mock('@/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils')>()),
+  showToast: (...args: unknown[]) => showToast(...args),
+}));
+
+// Boot side effects the issue names, stubbed at the module boundary.
+vi.mock('@/services/checkout-return', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/checkout-return')>()),
+  handleCheckoutReturn: () => ({ kind: 'none' }),
+  resolveCheckoutReturnRouting: () => ({ kind: 'none' }),
+}));
+
+vi.mock('@/services/checkout', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/checkout')>()),
+  consumePostCheckoutFlag: () => false,
+  loadCheckoutAttempt: () => null,
+  clearCheckoutAttempt: () => {},
+  registerCheckoutSuccessCallback: () => {},
+  showCheckoutSuccess: () => {},
+}));
+
+vi.mock('@/app/pro-activation-controller', () => ({
+  ProActivationController: class {
+    init(): void {}
+    destroy(): void {}
+  },
+  markProActivationPending: () => {},
+}));
+
+vi.mock('@/app/passkey-offer-boot', () => ({
+  PasskeyOfferBoot: class {
+    init(): void {}
+    destroy(): void {}
+  },
+}));
+
+vi.mock('@/components/payment-failure-banner', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/components/payment-failure-banner')>()),
+  initPaymentFailureBanner: () => () => {},
+}));
+
+const { PanelLayoutManager } = await import('@/app/panel-layout');
+
+const SIGNED_IN = { isPending: false, user: { id: 'user_1' } } as unknown as AuthSession;
+const SIGNED_OUT = { isPending: false, user: null } as unknown as AuthSession;
+
+function snapshot(maxDashboards: number): EntitlementState {
+  return {
+    planKey: 'pro',
+    validUntil: Date.now() + 86_400_000,
+    features: {
+      tier: 1,
+      apiAccess: false,
+      apiRateLimit: 0,
+      maxDashboards,
+      prioritySupport: false,
+      exportFormats: [],
+      dataExport: false,
+    },
+  } as unknown as EntitlementState;
+}
+
+type TabsStateShape = {
+  activeTabId: string;
+  tabs: Array<{ id: string; name: string; panelSettings: object; panelOrder: string[]; bottomSet: string[] }>;
+};
+
+type ManagerInternals = {
+  tabsState: TabsStateShape | null;
+  addTab(): void;
+  renderLayout(): Promise<void>;
+};
+
+function makeManager(): { manager: InstanceType<typeof PanelLayoutManager>; internals: ManagerInternals } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const ctx = {
+    container,
+    panels: {},
+    panelSettings: {},
+    isMobile: false,
+    isDesktopApp: false,
+    isDestroyed: false,
+    authModal: null,
+    unifiedSettings: null,
+    PANEL_ORDER_KEY: 'test-panel-order',
+  } as never;
+  const callbacks = {
+    openCountryStory: () => {},
+    openCountryBrief: () => {},
+    openSearch: () => {},
+    loadAllData: async () => {},
+    primeVisiblePanelData: () => {},
+    updateMonitorResults: () => {},
+  } as never;
+  const manager = new PanelLayoutManager(ctx, callbacks);
+  return { manager, internals: manager as unknown as ManagerInternals };
+}
+
+function seedTabs(internals: ManagerInternals, ids: string[]): void {
+  internals.tabsState = {
+    activeTabId: ids[0]!,
+    tabs: ids.map((id) => ({ id, name: `Tab ${id}`, panelSettings: {}, panelOrder: [], bottomSet: [] })),
+  };
+}
+
+beforeEach(() => {
+  authState = SIGNED_OUT;
+  entitlement = null;
+  authListeners.length = 0;
+  entitlementListeners.length = 0;
+  subscriptionListeners.length = 0;
+  trackGateHit.mockClear();
+  saveTabsState.mockClear();
+  showToast.mockClear();
+  capEvaluations.count = 0;
+  document.body.innerHTML = '';
+});
+
+describe('PanelLayoutManager tab cap, driven live (#5892)', () => {
+  it('a blocked addTab() leaves tabsState byte-identical and fires trackGateHit exactly once', () => {
+    const { internals } = makeManager();
+    authState = SIGNED_IN;
+    entitlement = snapshot(2);
+    seedTabs(internals, ['t1', 't2']);
+    const before = JSON.stringify(internals.tabsState);
+
+    internals.addTab();
+
+    expect(JSON.stringify(internals.tabsState)).toBe(before);
+    expect(trackGateHit).toHaveBeenCalledTimes(1);
+    expect(trackGateHit).toHaveBeenCalledWith('dashboard-tab');
+    expect(saveTabsState).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('an allowed addTab() appends exactly one tab and never reorders or drops an existing one', () => {
+    const { internals } = makeManager();
+    authState = SIGNED_IN;
+    entitlement = snapshot(7);
+    seedTabs(internals, ['t1', 't2']);
+
+    internals.addTab();
+
+    const tabs = internals.tabsState!.tabs;
+    expect(tabs.length).toBe(3);
+    expect(tabs.slice(0, 2).map((t) => t.id)).toEqual(['t1', 't2']);
+    expect(internals.tabsState!.activeTabId).toBe(tabs[2]!.id);
+    expect(saveTabsState).toHaveBeenCalled();
+    expect(trackGateHit).not.toHaveBeenCalled();
+  });
+
+  it('an auth emission re-runs the cap', async () => {
+    const { manager, internals } = makeManager();
+    seedTabs(internals, ['t1']);
+    // renderLayout builds the whole dashboard; the subscription wiring under
+    // test lives in init() AFTER it, so replace only the render.
+    internals.renderLayout = async () => {};
+    await manager.init();
+    expect(authListeners.length).toBeGreaterThan(0);
+
+    const before = capEvaluations.count;
+    authState = SIGNED_IN;
+    entitlement = snapshot(7);
+    for (const listener of authListeners) listener(SIGNED_IN);
+
+    expect(capEvaluations.count).toBeGreaterThan(before);
+    expect(trackGateHit).not.toHaveBeenCalled();
+  });
+
+  it('an entitlement emission re-runs the cap even with no auth emission', () => {
+    const { internals } = makeManager();
+    seedTabs(internals, ['t1']);
+    expect(entitlementListeners.length).toBeGreaterThan(0);
+
+    authState = SIGNED_IN;
+    entitlement = snapshot(7);
+    const before = capEvaluations.count;
+    for (const listener of entitlementListeners) listener(snapshot(7));
+
+    expect(capEvaluations.count).toBeGreaterThan(before);
+  });
+
+  it('a subscription-row emission re-runs the cap too (#4771 billing transitions)', () => {
+    const { internals } = makeManager();
+    seedTabs(internals, ['t1']);
+    expect(subscriptionListeners.length).toBeGreaterThan(0);
+
+    authState = SIGNED_IN;
+    entitlement = snapshot(7);
+    const before = capEvaluations.count;
+    for (const listener of subscriptionListeners) listener();
+
+    expect(capEvaluations.count).toBeGreaterThan(before);
+  });
+});

--- a/tests/tab-cap.test.mts
+++ b/tests/tab-cap.test.mts
@@ -236,72 +236,13 @@ describe('FREE_TAB_CAP — catalog drift guard', () => {
  * Do NOT re-point these at a new path if the code moves — build the harness
  * and delete them, the way #5813 replaced the allowance-forwarding greps with
  * tests/dom/gate-reader-forwarding.test.mts.
- */
-describe('tab-cap wiring', () => {
-  const panelLayout = readFileSync(resolve(process.cwd(), 'src/app/panel-layout.ts'), 'utf8');
-
-  const addTabBody = panelLayout.slice(
-    panelLayout.indexOf('private addTab(): void {'),
-    panelLayout.indexOf('private renameTab('),
-  );
-  const gatingBody = panelLayout.slice(
-    panelLayout.indexOf('private updatePanelGating(state: AuthSession): void {'),
-    panelLayout.indexOf('private static isMobileMapCollapsedPreferred()'),
-  );
-
-  it('extracts non-empty function bodies', () => {
-    assert.ok(addTabBody.length > 200, 'guard needs the real addTab body');
-    assert.ok(gatingBody.length > 500, 'guard needs the real updatePanelGating body');
-  });
-
-  it('addTab resolves the cap and returns before creating anything', () => {
-    assert.match(addTabBody, /updateTabCapLock\(\)/);
-    assert.match(addTabBody, /if \(!verdict\.allowed\)/);
-    assert.match(addTabBody, /showAddLockNotice\(\)/);
-    assert.match(addTabBody, /trackGateHit\('dashboard-tab'\)/);
-  });
-
-  it('addTab never prunes or trims existing tabs', () => {
-    for (const forbidden of ['splice(', '.slice(0,', '.pop()', '.shift()']) {
-      assert.ok(
-        !addTabBody.includes(forbidden),
-        `addTab must not ${forbidden} — the cap is creation-only (AE4)`,
-      );
-    }
-  });
-
-  it('the cap re-evaluates on BOTH auth and entitlement emissions', () => {
-    // updatePanelGating is the single gating pass; it is driven by
-    // subscribeAuthState AND onEntitlementChange (the auth-only-subscription
-    // bug is documented in this file at the proBlock wiring). Entitlement
-    // emissions now flow through the reload controller so a null auth-handoff
-    // snapshot is not collapsed to a false entitlement transition.
-    assert.match(gatingBody, /this\.updateTabCapLock\(\)/);
-    assert.match(panelLayout, /subscribeAuthState\(\(state\) => \{\s*this\.updatePanelGating\(state\);/);
-    assert.match(
-      panelLayout,
-      /onSnapshot:\s*\(\) => this\.updatePanelGating\(getAuthState\(\)\)/,
-    );
-    assert.match(
-      panelLayout,
-      /onEntitlementChange\(\(state\) => \{[\s\S]*?entitlementReloadController\.handleSnapshot\(/,
-    );
-  });
-
-  // The allowance-forwarding guard that used to live here was two greps over
-  // panel-gating.ts's source text. #5813 moved the reader into
-  // `src/services/gates/export.ts` and made it module-private; the guarantee is
-  // now proven behaviourally, by calling the real `evaluateTabCap` against a
-  // stubbed entitlement snapshot — see tests/dom/gate-reader-forwarding.test.mts.
-
-  // The two PanelTabBar greps that used to close this block are gone (#5813).
-  // They asserted that `components.tabCap.lockedAriaLabel`,
-  // `components.tabCap.unlockedAnnouncement`, `aria-live'/'polite'`,
-  // `setAddLock(` and `showAddLockNotice(` appear somewhere in the component's
-  // source. tests/dom/panel-tab-bar-lock-notice.test.mts already proves all
-  // five behaviourally and strictly more strongly — it asserts the rendered
-  // aria-label VALUE, the live region's actual announcement text and
-  // role="status", selects the region by [aria-live="polite"], and calls both
-  // methods for real. A grep that a name exists adds nothing on top of a test
-  // that drives it.
-});
+ */// The `tab-cap wiring` source-grep block that lived here (#5892) is replaced
+// by tests/dom/panel-layout-tab-cap.test.mts, which constructs a live
+// PanelLayoutManager (boot side effects stubbed at the module boundary) and
+// proves the same three guarantees behaviourally: a blocked addTab() leaves
+// tabsState byte-identical and fires trackGateHit('dashboard-tab') exactly
+// once; an allowed addTab() appends exactly one tab without reordering or
+// dropping any; and auth, entitlement, AND subscription emissions each
+// re-run the cap. A grep proves a name exists in a file — it never drives
+// the decision (docs/solutions/logic-errors/
+// playback-control-gated-on-a-clerk-role-field-with-no-writer.md).


### PR DESCRIPTION
Fixes #5892

## What changed

The proposed shape from the issue, implemented: a `tests/dom/` harness that constructs the **real** `PanelLayoutManager` against a minimal `AppContext`, with the boot-time side effects stubbed at the module boundary (`handleCheckoutReturn`/checkout session flags, `ProActivationController`, `PasskeyOfferBoot`, payment-failure banner, Convex entitlement/subscription watches, `saveTabsState`, `showToast`) — and the three source-regex guards in `tests/tab-cap.test.mts` replaced by behavioural assertions:

- **Blocked `addTab()`**: `tabsState.tabs` byte-identical (JSON compare), `trackGateHit('dashboard-tab')` exactly once, nothing persisted, no toast.
- **Allowed `addTab()`**: exactly one tab appended, existing ids in original order, new tab activated, state persisted.
- **Cap re-evaluation on emissions**: a counting wrapper around the REAL `evaluateTabCap` (verdict logic untouched) observes that an auth emission (via `init()`'s subscription, with only `renderLayout` no-opped), an entitlement emission (constructor wiring through the reload controller), and a subscription-row emission (#4771) each re-run the cap — the auth-only-subscription bug the old greps were written for, now driven instead of pattern-matched.

The old `tab-cap wiring` describe block is removed with a pointer comment (same shape as the #5813 removals it sat beside); the rest of `tab-cap.test.mts` (resolver/catalog blocks) is untouched and green (21/21).

## Teeth (mutation-verified)

- Bypassing the `!verdict.allowed` branch in `addTab` → blocked case red.
- Removing `updateTabCapLock()` from the gating pass → all three emission cases red.

## Verification

- New suite 5/5; full `npm run test:dom` shows the same 13 failed files / 110 failed tests as clean `upstream/main` in this environment (Node-version floor, verified in a clean worktree) — this change adds 5 green tests and regresses nothing.
- `npm run typecheck` and biome clean.