### PR TITLE
chore(agents): add the verify-worldmonitor dashboard verification skill

### DIFF
--- a/.agents/skills/verify-worldmonitor/SKILL.md
+++ b/.agents/skills/verify-worldmonitor/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: verify-worldmonitor
+description: Launch and drive the WorldMonitor browser dashboard (Vite app at /dashboard) to prove user-facing behavior with screenshots and transcripts. Use when a change needs proof in the real app rather than only unit tests — panels, map layers, settings, search, country briefs, boot — or when asked to run, screenshot, or verify the dashboard.
+---
+
+# Verify WorldMonitor
+
+WorldMonitor's primary surface is a browser dashboard: a Vite/TypeScript SPA served at `/dashboard`, with a map, a panel grid, a settings overlay, and a command palette. This skill launches one isolated instance of it, drives a feature the way a user does, and leaves evidence behind.
+
+Other surfaces exist and are **out of scope** here: the Vercel Edge API (`api/`), the Tauri desktop app + Node sidecar (`src-tauri/`), Railway seeders (`scripts/`), the embed widget (`embed.html`), and the blog (`blog-site/`). Verify those with their own gates (`npm run test:sidecar`, `npm run test:data`, `npm run typecheck:api`).
+
+Run everything from the repo root of the worktree under test.
+
+## Launch
+
+One long-lived dev server per run; every drive gets a fresh browser context against it.
+
+```bash
+.agents/skills/verify-worldmonitor/scripts/wm-verify.sh launch
+```
+
+It picks the first free port in 4480-4487, starts `VITE_E2E=1 VITE_VARIANT=full npm run dev`, waits until `/tests/map-harness.html` answers 200 (the same readiness probe `playwright.config.ts` uses — it forces a real module transform, so 200 means "can serve the app", not just "socket open"), and writes `.claude/verify-evidence/instance.json` with the pid, port and base URL.
+
+- `VITE_E2E=1` is not optional. It is what stamps `data-wm-event-handlers-ready` and `data-wm-initial-data-ready` on `<html>`; every drive waits on those markers.
+- Pick a variant with `WM_VERIFY_VARIANT=tech|finance|commodity|energy|happy`.
+- Force a port with `launch <port>`. Launch refuses a port someone else holds rather than fighting for it.
+- First run in a fresh worktree needs dependencies: `npm run worktree:bootstrap` (see the `wm-worktree-bootstrap` skill).
+
+**Isolation.** Two instances can run side by side on different ports, but they share `.claude/verify-evidence/instance.json`, so this skill supports **one instance per worktree**. If `launch` reports an instance already running, either reuse it (`doctor` first) or `cleanup`. Never adopt a dev server this run did not start — the user's own `npm run dev` and other worktrees are also vite processes.
+
+## Doctor
+
+```bash
+.agents/skills/verify-worldmonitor/scripts/wm-verify.sh doctor
+```
+
+Read-only. Answers "is this instance worth driving?": the recorded pid is alive, the port is held by **our** process tree (walking parents, so vite-under-npm counts), `/dashboard` returns 200 with the app shell, the process is still vite/npm, and the launch recorded `VITE_E2E=1`. It also prints the dev-server log's error-line count and path.
+
+Run it before the first drive, after any drive that failed, and any time behavior looks wrong. Exit code 0 = OK.
+
+If doctor cannot see the problem — a wedged page on a healthy server — relaunch rather than hoping: `cleanup` then `launch`.
+
+## Drive
+
+```bash
+.agents/skills/verify-worldmonitor/scripts/wm-verify.sh drive <step.mjs> --name <label>
+```
+
+A step file default-exports an async function and lives in `steps/`:
+
+```js
+import { seedProfile, waitForBoot, waitForMap } from './_profile.mjs';
+
+export default async function ({ page, base, shot, log, expectVisible }) {
+  await seedProfile(page);                       // clear storage, dismiss first-run overlays
+  await page.goto(`${base}/dashboard`, { waitUntil: 'domcontentloaded' });
+  await waitForBoot(page, { data: true });       // data-wm-* readiness markers
+  const renderer = await waitForMap(page);       // 'deckgl' | 'globe' | 'svg'
+  await expectVisible('#panelsGrid .panel');
+  await shot('booted');
+  log('renderer', renderer);
+}
+```
+
+The harness gives each step `page`, `context`, `base`, `shot(name)`, `log(...)`, and `expectVisible(selector)`. It records console errors and warnings, every response ≥400, a transcript, and a failure screenshot if the step throws.
+
+Ready-made steps, one per mapped feature:
+
+| Step | Feature |
+|---|---|
+| `steps/dashboard-boot.mjs` | [Dashboard boot](features/dashboard-boot.md) |
+| `steps/panel-settings.mjs` | [Panel settings](features/panel-settings.md) |
+| `steps/country-brief.mjs` | [Country brief](features/country-brief.md) |
+| `steps/global-search.mjs` | [Global search](features/global-search.md) |
+| `steps/map-layers.mjs` | [Map layers](features/map-layers.md) |
+| `steps/_inspect.mjs` | not a feature — dumps live panel keys, layer handles, header ids, and the map renderer when a handle in the map has drifted |
+
+Environment switches: `WM_VERIFY_HEADED=1` (real window, real GPU — the only way to get the deck.gl map), `WM_VERIFY_SOFTWARE_GL=1` (reproduce the repo's playwright GL flags), `WM_VERIFY_PANEL`, `WM_VERIFY_LAYER`, `WM_VERIFY_COUNTRY`, `WM_VERIFY_SEARCH`.
+
+Stable handles worth knowing: `#panelsGrid .panel[data-panel="<key>"]`, `#unifiedSettingsBtn`, `#us-tab-panels`, `#usPanelToggles .panel-toggle-item[data-panel="<key>"]`, `.panels-save-layout`, `#searchBtn`, `.search-modal .search-input`, `.search-result-item[data-index]`, `.layer-toggle[data-layer="<key>"]`, `#country-deep-dive-panel`, `#deep-dive-close`, `#mapDimensionToggle`.
+
+## Evidence
+
+Every drive writes `.claude/verify-evidence/<timestamp>-<label>/` containing numbered screenshots, `transcript.txt`, `console-errors.json`, `console-warnings.json`, `failed-requests.json`, and `result.json`. **Cleanup never touches these** — they are the proof and they outlive the run. `.claude/` is gitignored, so nothing here is ever committed.
+
+Proof standards for this app:
+
+- Drive the real user path — the gear button, the chip, the deep link — not an internal setter or a test-only endpoint.
+- Capture the action and its result, not just the final screen: a screenshot before the change and one after.
+- Check the side effect next to the pixel: the persisted `localStorage` key, the `?layers=` / `?country=` URL, the re-read DOM state. A panel that appears but is not persisted is a bug the screenshot cannot see.
+- Wait on the app's own readiness markers. A fixed sleep either flakes or hides a regression.
+- **The dev server is not the Edge runtime.** `/api/*` mostly returns its own JavaScript source here, so a local run always carries a baseline of console errors and 4xx/5xx responses. UI, routing, persistence and state are provable locally; the *content* of an Edge endpoint (bootstrap payloads, entitlements, auth) is not. Say "unverified — needs a deployed preview" rather than reporting a local pass.
+- `AGENTS.md` governs: locally verified, PR ready, merged, and deployed are different claims.
+
+## Cleanup
+
+```bash
+.agents/skills/verify-worldmonitor/scripts/wm-verify.sh cleanup
+```
+
+Terminates the recorded pid and its children (SIGTERM, then SIGKILL after 10 s) and removes `instance.json`. It kills **only what launch started** — never `pkill vite`, which would take out the user's own dev server and every other worktree's.
+
+Run it after the last drive of the run, and after any failed iteration, so a broken attempt does not strand a port.
+
+## Helpers
+
+- `scripts/wm-verify.sh` — `launch [port] | doctor | drive <step.mjs> [--name label] | cleanup`. Executable; invocations above.
+- `scripts/drive.mjs` — the Playwright driver `drive` delegates to. Runnable directly: `node .agents/skills/verify-worldmonitor/scripts/drive.mjs <step.mjs> --name <label>`.
+- `steps/_profile.mjs` — `seedProfile(page, overrides)`, `waitForBoot(page, {data})`, `waitForMap(page)`.
+
+## Feature map
+
+[`features/README.md`](features/README.md) is the maintained index: baseline preconditions, driving conventions, the local-API reality, and one file per feature with its user entry points, driving recipe, and gotchas. A proof that drives one convenient entry point is incomplete when the map lists others. Keep it honest with `/maintain-verification-skill`.
+
+## Registration
+
+The canonical copy lives in `.agents/skills/verify-worldmonitor/` because `.gitignore` excludes `.claude/` — a skill written there could never be reviewed or shipped in a PR. `.claude/skills/verify-worldmonitor` is a symlink to it so Claude Code registers the skill. Edit the `.agents/` copy.
+
+Two things about that path:
+
+- This clone's `.git/info/exclude` also lists `/.agents`, so **new** files here need `git add -f`. That exclude is local and uncommitted; already-tracked files (this skill, once added) stage normally afterwards.
+- The symlink is what makes the skill discoverable. If a fresh session does not list `verify-worldmonitor`, recreate it: `ln -sfn ../../.agents/skills/verify-worldmonitor .claude/skills/verify-worldmonitor`.

--- a/.agents/skills/verify-worldmonitor/features/README.md
+++ b/.agents/skills/verify-worldmonitor/features/README.md
@@ -1,0 +1,46 @@
+# WorldMonitor verification map
+
+This directory is the maintained source for verifying the user-facing behavior of the WorldMonitor browser dashboard. Read this index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Launch one instance with `.agents/skills/verify-worldmonitor/scripts/wm-verify.sh launch`. It picks a free port in 4480-4487, starts `VITE_E2E=1 VITE_VARIANT=full vite`, and records the pid, port, and base URL in `.claude/verify-evidence/instance.json`.
+- Run `wm-verify.sh doctor` before the first drive and again after any drive that failed. It refuses an instance whose port is held by someone else's process.
+- Never drive an instance this run did not start. Other worktrees and the user's own `npm run dev` are also vite processes on nearby ports.
+- Every drive gets a fresh browser context and a seeded localStorage profile (`steps/_profile.mjs`), so drives do not inherit each other's state.
+- The dev server serves the app only. `/api/*` is NOT the Vercel Edge runtime here — see "Local API reality" below.
+
+## Driving conventions
+
+- Drive through `wm-verify.sh drive <step.mjs> --name <label>`. Each drive writes its own evidence directory under `.claude/verify-evidence/`.
+- One step file per feature, in `../steps/`. A step default-exports `async ({ page, base, shot, log, expectVisible }) => {…}`.
+- Wait on the app's own readiness markers, never on a fixed sleep: `waitForBoot(page)` for `data-wm-event-handlers-ready`, `waitForBoot(page, { data: true })` for `data-wm-initial-data-ready`, and `waitForMap(page)` for a mounted map renderer.
+- Prefer the stable handles this map names (`#unifiedSettingsBtn`, `#panelsGrid .panel[data-panel="…"]`, `.layer-toggle[data-layer="…"]`) over coordinates or tab order.
+- URL state (`?layers=`, `?country=`) is written through a 250 ms debounce. Poll for it with `page.waitForFunction`; a single read right after the action is a race.
+- Use `steps/_inspect.mjs` when a handle in this map no longer matches the app — it dumps the live panel keys, layer handles, header ids, and map renderer.
+
+## Local API reality
+
+`npm run dev` is a Vite server, not `vercel dev`. Only a few `/api/*` routes have dev middleware (`/api/polymarket`, `/api/rss-proxy`, `/api/youtube/live`, `/api/gpsjam`, and the sebuf version alias). Every other `/api/*` path returns its own **JavaScript source** with `content-type: text/javascript`, so the client's `JSON.parse` throws.
+
+Consequences for verification:
+
+- A local run always shows a baseline of console errors and 4xx/5xx responses (`/api/wm-session` 404, `/api/gpsjam` 503, `SyntaxError: Unexpected token 'i', "import __v"…`). These are the dev server, not product regressions. Compare against a previous run's `console-errors.json`, do not expect zero.
+- UI behavior, routing, persistence, panel/layer/settings state, and bundled-data panels are fully verifiable locally.
+- Anything whose proof is the *content* of an Edge endpoint (bootstrap hydration payloads, premium gating, entitlements, auth sessions) is NOT verifiable here. Verify it against a deployed preview instead, and say so rather than reporting a local pass.
+- Setting `VITE_WS_API_URL` to redirect `/api/*` at production was tried and did **not** take effect through the shell environment — do not document it as a working lever without re-proving it.
+
+## Proof and skip reporting
+
+- Capture the action and the resulting state, not only the final screen: screenshot before the change and after it.
+- Verify the side effect alongside what is visible — the persisted `localStorage` key, the URL, the re-read DOM state — not just the pixel.
+- Every drive already records `transcript.txt`, `console-errors.json`, `console-warnings.json`, `failed-requests.json`, and `result.json`. Cite the evidence directory in any claim.
+- Report an unreachable feature with the concrete prerequisite (credential, entitlement, GPU, deployed API) and the route attempted. Do not report it as verified through a different path.
+
+## Features
+
+- [Dashboard boot](./dashboard-boot.md) — a cold visit hydrates into a real dashboard: header, mounted map renderer, populated panel grid.
+- [Panel settings](./panel-settings.md) — the Settings overlay applies a panel toggle to the live dashboard and persists it.
+- [Country brief](./country-brief.md) — the `?country=` deep link opens the country intelligence panel and round-trips through the URL.
+- [Global search](./global-search.md) — the command palette opens from the header and ⌘K, returns ranked matches, and closes.
+- [Map layers](./map-layers.md) — a layer toggle changes the map, the shareable URL, and the persisted preference, in both renderers.

--- a/.agents/skills/verify-worldmonitor/features/country-brief.md
+++ b/.agents/skills/verify-worldmonitor/features/country-brief.md
@@ -1,0 +1,40 @@
+# Country brief
+
+The country brief (deep dive) is the per-country intelligence panel that slides in over the dashboard. A user reaches it from the map, from search, or from a shared link, and the link they share must reopen exactly that country.
+
+## Sub-features
+
+- `brief-deeplink` opens the brief for `?country=<ISO2>` on load; `&expanded=1` opens it maximized.
+- `brief-content` renders the country's sections (heading, signal sections) rather than an empty shell.
+- `brief-url-roundtrip` re-adds `?country=<code>` to the address bar while the brief is visible, so the URL stays shareable.
+- `brief-close` closes the brief from `#deep-dive-close` and drops the parameter.
+- `brief-context-menu` offers "Open country brief" from the map right-click menu.
+- `brief-search` opens the brief from a `Brief: <country>` search result.
+
+## How to get to it (user POV)
+
+- Visit `/dashboard?country=UA` (the shareable link).
+- Right-click a country on the map and choose `Open country brief`.
+- Open the command palette and choose a `Brief: <country>` result.
+
+## Driving it with wm-verify
+
+Preconditions:
+
+- `wm-verify.sh doctor` reports OK.
+- No credential is needed; the brief renders from bundled and directly-fetched data.
+
+- **Deep link.** Navigate to `/dashboard?country=UA`. Run `wm-verify.sh drive .agents/skills/verify-worldmonitor/steps/country-brief.mjs --name country-brief`. Exit code `0`.
+- **Open state.** `#country-deep-dive-panel` reaches `aria-hidden="false"` with computed `visibility: visible`. Both matter — the panel is always in the DOM and slides in via transform, so attachment alone proves nothing.
+- **Content.** `#deep-dive-content` holds 200+ characters of text and a heading. A `UA` run on this checkout reports a `Ukraine` heading with ~23 sections and ~2 000 characters.
+- **URL round-trip.** Poll until `?country=UA` is back in `window.location`. Observed value includes the map state too: `?lat=…&lon=…&zoom=…&view=global&timeRange=7d&layers=…&country=UA`.
+- **Close.** Choose the `×`. `#deep-dive-close` click returns the panel to `aria-hidden="true"`.
+- **Proof.** `01-country-brief-open.png` and `02-country-brief-closed.png`, plus the transcript's content summary and post-open URL.
+
+## Gotchas
+
+- Reading `page.url()` immediately after the brief becomes visible finds NO `country` param and looks like a dropped deep link. `getShareUrl()` re-adds it only on the next debounced (250 ms) URL sync, and map-driven syncs compete with it. Poll for the parameter; do not assert once. This exact false positive was hit while writing this map.
+- The brief opens after `DEEP_LINK_INITIAL_DELAY_MS` and its own retry loop, not at DOM ready. Wait on `aria-hidden`, not on boot.
+- `visibility` is the honest open/closed signal. The panel keeps `right: 0px` in both states; only `transform` and `visibility` change.
+- Section counts and body length vary run to run as data arrives. Assert a floor, log the number.
+- Change the country with `WM_VERIFY_COUNTRY=<ISO2>`; the code is upper-cased and must resolve to a known country name.

--- a/.agents/skills/verify-worldmonitor/features/dashboard-boot.md
+++ b/.agents/skills/verify-worldmonitor/features/dashboard-boot.md
@@ -1,0 +1,41 @@
+# Dashboard boot
+
+A visitor opening WorldMonitor gets the live intelligence dashboard: a header with region, mission, search and settings controls; a world map with layer controls; and a grid of data panels. Until the app hydrates they see a pre-rendered skeleton, which must be gone by the time the dashboard is usable.
+
+## Sub-features
+
+- `boot-hydrate` replaces the `index.html` skeleton shell with the real dashboard.
+- `boot-header` renders the header controls (`#searchBtn`, `#unifiedSettingsBtn`, `#regionSelect`, `#missionPresetBtn`).
+- `boot-map` mounts one of the three map renderers into `#mapContainer` with its layer controls.
+- `boot-panels` fills `#panelsGrid` with the variant's panels, each keyed by `data-panel`.
+- `boot-status` shows the connectivity indicator (`LIVE` when data is flowing).
+- `boot-no-broken-panels` boots no panel straight into an error or unavailable state.
+
+## How to get to it (user POV)
+
+- Open `/dashboard` (the production dashboard route).
+- Open `/` on the dev server — Vite's SPA fallback serves the same document.
+- Open a variant host's `/dashboard` (`tech`, `finance`, `commodity`, `energy`, `happy`); locally, launch with `WM_VERIFY_VARIANT=<name>`.
+
+## Driving it with wm-verify
+
+Preconditions:
+
+- `wm-verify.sh doctor` reports OK.
+- No profile assumptions beyond `steps/_profile.mjs`, which clears storage and dismisses the first-run overlays.
+
+- **Cold visit.** Navigate to `/dashboard`. Run `wm-verify.sh drive .agents/skills/verify-worldmonitor/steps/dashboard-boot.mjs --name dashboard-boot`. Exit code `0`.
+- **Hydration.** The step waits for `html[data-wm-event-handlers-ready="true"]` then `html[data-wm-initial-data-ready="true"]`. Both markers exist only because the instance runs with `VITE_E2E=1`.
+- **Skeleton gone.** `.skeleton-shell` is absent from the DOM. Its presence means the bundle never took over.
+- **Map mounted.** `waitForMap()` resolves to `deckgl`, `globe`, or `svg`, and at least 5 `.layer-toggle[data-layer]` controls exist. The renderer name is logged in the transcript — record which one this run got.
+- **Panels populated.** `#panelsGrid .panel[data-panel]` has 3+ entries. A `full`-variant run on this checkout returns 40, starting `live-news, live-webcams, insights, threat-timeline, strategic-posture`.
+- **No broken panels.** No panel contains `.panel-error` or `.panel-unavailable`. The step logs the offenders by key rather than only failing.
+- **Proof.** `01-booted-dashboard.png` plus `transcript.txt` in the run's evidence directory show the header, map and grid together with the panel keys and renderer.
+
+## Gotchas
+
+- `#mapContainer` is present in the static shell from the first byte, so `expectVisible('#mapContainer')` proves nothing. Only `waitForMap()` proves a renderer mounted — an early DOM read reports `renderer: unknown, canvases: 0, layer control: none`.
+- Panel count is variant-dependent. Asserting an exact number pins the test to `full`; assert a floor and log the list.
+- A local run reports ~25-40 console errors and ~27 responses ≥400 from the dev server's missing `/api/*` runtime. That is the baseline, not a regression — see the map README.
+- `statusText: "LIVE"` reflects the connectivity indicator, not that Edge APIs answered. It goes `LIVE` locally too.
+- The service worker never registers locally (`sw.js` is served as `text/html`); that warning is expected.

--- a/.agents/skills/verify-worldmonitor/features/global-search.md
+++ b/.agents/skills/verify-worldmonitor/features/global-search.md
@@ -1,0 +1,42 @@
+# Global search
+
+The command palette is the dashboard's one search surface: countries, panels, hotspots, pipelines, nuclear sites and dashboard commands all resolve from the same box. It opens from the header, opens from ⌘K, ranks matches as the user types, and closes on Escape.
+
+## Sub-features
+
+- `search-open-button` opens the palette from the header `⌘K Search` button.
+- `search-open-shortcut` opens it from ⌘K / Ctrl+K.
+- `search-tips` shows the hint rows when the query is empty.
+- `search-match` returns ranked entity and command matches for a typed query.
+- `search-close` closes the palette on Escape without trapping focus.
+- `search-mobile` opens the bottom sheet from `#mobileSearchBtn`.
+
+## How to get to it (user POV)
+
+- Choose the `⌘K Search` button in the header.
+- Press ⌘K (macOS) or Ctrl+K while focus is outside an editable field.
+- On mobile, choose the search button in the bottom bar.
+
+## Driving it with wm-verify
+
+Preconditions:
+
+- `wm-verify.sh doctor` reports OK.
+- The dashboard has booted; the search index builds during boot.
+
+- **Header entry.** Choose `⌘K Search`. Run `wm-verify.sh drive .agents/skills/verify-worldmonitor/steps/global-search.mjs --name global-search`. `#searchBtn` click makes `.search-modal .search-input` visible.
+- **Empty state.** With no query the results list holds `.search-result-item.tip-item` hint rows (7 on this checkout) and zero real results.
+- **Typed match.** Type `ukraine` with `pressSequentially`. `.search-modal .search-results .search-result-item[data-index]` becomes visible. Observed top results: `🇺🇦 Brief: Ukraine Country`, `⚔️ Ukraine War …`, `📍 Kyiv Conflict Zone Hotspot`, `☢️ South Ukraine Nuclear Power Plant`.
+- **Relevance.** At least one result's text contains the query.
+- **Escape.** Press `Escape`. `.search-modal` reaches hidden state.
+- **Shortcut entry.** Press `Meta+k` (`Control+k` off macOS). The palette reopens with its input visible.
+- **Proof.** `01-search-results.png` (the ranked list for the query) and `02-search-palette-via-shortcut.png`.
+
+## Gotchas
+
+- **`.search-result-item` alone is a vacuous assertion.** The empty palette already renders 7 tip rows with that class, so a drive that waits on `.search-result-item` passes without ever searching — that is exactly what happened on the first attempt here. Real matches are the only rows carrying `data-index`; tips carry `.tip-item`.
+- Results are debounced. Wait for the first `[data-index]` row, never a fixed sleep.
+- `fill()` sets the value in one shot; `pressSequentially` better matches a user typing and reliably drives the incremental index.
+- Command rows also carry `data-index` (plus `data-command`). If a drive must isolate entity matches, exclude `.command-item`.
+- Flight search rows are PRO-gated and will not resolve on an unauthenticated local run.
+- The mobile sheet is a different DOM (`.search-sheet`, `.search-sheet-cancel`), not the desktop `.search-modal`.

--- a/.agents/skills/verify-worldmonitor/features/map-layers.md
+++ b/.agents/skills/verify-worldmonitor/features/map-layers.md
@@ -1,0 +1,40 @@
+# Map layers
+
+The layer controls under the map decide what a user sees on it — conflicts, hotspots, sanctions, military activity, weather and the rest. Toggling one must change the map, update the shareable URL, and be remembered next visit.
+
+## Sub-features
+
+- `layer-toggle` turns a layer on or off from the map's own control.
+- `layer-url` reflects the active set in `?layers=` so the view is shareable.
+- `layer-persist` stores the set under `worldmonitor-layers`.
+- `layer-explain` opens the per-layer explanation from `.layer-explain-btn[data-layer="…"]`.
+- `layer-svg-cap` disables further layers at 9 active in the SVG renderer (`limit-reached`).
+- `layer-dimension` switches renderer between 2D and 3D from `#mapDimensionToggle`.
+
+## How to get to it (user POV)
+
+- Choose a layer chip under the map on the dashboard.
+- Open a link whose `?layers=` list differs from the default.
+- Apply a mission preset, which sets a layer set in one action.
+
+## Driving it with wm-verify
+
+Preconditions:
+
+- `wm-verify.sh doctor` reports OK.
+- The step calls `waitForMap()` first and picks its handles from the renderer it reports.
+
+- **Boot state.** Run `wm-verify.sh drive .agents/skills/verify-worldmonitor/steps/map-layers.mjs --name map-layers`. `conflicts` must start enabled.
+- **Turn it off.** Choose the `conflicts` chip. `.layer-toggle[data-layer="conflicts"]` click. The control turns off, `?layers=` loses `conflicts`, and `localStorage['worldmonitor-layers'].conflicts === false`.
+- **Turn it back on.** Choose it again. All three observables return to on.
+- **Renderer coverage.** Headless runs drive the `svg` renderer; add `WM_VERIFY_HEADED=1` to drive `deckgl`. Both were exercised on this checkout and both pass. A run that covers only one renderer has covered only one DOM.
+- **Proof.** `01-layer-on.png`, `02-layer-off.png`, `03-layer-restored.png`, plus the transcript's three state triples.
+
+## Gotchas
+
+- **The control is a different element per renderer.** In the SVG renderer it is `button.layer-toggle[data-layer="…"]` and its state is the `active` class. In the deck.gl / globe renderers it is a label wrapping a checkbox, and the state is `.layer-toggle[data-layer="…"] input:checked`. Reading `input.checked` under SVG returns `null` and reading the `active` class under deck.gl is always false.
+- **Which renderer you get is decided by WebGL, and headless has none.** `MapContainer.hasWebGLSupport()` explicitly rejects a `swiftshader` / `llvmpipe` / `software rasterizer` renderer string, so headless Chromium always lands on the SVG map — with or without `--use-gl=swiftshader`, and with or without `--enable-unsafe-swiftshader`. Only a headed run with real GPU GL mounts deck.gl. The repo's own `playwright.config.ts` forces swiftshader, so its dashboard specs also run against the SVG map.
+- `?layers=` is written on a 250 ms debounce; it can be absent from the URL entirely until the first map-state sync fires. Poll for the parameter.
+- `limit-reached` on a chip is the SVG renderer's 9-layer cap (`MAX_SVG_LAYERS`), not a premium gate. Turning one layer off frees a slot.
+- Turning a layer on starts real data work (AIS opens a stream, flights flip the airline panel to live). Leave the layer set as you found it.
+- Pick another layer with `WM_VERIFY_LAYER=<key>`. Valid keys on this checkout: `conflicts, hotspots, sanctions, protests, bases, nuclear, irradiators, military, cables, pipelines, outages, datacenters, ais, flights, gpsJamming, natural, weather, economic, waterways`.

--- a/.agents/skills/verify-worldmonitor/features/panel-settings.md
+++ b/.agents/skills/verify-worldmonitor/features/panel-settings.md
@@ -1,0 +1,43 @@
+# Panel settings
+
+The Settings overlay is where a user chooses which panels the dashboard shows. Enabling a panel and saving must put it on the dashboard immediately — without a reload — and the choice must survive the next visit.
+
+## Sub-features
+
+- `settings-open` opens the overlay from the header gear (`#unifiedSettingsBtn`) or the mobile button (`#mobileSettingsBtn`).
+- `settings-tabs` switches between Settings, Panels, Sources, API Keys, and (when signed in) Plan & billing.
+- `panels-toggle` turns a panel on or off in the Panels tab grid.
+- `panels-save` applies the pending toggles to the live dashboard.
+- `panels-persist` stores the choice under `worldmonitor-panels`.
+- `panels-cap` refuses a toggle that would exceed the free-tier panel cap.
+
+## How to get to it (user POV)
+
+- Choose the gear button in the header, then the `Panels` tab.
+- On mobile, choose `#mobileSettingsBtn`, then the `Panels` tab.
+- Open the standalone settings window (`settings.html`) in the desktop app.
+
+## Driving it with wm-verify
+
+Preconditions:
+
+- `wm-verify.sh doctor` reports OK.
+- The step seeds `worldmonitor-panels` with `threat-timeline` disabled, so enabling it is an observable change.
+- The step seeds `wm-pro-key`. This is the product's own legacy tester-session path, not a test-only bypass: without it the `full` variant already sits at the free-tier cap and the modal answers the toggle with a cap toast instead of enabling the panel.
+
+- **Boot disabled.** Run `wm-verify.sh drive .agents/skills/verify-worldmonitor/steps/panel-settings.mjs --name panel-settings`. The step first asserts `#panelsGrid .panel[data-panel="threat-timeline"]` has count `0` while other panels are mounted.
+- **Open settings.** Choose the gear. `#unifiedSettingsBtn` click makes the overlay's tablist visible.
+- **Panels tab.** Choose `Panels`. `#us-tab-panels` click reveals `#usPanelToggles`.
+- **Toggle.** Choose the `threat-timeline` tile. `#usPanelToggles .panel-toggle-item[data-panel="threat-timeline"]` gains the `active` class.
+- **Save.** Choose `Save layout`. `.panels-save-layout` click, then `.unified-settings-close`. No reload after this point.
+- **Live apply.** `#panelsGrid .panel[data-panel="threat-timeline"]` becomes visible within 30 s.
+- **Side effect.** `localStorage['worldmonitor-panels']['threat-timeline'].enabled === true`.
+- **Proof.** `01-dashboard-without-panel.png`, `02-settings-panels-tab.png`, `03-panel-live-on-dashboard.png` — the before state, the action, and the result.
+
+## Gotchas
+
+- Enabling a panel without the pro seed silently does nothing on the `full` variant: the free cap is already reached, so the failure looks like a broken save rather than a refusal.
+- A disabled panel is parked in `deferredPanelMounts` with no shell at boot. Absence of the selector means "disabled", not "not created yet" — only assert absence after `#panelsGrid .panel` has real entries.
+- `seedProfile` guards itself with a `sessionStorage` flag because `addInitScript` re-runs on every navigation; a reload inside the drive would otherwise wipe the very preference under test.
+- Use a different panel via `WM_VERIFY_PANEL=<key>`, but pick one that boots disabled in the seed, or the before-assertion fails for the wrong reason.
+- The save button is `.panels-save-layout`; closing the overlay without saving discards the toggle.

--- a/.agents/skills/verify-worldmonitor/scripts/drive.mjs
+++ b/.agents/skills/verify-worldmonitor/scripts/drive.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * WorldMonitor verification driver.
+ *
+ *   node .agents/skills/verify-worldmonitor/scripts/drive.mjs <step.mjs> [--name <label>]
+ *
+ * Opens a Chromium page against the dev instance recorded in
+ * .claude/verify-evidence/instance.json, hands it to <step.mjs>, and writes
+ * every artifact of the run into .claude/verify-evidence/<timestamp>-<label>/.
+ *
+ * A step module default-exports an async function:
+ *
+ *   export default async function ({ page, base, shot, log, expectVisible }) { ... }
+ *
+ * Exit 0 = the step returned. Exit 1 = it threw (a failure screenshot and the
+ * console/network transcript are still written).
+ */
+import { chromium } from 'playwright';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SKILL_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+// .agents/skills/verify-worldmonitor -> repo root is three levels up. Fall back
+// to the cwd when the skill is reached through a symlink or copied elsewhere.
+const SKILL_REPO_ROOT = resolve(SKILL_DIR, '..', '..', '..');
+const REPO_ROOT = existsSync(resolve(SKILL_REPO_ROOT, 'package.json')) ? SKILL_REPO_ROOT : process.cwd();
+const EVIDENCE_ROOT = process.env.WM_VERIFY_EVIDENCE_ROOT
+  ? resolve(process.env.WM_VERIFY_EVIDENCE_ROOT)
+  : resolve(REPO_ROOT, '.claude', 'verify-evidence');
+const INSTANCE_FILE = resolve(EVIDENCE_ROOT, 'instance.json');
+
+const argv = process.argv.slice(2);
+const stepArg = argv.find((a) => !a.startsWith('--'));
+if (!stepArg) {
+  console.error('usage: drive.mjs <step.mjs> [--name <label>]');
+  process.exit(2);
+}
+const nameFlagIndex = argv.indexOf('--name');
+const label = (nameFlagIndex >= 0 ? argv[nameFlagIndex + 1] : stepArg.replace(/^.*\//, '').replace(/\.mjs$/, ''))
+  .replace(/[^a-zA-Z0-9._-]/g, '-');
+
+let instance;
+try {
+  instance = JSON.parse(readFileSync(INSTANCE_FILE, 'utf8'));
+} catch {
+  console.error(`[drive] no running instance recorded at ${INSTANCE_FILE}.`);
+  console.error('[drive] run `wm-verify.sh launch` first.');
+  process.exit(2);
+}
+const base = instance.baseUrl;
+
+const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19);
+const runDir = resolve(EVIDENCE_ROOT, `${stamp}-${label}`);
+mkdirSync(runDir, { recursive: true });
+
+const transcript = [];
+const consoleErrors = [];
+const consoleWarnings = [];
+const failedRequests = [];
+const log = (...parts) => {
+  const line = parts.map((p) => (typeof p === 'string' ? p : JSON.stringify(p))).join(' ');
+  transcript.push(`[${new Date().toISOString()}] ${line}`);
+  console.log(line);
+};
+
+const headed = process.env.WM_VERIFY_HEADED === '1';
+// Renderer choice is a product decision, not a flag detail: MapContainer's
+// hasWebGLSupport() deliberately REJECTS swiftshader/llvmpipe, so the
+// software-GL args playwright.config.ts uses pin the dashboard to the SVG map.
+// Default here is real GPU GL so drives see the deck.gl map users get; set
+// WM_VERIFY_SOFTWARE_GL=1 to reproduce the repo's e2e conditions instead.
+const softwareGl = process.env.WM_VERIFY_SOFTWARE_GL === '1';
+const browser = await chromium.launch({
+  headless: !headed,
+  args: softwareGl
+    ? ['--use-angle=swiftshader', '--use-gl=swiftshader', '--enable-unsafe-swiftshader']
+    : [],
+});
+const context = await browser.newContext({
+  viewport: { width: 1280, height: 720 },
+  colorScheme: 'dark',
+  locale: 'en-US',
+  timezoneId: 'UTC',
+});
+const page = await context.newPage();
+
+page.on('console', (msg) => {
+  const type = msg.type();
+  if (type === 'error') consoleErrors.push(msg.text().slice(0, 400));
+  // Warnings are where this app announces a degraded path (renderer fallback,
+  // blocked API base, quota). Capped so a chatty page cannot bloat the run.
+  else if (type === 'warning' && consoleWarnings.length < 200) consoleWarnings.push(msg.text().slice(0, 400));
+});
+page.on('pageerror', (err) => consoleErrors.push(`pageerror: ${String(err).slice(0, 400)}`));
+page.on('response', (res) => {
+  const status = res.status();
+  if (status >= 400) failedRequests.push({ status, url: res.url().slice(0, 240) });
+});
+
+let shotIndex = 0;
+const shot = async (name, options = {}) => {
+  shotIndex += 1;
+  const file = resolve(runDir, `${String(shotIndex).padStart(2, '0')}-${name.replace(/[^a-zA-Z0-9._-]/g, '-')}.png`);
+  const target = options.locator ?? page;
+  await target.screenshot({
+    animations: 'disabled',
+    caret: 'hide',
+    path: file,
+    ...(options.locator ? {} : { fullPage: options.fullPage ?? false }),
+  });
+  log(`shot -> ${file}`);
+  return file;
+};
+
+const expectVisible = async (selector, timeout = 60_000) => {
+  const locator = page.locator(selector).first();
+  await locator.waitFor({ state: 'visible', timeout });
+  log(`visible: ${selector}`);
+  return locator;
+};
+
+const stepPath = isAbsolute(stepArg) ? stepArg : resolve(process.cwd(), stepArg);
+const stepModule = await import(pathToFileURL(stepPath).href);
+const step = stepModule.default;
+if (typeof step !== 'function') {
+  console.error(`[drive] ${stepPath} must default-export an async function.`);
+  await browser.close();
+  process.exit(2);
+}
+
+let outcome = 'passed';
+let failure = null;
+try {
+  log(`base=${base} step=${stepPath}`);
+  await step({ page, context, base, shot, log, expectVisible });
+} catch (err) {
+  outcome = 'failed';
+  failure = String(err?.stack ?? err).slice(0, 4000);
+  log(`FAILED: ${failure.split('\n')[0]}`);
+  try {
+    await shot('failure', { fullPage: true });
+  } catch {
+    /* the page may be gone; the transcript still records the failure */
+  }
+}
+
+writeFileSync(resolve(runDir, 'transcript.txt'), `${transcript.join('\n')}\n`);
+writeFileSync(resolve(runDir, 'console-errors.json'), `${JSON.stringify(consoleErrors, null, 2)}\n`);
+writeFileSync(resolve(runDir, 'console-warnings.json'), `${JSON.stringify(consoleWarnings, null, 2)}\n`);
+writeFileSync(resolve(runDir, 'failed-requests.json'), `${JSON.stringify(failedRequests, null, 2)}\n`);
+writeFileSync(
+  resolve(runDir, 'result.json'),
+  `${JSON.stringify({ outcome, label, step: stepPath, base, instance, failure, consoleErrorCount: consoleErrors.length, consoleWarningCount: consoleWarnings.length, failedRequestCount: failedRequests.length }, null, 2)}\n`,
+);
+
+await context.close();
+await browser.close();
+
+console.log(`\n[drive] ${outcome} — evidence: ${runDir}`);
+console.log(`[drive] console errors: ${consoleErrors.length}, warnings: ${consoleWarnings.length}, responses >=400: ${failedRequests.length}`);
+process.exit(outcome === 'passed' ? 0 : 1);

--- a/.agents/skills/verify-worldmonitor/scripts/wm-verify.sh
+++ b/.agents/skills/verify-worldmonitor/scripts/wm-verify.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# WorldMonitor verification harness.
+#
+#   .agents/skills/verify-worldmonitor/scripts/wm-verify.sh launch [port]
+#   .agents/skills/verify-worldmonitor/scripts/wm-verify.sh doctor
+#   .agents/skills/verify-worldmonitor/scripts/wm-verify.sh drive <step.mjs> [--name label]
+#   .agents/skills/verify-worldmonitor/scripts/wm-verify.sh cleanup
+#
+# Run from the repo root of the worktree you are verifying.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+[ -f "$REPO_ROOT/package.json" ] || REPO_ROOT="$PWD"
+EVIDENCE_ROOT="$REPO_ROOT/.claude/verify-evidence"
+INSTANCE_FILE="$EVIDENCE_ROOT/instance.json"
+LOG_FILE="$EVIDENCE_ROOT/dev-server.log"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+port_free() { ! lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1; }
+
+pick_port() {
+  local p
+  for p in 4480 4481 4482 4483 4484 4485 4486 4487; do
+    if port_free "$p"; then echo "$p"; return 0; fi
+  done
+  echo "[wm-verify] no free port in 4480-4487" >&2
+  return 1
+}
+
+cmd_launch() {
+  if [ -f "$INSTANCE_FILE" ]; then
+    local old_pid
+    old_pid="$(node -e "process.stdout.write(String(require('$INSTANCE_FILE').pid))" 2>/dev/null || echo '')"
+    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+      echo "[wm-verify] an instance is already running (pid $old_pid). Run 'doctor', or 'cleanup' first."
+      cat "$INSTANCE_FILE"
+      return 0
+    fi
+    rm -f "$INSTANCE_FILE"
+  fi
+
+  local port="${1:-}"
+  if [ -z "$port" ]; then port="$(pick_port)"; fi
+  if ! port_free "$port"; then
+    echo "[wm-verify] port $port is already in use — another agent or the user owns it. Pick another." >&2
+    return 1
+  fi
+
+  mkdir -p "$EVIDENCE_ROOT"
+  local variant="${WM_VERIFY_VARIANT:-full}"
+  echo "VITE_E2E=1 VITE_VARIANT=$variant port=$port" >"$EVIDENCE_ROOT/launch-env.txt"
+  echo "[wm-verify] starting VITE_VARIANT=$variant dev server on 127.0.0.1:$port"
+  (
+    cd "$REPO_ROOT"
+    VITE_E2E=1 VITE_VARIANT="$variant" npm run dev -- --host 127.0.0.1 --port "$port" \
+      >"$LOG_FILE" 2>&1 &
+    echo $! >"$EVIDENCE_ROOT/.pid"
+  )
+  local pid
+  pid="$(cat "$EVIDENCE_ROOT/.pid")"
+  rm -f "$EVIDENCE_ROOT/.pid"
+
+  local waited=0
+  # /tests/map-harness.html is the same readiness probe playwright.config.ts uses:
+  # it forces Vite to transform a real module graph, so a 200 means "can serve the
+  # app", not just "socket is open".
+  until curl -sf -o /dev/null "http://127.0.0.1:$port/tests/map-harness.html"; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "[wm-verify] dev server died during startup. Last log lines:" >&2
+      tail -30 "$LOG_FILE" >&2
+      return 1
+    fi
+    if [ "$waited" -ge 180 ]; then
+      echo "[wm-verify] dev server did not become ready in 180s. Last log lines:" >&2
+      tail -30 "$LOG_FILE" >&2
+      kill "$pid" 2>/dev/null || true
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  node -e "
+    require('fs').writeFileSync(process.argv[1], JSON.stringify({
+      pid: Number(process.argv[2]),
+      port: Number(process.argv[3]),
+      baseUrl: 'http://127.0.0.1:' + process.argv[3],
+      variant: process.argv[4],
+      startedAt: new Date().toISOString(),
+      log: process.argv[5],
+    }, null, 2) + '\n');
+  " "$INSTANCE_FILE" "$pid" "$port" "$variant" "$LOG_FILE"
+
+  echo "[wm-verify] ready in ${waited}s — http://127.0.0.1:$port/dashboard (pid $pid)"
+  cat "$INSTANCE_FILE"
+}
+
+cmd_doctor() {
+  if [ ! -f "$INSTANCE_FILE" ]; then
+    echo "doctor: FAIL — no instance recorded. Run 'launch'."
+    return 1
+  fi
+  local pid port base
+  pid="$(node -e "process.stdout.write(String(require('$INSTANCE_FILE').pid))")"
+  port="$(node -e "process.stdout.write(String(require('$INSTANCE_FILE').port))")"
+  base="$(node -e "process.stdout.write(require('$INSTANCE_FILE').baseUrl)")"
+
+  local ok=0
+  if kill -0 "$pid" 2>/dev/null; then echo "doctor: process $pid alive"; else echo "doctor: FAIL — pid $pid is gone"; ok=1; fi
+
+  # The port must be held by OUR pid (or one of its children). A port answering
+  # for someone else's server is the failure this check exists to catch.
+  local owners
+  owners="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | tr '\n' ' ')"
+  if [ -z "$owners" ]; then
+    echo "doctor: FAIL — nothing listening on $port"; ok=1
+  else
+    local owned=1
+    local o
+    for o in $owners; do
+      local walk="$o"
+      local hops=0
+      while [ -n "$walk" ] && [ "$walk" != "1" ] && [ "$hops" -lt 8 ]; do
+        if [ "$walk" = "$pid" ]; then owned=0; break; fi
+        walk="$(ps -o ppid= -p "$walk" 2>/dev/null | tr -d ' ')"
+        hops=$((hops + 1))
+      done
+      [ "$owned" -eq 0 ] && break
+    done
+    if [ "$owned" -eq 0 ]; then
+      echo "doctor: port $port owned by our process tree ($owners)"
+    else
+      echo "doctor: FAIL — port $port is held by $owners, not by our pid $pid"; ok=1
+    fi
+  fi
+
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$base/dashboard" || echo 000)"
+  if [ "$code" = "200" ]; then echo "doctor: $base/dashboard -> 200"; else echo "doctor: FAIL — $base/dashboard -> $code"; ok=1; fi
+
+  if curl -sf "$base/dashboard" | grep -q "skeleton-shell"; then
+    echo "doctor: dashboard shell markup served"
+  else
+    echo "doctor: FAIL — dashboard HTML is not the app shell"; ok=1
+  fi
+
+  # Every drive waits on the data-wm-* readiness markers, and only VITE_E2E=1
+  # emits them. A server launched without it looks healthy and then times out
+  # in every drive, so prove the flag reached this process.
+  if ps -o command= -p "$pid" 2>/dev/null | grep -q 'vite\|npm'; then
+    echo "doctor: launcher process still running vite"
+  else
+    echo "doctor: FAIL — pid $pid is not a vite/npm process"; ok=1
+  fi
+  if grep -q 'VITE_E2E' "$EVIDENCE_ROOT/launch-env.txt" 2>/dev/null; then
+    echo "doctor: launched with VITE_E2E=1 (readiness markers available)"
+  else
+    echo "doctor: FAIL — no VITE_E2E=1 record; relaunch via 'wm-verify.sh launch'"; ok=1
+  fi
+
+  # grep exits 1 on zero matches and `set -o pipefail` would abort doctor here,
+  # reporting "not worth driving" for a perfectly clean log.
+  local errs=0
+  if [ -f "$LOG_FILE" ]; then
+    errs="$( { grep -ciE 'error|ERR_' "$LOG_FILE" || true; } 2>/dev/null | tr -d '[:space:]')"
+  fi
+  echo "doctor: dev-server log lines matching error: ${errs:-0} ($LOG_FILE)"
+
+  if [ "$ok" -eq 0 ]; then echo "doctor: OK"; else echo "doctor: NOT worth driving"; fi
+  return "$ok"
+}
+
+cmd_drive() {
+  [ $# -ge 1 ] || { echo "usage: wm-verify.sh drive <step.mjs> [--name label]" >&2; return 2; }
+  (cd "$REPO_ROOT" && node "$SCRIPT_DIR/drive.mjs" "$@")
+}
+
+cmd_cleanup() {
+  if [ ! -f "$INSTANCE_FILE" ]; then
+    echo "[wm-verify] nothing to clean up (no instance.json). Evidence under $EVIDENCE_ROOT is untouched."
+    return 0
+  fi
+  local pid
+  pid="$(node -e "process.stdout.write(String(require('$INSTANCE_FILE').pid))" 2>/dev/null || echo '')"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    # Kill the pid WE recorded and its children. Never pkill by name — other
+    # worktrees and the user's own dev server are also `vite` processes.
+    pkill -TERM -P "$pid" 2>/dev/null || true
+    kill -TERM "$pid" 2>/dev/null || true
+    local waited=0
+    while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt 10 ]; do sleep 1; waited=$((waited + 1)); done
+    kill -KILL "$pid" 2>/dev/null || true
+    echo "[wm-verify] stopped pid $pid"
+  else
+    echo "[wm-verify] recorded pid $pid was already gone"
+  fi
+  rm -f "$INSTANCE_FILE" "$EVIDENCE_ROOT/launch-env.txt"
+  echo "[wm-verify] evidence kept in $EVIDENCE_ROOT (run directories are never deleted by cleanup)"
+}
+
+case "${1:-}" in
+  launch) shift; cmd_launch "$@" ;;
+  doctor) shift; cmd_doctor "$@" ;;
+  drive) shift; cmd_drive "$@" ;;
+  cleanup) shift; cmd_cleanup "$@" ;;
+  *)
+    echo "usage: wm-verify.sh {launch [port]|doctor|drive <step.mjs> [--name label]|cleanup}" >&2
+    exit 2
+    ;;
+esac

--- a/.agents/skills/verify-worldmonitor/steps/_inspect.mjs
+++ b/.agents/skills/verify-worldmonitor/steps/_inspect.mjs
@@ -1,0 +1,32 @@
+import { seedProfile, waitForBoot, waitForMap } from './_profile.mjs';
+
+/**
+ * Not a feature drive — a discovery aid. Boots the dashboard and dumps the
+ * handles a new drive needs (panel keys, layer keys, header controls) so a
+ * step can be written against what the app actually renders today.
+ *
+ *   wm-verify.sh drive .agents/skills/verify-worldmonitor/steps/_inspect.mjs --name inspect
+ */
+export default async function ({ page, base, shot, log }) {
+  await seedProfile(page);
+  await page.goto(`${base}${process.env.WM_VERIFY_PATH ?? '/dashboard'}`, { waitUntil: 'domcontentloaded' });
+  await waitForBoot(page);
+  await page.locator('#panelsGrid .panel').first().waitFor({ state: 'visible', timeout: 90_000 });
+  const renderer = await waitForMap(page);
+
+  const handles = await page.evaluate(() => ({
+    mapCanvases: document.querySelectorAll('#mapContainer canvas').length,
+    layerControl: document.querySelector('button.layer-toggle') ? 'button' : (document.querySelector('.layer-toggle input') ? 'checkbox' : 'none'),
+    panelKeys: [...document.querySelectorAll('#panelsGrid .panel[data-panel]')].map((el) => el.getAttribute('data-panel')),
+    layerKeys: [...document.querySelectorAll('[data-layer]')].map((el) => `${el.tagName.toLowerCase()}.${el.className}[${el.getAttribute('data-layer')}]`),
+    headerIds: [...document.querySelectorAll('.header [id], #main > [id]')].map((el) => el.id).filter(Boolean),
+    urlLayers: new URL(window.location.href).searchParams.get('layers'),
+  }));
+  log('map renderer:', renderer, '| canvases:', String(handles.mapCanvases), '| layer control:', handles.layerControl);
+  log('panel keys:', JSON.stringify(handles.panelKeys));
+  log('layer handles:', JSON.stringify([...new Set(handles.layerKeys)]));
+  log('header ids:', JSON.stringify(handles.headerIds));
+  log('url layers:', String(handles.urlLayers));
+  await shot('inspect');
+  return handles;
+}

--- a/.agents/skills/verify-worldmonitor/steps/_profile.mjs
+++ b/.agents/skills/verify-worldmonitor/steps/_profile.mjs
@@ -1,0 +1,59 @@
+/**
+ * Shared browser-profile seeding for verification drives.
+ *
+ * The dashboard boots with several first-run overlays (layer warning, PRO
+ * banner, mission-preset prompt) that sit on top of the controls a drive needs
+ * to click. Dismissing them is exactly what a returning user's localStorage
+ * looks like — it is not a test-only bypass of any product gate.
+ *
+ * Call BEFORE page.goto(). addInitScript re-runs on every navigation, so the
+ * seed is guarded by a sessionStorage flag: a reload inside a drive must not
+ * wipe the very preference under test.
+ */
+export async function seedProfile(page, overrides = {}) {
+  await page.addInitScript((opts) => {
+    if (sessionStorage.getItem('__wm_verify_seeded__')) return;
+    localStorage.clear();
+    sessionStorage.clear();
+    sessionStorage.setItem('__wm_verify_seeded__', '1');
+    localStorage.setItem('worldmonitor-variant', opts.variant ?? 'full');
+    // First-run overlays that would otherwise steal the click target.
+    localStorage.setItem('wm-layer-warning-dismissed', 'true');
+    localStorage.setItem('wm-pro-banner-launched-dismissed', String(Date.now()));
+    localStorage.setItem('worldmonitor-mission-preset-dismissed-v1', '1');
+    for (const [key, value] of Object.entries(opts.localStorage ?? {})) {
+      if (value === null) localStorage.removeItem(key);
+      else localStorage.setItem(key, value);
+    }
+  }, overrides);
+}
+
+/** Wait for the two readiness markers VITE_E2E=1 stamps on <html>. */
+export async function waitForBoot(page, { data = false, timeout = 90_000 } = {}) {
+  await page.waitForSelector('html[data-wm-event-handlers-ready="true"]', { timeout });
+  if (data) {
+    await page.waitForSelector('html[data-wm-initial-data-ready="true"]', { timeout });
+  }
+}
+
+/**
+ * Wait for the map renderer to finish mounting, and report which one won.
+ *
+ * #mapContainer exists in the shell long before any renderer does, so waiting
+ * on the container is a race: MapContainer marks the shell with aria-busy +
+ * data-map-renderer-pending, then swaps in one of the mode classes. Returns
+ * 'deckgl' | 'globe' | 'svg' — deck.gl is the intended desktop renderer and
+ * 'svg' means it fell back (the reason is a [MapContainer] console warning).
+ */
+export async function waitForMap(page, { timeout = 90_000 } = {}) {
+  await page.waitForSelector(
+    '#mapContainer.deckgl-mode:not([aria-busy]), #mapContainer.globe-mode:not([aria-busy]), #mapContainer.svg-mode:not([aria-busy])',
+    { timeout },
+  );
+  return page.evaluate(() => {
+    const el = document.getElementById('mapContainer');
+    if (el?.classList.contains('deckgl-mode')) return 'deckgl';
+    if (el?.classList.contains('globe-mode')) return 'globe';
+    return 'svg';
+  });
+}

--- a/.agents/skills/verify-worldmonitor/steps/country-brief.mjs
+++ b/.agents/skills/verify-worldmonitor/steps/country-brief.mjs
@@ -1,0 +1,63 @@
+import { seedProfile, waitForBoot } from './_profile.mjs';
+
+/**
+ * Feature: country brief / deep dive (features/country-brief.md).
+ * Drives the shareable deep link a user actually receives — /dashboard?country=UA —
+ * and proves the brief slides in with that country's content, then closes.
+ */
+const COUNTRY = process.env.WM_VERIFY_COUNTRY ?? 'UA';
+
+export default async function ({ page, base, shot, log, expectVisible }) {
+  await seedProfile(page);
+  await page.goto(`${base}/dashboard?country=${COUNTRY}`, { waitUntil: 'domcontentloaded' });
+  await waitForBoot(page);
+  await expectVisible('#panelsGrid .panel');
+
+  const panel = page.locator('#country-deep-dive-panel');
+  await panel.waitFor({ state: 'attached', timeout: 90_000 });
+  // aria-hidden is the accessible open/closed state; visibility proves it is
+  // actually on screen rather than parked off-canvas by the slide-in transform.
+  await page.waitForFunction(() => {
+    const el = document.getElementById('country-deep-dive-panel');
+    if (!el) return false;
+    return el.getAttribute('aria-hidden') === 'false'
+      && getComputedStyle(el).visibility === 'visible';
+  }, undefined, { timeout: 90_000 });
+  log('country brief is open and visible');
+  await shot('country-brief-open');
+
+  const content = await page.evaluate(() => {
+    const el = document.getElementById('deep-dive-content');
+    return {
+      chars: el?.textContent?.replace(/\s+/g, ' ').trim().length ?? 0,
+      heading: el?.querySelector('h1, h2, .country-brief-title, .deep-dive-title')?.textContent?.trim() ?? null,
+      sections: el?.querySelectorAll('section, .brief-section').length ?? 0,
+    };
+  });
+  log('brief content', JSON.stringify(content));
+  if (content.chars < 200) {
+    throw new Error(`country brief rendered an effectively empty body (${content.chars} chars)`);
+  }
+
+  // The URL is the shareable artifact: getShareUrl() re-adds ?country=<code>
+  // while the brief is visible. That write is debounced (250 ms) and competes
+  // with map-driven syncs, so poll rather than reading it once.
+  await page.waitForFunction(
+    (code) => new URL(window.location.href).searchParams.get('country') === code,
+    COUNTRY,
+    { timeout: 15_000 },
+  ).catch(() => {
+    throw new Error(`?country=${COUNTRY} never reappeared in the URL; got ${page.url()}`);
+  });
+  log('url carries the country deep link:', page.url());
+
+  await page.locator('#deep-dive-close').click();
+  await page.waitForFunction(() => {
+    const el = document.getElementById('country-deep-dive-panel');
+    return !el || el.getAttribute('aria-hidden') === 'true';
+  }, undefined, { timeout: 30_000 });
+  log('country brief closed');
+  await shot('country-brief-closed');
+
+  return { country: COUNTRY, ...content };
+}

--- a/.agents/skills/verify-worldmonitor/steps/dashboard-boot.mjs
+++ b/.agents/skills/verify-worldmonitor/steps/dashboard-boot.mjs
@@ -1,0 +1,47 @@
+import { seedProfile, waitForBoot, waitForMap } from './_profile.mjs';
+
+/**
+ * Feature: dashboard boot (features/dashboard-boot.md).
+ * Proves a cold visitor gets a hydrated dashboard: header, map surface, and a
+ * grid of live panels — not the pre-render skeleton.
+ */
+export default async function ({ page, base, shot, log, expectVisible }) {
+  await seedProfile(page);
+  await page.goto(`${base}/dashboard`, { waitUntil: 'domcontentloaded' });
+
+  await waitForBoot(page, { data: true });
+  log('readiness markers: event handlers + initial data');
+
+  await expectVisible('.header');
+  await expectVisible('#panelsGrid .panel');
+  // #mapContainer exists in the shell from the first byte, so its visibility
+  // proves nothing. waitForMap waits for a renderer to actually mount.
+  const renderer = await waitForMap(page);
+  log(`map renderer: ${renderer}`);
+  await shot('booted-dashboard');
+
+  const state = await page.evaluate(() => ({
+    panels: [...document.querySelectorAll('#panelsGrid .panel[data-panel]')].map((el) =>
+      el.getAttribute('data-panel'),
+    ),
+    skeletonGone: !document.querySelector('.skeleton-shell'),
+    layerToggles: document.querySelectorAll('.layer-toggle[data-layer]').length,
+    statusText: document.querySelector('.status-indicator')?.textContent?.trim() ?? null,
+  }));
+  log('state', state.panels.length + ' panels', JSON.stringify({ ...state, panels: state.panels.slice(0, 8) }));
+
+  if (!state.skeletonGone) throw new Error('pre-render skeleton is still mounted — the app never hydrated');
+  if (state.panels.length < 3) throw new Error(`expected a populated panel grid, got ${state.panels.length} panels`);
+  if (state.layerToggles < 5) throw new Error(`the map mounted (${renderer}) but rendered ${state.layerToggles} layer controls`);
+
+  // Panels that boot into an error/unavailable state are the failure this
+  // drive exists to catch: the grid can be full and still be all red.
+  const broken = await page.evaluate(() =>
+    [...document.querySelectorAll('#panelsGrid .panel[data-panel]')]
+      .filter((el) => el.querySelector('.panel-error, .panel-unavailable'))
+      .map((el) => el.getAttribute('data-panel')),
+  );
+  log('panels in an error/unavailable state:', JSON.stringify(broken));
+
+  return { panels: state.panels.length, renderer, broken };
+}

--- a/.agents/skills/verify-worldmonitor/steps/global-search.mjs
+++ b/.agents/skills/verify-worldmonitor/steps/global-search.mjs
@@ -1,0 +1,56 @@
+import { seedProfile, waitForBoot } from './_profile.mjs';
+
+/**
+ * Feature: global search / command palette (features/global-search.md).
+ * Opens the palette the way a user does (header button and ⌘K), types a query,
+ * and proves ranked results appear and a result can be activated.
+ */
+const QUERY = process.env.WM_VERIFY_SEARCH ?? 'ukraine';
+
+export default async function ({ page, base, shot, log, expectVisible }) {
+  await seedProfile(page);
+  await page.goto(`${base}/dashboard`, { waitUntil: 'domcontentloaded' });
+  await waitForBoot(page);
+  await expectVisible('#panelsGrid .panel');
+
+  await (await expectVisible('#searchBtn')).click();
+  const input = await expectVisible('.search-modal .search-input');
+  log('search palette opened from the header button');
+
+  // The empty palette already renders `.search-result-item.tip-item` hints, so
+  // asserting on `.search-result-item` alone passes without ever searching.
+  // Real matches are the only ones carrying data-index.
+  const REAL_RESULT = '.search-modal .search-results .search-result-item[data-index]';
+  const tipsBefore = await page.locator('.search-modal .search-results .tip-item').count();
+  log(`palette opened showing ${tipsBefore} tip rows and 0 real results`);
+
+  await input.pressSequentially(QUERY, { delay: 25 });
+  await page.locator(REAL_RESULT).first().waitFor({ state: 'visible', timeout: 30_000 });
+  await shot('search-results');
+
+  const results = await page.evaluate((selector) =>
+    [...document.querySelectorAll(selector)]
+      .slice(0, 8)
+      .map((el) => el.textContent?.replace(/\s+/g, ' ').trim().slice(0, 90)),
+    REAL_RESULT,
+  );
+  log(`results for "${QUERY}":`, JSON.stringify(results));
+  if (results.length === 0) throw new Error(`no real search results for "${QUERY}"`);
+  if (!results.some((r) => r?.toLowerCase().includes(QUERY.toLowerCase().slice(0, 5)))) {
+    throw new Error(`results do not mention "${QUERY}": ${JSON.stringify(results)}`);
+  }
+
+  // Escape closes it — the palette must not trap the user.
+  await page.keyboard.press('Escape');
+  await page.locator('.search-modal').waitFor({ state: 'hidden', timeout: 15_000 });
+  log('Escape closed the palette');
+
+  // ⌘K is the advertised shortcut on the button itself; prove it opens too.
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+k' : 'Control+k');
+  await page.locator('.search-modal .search-input').waitFor({ state: 'visible', timeout: 15_000 });
+  log('keyboard shortcut reopened the palette');
+  await shot('search-palette-via-shortcut');
+  await page.keyboard.press('Escape');
+
+  return { query: QUERY, resultCount: results.length };
+}

--- a/.agents/skills/verify-worldmonitor/steps/map-layers.mjs
+++ b/.agents/skills/verify-worldmonitor/steps/map-layers.mjs
@@ -1,0 +1,87 @@
+import { seedProfile, waitForBoot, waitForMap } from './_profile.mjs';
+
+/**
+ * Feature: map layer toggles (features/map-layers.md).
+ * Turns a layer off and back on from the map's own control and proves all three
+ * observable consequences: the control's own state, the shareable ?layers=
+ * list, and the persisted worldmonitor-layers preference.
+ *
+ * The control is a different element per renderer — see features/map-layers.md.
+ */
+const LAYER = process.env.WM_VERIFY_LAYER ?? 'conflicts';
+
+const readLayerState = (page, layer, renderer) =>
+  page.evaluate(({ key, svg }) => {
+    let stored = null;
+    try {
+      stored = JSON.parse(localStorage.getItem('worldmonitor-layers') ?? 'null')?.[key] ?? null;
+    } catch {
+      stored = 'unparseable';
+    }
+    const control = document.querySelector(`.layer-toggle[data-layer="${key}"]`);
+    return {
+      on: svg
+        ? (control ? control.classList.contains('active') : null)
+        : (control?.querySelector('input')?.checked ?? null),
+      inUrl: (new URL(window.location.href).searchParams.get('layers') ?? '').split(',').includes(key),
+      stored,
+    };
+  }, { key: layer, svg: renderer === 'svg' });
+
+export default async function ({ page, base, shot, log }) {
+  await seedProfile(page);
+  await page.goto(`${base}/dashboard`, { waitUntil: 'domcontentloaded' });
+  await waitForBoot(page);
+  const renderer = await waitForMap(page);
+  log(`map renderer: ${renderer}`);
+
+  const control = page.locator(`.layer-toggle[data-layer="${LAYER}"]`);
+  await control.waitFor({ state: 'visible', timeout: 60_000 });
+
+  const before = await readLayerState(page, LAYER, renderer);
+  log('before:', JSON.stringify(before));
+  if (before.on !== true) {
+    throw new Error(`layer "${LAYER}" was expected to boot enabled; got ${JSON.stringify(before)}`);
+  }
+  await shot('layer-on');
+
+  const isOn = (want) =>
+    page.waitForFunction(
+      ({ key, svg, expected }) => {
+        const el = document.querySelector(`.layer-toggle[data-layer="${key}"]`);
+        if (!el) return false;
+        const on = svg ? el.classList.contains('active') : !!el.querySelector('input')?.checked;
+        return on === expected;
+      },
+      { key: LAYER, svg: renderer === 'svg', expected: want },
+      { timeout: 15_000 },
+    );
+
+  // ?layers= is written through the same 250 ms debounce as every other map URL
+  // sync, so poll for it rather than reading window.location once.
+  const inUrl = (want) =>
+    page.waitForFunction(
+      ({ key, expected }) =>
+        (new URL(window.location.href).searchParams.get('layers') ?? '').split(',').includes(key) === expected,
+      { key: LAYER, expected: want },
+      { timeout: 15_000 },
+    );
+
+  await control.click();
+  await isOn(false);
+  await inUrl(false);
+  const off = await readLayerState(page, LAYER, renderer);
+  log('after turning it off:', JSON.stringify(off));
+  if (off.stored !== false) throw new Error(`layer "${LAYER}" was not persisted as off: ${JSON.stringify(off)}`);
+  await shot('layer-off');
+
+  await control.click();
+  await isOn(true);
+  await inUrl(true);
+  const back = await readLayerState(page, LAYER, renderer);
+  log('after turning it back on:', JSON.stringify(back));
+  if (back.stored !== true) throw new Error(`layer "${LAYER}" was not persisted as on again: ${JSON.stringify(back)}`);
+  await shot('layer-restored');
+
+  return { layer: LAYER, renderer, before, off, back };
+}

--- a/.agents/skills/verify-worldmonitor/steps/panel-settings.mjs
+++ b/.agents/skills/verify-worldmonitor/steps/panel-settings.mjs
@@ -1,0 +1,71 @@
+import { seedProfile, waitForBoot } from './_profile.mjs';
+
+/**
+ * Feature: settings overlay (features/panel-settings.md).
+ * Proves the real user path — open Settings, enable a panel, Save — puts the
+ * panel on the LIVE dashboard with no reload.
+ */
+const PANEL_KEY = process.env.WM_VERIFY_PANEL ?? 'threat-timeline';
+
+export default async function ({ page, base, shot, log, expectVisible }) {
+  await seedProfile(page, {
+    localStorage: {
+      // The free tier clamps to FREE_MAX_PANELS and the full variant already
+      // defaults over that, so a free profile has no headroom and the modal
+      // refuses the toggle with a cap toast. wm-pro-key is the product's own
+      // legacy tester-session path, not a test-only bypass.
+      'wm-pro-key': 'wm-verify-panel-settings',
+      // Boot this one panel disabled so enabling it is an observable change.
+      'worldmonitor-panels': JSON.stringify({
+        [PANEL_KEY]: { name: PANEL_KEY, enabled: false, priority: 1 },
+      }),
+    },
+  });
+  await page.goto(`${base}/dashboard`, { waitUntil: 'domcontentloaded' });
+  await waitForBoot(page);
+
+  const panelSelector = `#panelsGrid .panel[data-panel="${PANEL_KEY}"]`;
+  await expectVisible('#panelsGrid .panel');
+  const before = await page.locator(panelSelector).count();
+  log(`before: ${PANEL_KEY} mounted = ${before}`);
+  if (before !== 0) throw new Error(`${PANEL_KEY} was expected to boot disabled, found ${before} on the grid`);
+  await shot('dashboard-without-panel');
+
+  await (await expectVisible('#unifiedSettingsBtn')).click();
+  await (await expectVisible('#us-tab-panels')).click();
+  await shot('settings-panels-tab');
+
+  const toggle = page.locator(`#usPanelToggles .panel-toggle-item[data-panel="${PANEL_KEY}"]`);
+  await toggle.waitFor({ state: 'visible', timeout: 30_000 });
+  await toggle.click();
+  await page
+    .locator(`#usPanelToggles .panel-toggle-item.active[data-panel="${PANEL_KEY}"]`)
+    .waitFor({ state: 'visible', timeout: 15_000 });
+  log(`toggle is active after the click`);
+
+  const save = page.locator('.panels-save-layout');
+  await save.waitFor({ state: 'visible', timeout: 15_000 });
+  await save.click();
+  await page.locator('.unified-settings-close').click();
+  log('saved and closed the settings overlay — no reload from here on');
+
+  await page.locator(panelSelector).waitFor({ state: 'visible', timeout: 30_000 });
+  await shot('panel-live-on-dashboard');
+
+  // Side effect: the choice must also be persisted, or it evaporates on reload.
+  const persisted = await page.evaluate((key) => {
+    const raw = localStorage.getItem('worldmonitor-panels');
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw)[key] ?? null;
+    } catch {
+      return 'unparseable';
+    }
+  }, PANEL_KEY);
+  log('persisted preference:', JSON.stringify(persisted));
+  if (!persisted || persisted === 'unparseable' || persisted.enabled !== true) {
+    throw new Error(`panel preference was not persisted as enabled: ${JSON.stringify(persisted)}`);
+  }
+
+  return { panel: PANEL_KEY, persisted };
+}


### PR DESCRIPTION
## What

Adds `verify-worldmonitor`, a project-local verification skill that launches one isolated dev instance of the browser dashboard, drives a feature the way a user does, and leaves screenshots plus a transcript behind. It exists so a change can be proved in the real app rather than only in unit tests.

No product code changes. Everything here is under `.agents/skills/verify-worldmonitor/`.

## Using it

```bash
.agents/skills/verify-worldmonitor/scripts/wm-verify.sh launch
.agents/skills/verify-worldmonitor/scripts/wm-verify.sh doctor
.agents/skills/verify-worldmonitor/scripts/wm-verify.sh drive .agents/skills/verify-worldmonitor/steps/dashboard-boot.mjs --name boot
.agents/skills/verify-worldmonitor/scripts/wm-verify.sh cleanup
```

- **launch** runs `VITE_E2E=1 VITE_VARIANT=full vite` on the first free port in 4480-4487 and records the pid, port and base URL. `VITE_E2E=1` is load-bearing — it is the only thing that stamps `data-wm-event-handlers-ready` and `data-wm-initial-data-ready` on `<html>`, which every drive waits on instead of sleeping. Readiness is probed with `/tests/map-harness.html`, the same probe `playwright.config.ts` uses, so a 200 means "can serve the app", not "socket is open".
- **doctor** is read-only and refuses an instance whose port is held by another process tree. Other worktrees and your own `npm run dev` are also vite processes.
- **cleanup** terminates only the recorded pid and its children — never `pkill vite` — and never deletes evidence.
- Evidence lands in `.claude/verify-evidence/<timestamp>-<label>/` (gitignored): numbered screenshots, `transcript.txt`, `console-errors.json`, `console-warnings.json`, `failed-requests.json`, `result.json`.

## Feature map

`features/README.md` is the maintained index. Five features, each with its user entry points, a driving recipe against a runnable step in `steps/`, and its gotchas: dashboard boot, panel settings, country brief, global search, map layers. `steps/_inspect.mjs` dumps live panel keys, layer handles and the map renderer when a handle has drifted.

## Three behaviours the map records

Each was established by driving the app, not by reading code:

- **`hasWebGLSupport()` rejects software GL, so headless never shows deck.gl.** `MapContainer.hasWebGLSupport()` returns false for a `swiftshader` / `llvmpipe` / `software rasterizer` renderer string, so headless Chromium always lands on the SVG map — with or without `--use-gl=swiftshader`, and with or without `--enable-unsafe-swiftshader`. Only a headed run with real GPU GL mounts deck.gl. The layer control is a different element in each (`button.layer-toggle` + `.active` vs a label wrapping `input:checked`), so the step handles both and was run under both. Worth knowing separately: `playwright.config.ts` forces swiftshader for every project, so the existing dashboard specs also exercise the SVG renderer rather than the one users get.
- **`npm run dev` is not `vercel dev`.** Apart from `/api/polymarket`, `/api/rss-proxy`, `/api/youtube/live`, `/api/gpsjam` and the sebuf alias, `/api/*` returns its own JavaScript source as `text/javascript`, so the client's `JSON.parse` throws. A clean local boot therefore carries a baseline of ~30 console errors and ~28 responses ≥400. UI, routing, persistence and panel/layer/settings state are provable locally; the *content* of an Edge endpoint (bootstrap payloads, entitlements, auth) is not, and the map says to report that as unverified rather than as a local pass.
- **`?country=` and `?layers=` are written on a 250 ms debounce.** A single `page.url()` read straight after an action is a race that reads exactly like a dropped deep link. It produced a false failure while this was being written; the steps poll instead.

## Verification

Run end to end on this branch against `/dashboard`: `launch` → `doctor` (OK) → all five feature drives (passed) → `cleanup` (port released, evidence intact). `npm run docs:check` is green; `.agents/**` is outside `lint:md` and the docs-stats claims.

The proof standards in the skill are the ones it follows itself: drive the real user path, capture the action *and* the result, and check the side effect (persisted `localStorage`, the URL) next to the pixel.

## Notes for review

- The canonical copy is under `.agents/` because `.gitignore` excludes `.claude/` — a skill written there could never be reviewed or shipped in a PR. `.claude/skills/verify-worldmonitor` is a symlink to this directory so Claude Code registers it; the symlink itself is gitignored and is recreated with one `ln -sfn`.
- This clone's `.git/info/exclude` also lists `/.agents`, so these files needed `git add -f`. That exclude is local and uncommitted; the files stage normally from here on.
- Maintain the map with `/maintain-verification-skill`.

https://claude.ai/code/session_01BmN9DZ8ZP6SaZ5BnbgqSkj
