### PR TITLE
fix(api): make telegram relay timeouts a warning-level canary

### DIFF
--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -377,14 +377,22 @@ export default async function handler(req) {
     const isTimeout = error?.name === 'AbortError';
     // No `details`: the underlying message can carry relay transport detail
     // (undici cause chains, MTProto text) and the browser has no use for it.
-    // Non-timeout failures are captured server-side instead.
+    // Failures are captured server-side instead.
     console.warn('[telegram-feed] relay request failed:', error?.message || String(error));
-    // Skip Sentry on AbortError — fetchWithTimeout aborts on the mode budget
-    // (TELEGRAM_RELAY_TIMEOUT_MS); those 504s are routine relay latency, not
-    // product defects. Match api/rss-proxy.js. Keep capturing real failures.
-    if (!isTimeout) {
-      void captureSilentError(error, { tags: { route: 'api/telegram-feed', step: 'relay-fetch' } });
-    }
+    // Timeouts capture at `warning`, not `error`: fetchWithTimeout aborts on the
+    // mode budget (TELEGRAM_RELAY_TIMEOUT_MS), so those 504s are routine relay
+    // latency rather than product defects. Skipping them outright (the previous
+    // posture, inherited from api/rss-proxy.js) left relay degradation with no
+    // signal at all — nothing in scripts/ or .github/workflows/ watches it.
+    // `warning` keeps it queryable without counting toward error totals.
+    // `mode` is mandatory on both paths: the budgets differ by 7s, so without
+    // it a feed stall and a channel stall are the same Sentry issue.
+    void captureSilentError(error, {
+      tags: { route: 'api/telegram-feed', step: 'relay-fetch', mode },
+      ...(isTimeout
+        ? { level: 'warning', extra: { timeout_ms: TELEGRAM_RELAY_TIMEOUT_MS[mode] } }
+        : {}),
+    });
     return jsonResponse({
       error: isTimeout ? 'Relay timeout' : 'Relay request failed',
     }, isTimeout ? 504 : 502, { 'Cache-Control': 'no-store', ...corsHeaders });

--- a/tests/telegram-feed-contract.test.mjs
+++ b/tests/telegram-feed-contract.test.mjs
@@ -365,9 +365,10 @@ describe('api/telegram-feed contract normalization', () => {
 
   it('maps a relay AbortError to 504 Relay timeout (WORLDMONITOR-11G)', async () => {
     // fetchWithTimeout aborts on TELEGRAM_RELAY_TIMEOUT_MS; AbortError is the
-    // expected timeout signal. Sentry skip (`if (!isTimeout)`) mirrors
-    // api/rss-proxy.js — captureSilentError is a no-op under NODE_TEST_CONTEXT,
-    // so this asserts only the 504 mapping (same deliberate limit as rss-proxy).
+    // expected timeout signal. This asserts only the 504 mapping:
+    // captureSilentError is a no-op under NODE_TEST_CONTEXT, so the capture
+    // policy (warning level, `mode` tag, `timeout_ms`) is pinned separately in
+    // tests/telegram-feed-relay-timeout-canary.test.mts, which clears that var.
     globalThis.fetch = async () => {
       const err = new Error('The operation was aborted');
       err.name = 'AbortError';

--- a/tests/telegram-feed-relay-timeout-canary.test.mts
+++ b/tests/telegram-feed-relay-timeout-canary.test.mts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
+
+// ─── api/telegram-feed relay-failure capture policy ────────────────────────
+//
+// PR #7438 made the outer catch SKIP `captureSilentError` on AbortError, which
+// deleted the only signal for telegram relay degradation — nothing in
+// `scripts/` or `.github/workflows/` watches it. The replacement is a
+// warning-level canary: still queryable, but out of error totals and off
+// on-call. The tag that makes it triageable is `mode`, because the three
+// budgets differ (feed 15s, resolve 20s, channel 22s) and a capture without it
+// cannot tell a 15s feed stall from a 22s channel stall.
+//
+// The two #7438 tests in `telegram-feed-contract.test.mjs` assert only the
+// 504/502 mapping — they pass on pre-#7438 code, because `captureSilentError`
+// no-ops unless `_sentry-common.js` parsed a DSN in its import-time
+// `parseDsn()` IIFE (`if (process.env.NODE_TEST_CONTEXT) return`). So this file
+// activates a throwaway DSN BEFORE the handler's module graph loads — hence the
+// dynamic `import()` below, after the env writes. Each `*.test.mts` runs in its
+// own `tsx --test` subprocess, so the DSN never leaks into the statically
+// imported handler in the contract suite.
+//
+// We observe the edge transport's envelope POST and parse its payload. The
+// non-timeout case doubles as the DSN-ACTIVATION CONTROL: if the DSN never
+// wired up, its hit count would be 0 and it fails loudly — so a 1-hit
+// warning-level assertion can never be a silent false-pass.
+
+const SESSION_SECRET = 'x'.repeat(48);
+
+const previousNodeTestContext = process.env.NODE_TEST_CONTEXT;
+delete process.env.NODE_TEST_CONTEXT;
+
+// Set before the dynamic import so parseDsn() wires up the envelope transport.
+process.env.VITE_SENTRY_DSN = 'https://testpublickey@sentry.test/12345';
+process.env.WS_RELAY_URL = 'https://relay.example.com';
+process.env.RELAY_SHARED_SECRET = 'test-secret';
+process.env.WM_SESSION_SECRET = SESSION_SECRET;
+// Leave UPSTASH_* unset: checkRateLimit returns null without fetching when the
+// limiter is unconfigured, so the relay and the Sentry envelope are the only
+// two URLs the handler ever hits.
+
+// parseDsn() derives `${protocol}//${host}/api/${projectId}/envelope/` from the
+// DSN above → this prefix.
+const ENVELOPE_URL_PREFIX = 'https://sentry.test/api/12345/envelope';
+const RELAY_URL_PREFIX = 'https://relay.example.com';
+
+const { default: handler } = await import('../api/telegram-feed.js');
+const { issueSessionToken } = await import('../api/_session.js');
+
+const originalFetch = globalThis.fetch;
+after(() => {
+  globalThis.fetch = originalFetch;
+  if (previousNodeTestContext === undefined) delete process.env.NODE_TEST_CONTEXT;
+  else process.env.NODE_TEST_CONTEXT = previousNodeTestContext;
+});
+
+interface SentryEvent {
+  level?: string;
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+  exception?: { values?: Array<{ type?: string; value?: string }> };
+}
+
+/** Envelope wire format: header line, item header line, item payload line. */
+function parseEnvelope(body: string): SentryEvent {
+  const lines = body.split('\n');
+  assert.equal(JSON.parse(lines[1]).type, 'event', 'envelope item must be an event');
+  return JSON.parse(lines[2]) as SentryEvent;
+}
+
+function abortError(): Error {
+  const err = new Error('The operation was aborted');
+  err.name = 'AbortError';
+  return err;
+}
+
+/**
+ * Drive the handler with the relay fetch rejecting, and report every Sentry
+ * event the edge transport dispatched alongside the client-facing response.
+ */
+async function runWithRelayFailure(path: string, relayError: Error): Promise<{
+  events: SentryEvent[];
+  status: number;
+  body: unknown;
+}> {
+  const envelopes: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.startsWith(ENVELOPE_URL_PREFIX)) {
+      envelopes.push(String(init?.body ?? ''));
+      return new Response('', { status: 200 });
+    }
+    if (url.startsWith(RELAY_URL_PREFIX)) throw relayError;
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const { token } = await issueSessionToken();
+  const res = await handler(new Request(`https://worldmonitor.app${path}`, {
+    method: 'GET',
+    headers: { origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': token },
+  }));
+  const body = await res.json();
+  // The handler takes no `ctx`, so delivery is fire-and-forget on `keepalive`;
+  // yield a macrotask so the transport's fetch has run before we read it.
+  await new Promise((resolve) => { setImmediate(resolve); });
+  return { events: envelopes.map(parseEnvelope), status: res.status, body };
+}
+
+describe('api/telegram-feed relay timeout canary', () => {
+  // Two modes, because a single-mode fixture cannot prove the tag VARIES — a
+  // hardcoded `mode: 'feed'` would satisfy it.
+  for (const { mode, path, timeoutMs } of [
+    { mode: 'feed', path: '/api/telegram-feed?limit=50', timeoutMs: 15_000 },
+    { mode: 'channel', path: '/api/telegram-feed?mode=channel&username=warintel', timeoutMs: 22_000 },
+  ]) {
+    it(`captures a ${mode} relay timeout at warning level with its own budget`, async () => {
+      const { events, status, body } = await runWithRelayFailure(path, abortError());
+
+      assert.equal(events.length, 1, `a ${mode} relay timeout must stay queryable in Sentry`);
+      const [event] = events;
+      assert.equal(event.level, 'warning', 'routine relay latency must not count toward error totals');
+      assert.equal(event.tags?.route, 'api/telegram-feed');
+      assert.equal(event.tags?.step, 'relay-fetch');
+      assert.equal(event.tags?.mode, mode, 'the mode tag is what makes the capture triageable');
+      assert.equal(event.exception?.values?.[0]?.type, 'AbortError');
+      assert.equal(
+        event.extra?.timeout_ms,
+        timeoutMs,
+        'without the budget a 15s feed stall and a 22s channel stall are indistinguishable',
+      );
+
+      assert.equal(status, 504);
+      assert.deepEqual(body, { error: 'Relay timeout' });
+    });
+  }
+
+  // Positive control AND the DSN-activation control: a 0-hit here would mean
+  // the transport never wired up, making every assertion above vacuous.
+  it('keeps a non-timeout relay failure at error level, tagged but without a budget', async () => {
+    const { events, status, body } = await runWithRelayFailure(
+      '/api/telegram-feed?limit=50',
+      new Error('relay ECONNREFUSED'),
+    );
+
+    assert.equal(events.length, 1, 'a real relay failure must still reach Sentry');
+    const [event] = events;
+    assert.equal(event.level, 'error', 'a transport failure is a defect, not routine latency');
+    assert.equal(event.tags?.step, 'relay-fetch');
+    assert.equal(event.tags?.mode, 'feed');
+    assert.equal(event.exception?.values?.[0]?.type, 'Error');
+    assert.ok(
+      !('timeout_ms' in (event.extra ?? {})),
+      'timeout_ms describes an abort deadline that this failure never reached',
+    );
+
+    assert.equal(status, 502);
+    assert.deepEqual(body, { error: 'Relay request failed' });
+  });
+});

--- a/tests/telegram-feed-relay-timeout-canary.test.mts
+++ b/tests/telegram-feed-relay-timeout-canary.test.mts
@@ -30,14 +30,25 @@ const SESSION_SECRET = 'x'.repeat(48);
 const previousNodeTestContext = process.env.NODE_TEST_CONTEXT;
 delete process.env.NODE_TEST_CONTEXT;
 
+// UPSTASH_* must be UNSET, not merely assumed unset. `getRatelimit` reads both
+// on every call, so an inherited pair (a shell that sourced .env.local, a job
+// that exports the secrets) sends checkRateLimit down the real Redis path —
+// and with NODE_TEST_CONTEXT cleared above, REDIS_TEST_RETRY_OPTS no longer
+// suppresses its retries. The stub then rejects the Upstash URL, the fail-open
+// catch in `logRateLimitDegraded` fires a SECOND envelope, and every
+// `events.length === 1` assertion fails ~4.3s late. Restored in `after()`.
+const previousUpstash = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
 // Set before the dynamic import so parseDsn() wires up the envelope transport.
 process.env.VITE_SENTRY_DSN = 'https://testpublickey@sentry.test/12345';
 process.env.WS_RELAY_URL = 'https://relay.example.com';
 process.env.RELAY_SHARED_SECRET = 'test-secret';
 process.env.WM_SESSION_SECRET = SESSION_SECRET;
-// Leave UPSTASH_* unset: checkRateLimit returns null without fetching when the
-// limiter is unconfigured, so the relay and the Sentry envelope are the only
-// two URLs the handler ever hits.
 
 // parseDsn() derives `${protocol}//${host}/api/${projectId}/envelope/` from the
 // DSN above → this prefix.
@@ -52,6 +63,8 @@ after(() => {
   globalThis.fetch = originalFetch;
   if (previousNodeTestContext === undefined) delete process.env.NODE_TEST_CONTEXT;
   else process.env.NODE_TEST_CONTEXT = previousNodeTestContext;
+  if (previousUpstash.url !== undefined) process.env.UPSTASH_REDIS_REST_URL = previousUpstash.url;
+  if (previousUpstash.token !== undefined) process.env.UPSTASH_REDIS_REST_TOKEN = previousUpstash.token;
 });
 
 interface SentryEvent {


### PR DESCRIPTION
## Summary

PR #7438 stopped capturing `AbortError` timeouts from the telegram-feed relay. That removed the only signal for relay degradation — nothing in `scripts/` or `.github/workflows/` watches it, so a chronic stall would surface as 504s in Vercel logs and nowhere else.

This restores the capture at `warning` level instead of skipping it, so relay latency stays queryable without counting toward error totals or paging. `level` is already a documented option on `captureSilentError` (see the `buildEnvelope` JSDoc in `api/_sentry-common.js`) for exactly this case.

Both the timeout and the failure paths now carry a `mode` tag, and the timeout path carries the blown budget as `extra.timeout_ms`. WORLDMONITOR-11G had neither, so a 15s `feed` stall and a 22s `channel` stall were the same undifferentiated event.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Client contract: unchanged

Same `504` / `502` mapping, same body, same `Cache-Control: no-store` and CORS headers. The `jsonResponse` call is byte-identical, and the 25 existing contract tests still cover it. No user-facing behavior changes, so no docs claims move.

## The test actually goes red

The two tests #7438 added assert only the 504/502 mapping, which was already correct before that PR — they pass on pre-#7438 code and pin nothing about capture policy, because `captureSilentError` no-ops under `NODE_TEST_CONTEXT`.

`tests/telegram-feed-relay-timeout-canary.test.mts` follows the proven pattern in `tests/symbol-search-sentry-capture.test.mts`: clear `NODE_TEST_CONTEXT`, activate a throwaway DSN before the handler's module graph loads, stub the transport, and parse the envelope payload. It pins `level`, `tags.mode`, `tags.step`, the exception type, and `extra.timeout_ms`.

Proven red against the merged #7438 handler before the fix:

```
✖ captures a feed relay timeout at warning level with its own budget
✖ captures a channel relay timeout at warning level with its own budget
✖ keeps a non-timeout relay failure at error level, tagged but without a budget
ℹ tests 3 | pass 0 | fail 3
```

Two modes are covered so the tag is proven to vary; a single-mode fixture would be satisfied by a hardcoded `mode: 'feed'`. The non-timeout case doubles as the DSN-activation control: a 0-hit there would mean the transport never wired up, so a passing warning-level assertion cannot be vacuous.

## Checklist

- [x] No API keys or secrets committed
- [x] `npx tsx --test tests/telegram-feed-relay-timeout-canary.test.mts tests/telegram-feed-contract.test.mjs` — 26 pass, 0 fail
- [x] New test proven to fail against the pre-fix handler
- [x] `npm run typecheck` and `npm run typecheck:api` clean
- [x] `npx biome lint` clean on all three files

## Documentation Alignment Checklist

- N/A — no client-facing behavior or documentation claims changed.

## Known follow-up

`api/rss-proxy.js` (skips timeouts) and `api/x-feed.js` plus the `api/_relay.js` factory (capture nothing in their catch at all) carry the same blind spot. Deliberately out of scope here; `api/rss-proxy.test.mjs:752` already documents the gap on its side.

## Sentry

WORLDMONITOR-11G is resolved with an empty `statusDetails`. It will regress the next time the relay stalls, at `warning` — that is this canary working, not a defect to re-triage.

Refs #7438
