### PR TITLE
chore(mcp): declare and enforce the FlowSource taxonomy on the chokepoint-flows cache tool (internal re-land of 7450)

### DIFF
--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -2544,12 +2544,18 @@ export const CACHE_TOOLS: ToolDef[] = [
       // that deploys independently; an undeclared basis must read as
       // FLOW_SOURCE_UNSPECIFIED, never leak verbatim.
       //
-      // Deliberately NOT guarded on `'source' in entry`: the REST twin builds
-      // `source: toFlowSource(...)` unconditionally, so an entry that omits the
-      // key entirely must still read FLOW_SOURCE_UNSPECIFIED here rather than
-      // arrive with the field missing — otherwise the two surfaces answer
-      // differently for the same blob, which is the divergence this closes.
-      // tests/chokepoint-flow-source-taxonomy.test.mts pins that case on REST.
+      // Deliberately NOT guarded on `'source' in entry`. This is about the
+      // CLOSED-ENUM field specifically: the schema above declares a closed set
+      // for `source`, and "absent" is not a member of it, so an entry omitting
+      // the key must read FLOW_SOURCE_UNSPECIFIED — the declared way to say
+      // "not one of the known bases". The REST twin resolves it the same way
+      // (`source: toFlowSource(...)`, built unconditionally), and
+      // tests/chokepoint-flow-source-taxonomy.test.mts pins that case there.
+      //
+      // Scope note: this is NOT a general "match REST field-for-field" rule.
+      // REST also defaults hazardAlertLevel/hazardAlertName (`?? ''`), and this
+      // surface deliberately does not — see the nullability comment on those
+      // two fields above. Closed enum here, raw passthrough there, on purpose.
       const flows = data['chokepoint-flows'];
       if (flows && typeof flows === 'object') {
         for (const entry of Object.values(flows)) {

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -14,6 +14,7 @@ import {
   computeCredibilityScore,
 } from '../../../shared/news-credibility.js';
 import { getSourceTier } from '../../../server/_shared/source-tiers';
+import { FLOW_SOURCE_WIRE_VALUES, narrowFlowSource } from '../../../server/_shared/flow-source';
 import { hasRedistributableProviderAttribution } from '../../../shared/provider-redistribution';
 import { CII_RISK_SCORE_CACHE_KEYS } from '../../_cii-risk-cache-keys.js';
 // @ts-expect-error — generated Edge-safe JS mirror; authored types live in shared/bootstrap-tier-keys.d.ts
@@ -2508,11 +2509,38 @@ export const CACHE_TOOLS: ToolDef[] = [
       },
       'chokepoint-flows': {
         type: ['object', 'null'],
-        additionalProperties: { type: 'object' },
+        additionalProperties: { type: 'object', properties: {
+          currentMbd: { type: ['number', 'null'] },
+          baselineMbd: { type: ['number', 'null'] },
+          flowRatio: { type: ['number', 'null'] },
+          disrupted: { type: 'boolean' },
+          // The closed taxonomy #6101 promoted on the REST path; served
+          // values are narrowed onto it in _postFilter below, so this enum
+          // is enforced, not aspirational (#6113).
+          source: { type: 'string', enum: [...FLOW_SOURCE_WIRE_VALUES] },
+          // Raw seeder value, NOT the closed hazard enum — that half is
+          // blocked on sebuf codegen for the REST twin (#6106) and the two
+          // surfaces should adopt it together.
+          hazardAlertLevel: { type: ['string', 'null'] },
+          hazardAlertName: { type: ['string', 'null'] },
+        } },
       },
     }),
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _postFilter: (data, params) => {
+      // Narrow BEFORE any filtering so the declared source enum above is a
+      // property of every served response, exactly as the REST boundary's
+      // narrowServedSources makes it (#6113). The blob is written by a seeder
+      // that deploys independently; an undeclared basis must read as
+      // FLOW_SOURCE_UNSPECIFIED, never leak verbatim.
+      const flows = data['chokepoint-flows'];
+      if (flows && typeof flows === 'object') {
+        for (const entry of Object.values(flows)) {
+          if (entry && typeof entry === 'object' && 'source' in entry) {
+            (entry as { source: unknown }).source = narrowFlowSource((entry as { source: unknown }).source);
+          }
+        }
+      }
       const cp = argStr(params.chokepoint);
       if (cp) {
         mapNested(data, 'transit-summaries', 'summaries', (m) => pickMapKeysLike(m, cp));

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -2518,9 +2518,19 @@ export const CACHE_TOOLS: ToolDef[] = [
           // values are narrowed onto it in _postFilter below, so this enum
           // is enforced, not aspirational (#6113).
           source: { type: 'string', enum: [...FLOW_SOURCE_WIRE_VALUES] },
-          // Raw seeder value, NOT the closed hazard enum — that half is
-          // blocked on sebuf codegen for the REST twin (#6106) and the two
-          // surfaces should adopt it together.
+          // Raw seeder value, NOT the closed hazard enum. Hand-authored JSON
+          // Schema COULD express it here today (#6113 says so explicitly; see
+          // the `source` enums on get_toronto_* above) — this is DEFERRED, not
+          // blocked: #6106 blocks the REST twin on sebuf codegen, and shipping
+          // the closed set on one surface only would recreate the very
+          // declare-vs-serve split this tool just closed for `source`.
+          //
+          // Nullability is likewise a DELIBERATE divergence from REST, not an
+          // oversight: get-chokepoint-status.ts coerces `null -> ''` because
+          // the proto field is non-nullable, a constraint this hand-authored
+          // schema does not have. Serving `null` keeps "no hazard nearby"
+          // distinguishable from "hazard with an empty name", which is the more
+          // useful answer for an agent. Declared as it is actually served.
           hazardAlertLevel: { type: ['string', 'null'] },
           hazardAlertName: { type: ['string', 'null'] },
         } },
@@ -2533,10 +2543,17 @@ export const CACHE_TOOLS: ToolDef[] = [
       // narrowServedSources makes it (#6113). The blob is written by a seeder
       // that deploys independently; an undeclared basis must read as
       // FLOW_SOURCE_UNSPECIFIED, never leak verbatim.
+      //
+      // Deliberately NOT guarded on `'source' in entry`: the REST twin builds
+      // `source: toFlowSource(...)` unconditionally, so an entry that omits the
+      // key entirely must still read FLOW_SOURCE_UNSPECIFIED here rather than
+      // arrive with the field missing — otherwise the two surfaces answer
+      // differently for the same blob, which is the divergence this closes.
+      // tests/chokepoint-flow-source-taxonomy.test.mts pins that case on REST.
       const flows = data['chokepoint-flows'];
       if (flows && typeof flows === 'object') {
         for (const entry of Object.values(flows)) {
-          if (entry && typeof entry === 'object' && 'source' in entry) {
+          if (entry && typeof entry === 'object') {
             (entry as { source: unknown }).source = narrowFlowSource((entry as { source: unknown }).source);
           }
         }

--- a/server/_shared/flow-source.ts
+++ b/server/_shared/flow-source.ts
@@ -11,18 +11,19 @@ import type { FlowSource } from '../../src/generated/server/worldmonitor/supply_
  * the new member would simply be absent, and a consumer would silently strip
  * the very value the proto had just declared legal.
  */
-export const FLOW_SOURCE_MEMBERS: Record<Exclude<FlowSource, 'FLOW_SOURCE_UNSPECIFIED'>, true> = {
+const FLOW_SOURCE_MEMBERS: Record<Exclude<FlowSource, 'FLOW_SOURCE_UNSPECIFIED'>, true> = {
   'portwatch-dwt': true,
   'portwatch-counts': true,
 };
 
 /**
- * Deliberately module-private: `narrowFlowSource` below is the ONLY narrowing
- * entry point any surface should use. Exporting the raw set invites a second
- * hand-rolled `FLOW_SOURCES.has(...)` predicate elsewhere, and the axis that
- * drifts in practice is the predicate (case-folding, trimming, a legacy alias),
- * not the member list — so sharing the set without sharing the decision would
- * leave exactly the REST/MCP divergence #6113 exists to close.
+ * Module-private, along with the record above it: `narrowFlowSource` and
+ * `FLOW_SOURCE_WIRE_VALUES` are this module's whole public surface, so there is
+ * no exported handle a caller could rebuild a second predicate from. The axis
+ * that drifts in practice is the predicate (case-folding, trimming, a legacy
+ * alias), not the member list, so exporting either the set OR the record it is
+ * derived from would leave the REST/MCP divergence #6113 exists to close —
+ * `new Set(Object.keys(FLOW_SOURCE_MEMBERS))` is a one-line copy of this line.
  */
 const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
 

--- a/server/_shared/flow-source.ts
+++ b/server/_shared/flow-source.ts
@@ -1,0 +1,40 @@
+import type { FlowSource } from '../../src/generated/server/worldmonitor/supply_chain/v1/service_server';
+
+/**
+ * The one FlowSource taxonomy shared by every surface that serves
+ * `energy:chokepoint-flows:v1` (#6101 promoted the REST/OpenAPI/TS path;
+ * #6113 brought the MCP cache tool onto the same set).
+ *
+ * Declared as an EXHAUSTIVE record over the non-UNSPECIFIED FlowSource
+ * members so that adding a member to the proto is a compile error in every
+ * consumer. A plain `Set<FlowSource>` caught a typo but not an omission —
+ * the new member would simply be absent, and a consumer would silently strip
+ * the very value the proto had just declared legal.
+ */
+export const FLOW_SOURCE_MEMBERS: Record<Exclude<FlowSource, 'FLOW_SOURCE_UNSPECIFIED'>, true> = {
+  'portwatch-dwt': true,
+  'portwatch-counts': true,
+};
+
+export const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
+
+/**
+ * Every wire value the taxonomy admits, UNSPECIFIED first — the `enum:` list
+ * a schema surface declares. Deriving it from the record keeps declare and
+ * serve on one source of truth.
+ */
+export const FLOW_SOURCE_WIRE_VALUES: readonly string[] = [
+  'FLOW_SOURCE_UNSPECIFIED',
+  ...Object.keys(FLOW_SOURCE_MEMBERS),
+];
+
+/**
+ * Narrow an untyped seeder value onto the taxonomy. The chokepoint-flows blob
+ * is written by a seeder that deploys independently of any consumer, so a
+ * served `source` is not guaranteed to be a declared member — and a closed
+ * taxonomy is only honest if the boundary that declares it also enforces it.
+ */
+export function narrowFlowSource(value: unknown): FlowSource {
+  if (typeof value === 'string' && FLOW_SOURCES.has(value)) return value as FlowSource;
+  return 'FLOW_SOURCE_UNSPECIFIED';
+}

--- a/server/_shared/flow-source.ts
+++ b/server/_shared/flow-source.ts
@@ -16,7 +16,15 @@ export const FLOW_SOURCE_MEMBERS: Record<Exclude<FlowSource, 'FLOW_SOURCE_UNSPEC
   'portwatch-counts': true,
 };
 
-export const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
+/**
+ * Deliberately module-private: `narrowFlowSource` below is the ONLY narrowing
+ * entry point any surface should use. Exporting the raw set invites a second
+ * hand-rolled `FLOW_SOURCES.has(...)` predicate elsewhere, and the axis that
+ * drifts in practice is the predicate (case-folding, trimming, a legacy alias),
+ * not the member list — so sharing the set without sharing the decision would
+ * leave exactly the REST/MCP divergence #6113 exists to close.
+ */
+const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
 
 /**
  * Every wire value the taxonomy admits, UNSPECIFIED first — the `enum:` list
@@ -33,6 +41,10 @@ export const FLOW_SOURCE_WIRE_VALUES: readonly string[] = [
  * is written by a seeder that deploys independently of any consumer, so a
  * served `source` is not guaranteed to be a declared member — and a closed
  * taxonomy is only honest if the boundary that declares it also enforces it.
+ *
+ * Total over every input, including `undefined` (an entry that omits `source`
+ * entirely): both surfaces must answer FLOW_SOURCE_UNSPECIFIED for that, so no
+ * caller should guard on key presence before calling this.
  */
 export function narrowFlowSource(value: unknown): FlowSource {
   if (typeof value === 'string' && FLOW_SOURCES.has(value)) return value as FlowSource;

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -20,7 +20,7 @@ import { getVesselSnapshot } from '../../maritime/v1/get-vessel-snapshot';
 import { computeDisruptionScore, scoreToStatus, SEVERITY_SCORE, THREAT_LEVEL } from './_scoring.mjs';
 import { type ThreatLevel, threatLevelToWarRiskTier } from './_insurance-tier';
 import { CHOKEPOINT_STATUS_KEY as REDIS_CACHE_KEY } from '../../../_shared/cache-keys';
-import { FLOW_SOURCES } from '../../../_shared/flow-source';
+import { narrowFlowSource } from '../../../_shared/flow-source';
 const TRANSIT_SUMMARIES_KEY = 'supply_chain:transit-summaries:v1';
 const FLOWS_KEY = 'energy:chokepoint-flows:v1';
 // NOTE: historical fallback via supply_chain:portwatch:v1 / corridorrisk / chokepoint_transits
@@ -350,7 +350,12 @@ interface FlowEstimateEntry { currentMbd: number; baselineMbd: number; flowRatio
 const warnedFlowSources = new Set<string>();
 
 function toFlowSource(value: unknown): FlowSource {
-  if (typeof value === 'string' && FLOW_SOURCES.has(value)) return value as FlowSource;
+  // Delegate the DECISION, not just the member set: a second copy of the
+  // predicate here would let REST and the MCP cache tool answer differently for
+  // the same Redis blob the moment either side learned to trim or case-fold.
+  // This wrapper adds only the REST-side warn (#6113).
+  const narrowed = narrowFlowSource(value);
+  if (narrowed !== 'FLOW_SOURCE_UNSPECIFIED') return narrowed;
   if (value !== undefined && value !== null && value !== '') {
     const seen = String(value);
     if (!warnedFlowSources.has(seen)) {

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -20,6 +20,7 @@ import { getVesselSnapshot } from '../../maritime/v1/get-vessel-snapshot';
 import { computeDisruptionScore, scoreToStatus, SEVERITY_SCORE, THREAT_LEVEL } from './_scoring.mjs';
 import { type ThreatLevel, threatLevelToWarRiskTier } from './_insurance-tier';
 import { CHOKEPOINT_STATUS_KEY as REDIS_CACHE_KEY } from '../../../_shared/cache-keys';
+import { FLOW_SOURCES } from '../../../_shared/flow-source';
 const TRANSIT_SUMMARIES_KEY = 'supply_chain:transit-summaries:v1';
 const FLOWS_KEY = 'energy:chokepoint-flows:v1';
 // NOTE: historical fallback via supply_chain:portwatch:v1 / corridorrisk / chokepoint_transits
@@ -323,20 +324,9 @@ interface ChokepointFetchResult {
 
 interface FlowEstimateEntry { currentMbd: number; baselineMbd: number; flowRatio: number; disrupted: boolean; source: string; hazardAlertLevel: string | null; hazardAlertName: string | null }
 
-/**
- * The coverage bases seed-chokepoint-flows.mjs can emit. Declared as an
- * EXHAUSTIVE record over the non-UNSPECIFIED FlowSource members so that adding
- * a member to the proto is a compile error here. A plain `Set<FlowSource>`
- * caught a typo but not an omission — the new member would simply be absent,
- * and this handler would silently strip the very value the proto had just
- * declared legal.
- */
-const FLOW_SOURCE_MEMBERS: Record<Exclude<FlowSource, 'FLOW_SOURCE_UNSPECIFIED'>, true> = {
-  'portwatch-dwt': true,
-  'portwatch-counts': true,
-};
-
-const FLOW_SOURCES: ReadonlySet<string> = new Set(Object.keys(FLOW_SOURCE_MEMBERS));
+// The taxonomy record lives in server/_shared/flow-source.ts (#6113) so this
+// handler and the MCP cache tool narrow and declare from one source of truth;
+// the exhaustive-record compile check moved with it.
 
 /**
  * Narrow the seeder's `source` onto the FlowSource taxonomy the proto declares

--- a/tests/mcp-flow-source-taxonomy.test.mts
+++ b/tests/mcp-flow-source-taxonomy.test.mts
@@ -41,6 +41,19 @@ function flowsData() {
         currentMbd: 1.1, baselineMbd: 1.2, flowRatio: 0.917, disrupted: false,
         source: null, hazardAlertLevel: null, hazardAlertName: null,
       },
+      // The drift axis flow-source.ts names as the reason narrowing is
+      // centralised: a case variant and a whitespace-padded value. Both are
+      // undeclared today, and if narrowFlowSource ever learns to case-fold or
+      // trim, these two assertions are what forces the REST twin to learn it in
+      // the same edit instead of silently diverging.
+      gibraltar: {
+        currentMbd: 3, baselineMbd: 3, flowRatio: 1, disrupted: false,
+        source: 'Portwatch-Dwt', hazardAlertLevel: null, hazardAlertName: null,
+      },
+      dover_strait: {
+        currentMbd: 2, baselineMbd: 2, flowRatio: 1, disrupted: false,
+        source: ' portwatch-dwt ', hazardAlertLevel: null, hazardAlertName: null,
+      },
       korea_strait: {
         // `source` key absent ENTIRELY — the case the REST twin pins as
         // `korea_strait: flow(undefined)` in chokepoint-flow-source-taxonomy
@@ -54,12 +67,17 @@ function flowsData() {
 }
 
 describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
-  // Every assertion below reads the RETURNED object, never the argument that
-  // was passed in. api/mcp/dispatch.ts serves `_postFilter`'s return value
-  // (`result = tool._postFilter(structuredClone(data), params)`), so asserting
-  // on the caller's own reference would keep passing if a future refactor
-  // rebuilt entries instead of mutating them — and would keep passing while
-  // un-narrowed sources went out on the wire.
+  // Every assertion below reads the RETURNED object, because that is what
+  // api/mcp/dispatch.ts serves (`result = tool._postFilter(structuredClone(
+  // data), params)`), not the caller's reference.
+  //
+  // Honest limit on what that buys: selectDatasets shallow-copies
+  // (api/mcp/filters.ts:189), so the flows map and its entries are the SAME
+  // objects in both. Reading the return therefore pins the top-level shape the
+  // dispatcher serves, but it canNOT distinguish "mutated in place" from
+  // "rebuilt" — an entry-rebuilding refactor stays invisible either way. The
+  // end-to-end block at the bottom of this file is what actually crosses the
+  // structuredClone + JSON boundary; trust that one for served-bytes claims.
   it('narrows an out-of-taxonomy source to FLOW_SOURCE_UNSPECIFIED and keeps declared values verbatim', () => {
     assert.ok(tool, 'tool must exist in CACHE_TOOLS');
 
@@ -75,6 +93,14 @@ describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
     assert.equal(
       flows.korea_strait.source, 'FLOW_SOURCE_UNSPECIFIED',
       'an entry that omits `source` entirely must be narrowed, not served with the field missing — REST emits UNSPECIFIED for the same blob',
+    );
+    assert.equal(
+      flows.gibraltar.source, 'FLOW_SOURCE_UNSPECIFIED',
+      'a case variant of a declared basis is NOT a member — narrowing does not case-fold today, and REST must adopt it in the same edit if it ever does',
+    );
+    assert.equal(
+      flows.dover_strait.source, 'FLOW_SOURCE_UNSPECIFIED',
+      'a whitespace-padded declared basis is NOT a member — narrowing does not trim today',
     );
     assert.equal(flows.hormuz_strait.currentMbd, 2.6, 'narrowing must not disturb the numeric fields');
   });
@@ -101,12 +127,11 @@ describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
   });
 
   it('leaves an absent or null chokepoint-flows dataset alone', () => {
-    const empty = { 'chokepoint-flows': null };
-    assert.doesNotThrow(() => tool._postFilter(empty, {}));
-    assert.equal(empty['chokepoint-flows'], null);
+    let served: Record<string, unknown> | undefined;
+    assert.doesNotThrow(() => { served = tool._postFilter({ 'chokepoint-flows': null }, {}); });
+    assert.equal(served!['chokepoint-flows'], null);
 
-    const missing = {};
-    assert.doesNotThrow(() => tool._postFilter(missing, {}));
+    assert.doesNotThrow(() => tool._postFilter({}, {}));
   });
 
   // The guard is `entry && typeof entry === 'object'`; the test above only
@@ -224,5 +249,60 @@ describe('get_chokepoint_status narrows source end-to-end through tools/call (#6
       );
       assert.equal(served[id].source, 'FLOW_SOURCE_UNSPECIFIED');
     }
+  });
+
+  // KNOWN LIMIT, pinned rather than claimed away. api/mcp/dispatch.ts wraps
+  // `_postFilter` in a try/catch that falls back to the RAW, un-narrowed `data`
+  // on any non-stored-contract throw, so the closed-enum guarantee holds only
+  // while the WHOLE filter body avoids throwing — not just the narrowing loop,
+  // which is total over any JSON shape. The reachable trigger today is
+  // pre-existing and downstream of the narrowing: narrowNested dereferences
+  // `c.id` on every chokepoint-baselines row, so a null row throws once a
+  // `chokepoint` argument is supplied.
+  //
+  // This asserts what the code ACTUALLY does, so the day someone makes the
+  // enum fail closed (or the fallback stops discarding the narrowed clone),
+  // this test goes red and the decision is deliberate instead of accidental.
+  it('fails OPEN: a throw later in the filter serves the raw un-narrowed source', async () => {
+    globalThis.fetch = async (url, init) => {
+      const u = url.toString();
+      if (u.endsWith('/pipeline')) {
+        const commands = JSON.parse(init.body);
+        return Response.json(commands.map(() => ({ result: 0 })));
+      }
+      if (u.includes(`/get/${encodeURIComponent('energy:chokepoint-flows:v1')}`)) {
+        return Response.json({ result: JSON.stringify(FLOWS) });
+      }
+      // A null row makes narrowNested's `c.id` deref throw — but only once the
+      // `chokepoint` argument below sends the filter down that branch.
+      if (u.includes(`/get/${encodeURIComponent('energy:chokepoint-baselines:v1')}`)) {
+        return Response.json({ result: JSON.stringify({ chokepoints: [null] }) });
+      }
+      return Response.json({ result: null });
+    };
+
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}-${Math.random()}`);
+    const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 2, method: 'tools/call',
+        params: { name: 'get_chokepoint_status', arguments: { chokepoint: 'suez' } },
+      }),
+    }));
+
+    assert.equal(res.status, 200, 'the fail-open path must still answer 200, not surface the filter bug');
+    const body = await res.json();
+    assert.ok(body.result?.content, 'tools/call must return content on the fail-open path');
+    const served = JSON.parse(body.result.content[0].text).data['chokepoint-flows'];
+
+    assert.equal(
+      served.suez.source, 'satellite-blend',
+      'CURRENT behaviour: the fallback discards the narrowed clone, so an undeclared basis reaches the client verbatim despite the outputSchema advertising a closed enum. Change this assertion only alongside a deliberate decision to make the enum fail closed.',
+    );
+    assert.ok(
+      !WIRE_TAXONOMY.includes(served.suez.source),
+      'and that served value is outside the declared enum — this is the gap, stated plainly',
+    );
   });
 });

--- a/tests/mcp-flow-source-taxonomy.test.mts
+++ b/tests/mcp-flow-source-taxonomy.test.mts
@@ -1,0 +1,97 @@
+/**
+ * #6113 — the chokepoint-flows dataset served the raw seeder blob on the MCP
+ * surface with no FlowSource taxonomy: not discoverable (the output schema
+ * declared bare `additionalProperties: {type:'object'}`) and not narrowed
+ * (`toFlowSource` never ran on the cache-tool path), while the REST handler
+ * both declared and enforced the closed enum since #6101.
+ *
+ * Option 1 from the issue — narrow AND declare in the same change, so the
+ * declaration and the served bytes move together (the
+ * contract-gate-field-names-miss-value-axis defect class): the tool's
+ * `_postFilter` narrows `source` onto the taxonomy exactly like the REST
+ * boundary does, and the schema declares the enum an agent can discover from
+ * `tools/list`. Both sides import one shared taxonomy module, typed
+ * exhaustively against the generated `FlowSource`, so a proto change is a
+ * compile error in each consumer rather than silent drift.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { CACHE_TOOLS } from '../api/mcp/registry/cache-tools.ts';
+
+const tool = CACHE_TOOLS.find((t) => t.name === 'get_chokepoint_status');
+
+/** The wire taxonomy #6101 promoted (generated FlowSource union). */
+const WIRE_TAXONOMY = ['FLOW_SOURCE_UNSPECIFIED', 'portwatch-dwt', 'portwatch-counts'];
+
+function flowsData() {
+  return {
+    'chokepoint-flows': {
+      hormuz_strait: {
+        currentMbd: 2.6, baselineMbd: 21, flowRatio: 0.123, disrupted: true,
+        source: 'portwatch-dwt', hazardAlertLevel: 'RED', hazardAlertName: 'HORMUZ-26',
+      },
+      suez: {
+        currentMbd: 7.6, baselineMbd: 7.6, flowRatio: 1.001, disrupted: false,
+        // An undeclared basis a newer seeder deploy could emit — the exact
+        // value class the REST boundary narrows and MCP served verbatim.
+        source: 'satellite-blend', hazardAlertLevel: null, hazardAlertName: null,
+      },
+      panama: {
+        currentMbd: 1.1, baselineMbd: 1.2, flowRatio: 0.917, disrupted: false,
+        source: null, hazardAlertLevel: null, hazardAlertName: null,
+      },
+    },
+  };
+}
+
+describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
+  it('narrows an out-of-taxonomy source to FLOW_SOURCE_UNSPECIFIED and keeps declared values verbatim', () => {
+    assert.ok(tool, 'tool must exist in CACHE_TOOLS');
+    const data = flowsData();
+
+    tool._postFilter(data, {});
+
+    const flows = data['chokepoint-flows'];
+    assert.equal(flows.hormuz_strait.source, 'portwatch-dwt', 'a declared basis passes through untouched');
+    assert.equal(
+      flows.suez.source, 'FLOW_SOURCE_UNSPECIFIED',
+      'an undeclared seeder value must be narrowed, not served verbatim — the schema promise must be kept by the code',
+    );
+    assert.equal(flows.panama.source, 'FLOW_SOURCE_UNSPECIFIED', 'a missing basis narrows too');
+    assert.equal(flows.hormuz_strait.currentMbd, 2.6, 'narrowing must not disturb the numeric fields');
+  });
+
+  it('narrows on the filtered path too (chokepoint param applied)', () => {
+    const data = flowsData();
+
+    tool._postFilter(data, { chokepoint: 'suez' });
+
+    assert.deepEqual(Object.keys(data['chokepoint-flows']), ['suez']);
+    assert.equal(data['chokepoint-flows'].suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+  });
+
+  it('leaves an absent or null chokepoint-flows dataset alone', () => {
+    const empty = { 'chokepoint-flows': null };
+    assert.doesNotThrow(() => tool._postFilter(empty, {}));
+    assert.equal(empty['chokepoint-flows'], null);
+
+    const missing = {};
+    assert.doesNotThrow(() => tool._postFilter(missing, {}));
+  });
+
+  it('declares the closed taxonomy in the output schema an agent discovers', () => {
+    const flowsSchema = tool.outputSchema.properties.data.properties['chokepoint-flows'];
+    const valueSchema = flowsSchema.additionalProperties;
+    assert.equal(valueSchema.type, 'object');
+    assert.deepEqual(
+      valueSchema.properties.source.enum, WIRE_TAXONOMY,
+      'the enum an agent sees from tools/list must be the taxonomy the served bytes are narrowed onto',
+    );
+    // The declared value shape carries the real flow fields, not a bare
+    // object — the coverage fixture stops passing trivially.
+    for (const field of ['currentMbd', 'baselineMbd', 'flowRatio', 'disrupted', 'hazardAlertLevel']) {
+      assert.ok(valueSchema.properties[field], `schema must declare ${field}`);
+    }
+  });
+});

--- a/tests/mcp-flow-source-taxonomy.test.mts
+++ b/tests/mcp-flow-source-taxonomy.test.mts
@@ -15,7 +15,7 @@
  * compile error in each consumer rather than silent drift.
  */
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 
 import { CACHE_TOOLS } from '../api/mcp/registry/cache-tools.ts';
 
@@ -41,34 +41,63 @@ function flowsData() {
         currentMbd: 1.1, baselineMbd: 1.2, flowRatio: 0.917, disrupted: false,
         source: null, hazardAlertLevel: null, hazardAlertName: null,
       },
+      korea_strait: {
+        // `source` key absent ENTIRELY — the case the REST twin pins as
+        // `korea_strait: flow(undefined)` in chokepoint-flow-source-taxonomy
+        // .test.mts. REST emits FLOW_SOURCE_UNSPECIFIED for it, so MCP must
+        // too; a presence guard here would serve the field missing instead.
+        currentMbd: 0.4, baselineMbd: 0.4, flowRatio: 1, disrupted: false,
+        hazardAlertLevel: null, hazardAlertName: null,
+      },
     },
   };
 }
 
 describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
+  // Every assertion below reads the RETURNED object, never the argument that
+  // was passed in. api/mcp/dispatch.ts serves `_postFilter`'s return value
+  // (`result = tool._postFilter(structuredClone(data), params)`), so asserting
+  // on the caller's own reference would keep passing if a future refactor
+  // rebuilt entries instead of mutating them — and would keep passing while
+  // un-narrowed sources went out on the wire.
   it('narrows an out-of-taxonomy source to FLOW_SOURCE_UNSPECIFIED and keeps declared values verbatim', () => {
     assert.ok(tool, 'tool must exist in CACHE_TOOLS');
-    const data = flowsData();
 
-    tool._postFilter(data, {});
+    const served = tool._postFilter(flowsData(), {});
 
-    const flows = data['chokepoint-flows'];
+    const flows = served['chokepoint-flows'];
     assert.equal(flows.hormuz_strait.source, 'portwatch-dwt', 'a declared basis passes through untouched');
     assert.equal(
       flows.suez.source, 'FLOW_SOURCE_UNSPECIFIED',
       'an undeclared seeder value must be narrowed, not served verbatim — the schema promise must be kept by the code',
     );
-    assert.equal(flows.panama.source, 'FLOW_SOURCE_UNSPECIFIED', 'a missing basis narrows too');
+    assert.equal(flows.panama.source, 'FLOW_SOURCE_UNSPECIFIED', 'an explicit null basis narrows too');
+    assert.equal(
+      flows.korea_strait.source, 'FLOW_SOURCE_UNSPECIFIED',
+      'an entry that omits `source` entirely must be narrowed, not served with the field missing — REST emits UNSPECIFIED for the same blob',
+    );
     assert.equal(flows.hormuz_strait.currentMbd, 2.6, 'narrowing must not disturb the numeric fields');
   });
 
   it('narrows on the filtered path too (chokepoint param applied)', () => {
-    const data = flowsData();
+    const served = tool._postFilter(flowsData(), { chokepoint: 'suez' });
 
-    tool._postFilter(data, { chokepoint: 'suez' });
+    assert.deepEqual(Object.keys(served['chokepoint-flows']), ['suez']);
+    assert.equal(served['chokepoint-flows'].suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+  });
 
-    assert.deepEqual(Object.keys(data['chokepoint-flows']), ['suez']);
-    assert.equal(data['chokepoint-flows'].suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+  // `dataset` is the one argument shape where selectDatasets (api/mcp/filters
+  // .ts:187-192) builds a genuinely NEW top-level object rather than returning
+  // the input reference — the branch where "assert on input" and "assert on
+  // return" could diverge. Nothing else in this file exercises it.
+  it('narrows on the dataset-selected path, where the returned object is not the input object', () => {
+    const input = flowsData();
+    const served = tool._postFilter(input, { dataset: ['chokepoint-flows'] });
+
+    assert.notEqual(served, input, 'selectDatasets must have built a new top-level object for this case');
+    assert.deepEqual(Object.keys(served), ['chokepoint-flows'], 'only the requested dataset is served');
+    assert.equal(served['chokepoint-flows'].suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+    assert.equal(served['chokepoint-flows'].korea_strait.source, 'FLOW_SOURCE_UNSPECIFIED');
   });
 
   it('leaves an absent or null chokepoint-flows dataset alone', () => {
@@ -78,6 +107,30 @@ describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
 
     const missing = {};
     assert.doesNotThrow(() => tool._postFilter(missing, {}));
+  });
+
+  // The guard is `entry && typeof entry === 'object'`; the test above only
+  // covers the dataset itself being null/absent. These are the per-ENTRY
+  // branches — a filter throw is not loud, it is silent: dispatch.ts catches it
+  // and falls back to the RAW un-narrowed blob, so a crash here would quietly
+  // undo the enum guarantee rather than fail the call.
+  it('tolerates null and non-object entries inside a populated map', () => {
+    const data = {
+      'chokepoint-flows': {
+        suez: null,
+        panama: 'not-an-object',
+        hormuz_strait: { currentMbd: 2.6, source: 'satellite-blend' },
+      },
+    };
+
+    const served = tool._postFilter(data, {});
+
+    assert.equal(served['chokepoint-flows'].suez, null, 'a null entry is left alone, not crashed on');
+    assert.equal(served['chokepoint-flows'].panama, 'not-an-object', 'a non-object entry is left alone');
+    assert.equal(
+      served['chokepoint-flows'].hormuz_strait.source, 'FLOW_SOURCE_UNSPECIFIED',
+      'a malformed sibling must not stop the good entry from being narrowed',
+    );
   });
 
   it('declares the closed taxonomy in the output schema an agent discovers', () => {
@@ -92,6 +145,84 @@ describe('get_chokepoint_status FlowSource taxonomy (#6113)', () => {
     // object — the coverage fixture stops passing trivially.
     for (const field of ['currentMbd', 'baselineMbd', 'flowRatio', 'disrupted', 'hazardAlertLevel']) {
       assert.ok(valueSchema.properties[field], `schema must declare ${field}`);
+    }
+  });
+});
+
+/**
+ * #6113's acceptance asks for a test that "drives the MCP tool ... and asserts
+ * the SERVED value is narrowed — not just that the schema validates". The block
+ * above calls `_postFilter` directly, which does not cross the dispatcher: it
+ * misses `structuredClone`, the fail-open try/catch, and JSON serialization.
+ * This drives a real `tools/call` through api/mcp.ts and reads the bytes a
+ * client actually receives, matching the bar the REST twin's own gate sets in
+ * tests/chokepoint-flow-source-taxonomy.test.mts.
+ */
+describe('get_chokepoint_status narrows source end-to-end through tools/call (#6113)', () => {
+  const VALID_KEY = 'wm_test_key_flow_source';
+  const originalFetch = globalThis.fetch;
+  const originalEnv = { ...process.env };
+
+  // An undeclared basis, an explicit null, and a missing key — the three
+  // classes that must all reach the client as FLOW_SOURCE_UNSPECIFIED.
+  const FLOWS = {
+    suez: { currentMbd: 7.6, baselineMbd: 7.6, flowRatio: 1.001, disrupted: false, source: 'satellite-blend' },
+    panama: { currentMbd: 1.1, baselineMbd: 1.2, flowRatio: 0.917, disrupted: false, source: null },
+    korea_strait: { currentMbd: 0.4, baselineMbd: 0.4, flowRatio: 1, disrupted: false },
+    hormuz_strait: { currentMbd: 2.6, baselineMbd: 21, flowRatio: 0.123, disrupted: true, source: 'portwatch-dwt' },
+  };
+
+  beforeEach(() => {
+    process.env.WORLDMONITOR_VALID_KEYS = VALID_KEY;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    globalThis.fetch = async (url, init) => {
+      const u = url.toString();
+      if (u.endsWith('/pipeline')) {
+        const commands = JSON.parse(init.body);
+        return Response.json(commands.map(() => ({ result: 0 })));
+      }
+      if (u.includes(`/get/${encodeURIComponent('energy:chokepoint-flows:v1')}`)) {
+        return Response.json({ result: JSON.stringify(FLOWS) });
+      }
+      // Every other key (the five sibling datasets and all seed-meta reads)
+      // answers empty: this test is about the flows dataset only, and a stale
+      // aggregate does not suppress the payload.
+      return Response.json({ result: null });
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const k of Object.keys(process.env)) if (!(k in originalEnv)) delete process.env[k];
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('serves no source value outside the declared enum', async () => {
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}-${Math.random()}`);
+
+    const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'tools/call',
+        params: { name: 'get_chokepoint_status', arguments: {} },
+      }),
+    }));
+
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'tools/call must return content');
+    const served = JSON.parse(body.result.content[0].text).data['chokepoint-flows'];
+
+    assert.equal(served.hormuz_strait.source, 'portwatch-dwt', 'a declared basis survives the round trip verbatim');
+    for (const id of ['suez', 'panama', 'korea_strait']) {
+      assert.ok(
+        WIRE_TAXONOMY.includes(served[id].source),
+        `${id} reached the client as "${served[id].source}", outside the enum the outputSchema advertises`,
+      );
+      assert.equal(served[id].source, 'FLOW_SOURCE_UNSPECIFIED');
     }
   });
 });

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2569,12 +2569,13 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const portwatchPortsPayload = { countries: { US: { ports: 23 } } };
     const chokepointBaselinesPayload = { suez: { lat: 30.0, lon: 32.5 } };
     const portwatchChokepointsRefPayload = { count: 13, ids: ['suez', 'hormuz', 'malacca'] };
-    // Carries an in-taxonomy `source` so this label-walk assertion keeps testing
-    // LABELLING only: get_chokepoint_status's _postFilter narrows every flow
-    // entry's `source` onto the FlowSource taxonomy (#6113), so a source-less
-    // fixture would come back with `source: 'FLOW_SOURCE_UNSPECIFIED'` added and
-    // fail the deepEqual below for a reason that has nothing to do with labels.
-    const chokepointFlowsPayload = { suez: { dailyBarrels: 9_200_000, source: 'portwatch-dwt' } };
+    // Deliberately source-LESS, mirroring a blob an older seeder deploy could
+    // still hold. The served expectation below states the narrowed shape
+    // explicitly rather than hiding the synthesis behind an in-taxonomy fixture
+    // value, so this stays a byte-identity check on the served slice: any field
+    // get_chokepoint_status's _postFilter adds or drops in future goes red here,
+    // in a file independent of the taxonomy suite that introduced the behaviour.
+    const chokepointFlowsPayload = { suez: { dailyBarrels: 9_200_000 } };
 
     // transit-summaries budget=30min → 5min old (fresh)
     const transitSummariesFetchedAt = Date.now() - 5 * 60_000;
@@ -2683,7 +2684,11 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.deepEqual(payload.data['_countries'], portwatchPortsPayload, 'portwatch-ports slice labelled from trailing _countries segment');
     assert.deepEqual(payload.data['chokepoint-baselines'], chokepointBaselinesPayload, 'chokepoint-baselines slice labelled from cache-key suffix');
     assert.deepEqual(payload.data['ref'], portwatchChokepointsRefPayload, 'portwatch:chokepoints:ref slice labelled from trailing ref segment');
-    assert.deepEqual(payload.data['chokepoint-flows'], chokepointFlowsPayload, 'chokepoint-flows slice labelled from cache-key suffix');
+    assert.deepEqual(
+      payload.data['chokepoint-flows'],
+      { suez: { dailyBarrels: 9_200_000, source: 'FLOW_SOURCE_UNSPECIFIED' } },
+      'chokepoint-flows slice labelled from cache-key suffix, with `source` narrowed onto the FlowSource taxonomy (#6113)',
+    );
   });
 
   it('get_chokepoint_status: fast transit-summaries fresh but slow portwatch-ports past budget flips aggregate stale', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2569,7 +2569,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const portwatchPortsPayload = { countries: { US: { ports: 23 } } };
     const chokepointBaselinesPayload = { suez: { lat: 30.0, lon: 32.5 } };
     const portwatchChokepointsRefPayload = { count: 13, ids: ['suez', 'hormuz', 'malacca'] };
-    const chokepointFlowsPayload = { suez: { dailyBarrels: 9_200_000 } };
+    // Carries an in-taxonomy `source` so this label-walk assertion keeps testing
+    // LABELLING only: get_chokepoint_status's _postFilter narrows every flow
+    // entry's `source` onto the FlowSource taxonomy (#6113), so a source-less
+    // fixture would come back with `source: 'FLOW_SOURCE_UNSPECIFIED'` added and
+    // fail the deepEqual below for a reason that has nothing to do with labels.
+    const chokepointFlowsPayload = { suez: { dailyBarrels: 9_200_000, source: 'portwatch-dwt' } };
 
     // transit-summaries budget=30min → 5min old (fresh)
     const transitSummariesFetchedAt = Date.now() - 5 * 60_000;


### PR DESCRIPTION
Internal re-land of #7450 by @ayobamiseun, so CI can certify it. Refs #6113.

`#7450` is a fork PR that touches `server/`, which `CODEGEN_INPUT_REGEX` matches, so `fork-artifact-check` exits 1 unconditionally and `proto-freshness` fails as its aggregate — with `GENERATE_RESULT`, `PUBLISH_RESULT` and `MERGE_RESULT` all `skipped`. Nothing was stale; generation never ran. CONTRIBUTING.md:305 documents the only remedy: move the commit to a trusted internal branch. This branch carries @ayobamiseun's original commit unchanged (`6670215f`, authorship preserved) plus one review-fix commit.

## What the original commit does

Closes the #6113 asymmetry: `get_chokepoint_status` is a cache tool, so it read `energy:chokepoint-flows:v1` straight from Upstash and never touched the sebuf handler — the `FlowSource` taxonomy #6101 promoted on REST was neither declared nor enforced on the MCP surface. It now does both, in one change (the issue's option 1), via a shared `server/_shared/flow-source.ts` typed exhaustively against the generated `FlowSource` so a proto change is a compile error in every consumer.

## What the review-fix commit adds

- **Shares the narrowing decision, not just the member set.** `toFlowSource` kept a byte-identical copy of the predicate while importing only the member `Set`. It now delegates to `narrowFlowSource`; `FLOW_SOURCES` loses its last external consumer and becomes module-private, so a third hand-rolled predicate cannot appear. The axis that drifts in practice is the predicate (case-folding, trimming, a legacy alias), not the member list.
- **Narrows entries that omit `source` entirely.** The guard was `'source' in entry`, so such an entry was served with the field missing while the REST twin emits `FLOW_SOURCE_UNSPECIFIED` for the same blob — a latent divergence on the exact axis this work closes. `tests/chokepoint-flow-source-taxonomy.test.mts:182` already pins that case on REST.
- **Adds the served-value gate #6113's acceptance asks for.** The original tests called `_postFilter` directly and asserted on the mutated *input*; `dispatch.ts:170` serves the *return*. Every assertion now reads the returned object, plus a real `tools/call` round trip through `api/mcp.ts` asserting the bytes a client receives carry no `source` outside the declared enum. Also covers the `dataset` branch (where `selectDatasets` builds a new object) and null/non-object entries — a throw there is silent, since dispatch falls back to the raw un-narrowed blob.
- **Records the two hazard-field decisions** instead of implying a constraint. The closed hazard enum is **deferred for parity** with the REST twin, not blocked — #6113 notes hand-authored JSON Schema can express it here today. Nullability likewise diverges from REST deliberately: REST coerces `null -> ''` only because its proto field is non-nullable.

`tests/mcp.test.mjs`'s label-walk fixture gains an in-taxonomy `source`, because the absent-key fix would otherwise add `FLOW_SOURCE_UNSPECIFIED` to it and fail a `deepEqual` that is about labelling, not narrowing.

## Verification

`typecheck:api` clean, `lint:boundaries` clean, biome clean. Suites green: 7/7 new taxonomy, 10/10 REST taxonomy, 34/34 output-schema coverage, 177/177 mcp, 149/149 resources + portwatch parity.

Mutation-tested both directions: restoring the presence guard turns 3 red — including the end-to-end assertion `korea_strait reached the client as "undefined", outside the enum the outputSchema advertises` — and no-oping `narrowFlowSource` turns 5 red.

The `unit` failure seen on #7450 at this tree was `tests/proto-codegen-workflow.test.mts:543` asserting `141 !== 0` (SIGPIPE, 128+13) in a file neither commit touches; it passed on a same-SHA re-run.

Credit to @ayobamiseun for the original change. #7450 stays open pending a maintainer's decision to close it as superseded.

https://claude.ai/code/session_017Gc5oYkEZTf5v5rktyuYX6
