### PR TITLE
feat(markets): SEC Material Events panel — first dashboard surface for the 8-K stream

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -103,6 +103,7 @@ import type { NqPulsePanel } from '@/components/NqPulsePanel';
 import type { NqCatalystsPanel } from '@/components/NqCatalystsPanel';
 import type { YieldCurvePanel } from '@/components/YieldCurvePanel';
 import type { EarningsCalendarPanel } from '@/components/EarningsCalendarPanel';
+import type { MaterialEventsPanel } from '@/components/MaterialEventsPanel';
 import type { EconomicCalendarPanel } from '@/components/EconomicCalendarPanel';
 import type { CotPositioningPanel } from '@/components/CotPositioningPanel';
 import type { LiquidityShiftsPanel } from '@/components/LiquidityShiftsPanel';
@@ -856,6 +857,10 @@ export class App {
     if (shouldPrime('earnings-calendar')) {
       const panel = this.state.panels['earnings-calendar'] as EarningsCalendarPanel | undefined;
       if (panel) primeTask('earnings-calendar', () => panel.fetchData());
+    }
+    if (shouldPrime('material-events')) {
+      const panel = this.state.panels['material-events'] as MaterialEventsPanel | undefined;
+      if (panel) primeTask('material-events', () => panel.fetchData());
     }
     if (shouldPrime('economic-calendar')) {
       const panel = this.state.panels['economic-calendar'] as EconomicCalendarPanel | undefined;
@@ -4025,6 +4030,12 @@ export class App {
       () => (this.state.panels['earnings-calendar'] as EarningsCalendarPanel).fetchData(),
       REFRESH_INTERVALS.earningsCalendar,
       () => this.isPanelNearViewport('earnings-calendar')
+    );
+    this.refreshScheduler.scheduleRefresh(
+      'material-events',
+      () => (this.state.panels['material-events'] as MaterialEventsPanel).fetchData(),
+      REFRESH_INTERVALS.materialEvents,
+      () => this.isPanelNearViewport('material-events')
     );
     this.refreshScheduler.scheduleRefresh(
       'economic-calendar',

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -3137,6 +3137,7 @@ export class PanelLayoutManager implements AppModule {
     this.lazyDefaultPanel('nq-catalysts', () => import('@/components/NqCatalystsPanel'), 'NqCatalystsPanel');
     this.lazyDefaultPanel('yield-curve', () => import('@/components/YieldCurvePanel'), 'YieldCurvePanel');
     this.lazyDefaultPanel('earnings-calendar', () => import('@/components/EarningsCalendarPanel'), 'EarningsCalendarPanel');
+    this.lazyDefaultPanel('material-events', () => import('@/components/MaterialEventsPanel'), 'MaterialEventsPanel');
     this.lazyDefaultPanel('economic-calendar', () => import('@/components/EconomicCalendarPanel'), 'EconomicCalendarPanel');
     this.lazyDefaultPanel('cot-positioning', () => import('@/components/CotPositioningPanel'), 'CotPositioningPanel');
     this.lazyDefaultPanel('liquidity-shifts', () => import('@/components/LiquidityShiftsPanel'), 'LiquidityShiftsPanel');

--- a/src/components/MaterialEventsPanel.ts
+++ b/src/components/MaterialEventsPanel.ts
@@ -1,0 +1,150 @@
+import type {
+  IntelligenceServiceClient,
+  MaterialEvent,
+  MaterialEventItem,
+} from '@/generated/client/worldmonitor/intelligence/v1/service_client';
+import { Panel } from './Panel';
+import { getLocale } from '@/services/i18n';
+import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
+
+/**
+ * SEC material events (#6429) — the first dashboard surface over the 8-K
+ * stream the backend has seeded and served (scripts/seed-sec-8k-stream.mjs →
+ * listMaterialEvents) since #5695 with no renderer at all. Deliberately a
+ * thin list: company, form + item-code badge, item description, filing time,
+ * and an origin-locked link to the filing index. Default-off in every
+ * variant, like earnings-calendar — enabling it is a product decision.
+ */
+
+let _client: IntelligenceServiceClient | null = null;
+async function getIntelligenceClient(): Promise<IntelligenceServiceClient> {
+  if (!_client) {
+    const { IntelligenceServiceClient } = await import('@/generated/client/worldmonitor/intelligence/v1/service_client');
+    const { getRpcBaseUrl } = await import('@/services/rpc-client');
+    _client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
+  }
+  return _client;
+}
+
+const EVENT_LIMIT = 30;
+
+export interface ProjectedMaterialEvent {
+  company: string;
+  form: string;
+  filedAtMs: number;
+  items: MaterialEventItem[];
+  url: string;
+}
+
+/**
+ * Filing links come from a seeded Redis blob, not from code this bundle
+ * controls — so only canonical https sec.gov URLs may render as anchors.
+ * Everything else (other origins, downgraded schemes, lookalike hosts,
+ * javascript:) renders as plain text.
+ */
+export function secArchiveUrl(url: unknown): string | null {
+  if (typeof url !== 'string' || url.length === 0) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return null;
+    if (parsed.hostname !== 'www.sec.gov' && parsed.hostname !== 'sec.gov') return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+/** Newest-first, identity-bearing rows only, items always an array. */
+export function projectMaterialEvents(events: readonly MaterialEvent[]): ProjectedMaterialEvent[] {
+  return events
+    .filter((event) => Boolean(event.company || event.cik))
+    .map((event) => ({
+      company: event.company || `CIK ${event.cik}`,
+      form: event.form || '8-K',
+      filedAtMs: Number.isFinite(event.filedAtMs) ? event.filedAtMs : 0,
+      items: Array.isArray(event.items) ? event.items : [],
+      url: event.url,
+    }))
+    .sort((a, b) => b.filedAtMs - a.filedAtMs);
+}
+
+/** A time for same-day filings, a date for older ones, '' when unusable. */
+export function filedAtLabel(filedAtMs: number, nowMs: number, locale: string): string {
+  if (!Number.isFinite(filedAtMs) || filedAtMs <= 0) return '';
+  const filed = new Date(filedAtMs);
+  const now = new Date(nowMs);
+  const sameDay = filed.getFullYear() === now.getFullYear()
+    && filed.getMonth() === now.getMonth()
+    && filed.getDate() === now.getDate();
+  return sameDay
+    ? filed.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' })
+    : filed.toLocaleDateString(locale, { month: 'short', day: 'numeric' });
+}
+
+export function renderMaterialEvent(event: ProjectedMaterialEvent, nowMs: number, locale: string): string {
+  const primary = event.items[0];
+  const extraItems = event.items.length > 1 ? ` +${event.items.length - 1}` : '';
+  const link = secArchiveUrl(event.url);
+  const company = escapeHtml(event.company);
+  const companyHtml = link
+    ? `<a href="${escapeHtml(link)}" target="_blank" rel="noopener noreferrer" style="color:var(--text);text-decoration:none">${company}</a>`
+    : company;
+  const timeLabel = filedAtLabel(event.filedAtMs, nowMs, locale);
+
+  return `
+    <div style="display:flex;align-items:flex-start;gap:8px;padding:6px 0;border-bottom:1px solid rgba(255,255,255,0.04)">
+      <div style="display:flex;flex-direction:column;align-items:center;gap:3px;flex-shrink:0;padding-top:1px">
+        <span style="font-size:calc(9px * var(--wm-panel-effective-scale, 1));font-weight:700;padding:2px 5px;border-radius:3px;background:rgba(52,152,219,0.15);color:#3498db;letter-spacing:0.04em">${escapeHtml(event.form)}</span>
+        ${primary ? `<span style="font-size:calc(9px * var(--wm-panel-effective-scale, 1));font-weight:700;padding:1px 4px;border-radius:3px;background:rgba(255,255,255,0.08);color:var(--text-dim)">${escapeHtml(primary.code)}${escapeHtml(extraItems)}</span>` : ''}
+      </div>
+      <div style="flex:1;min-width:0">
+        <div style="font-size:calc(12px * var(--wm-panel-effective-scale, 1));font-weight:600;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${companyHtml}</div>
+        ${primary ? `<div style="font-size:calc(10px * var(--wm-panel-effective-scale, 1));color:var(--text-dim)">${escapeHtml(primary.description)}</div>` : ''}
+      </div>
+      ${timeLabel ? `<div style="flex-shrink:0;font-size:calc(10px * var(--wm-panel-effective-scale, 1));color:var(--text-dim);padding-top:1px">${escapeHtml(timeLabel)}</div>` : ''}
+    </div>`;
+}
+
+export class MaterialEventsPanel extends Panel {
+  private _hasData = false;
+
+  constructor() {
+    super({
+      id: 'material-events',
+      title: 'SEC Material Events',
+      showCount: false,
+      infoTooltip: 'Recent SEC 8-K material-event filings across all filers — item codes flag what happened (e.g. 5.02 executive departures, 2.02 results, 1.01 material agreements). Links open the filing index on sec.gov.',
+    });
+  }
+
+  public async fetchData(): Promise<boolean> {
+    this.showLoading();
+    try {
+      const client = await getIntelligenceClient();
+      const resp = await client.listMaterialEvents({ itemCode: '', limit: EVENT_LIMIT });
+
+      const events = projectMaterialEvents(resp.events ?? []);
+      if (resp.unavailable || events.length === 0) {
+        if (!this._hasData) this.showError('No recent SEC material events', () => void this.fetchData());
+        return false;
+      }
+
+      this.render(events);
+      return true;
+    } catch (e) {
+      if (!this._hasData) this.showError(e instanceof Error ? e.message : 'Failed to load SEC material events', () => void this.fetchData());
+      return false;
+    }
+  }
+
+  private render(events: ProjectedMaterialEvent[]): void {
+    this._hasData = true;
+    const now = Date.now();
+    const locale = getLocale();
+    const html = `
+      <div style="padding:0 14px 12px;max-height:480px;overflow-y:auto">
+        ${events.map((event) => renderMaterialEvent(event, now, locale)).join('')}
+      </div>`;
+    this.setSafeContent(unsafeRawHtml(html, 'material-events controlled panel markup — every dynamic field passes escapeHtml'));
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -92,6 +92,7 @@ export * from './NqPulsePanel';
 export * from './NqCatalystsPanel';
 export * from './YieldCurvePanel';
 export * from './EarningsCalendarPanel';
+export * from './MaterialEventsPanel';
 export * from './EconomicCalendarPanel';
 export * from './CotPositioningPanel';
 export * from './LiquidityShiftsPanel';

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -207,6 +207,7 @@ export const COMMANDS: Command[] = [
   { id: 'panel:nq-news', keywords: ['nq news', 'nasdaq futures news', 'qqq headlines', 'fed press', 'semiconductor news'], label: 'Panel: NQ News', icon: '\u{1F4F0}', category: 'panels' },
   { id: 'panel:yield-curve', keywords: ['yield curve', 'rates', 'treasury', 'ecb rates', 'bond yield', 'inversion'], label: 'Panel: Yield Curve & Rates', icon: '\u{1F4C8}', category: 'panels' },
   { id: 'panel:earnings-calendar', keywords: ['earnings', 'earnings calendar', 'eps', 'quarterly results'], label: 'Panel: Earnings Calendar', icon: '\u{1F4C5}', category: 'panels' },
+  { id: 'panel:material-events', keywords: ['sec', '8-k', 'material events', 'filings', 'disclosures'], label: 'Panel: SEC Material Events', icon: '\u{1F4C4}', category: 'panels' },
   { id: 'panel:economic-calendar', keywords: ['economic calendar', 'macro events', 'nonfarm payrolls', 'gdp release', 'fomc'], label: 'Panel: Economic Calendar', icon: '\u{1F4C6}', category: 'panels' },
   { id: 'panel:cot-positioning', keywords: ['cot', 'cot positioning', 'commitments of traders', 'futures positioning', 'cftc'], label: 'Panel: CFTC COT Positioning', icon: '\u{1F4CA}', category: 'panels' },
   { id: 'panel:liquidity-shifts', keywords: ['liquidity', 'liquidity shifts', 'oil gold silver', 'top stocks', 'positioning'], label: 'Panel: Liquidity Shifts', icon: '\u{1F4B0}', category: 'panels' },

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -82,6 +82,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'fsi': { name: 'Financial Stress', enabled: false, priority: 2 },
   'yield-curve': { name: 'Yield Curve', enabled: false, priority: 2 },
   'earnings-calendar': { name: 'Earnings Calendar', enabled: false, priority: 2 },
+  'material-events': { name: 'SEC Material Events', enabled: false, priority: 2 },
   'economic-calendar': { name: 'Economic Calendar', enabled: false, priority: 2 },
   'cot-positioning': { name: 'COT Positioning', enabled: true, priority: 2 },
   'liquidity-shifts': { name: 'Liquidity Shifts', enabled: true, priority: 2 },
@@ -503,6 +504,7 @@ const FINANCE_PANELS: Record<string, PanelConfig> = {
   'fsi': { name: 'Financial Stress', enabled: true, priority: 1 },
   'yield-curve': { name: 'Yield Curve', enabled: true, priority: 1 },
   'earnings-calendar': { name: 'Earnings Calendar', enabled: true, priority: 1 },
+  'material-events': { name: 'SEC Material Events', enabled: false, priority: 2 },
   'economic-calendar': { name: 'Economic Calendar', enabled: true, priority: 1 },
   'cot-positioning': { name: 'COT Positioning', enabled: true, priority: 2 },
   'liquidity-shifts': { name: 'Liquidity Shifts', enabled: true, priority: 1 },
@@ -1525,7 +1527,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   marketsFinance: {
     labelKey: 'header.panelCatMarketsFinance',
-    panelKeys: ['commodities', 'energy-complex', 'energy-risk-overview', 'pipeline-status', 'storage-facility-map', 'oil-inventories', 'fuel-prices', 'chokepoint-strip', 'fuel-shortages', 'energy-disruptions', 'hormuz-tracker', 'energy-crisis', 'markets', 'economic', 'global-procurement', 'trade-policy', 'sanctions-pressure', 'supply-chain', 'china-corridors', 'china-activity-nowcast', 'finance', 'polymarket', 'macro-signals', 'gulf-economies', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'aaii-sentiment', 'cot-positioning', 'earnings-calendar', 'economic-calendar', 'fear-greed', 'fsi', 'macro-tiles', 'market-breadth', 'news-market-correlation', 'liquidity-shifts', 'national-debt', 'positioning-247', 'wsb-ticker-scanner', 'yield-curve', 'gold-intelligence', 'bigmac', 'fx', 'market-implications'],
+    panelKeys: ['commodities', 'energy-complex', 'energy-risk-overview', 'pipeline-status', 'storage-facility-map', 'oil-inventories', 'fuel-prices', 'chokepoint-strip', 'fuel-shortages', 'energy-disruptions', 'hormuz-tracker', 'energy-crisis', 'markets', 'economic', 'global-procurement', 'trade-policy', 'sanctions-pressure', 'supply-chain', 'china-corridors', 'china-activity-nowcast', 'finance', 'polymarket', 'macro-signals', 'gulf-economies', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'aaii-sentiment', 'cot-positioning', 'earnings-calendar', 'material-events', 'economic-calendar', 'fear-greed', 'fsi', 'macro-tiles', 'market-breadth', 'news-market-correlation', 'liquidity-shifts', 'national-debt', 'positioning-247', 'wsb-ticker-scanner', 'yield-curve', 'gold-intelligence', 'bigmac', 'fx', 'market-implications'],
     variants: ['full', 'energy'],
   },
   topical: {

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -79,6 +79,7 @@ export const REFRESH_INTERVALS = {
   fsi: 30 * 60 * 1000,
   yieldCurve: 30 * 60 * 1000,
   earningsCalendar: 60 * 60 * 1000,
+  materialEvents: 15 * 60 * 1000,
   economicCalendar: 60 * 60 * 1000,
   cotPositioning: 60 * 60 * 1000,
   goldIntelligence: 5 * 60 * 1000,

--- a/tests/dom/material-events-panel.test.mts
+++ b/tests/dom/material-events-panel.test.mts
@@ -1,0 +1,118 @@
+/**
+ * #6429 — the SEC material-events backend (8-K stream seeder + RPCs + MCP
+ * tool) had no dashboard surface at all. MaterialEventsPanel is the first
+ * one: a list panel over listMaterialEvents, default-off in every variant
+ * like earnings-calendar, so enabling it stays a product decision.
+ *
+ * These tests drive the exported pure helpers (the EnergyRiskOverviewPanel
+ * pattern) — projection, labels, URL policy, and row rendering — in the
+ * vitest dom project (the component imports @/services/i18n, whose
+ * import.meta.glob only a Vite pipeline can transform). The URL policy is the tooth that matters: filing links come from a
+ * seeded Redis blob, so only https://www.sec.gov/ URLs may render as
+ * anchors; anything else renders as plain text.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+
+import {
+  filedAtLabel,
+  projectMaterialEvents,
+  renderMaterialEvent,
+  secArchiveUrl,
+} from '@/components/MaterialEventsPanel';
+
+const NOW = Date.parse('2026-08-31T12:00:00Z');
+
+function event(overrides: Record<string, unknown> = {}) {
+  return {
+    company: 'ACME CORP',
+    cik: '0000123456',
+    form: '8-K',
+    accession: '0000123456-26-000001',
+    filedAtMs: NOW - 3_600_000,
+    items: [{ code: '5.02', description: 'Departure of Directors or Certain Officers' }],
+    url: 'https://www.sec.gov/Archives/edgar/data/123456/000012345626000001-index.htm',
+    ...overrides,
+  };
+}
+
+describe('secArchiveUrl — filing links come from a seeded blob and must be origin-locked', () => {
+  it('accepts an https sec.gov archive URL', () => {
+    assert.equal(
+      secArchiveUrl('https://www.sec.gov/Archives/edgar/data/1/x.htm'),
+      'https://www.sec.gov/Archives/edgar/data/1/x.htm',
+    );
+  });
+
+  it('rejects other origins, downgraded schemes, and javascript: URLs', () => {
+    assert.equal(secArchiveUrl('http://www.sec.gov/Archives/x.htm'), null);
+    assert.equal(secArchiveUrl('https://evil.example/www.sec.gov/x'), null);
+    assert.equal(secArchiveUrl('https://www.sec.gov.evil.example/x'), null);
+    assert.equal(secArchiveUrl('javascript:alert(1)'), null);
+    assert.equal(secArchiveUrl(''), null);
+  });
+});
+
+describe('projectMaterialEvents', () => {
+  it('sorts newest-first and drops entries with no usable identity', () => {
+    const projected = projectMaterialEvents([
+      event({ company: 'OLDER', filedAtMs: NOW - 7_200_000 }),
+      event({ company: 'NEWER', filedAtMs: NOW - 60_000 }),
+      event({ company: '', cik: '' }),
+    ]);
+
+    assert.deepEqual(projected.map((e) => e.company), ['NEWER', 'OLDER']);
+  });
+
+  it('tolerates a malformed items array', () => {
+    const projected = projectMaterialEvents([
+      event({ items: undefined }),
+      event({ items: [] }),
+    ]);
+    assert.equal(projected.length, 2);
+    assert.deepEqual(projected[0]!.items, []);
+  });
+});
+
+describe('filedAtLabel', () => {
+  it('renders a time for a same-day filing and a date otherwise', () => {
+    const sameDay = filedAtLabel(NOW - 3_600_000, NOW, 'en');
+    const older = filedAtLabel(NOW - 3 * 86_400_000, NOW, 'en');
+    assert.ok(/\d/.test(sameDay));
+    assert.notEqual(sameDay, older);
+  });
+
+  it('renders an empty label for an unusable timestamp', () => {
+    assert.equal(filedAtLabel(0, NOW, 'en'), '');
+    assert.equal(filedAtLabel(Number.NaN, NOW, 'en'), '');
+  });
+});
+
+describe('renderMaterialEvent', () => {
+  it('escapes seeded text and carries the form + item badge', () => {
+    const html = renderMaterialEvent(
+      projectMaterialEvents([event({ company: '<img src=x onerror=alert(1)>' })])[0]!,
+      NOW,
+      'en',
+    );
+    assert.ok(!html.includes('<img'), 'seeded company names must be escaped');
+    assert.ok(html.includes('&lt;img'));
+    assert.ok(html.includes('8-K'));
+    assert.ok(html.includes('5.02'));
+    assert.ok(html.includes('Departure of Directors'));
+  });
+
+  it('links only origin-locked filing URLs and never emits a bare anchor otherwise', () => {
+    const linked = renderMaterialEvent(projectMaterialEvents([event()])[0]!, NOW, 'en');
+    assert.ok(linked.includes('href="https://www.sec.gov/Archives/'));
+    assert.ok(linked.includes('rel="noopener'), 'external links must carry noopener');
+
+    const unlinked = renderMaterialEvent(
+      projectMaterialEvents([event({ url: 'https://evil.example/x' })])[0]!,
+      NOW,
+      'en',
+    );
+    assert.ok(!unlinked.includes('<a '), 'an off-origin URL must not render as a link');
+    assert.ok(unlinked.includes('ACME CORP'), 'the row still renders as text');
+  });
+});

--- a/tests/webmcp-panel-catalog.test.mts
+++ b/tests/webmcp-panel-catalog.test.mts
@@ -79,7 +79,7 @@ describe('WebMCP dashboard panel catalog', () => {
       .filter((panelId) => getEffectivePanelConfig(panelId, 'full').enabled !== true);
 
     assert.equal(uniqueIds.length, Object.keys(ALL_PANELS).length);
-    assert.equal(worldIds.length, 109);
+    assert.equal(worldIds.length, 110);
     assert.ok(uniqueIds.includes('regionalStartups'));
     assert.ok(uniqueIds.includes('gccNews'));
     assert.ok(disabledWorld.length > 0, 'World registry must include disabled panels');
@@ -92,7 +92,7 @@ describe('WebMCP dashboard panel catalog', () => {
     const pages = collectPages(live, { variant: 'full', limit: 4 });
     const ids = pages.flatMap((page) => page.panels.map((panel) => panel.id));
 
-    assert.equal(pages[0]?.total, 109);
+    assert.equal(pages[0]?.total, 110);
     assert.ok(pages.length > 1);
     assert.equal(new Set(ids).size, ids.length);
     assert.deepEqual(ids, [...getCanonicalDashboardPanelIds('full')]);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,7 +102,7 @@ const LAZY_HTML_PRELOAD_RE = new RegExp(
 const PANEL_CLUSTER: Record<string, PanelChunkName> = {
   // Markets / equities / crypto positioning
   AAIISentiment: 'panels-markets', CotPositioning: 'panels-markets',
-  ETFFlows: 'panels-markets', EarningsCalendar: 'panels-markets',
+  ETFFlows: 'panels-markets', EarningsCalendar: 'panels-markets', MaterialEvents: 'panels-markets',
   EconomicCalendar: 'panels-markets', FearGreed: 'panels-markets',
   Fx: 'panels-markets',
   GoldIntelligence: 'panels-markets', LiquidityShifts: 'panels-markets',


### PR DESCRIPTION
Fixes #6429

## What this adds

The issue's gap, verified still true on current main: the SEC material-events backend (`seed-sec-8k-stream`, `listMaterialEvents`/`searchSecFilings` RPCs, MCP company-intel tools) has zero dashboard surface — `grep -rniE 'materialEvents|sec-filings' src/components src/config src/services` still returns nothing. This PR adds the thin first surface: `MaterialEventsPanel`, a list over `listMaterialEvents` (company, form + 8-K item-code badge, item description, filing time, origin-locked link to the filing index), modeled line-for-line on `EarningsCalendarPanel`'s wiring.

## Deliberately opt-in everywhere

`enabled: false` in BOTH the World and finance variant registries (earnings-calendar's flagship posture, applied to both) — this PR makes the reports half reachable from the panel picker and command deck; turning it on anywhere stays a product decision.

## Wiring (the six standard surfaces)

panel component + `components/index` export, `panels.ts` (two variant registries + the finance category list), `commands.ts` palette entry, `panel-layout.ts` `lazyDefaultPanel`, `App.ts` prime + refresh scheduling (`REFRESH_INTERVALS.materialEvents` = 15 min against the seeded stream). No new backend, seeder, or i18n keys (plain-English strings, the NewsMarketCorrelationPanel precedent).

## Safety shape

Filing URLs come from a seeded Redis blob, not from code this bundle controls: `secArchiveUrl` locks anchors to `https://(www.)sec.gov` — other origins, downgraded schemes, lookalike hosts, and `javascript:` render as plain text — and every dynamic field passes `escapeHtml`.

## Tests

`tests/dom/material-events-panel.test.mts` (8 tests) drives the exported pure helpers: URL origin policy both ways, newest-first projection + malformed-items tolerance, filing-time labels, row rendering (escaping proven with an injected `<img>` payload, `rel=noopener` pinned, off-origin URL renders linkless). Mutation check: dropping the hostname lock turns 2 tests red. The WebMCP panel-catalog count pins move 109 → 110 with the deliberate addition; `panel-config-guardrails` (23/23), `panel-variant-config` + catalog + mobile-nav + command-deck (43/43), `docs-stats --check` OK, typecheck + biome clean.