### PR TITLE
fix(sentry): attribute passkey-offer timeouts, filter injected-script noise

### DIFF
--- a/api/user/passkey-offer.ts
+++ b/api/user/passkey-offer.ts
@@ -29,11 +29,41 @@ const CLERK_API_TIMEOUT_MS = 3_000;
 const REDIS_CLAIM_TIMEOUT_MS = 2_000;
 const SLOT_KEY_PREFIX = 'passkey-offer-slots';
 
+/** The upstream a failed reservation was actually talking to. */
+export type PasskeyOfferFailureStep = 'clerk-read' | 'redis-claim' | 'clerk-mirror';
+
 export interface PasskeyOfferDeps {
   resolveUserId(request: Request): Promise<string | null>;
   readMigratedCount(userId: string): Promise<number>;
   reserve(userId: string, migratedCount: number): Promise<PasskeyOfferReservation>;
   persistTerminalCount(userId: string): Promise<void>;
+  /**
+   * Injected so the step/fingerprint attribution below is assertable without a
+   * Sentry DSN. Defaults to `captureSilentError` in the exported handler.
+   */
+  report?(error: unknown, step: PasskeyOfferFailureStep): void;
+}
+
+/**
+ * Stable Sentry grouping key for a passkey-offer upstream failure.
+ *
+ * Why it exists: the minified edge bundle gives every rejection the same
+ * anonymous frames (`(vc/edge/function`, no source map), and BOTH upstreams here
+ * abort through `AbortSignal.timeout`, so a Clerk read timeout, a Redis claim
+ * timeout and an unrelated route's timeout all arrive as
+ * `TimeoutError: The operation was aborted due to timeout` with an identical
+ * stack. Sentry's default stack grouping therefore pooled them into one issue —
+ * WORLDMONITOR-10E held 32 `reserve` events, one `clerk-mirror` and one
+ * `api/fwdstart` `scrape`, so the 2026-08-31 13:31–14:08 burst could not be
+ * attributed to Clerk or to Redis without reading the code. Same derivation as
+ * `mcpErrorFingerprint` (api/mcp/error-fingerprint.ts): scope, subject, then the
+ * stable `err.name` so distinct faults on one upstream stay separable.
+ */
+export function passkeyOfferFingerprint(step: PasskeyOfferFailureStep, err: unknown): string[] {
+  const signature = err instanceof Error
+    ? (err.name || err.constructor.name || 'Error')
+    : 'non-error';
+  return ['passkey-offer', step, signature];
 }
 
 function clerkHeaders(): Record<string, string> {
@@ -90,6 +120,13 @@ export function createRedisSlotStore(userId: string): PasskeyOfferSlotStore {
   };
 }
 
+function defaultReport(error: unknown, step: PasskeyOfferFailureStep): void {
+  captureSilentError(error, {
+    tags: { route: 'api/user/passkey-offer', step },
+    fingerprint: passkeyOfferFingerprint(step, error),
+  });
+}
+
 export async function passkeyOfferHandler(
   request: Request,
   deps: PasskeyOfferDeps,
@@ -117,17 +154,26 @@ export async function passkeyOfferHandler(
     });
   }
 
+  const report = deps.report ?? defaultReport;
+
   let migratedCount: number;
   let reservation: PasskeyOfferReservation;
+  // Names which upstream failed. The two calls below have different owners
+  // (Clerk's API vs Upstash Redis) but identical failure signatures — both abort
+  // via `AbortSignal.timeout`, both surface as `TimeoutError: The operation was
+  // aborted due to timeout` — so a single `step: 'reserve'` tag made a Clerk
+  // outage indistinguishable from a Redis one (WORLDMONITOR-10E).
+  let step: PasskeyOfferFailureStep = 'clerk-read';
   try {
     migratedCount = await deps.readMigratedCount(userId);
+    step = 'redis-claim';
     reservation = await deps.reserve(userId, migratedCount);
   } catch (error) {
     console.warn(
-      '[passkey-offer] reservation failed:',
+      `[passkey-offer] reservation failed at ${step}:`,
       error instanceof Error ? error.message : String(error),
     );
-    captureSilentError(error, { tags: { route: 'api/user/passkey-offer', step: 'reserve' } });
+    report(error, step);
     return new Response(JSON.stringify({ error: 'service_unavailable' }), {
       status: 503,
       headers: { ...jsonHeaders, 'Retry-After': '5' },
@@ -142,7 +188,13 @@ export async function passkeyOfferHandler(
         '[passkey-offer] Clerk terminal mirror failed:',
         error instanceof Error ? error.message : String(error),
       );
-      captureSilentError(error, { tags: { route: 'api/user/passkey-offer', step: 'clerk-mirror' } });
+      // sentry-coverage-ok reported via `report` → `defaultReport` →
+      // captureSilentError. The indirection exists so the step/fingerprint
+      // attribution is assertable without a DSN (see PasskeyOfferDeps.report);
+      // scripts/check-sentry-coverage.mjs only reads the catch body, so it
+      // cannot follow the seam. tests/passkey-offer-api.test.mts pins that this
+      // path reports, and with step 'clerk-mirror'.
+      report(error, 'clerk-mirror');
     }
   }
 

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -205,6 +205,22 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /Worker is not a constructor/,
       /_pcmBridgeCallbackHandler/,
       /UCShellJava/,
+      // UC Browser's native JS bridge object, injected into every page by the
+      // in-app WebView's own chrome script and referenced before (or after) the
+      // native side has defined it. Sibling of `UCShellJava` / `ucapi` /
+      // `ucConfig` / `ucbrowser_script` already here, and of the other named
+      // in-app-bridge globals (`zaloJSV2`, `iabjs_unified_bridge`,
+      // `SCDynimacBridge`). The double-underscore-prefixed vendor identifier
+      // appears nowhere in src/, api/, shared/, server/, public/ or index.html,
+      // so it can never come from our bundle, minified or not.
+      //
+      // Matched on the identifier rather than folded into the
+      // `Can.t find variable: (...)` alternation above so BOTH engine phrasings
+      // are covered from one entry — WebKit says `Can't find variable: X`,
+      // Chromium says `X is not defined`, and UC Browser ships on both engines.
+      // WORLDMONITOR-10W (UC Browser 12.2.1 / iOS 17.6.1, single `global code`
+      // frame on the /dashboard document).
+      /__BrowserJSBridgeObj/,
       /Cannot define multiple custom elements/,
       /maxTextureDimension2D/,
       /Container app not found/,
@@ -966,6 +982,31 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
         || (excType === 'SyntaxError' && /^Unexpected (?:token|keyword)/.test(msg))
         || /^SyntaxError: Unexpected (?:token|keyword)/.test(msg)
         || /Invalid or unexpected token/.test(msg)
+        // SpiderMonkey's wording for a malformed numeric literal (`3foo`,
+        // `0x1z`) — the Gecko sibling of the `Invalid or unexpected token` /
+        // `Unexpected token` entries above, and of the `literal not terminated
+        // before end of script` and `Octal literals are not allowed in strict
+        // mode` entries already in ignoreErrors. A runtime parse error cannot
+        // come from our own bundle: it is compiled and parsed at build time, and
+        // a genuine first-party SyntaxError keeps a source-mapped .ts frame or
+        // an owned hashed-chunk URL in the message (both preserved by the
+        // `!hasFirstParty` gate). Observed only with the page DOCUMENT url as
+        // the sole frame (`https://www.worldmonitor.app/:1`), which is how
+        // WebKit/Gecko attribute a main-world injected content script —
+        // WORLDMONITOR-10B (Firefox iOS 154.1 / iOS 18.7).
+        || (excType === 'SyntaxError' && /^No identifiers allowed directly after numeric literal$/.test(msg))
+        // SpiderMonkey's wording for a malformed numeric literal (`3foo`,
+        // `0x1z`) — the Gecko sibling of the `Invalid or unexpected token` /
+        // `Unexpected token` entries above, and of the `literal not terminated
+        // before end of script` and `Octal literals are not allowed in strict
+        // mode` entries already in ignoreErrors. A runtime parse error cannot
+        // come from our own bundle: it is compiled and parsed at build time, and
+        // a genuine first-party SyntaxError keeps a source-mapped .ts frame or
+        // an owned hashed-chunk URL in the message (both preserved by the
+        // `!hasFirstParty` gate). Observed only with the page DOCUMENT url as
+        // the sole frame (`https://www.worldmonitor.app/:1`), which is how
+        // WebKit/Gecko attribute a main-world injected content script —
+        // WORLDMONITOR-10B (Firefox iOS 154.1 / iOS 18.7).
         // V8 wording when HTML (or other non-JS) is parsed as a script:
         // Electron / in-app wrappers fetch the SPA document (`/dashboard`)
         // as if it were JS, then report the parse failure against the

--- a/tests/passkey-offer-api.test.mts
+++ b/tests/passkey-offer-api.test.mts
@@ -3,10 +3,12 @@ import { afterEach, describe, it } from 'node:test';
 
 import {
   createRedisSlotStore,
+  passkeyOfferFingerprint,
   passkeyOfferHandler,
   persistClerkTerminalCount,
   readClerkMigratedCount,
   type PasskeyOfferDeps,
+  type PasskeyOfferFailureStep,
 } from '../api/user/passkey-offer.ts';
 
 const originalFetch = globalThis.fetch;
@@ -105,6 +107,79 @@ describe('passkey offer route', () => {
 
     assert.equal(response.status, 503);
     assert.equal(response.headers.get('Retry-After'), '5');
+  });
+
+  // WORLDMONITOR-10E: both upstreams abort through `AbortSignal.timeout` and the
+  // minified edge bundle gives them identical anonymous frames, so a single
+  // `step` value left a Clerk outage and a Redis outage indistinguishable in
+  // Sentry. Each upstream must name itself.
+  it('attributes a Clerk read failure to the clerk-read step', async () => {
+    const steps: PasskeyOfferFailureStep[] = [];
+    const response = await passkeyOfferHandler(request(), deps({
+      readMigratedCount: async () => { throw new Error('clerk unavailable'); },
+      reserve: async () => { throw new Error('reserve must not run'); },
+      report: (_error, step) => { steps.push(step); },
+    }));
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(steps, ['clerk-read']);
+  });
+
+  it('attributes a Redis claim failure to the redis-claim step', async () => {
+    const steps: PasskeyOfferFailureStep[] = [];
+    const response = await passkeyOfferHandler(request(), deps({
+      reserve: async () => { throw new Error('redis unavailable'); },
+      report: (_error, step) => { steps.push(step); },
+    }));
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(steps, ['redis-claim']);
+  });
+
+  it('attributes a terminal-mirror failure to the clerk-mirror step and still returns the slot', async () => {
+    const steps: PasskeyOfferFailureStep[] = [];
+    const response = await passkeyOfferHandler(request(), deps({
+      readMigratedCount: async () => 2,
+      reserve: async () => ({ status: 'reserved', count: 3 }),
+      persistTerminalCount: async () => { throw new Error('clerk mirror unavailable'); },
+      report: (_error, step) => { steps.push(step); },
+    }));
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(steps, ['clerk-mirror']);
+  });
+});
+
+describe('passkey offer Sentry fingerprint', () => {
+  // A timeout on Clerk and a timeout on Redis carry the same message and the
+  // same anonymous stack; only the step keeps them in separate Sentry issues.
+  it('separates the two upstreams for an identical error', () => {
+    const timeout = Object.assign(new Error('The operation was aborted due to timeout'), {
+      name: 'TimeoutError',
+    });
+
+    assert.deepEqual(
+      passkeyOfferFingerprint('clerk-read', timeout),
+      ['passkey-offer', 'clerk-read', 'TimeoutError'],
+    );
+    assert.notDeepEqual(
+      passkeyOfferFingerprint('clerk-read', timeout),
+      passkeyOfferFingerprint('redis-claim', timeout),
+    );
+  });
+
+  it('separates distinct faults on the same upstream', () => {
+    assert.notDeepEqual(
+      passkeyOfferFingerprint('clerk-read', Object.assign(new Error('x'), { name: 'TimeoutError' })),
+      passkeyOfferFingerprint('clerk-read', new Error('Clerk user read failed with 500')),
+    );
+  });
+
+  it('keys a non-Error throw without reading properties off it', () => {
+    assert.deepEqual(
+      passkeyOfferFingerprint('redis-claim', 'boom'),
+      ['passkey-offer', 'redis-claim', 'non-error'],
+    );
   });
 });
 

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -1952,3 +1952,93 @@ describe('ignoreErrors — Android WebView Java bridge (WORLDMONITOR-117, -YN)',
     assert.ok(files.some((f) => f.endsWith('sentry-init.ts')), 'scan must reach sentry-init.ts');
   });
 });
+
+// ─── WORLDMONITOR-10W: UC Browser native JS bridge global ─────────────────
+//
+// UC Browser's in-app WebView injects `__BrowserJSBridgeObj` and its own chrome
+// script references it before (or after) the native side defines it. Observed on
+// UC Browser 12.2.1 / iOS 17.6.1 with a single `global code` frame on the
+// /dashboard document. Named vendor bridge global, same class as the
+// UCShellJava / ucapi / ucConfig / zaloJSV2 entries already in ignoreErrors.
+describe('ignoreErrors — UC Browser bridge global (WORLDMONITOR-10W)', () => {
+  const PROD_MSG = "Can't find variable: __BrowserJSBridgeObj";
+  const pattern = ignoreErrors.find(p => p instanceof RegExp && /__BrowserJSBridgeObj/.test(p.source));
+
+  it('defines a __BrowserJSBridgeObj ignore pattern', () => {
+    assert.ok(pattern, 'a /__BrowserJSBridgeObj/ ignoreErrors pattern must exist');
+  });
+
+  it('suppresses the verbatim production WebKit message', () => {
+    assert.ok(isIgnored(PROD_MSG), `ignoreErrors must drop: ${PROD_MSG}`);
+  });
+
+  it('suppresses the Chromium phrasing of the same global', () => {
+    // UC Browser ships on both engines: WebKit says `Can't find variable: X`,
+    // Chromium says `X is not defined`. Matching the identifier covers both.
+    assert.ok(isIgnored('__BrowserJSBridgeObj is not defined'),
+      'the Chromium phrasing must be dropped by the same entry');
+  });
+
+  it('does not swallow an unrelated bridge-shaped identifier', () => {
+    assert.ok(!isIgnored('BrowserJSBridgeObj is not defined'),
+      'the double-underscore vendor prefix is load-bearing');
+  });
+
+  // The source-level invariant the message-only suppression rests on.
+  it('keeps the licence true: __BrowserJSBridgeObj is absent from our own source', () => {
+    const offenders = [];
+    for (const rel of ['../src', '../api']) {
+      for (const file of walkTsFiles(resolve(__dirname, rel))) {
+        if (/sentry-init\.ts$|sentry-filter-policy\.ts$/.test(file)) continue;
+        if (/__BrowserJSBridgeObj/.test(readFileSync(file, 'utf-8'))) offenders.push(file);
+      }
+    }
+    assert.deepEqual(offenders, [],
+      `__BrowserJSBridgeObj now appears in our own source — the suppression is no longer safe:\n${offenders.join('\n')}`);
+  });
+});
+
+// ─── WORLDMONITOR-10B: SpiderMonkey malformed-numeric-literal parse error ──
+//
+// Firefox iOS 154.1 / iOS 18.7, sole frame `https://www.worldmonitor.app/:1` —
+// how Gecko/WebKit attribute a main-world injected content script. A runtime
+// parse error cannot come from our own bundle (compiled and parsed at build
+// time), so this joins the `hasAnyStack && !hasFirstParty` SyntaxError family
+// alongside Unexpected token/keyword and Invalid or unexpected token.
+describe('malformed numeric literal SyntaxError (WORLDMONITOR-10B)', () => {
+  const MSG = 'No identifiers allowed directly after numeric literal';
+  const documentFrame = { filename: 'https://www.worldmonitor.app/', lineno: 1, function: null };
+
+  it('suppresses the parse error attributed to the page document URL', () => {
+    const event = makeEvent(MSG, 'SyntaxError', [documentFrame]);
+    assert.equal(beforeSend(event), null,
+      'document-URL numeric-literal parse error must be suppressed as injected-script noise');
+  });
+
+  it('suppresses the same message with an extension-only stack', () => {
+    const event = makeEvent(MSG, 'SyntaxError', [extensionFrame()]);
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('does NOT suppress the same SyntaxError with a first-party frame', () => {
+    const event = makeEvent(MSG, 'SyntaxError', [firstPartyFrame()]);
+    assert.ok(beforeSend(event) !== null,
+      'a first-party parse error must still reach Sentry');
+  });
+
+  it('does NOT suppress the same SyntaxError with an empty stack', () => {
+    const event = makeEvent(MSG, 'SyntaxError', []);
+    assert.ok(beforeSend(event) !== null,
+      'empty-stack parse error is not proven third-party and must surface');
+  });
+
+  it('is anchored so a longer first-party message still surfaces', () => {
+    const event = makeEvent(
+      `${MSG} while parsing the operator config`,
+      'SyntaxError',
+      [documentFrame],
+    );
+    assert.ok(beforeSend(event) !== null,
+      'the entry is anchored to the whole engine sentence');
+  });
+});


### PR DESCRIPTION
## Summary

When `/api/user/passkey-offer` started failing on 2026-08-31, Sentry could not say which vendor had gone down. The route reads Clerk's user metadata and then claims an Upstash Redis slot inside one `try`, and reported every failure as `step: 'reserve'`. Both calls abort through `AbortSignal.timeout`, so both produce the identical `TimeoutError: The operation was aborted due to timeout`, and the minified edge bundle gives both the same anonymous `(vc/edge/function` frames with no source map. Sentry groups on the stack, so the two vendors — plus every other route that times out the same way — landed in one issue.

That issue is WORLDMONITOR-10E, and it held three unrelated populations at once:

| Route | Step | Events |
|---|---|---|
| `api/user/passkey-offer` | `reserve` | 32 |
| `api/user/passkey-offer` | `clerk-mirror` | 1 |
| `api/fwdstart` | `scrape` | 1 |

33 of its 34 lifetime events arrived in a single ~37-minute burst (13:31–14:08 UTC) across many distinct AWS egress IPs. The one `clerk-mirror` event mid-window is the only hint that Clerk rather than Redis was the failing side — and only to a reader who already knows that `clerk-mirror` is the Clerk-only write path.

So the step now names the vendor that actually failed (`clerk-read`, `redis-claim`, or the existing `clerk-mirror`), and `passkeyOfferFingerprint` overrides the stack grouping with `['passkey-offer', step, err.name]`. That derivation mirrors `mcpErrorFingerprint` in `api/mcp/error-fingerprint.ts`, which exists for the same reason on the `api/mcp` catch-all. It keys on `err.name` rather than `err.constructor.name` because the edge bundle mangles class names (WORLDMONITOR-Y2) and a `DOMException` reports the more specific `TimeoutError` anyway.

**Runtime behavior is unchanged** — the same 503 with `Retry-After: 5`, on the same conditions. Only the attribution moves.

## Two injected-script signatures

Each is routed through the mechanism its ambiguity earns, which is the reviewable decision here:

- **`ignoreErrors`** for `__BrowserJSBridgeObj` (WORLDMONITOR-10W, UC Browser 12.2.1 / iOS 17.6.1). UC Browser's in-app WebView injects this native bridge object and its own chrome script references it before the native side defines it. A named vendor global is safe to suppress by message alone because it appears nowhere in `src/`, `api/`, `shared/`, `server/`, `public/` or `index.html` — the same licence the neighbouring `UCShellJava` / `ucapi` / `zaloJSV2` entries rest on, and a test pins that licence so it cannot rot. Matching the identifier rather than extending the `Can.t find variable: (...)` alternation lets one entry cover both engines UC Browser ships on.
- **`beforeSend`** for `No identifiers allowed directly after numeric literal` (WORLDMONITOR-10B, Firefox iOS 154.1). A generic parse error *could* in principle be phrased by our own bundle, so it goes under the existing `hasAnyStack && !hasFirstParty` gate instead — the Gecko sibling of the `Invalid or unexpected token` entries already there. Our bundle is parsed at build time and cannot mint a runtime parse error, and a genuine first-party `SyntaxError` keeps a source-mapped `.ts` frame, which the gate preserves.

## Note for reviewers

`report` joins `PasskeyOfferDeps` so the attribution is assertable without a Sentry DSN, matching how the route already injects its other four collaborators. That indirection is invisible to `scripts/check-sentry-coverage.mjs`, which only reads the catch body, so the `clerk-mirror` catch carries a `// sentry-coverage-ok` marker naming the `report` → `defaultReport` → `captureSilentError` path. The guard's teeth are replaced rather than removed: a test drives that catch and asserts it reports, with step `clerk-mirror`.

## Validation

`npx tsc --noEmit` clean; 349 tests pass across `tests/passkey-offer-api.test.mts`, `tests/sentry-beforesend.test.mjs` and the three sibling passkey suites. All pre-push gates pass.

Each new assertion was proven able to fail, since a filter test that cannot go red is the failure mode this kind of change invites:

- Deleting the `step = 'redis-claim'` transition reds the redis-claim test.
- Deleting the WORLDMONITOR-10B `beforeSend` clause reds the document-URL case.

One honest gap: the 10B suite's extension-only-stack case still passes without the new clause, because the pre-existing extension-frame gate catches it independently. The document-URL case is the one that proves the new clause, and it is the production shape.

The three Sentry issues are resolved with a plain `{"status": "resolved"}` — no `inNextRelease` pin — and read back with empty `statusDetails`. The two browser filters only take effect after this deploys, so 10W and 10B can each reopen once before then.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
