### PR TITLE
spike(deps): measure bun as the fix for per-worktree node_modules duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,11 @@ playground-pricing.html
 # compile time — `cargo test` fails on a resource path that does not exist.
 src-tauri/notices/*
 !src-tauri/notices/.gitkeep
+
+# Bun package-manager spike (#SPIKE): package-lock.json stays the single source
+# of truth while the spike is open. bun.lock is generated locally for
+# measurement only and must NOT be committed — two lockfiles that can disagree
+# is exactly the drift this policy exists to prevent. Deleting these lines is
+# the deliberate act that makes bun authoritative.
+bun.lock
+bun.lockb

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -449,7 +449,22 @@ fi
 # at the wrong thing. npm writes .package-lock.json only on a completed install,
 # which is exactly the check shouldInstallDependencies() in
 # scripts/bootstrap-worktree.mjs already uses. Keep the two in agreement.
-if [ ! -f node_modules/.package-lock.json ]; then
+# Bun leaves no completed-install marker of its own (only node_modules/.bin,
+# which a half-finished install also creates), and `bun install --frozen-lockfile`
+# on an installed tree costs ~11s — too slow to run unconditionally in a gate
+# whose cached-green re-push is ~0.5s. So a bun install writes the sha256 of the
+# lockfile it installed from, and we compare against the current lockfile here.
+# That also catches a STALE tree, which npm's marker cannot. Kept in agreement
+# with hasFreshBunInstall() in scripts/bootstrap-worktree.mjs.
+bun_install_is_fresh() {
+  [ -f bun.lock ] || return 1
+  [ -f node_modules/.wm-bun-install ] || return 1
+  _wm_want=$(shasum -a 256 bun.lock 2>/dev/null | awk '{print $1}')
+  _wm_have=$(tr -d '[:space:]' < node_modules/.wm-bun-install 2>/dev/null)
+  [ -n "$_wm_want" ] && [ "$_wm_want" = "$_wm_have" ]
+}
+
+if [ ! -f node_modules/.package-lock.json ] && ! bun_install_is_fresh; then
   echo "node_modules missing or incomplete, running npm ci..."
   npm ci --cache "$npm_config_cache" --prefer-offline || exit 1
 fi

--- a/docs/solutions/performance-issues/worktree-node-modules-duplication-bun-spike.md
+++ b/docs/solutions/performance-issues/worktree-node-modules-duplication-bun-spike.md
@@ -1,0 +1,150 @@
+---
+title: Per-worktree node_modules duplication - measuring bun as the fix (spike)
+date: 2026-09-01
+category: performance-issues
+module: package-management-worktree-tooling
+problem_type: performance_issue
+component: development_workflow
+symptoms:
+  - "125 worktrees hold 181.8 GB, of which 135.5 GB is node_modules across 70 worktrees, on a volume with 47 GB free"
+  - "a 7-day dormancy filter reclaims only 2.0 GB - the pile is generated faster than cleanup can sweep it"
+  - "npm ci writes fresh blocks per worktree; installed files report links=1, so nothing is shared with the cache"
+root_cause: design_limitation
+resolution_type: investigation
+severity: medium
+related_components:
+  - tooling
+  - development_workflow
+tags: [package-manager, bun, pnpm, npm, worktree, node-modules, disk-space, clonefile, apfs, spike]
+---
+
+# Spike: bun as the package manager, to stop per-worktree node_modules duplication
+
+Status: **spike / draft — not a recommendation to merge.** Nothing here changes
+how the repo installs today. `package-lock.json` remains the single source of
+truth and `npm ci` remains the install path.
+
+## The problem this is a candidate answer to
+
+One local machine currently carries **125 worktrees / 181.8 GB**, of which
+**135.5 GB is `node_modules` across 70 worktrees** — on a volume with 47 GB
+free. Every bootstrapped worktree pays a fresh ~2.0 GB because `npm ci` writes
+new blocks for every file.
+
+That is not an old-junk problem that cleanup fixes. Measured with a 7-day
+dormancy filter, only **one** of those 70 worktrees is untouched — the pile is
+generated faster than it can be swept.
+
+## Why npm cannot fix it
+
+Verified, not assumed:
+
+- `npm --install-strategy=linked` exists (npm 11.12.1 supports it) but its store
+  is `node_modules/.store` **inside each project**. It is an isolation feature
+  for catching phantom dependencies; it shares nothing between checkouts.
+- npm's cache is content-addressable but stores **gzipped tarballs**
+  (`~/.npm/_cacache/content-v2`), so extraction must write new bytes. Confirmed
+  on a real install: every file in `node_modules` reports `links=1`.
+- The two upstream paths that would change this are not moving:
+  [nodejs/node#26489](https://github.com/nodejs/node/issues/26489) (reflink
+  support) is **closed**, and [npm/rfcs#912](https://github.com/npm/rfcs/discussions/912)
+  ("RFC: Content-Addressable Store") was opened 2026-07-11 with zero comments.
+
+## Why bun rather than pnpm
+
+Both solve the duplication. bun is proposed here for two repo-specific reasons:
+
+1. **bun's default install backend on macOS is `clonefile`** (`--backend` accepts
+   `clonefile` (default), `hardlink`, `symlink`, `copyfile`). It produces real
+   files. pnpm's global virtual store is **symlink**-based, and `.husky/pre-push`
+   hard-fails on `node_modules` being a symlink — the guard exists because a
+   later cleanup can delete the symlink *target*.
+2. bun needs no configuration to get the win; pnpm needs `virtualStoreType: global`
+   plus a store on the same filesystem.
+
+Ecosystem context (measured 2026-09-01 by classifying the root lockfile of the
+top 100 TypeScript repos by stars, via the GitHub API):
+
+| package manager | >15k stars, pushed since 2026-08-01 | created in 2026, >2k stars |
+|---|---|---|
+| pnpm | 48 | 33 |
+| npm | 21 | 31 |
+| bun | 8 | **24** |
+| yarn | 18 | 2 |
+| unknown | 5 | 10 |
+
+pnpm leads the established cohort (`vitejs/vite` itself, angular, supabase,
+tailwindcss, shadcn-ui, n8n, immich). bun is the fastest riser among new
+projects. WorldMonitor appears in the npm column of the first cohort.
+
+## What was measured on this repo
+
+Two throwaway worktrees off `origin/main`, since removed.
+
+| check | result |
+|---|---|
+| `bun install` (1517 packages resolved) | exit 0, **28s** cold / **9s** warm |
+| `npm run typecheck` (`tsc --noEmit`) | exit 0 |
+| `npx vite build --mode production` | exit 0, 30.7s — maplibre 1.05 MB, GlobeMap 1.83 MB, deck-stack 765 kB, PWA SW generated |
+| `npm run test:sidecar` | **447 pass / 0 fail** |
+| `npm run test:data` (387 files) | **29,142 pass / 0 fail / 35 skipped**, 7m8s |
+| `blog-site` nested install (postinstall chain) | ran, 263 entries |
+
+Disk, measured as real free-space delta rather than `du`:
+
+```
+worktree #1 (cold cache):  2274 MB real
+worktree #2 (warm cache):   341 MB real   <- du reports 2.1 GB
+   of which blog-site:      142 MB  (npm installs it; no sharing)
+   bun's own tree:         ~199 MB  -> ~10x sharing
+shared ~/.bun/install/cache: 2.1 GB, paid ONCE
+```
+
+Extrapolated to the current 70 bootstrapped worktrees: roughly **135 GB -> ~25 GB**.
+
+## What this spike changes
+
+Three things, each inert on a checkout with no `bun.lock`:
+
+1. **`trustedDependencies` in `package.json`.** bun blocks dependency lifecycle
+   scripts by default; it blocked 4 here (`browser-tabs-lock`, `core-js`,
+   `es5-ext`, `protobufjs`). The build and 447 sidecar tests passed anyway, but
+   `protobufjs` is listed explicitly because of the generated sebuf clients.
+   npm ignores the field.
+2. **A completed-install marker for bun.** This is the load-bearing fix. bun
+   leaves **no** marker inside `node_modules` — only `.bin`, which an interrupted
+   install also creates — so `.husky/pre-push` would see no
+   `node_modules/.package-lock.json` and run a full `npm ci` **on every push**,
+   silently undoing the win. `bun install --frozen-lockfile` on an installed
+   tree is not a workaround: it costs **~11s** (measured twice), against a
+   cached-green re-push of ~0.5s.
+
+   So `scripts/bun-install.mjs` stamps `node_modules/.wm-bun-install` with the
+   sha256 of the `bun.lock` it installed from, and both the gate and
+   `shouldInstallDependencies()` check it. That is **stronger** than npm's
+   marker, which proves completion but not freshness — a stale tree after a
+   dependency bump is invisible to `.package-lock.json` and caught here.
+3. **Lockfile policy.** `bun.lock` is gitignored. `package-lock.json` stays
+   authoritative for the life of the spike; deleting those `.gitignore` lines is
+   the deliberate act that flips it.
+
+## What is still unproven
+
+- CI. Every workflow still runs `npm ci`; nothing here touches them.
+- `pro-test/node_modules` is not installed by the postinstall chain (it belongs
+  to `build:pro`), so the built-output tests were not exercised under bun.
+- Linux/CI filesystems have no APFS `clonefile`. bun falls back to `hardlink`
+  there, which shares blocks differently; unmeasured.
+- Desktop/Tauri and the Railway seeder images were not exercised.
+
+## How to reproduce
+
+```bash
+git worktree add --detach /tmp/wm-bun origin/main
+cd /tmp/wm-bun
+node scripts/bun-install.mjs      # bun install + stamp the marker
+npm run typecheck && npx vite build --mode production && npm run test:sidecar
+```
+
+Measure the sharing with a second worktree, comparing `df` free-space delta
+against what `du` reports — `du` counts cloned blocks that cost nothing.

--- a/package.json
+++ b/package.json
@@ -277,6 +277,12 @@
     "youtubei.js": "^16.0.1",
     "zod": "^4.3.6"
   },
+  "trustedDependencies": [
+    "browser-tabs-lock",
+    "core-js",
+    "es5-ext",
+    "protobufjs"
+  ],
   "overrides": {
     "convex": {
       "esbuild": "0.28.1"

--- a/scripts/bootstrap-worktree.mjs
+++ b/scripts/bootstrap-worktree.mjs
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   existsSync,
   lstatSync,
   mkdirSync,
+  readFileSync,
   readlinkSync,
   symlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { basename, dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -202,11 +205,46 @@ export function linkEnvFiles({
   return result;
 }
 
+// Bun leaves NO completed-install marker inside node_modules — only `.bin`,
+// which an interrupted install also creates. npm's `.package-lock.json` has no
+// bun equivalent, and `bun install --frozen-lockfile` on an already-installed
+// tree costs ~11s (measured), far too slow to run unconditionally in a gate
+// whose cached-green re-push is ~0.5s. So the repo writes its own marker: the
+// sha256 of the bun lockfile the tree was installed from. That is strictly
+// stronger than npm's marker, which proves completion but not freshness.
+export const BUN_INSTALL_MARKER = 'node_modules/.wm-bun-install';
+
+function bunLockDigest(rootDir) {
+  const lockfile = resolve(rootDir, 'bun.lock');
+  if (!existsSync(lockfile)) return null;
+  return createHash('sha256').update(readFileSync(lockfile)).digest('hex');
+}
+
+export function writeBunInstallMarker(rootDir = process.cwd()) {
+  const digest = bunLockDigest(rootDir);
+  if (!digest) return false;
+  writeFileSync(resolve(rootDir, BUN_INSTALL_MARKER), `${digest}\n`);
+  return true;
+}
+
+export function hasFreshBunInstall(rootDir = process.cwd()) {
+  const digest = bunLockDigest(rootDir);
+  if (!digest) return false;
+  const marker = resolve(rootDir, BUN_INSTALL_MARKER);
+  if (!existsSync(marker)) return false;
+  return readFileSync(marker, 'utf8').trim() === digest;
+}
+
 export function shouldInstallDependencies({
   forceInstall = false,
   rootDir = process.cwd(),
 } = {}) {
-  return forceInstall || !existsSync(resolve(rootDir, 'node_modules/.package-lock.json'));
+  if (forceInstall) return true;
+  if (existsSync(resolve(rootDir, 'node_modules/.package-lock.json'))) return false;
+  // Consulted only when a bun lockfile is present, so a checkout without one
+  // takes the exact npm path this function has always taken.
+  if (hasFreshBunInstall(rootDir)) return false;
+  return true;
 }
 
 export function assertNodeModulesNotSymlink(rootDir = process.cwd(), label = 'node_modules') {

--- a/scripts/bun-install.mjs
+++ b/scripts/bun-install.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Spike helper: `bun install`, then stamp the completed-install marker the
+// pre-push gate and bootstrap-worktree.mjs both look for.
+//
+// Bun does not write a marker of its own (see writeBunInstallMarker), so this
+// wrapper is what makes a bun-installed tree legible to the existing gates.
+// Not wired into any npm lifecycle script — the spike is opt-in.
+//
+//   node scripts/bun-install.mjs [...bun install args]
+import { spawnSync } from 'node:child_process';
+
+import { writeBunInstallMarker } from './bootstrap-worktree.mjs';
+
+const args = process.argv.slice(2);
+const result = spawnSync('bun', ['install', ...args], { stdio: 'inherit' });
+
+if (result.error) {
+  console.error(`[bun-install] could not run bun: ${result.error.message}`);
+  process.exit(1);
+}
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+if (writeBunInstallMarker()) {
+  console.log('[bun-install] stamped node_modules/.wm-bun-install');
+} else {
+  // No bun.lock means bun did not produce a lockfile to hash — the gate will
+  // fall through to npm ci rather than trusting an unverifiable tree.
+  console.warn('[bun-install] no bun.lock found; marker not written');
+}

--- a/tests/bun-install-marker.test.mjs
+++ b/tests/bun-install-marker.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, describe, it } from 'node:test';
+
+import {
+  BUN_INSTALL_MARKER,
+  hasFreshBunInstall,
+  shouldInstallDependencies,
+  writeBunInstallMarker,
+} from '../scripts/bootstrap-worktree.mjs';
+
+const roots = [];
+
+function makeRoot() {
+  const dir = mkdtempSync(join(tmpdir(), 'wm-bun-marker-'));
+  mkdirSync(join(dir, 'node_modules'), { recursive: true });
+  roots.push(dir);
+  return dir;
+}
+
+after(() => {
+  for (const dir of roots) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('bun completed-install marker', () => {
+  it('treats an npm-installed tree exactly as before (no bun lockfile present)', () => {
+    const root = makeRoot();
+    assert.equal(shouldInstallDependencies({ rootDir: root }), true);
+    writeFileSync(join(root, 'node_modules/.package-lock.json'), '{}');
+    assert.equal(shouldInstallDependencies({ rootDir: root }), false);
+  });
+
+  it('does not trust a bun tree that carries no marker', () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'bun.lock'), 'lock-v1');
+    // node_modules/.bin exists after an INTERRUPTED install too, so its
+    // presence must not be enough to skip the install.
+    mkdirSync(join(root, 'node_modules/.bin'), { recursive: true });
+    assert.equal(hasFreshBunInstall(root), false);
+    assert.equal(shouldInstallDependencies({ rootDir: root }), true);
+  });
+
+  it('trusts a marker that matches the current lockfile', () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'bun.lock'), 'lock-v1');
+    assert.equal(writeBunInstallMarker(root), true);
+    assert.equal(hasFreshBunInstall(root), true);
+    assert.equal(shouldInstallDependencies({ rootDir: root }), false);
+  });
+
+  it('rejects a STALE marker after the lockfile changes', () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'bun.lock'), 'lock-v1');
+    writeBunInstallMarker(root);
+    assert.equal(hasFreshBunInstall(root), true);
+
+    // A dependency bump rewrites the lockfile. npm's .package-lock.json marker
+    // cannot detect this; the digest marker must.
+    writeFileSync(join(root, 'bun.lock'), 'lock-v2');
+    assert.equal(hasFreshBunInstall(root), false);
+    assert.equal(shouldInstallDependencies({ rootDir: root }), true);
+  });
+
+  it('writes no marker when there is no bun lockfile to hash', () => {
+    const root = makeRoot();
+    assert.equal(writeBunInstallMarker(root), false);
+    assert.equal(hasFreshBunInstall(root), false);
+  });
+
+  it('still honours forceInstall over a fresh marker', () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'bun.lock'), 'lock-v1');
+    writeBunInstallMarker(root);
+    assert.equal(shouldInstallDependencies({ rootDir: root, forceInstall: true }), true);
+  });
+
+  it('names the marker inside node_modules so a clean wipe resets it', () => {
+    assert.equal(BUN_INSTALL_MARKER, 'node_modules/.wm-bun-install');
+  });
+});


### PR DESCRIPTION
> **Draft spike — do not merge.** This is a decision aid, not a migration. `package-lock.json` remains the single source of truth, `npm ci` remains the install path, and every change here is inert on a checkout with no `bun.lock`.

## Why

One machine currently carries **125 worktrees / 181.8 GB**, of which **135.5 GB is `node_modules` across 70 worktrees**, on a volume with **47 GB free**.

Applying a 7-day dormancy filter reclaims **2.0 GB**. Only 1 of the 70 worktrees carrying `node_modules` is untouched — the pile is generated faster than cleanup can sweep it. This is a duplication problem, not a stale-junk problem, so cleanup automation cannot fix it.

## npm has no answer, verified rather than assumed

- **`--install-strategy=linked`** exists (npm 11.12.1 supports it) but its store is `node_modules/.store` **inside each project**. It is an isolation feature for catching phantom dependencies; it shares nothing between checkouts.
- **npm's cache cannot be linked from.** It is content-addressable but stores gzipped tarballs (`~/.npm/_cacache/content-v2`), so extraction must write new bytes. Confirmed on a real install: every file reports `links=1`.
- **Upstream is not moving.** [nodejs/node#26489](https://github.com/nodejs/node/issues/26489) (reflink support) is **closed**; [npm/rfcs#912](https://github.com/npm/rfcs/discussions/912) ("Content-Addressable Store") has sat at **zero comments** since 2026-07-11.

## Why bun and not pnpm

Both solve it. bun is proposed for two repo-specific reasons:

1. **bun's default backend on macOS is `clonefile`**, which produces real files. pnpm's global virtual store is **symlink**-based and would trip `.husky/pre-push`'s `ERROR: node_modules is a symlink` guard — a guard that exists because a later cleanup can delete the symlink's *target*.
2. bun needs no configuration; pnpm needs `virtualStoreType: global` plus a store on the same filesystem.

Ecosystem context, measured 2026-09-01 by classifying the root lockfile of the top 100 TypeScript repos via the GitHub API:

| | >15k ⭐, pushed since 2026-08-01 | created in 2026, >2k ⭐ |
|---|---|---|
| pnpm | 48 | 33 |
| npm | 21 | 31 |
| **bun** | 8 | **24** |
| yarn | 18 | 2 |

pnpm leads the established cohort (`vitejs/vite` itself, angular, supabase, tailwindcss, shadcn-ui, n8n, immich). bun is the fastest riser among new projects.

## What was measured on this repo

Two throwaway worktrees off `origin/main`, since removed.

| check | result |
|---|---|
| `bun install` (1517 packages) | exit 0, **28s** cold / **9s** warm |
| `npm run typecheck` | exit 0 |
| `npx vite build --mode production` | exit 0, 30.7s — maplibre 1.05 MB, GlobeMap 1.83 MB, deck-stack 765 kB, PWA SW generated |
| `npm run test:sidecar` | **447 pass / 0 fail** |
| `npm run test:data` (387 files) | **29,142 pass / 0 fail / 35 skipped**, 7m8s |

Disk, measured as real free-space delta rather than `du` (which counts cloned blocks that cost nothing):

```
worktree #1 (cold cache):  2274 MB real
worktree #2 (warm cache):   341 MB real   <- du reports 2.1 GB
   of which blog-site:      142 MB  (npm installs it; no sharing)
   bun's own tree:         ~199 MB  -> ~10x sharing
shared ~/.bun/install/cache: 2.1 GB, paid ONCE
```

Roughly **135 GB → ~25 GB** at the current worktree count.

## The three changes

**1. `trustedDependencies` in `package.json`.** bun blocks dependency lifecycle scripts by default and blocked 4 here: `browser-tabs-lock`, `core-js`, `es5-ext`, `protobufjs`. Build and all tests passed anyway, but `protobufjs` is listed explicitly because of the generated sebuf clients. npm ignores the field.

**2. A completed-install marker for bun — the load-bearing fix.** bun leaves **no** marker inside `node_modules`, only `.bin`, which an interrupted install also creates. So `.husky/pre-push` would find no `node_modules/.package-lock.json` and run a full `npm ci` **on every push**, silently undoing the entire win.

Running `bun install --frozen-lockfile` unconditionally is not an alternative — it costs **~11s** on an already-installed tree (measured twice) against a cached-green re-push of ~0.5s.

So `scripts/bun-install.mjs` stamps `node_modules/.wm-bun-install` with the sha256 of the `bun.lock` it installed from, and both the shell gate and `shouldInstallDependencies()` verify it. That is **stronger** than npm's marker, which proves completion but not freshness: a stale tree after a dependency bump is invisible to `.package-lock.json` and is caught here. Node-side and shell-side digests were confirmed byte-identical on a real tree.

**3. Lockfile policy.** `bun.lock` is gitignored so the spike cannot ship a second source of truth. Deleting those `.gitignore` lines is the deliberate act that would make bun authoritative.

## Verification

- `tests/bootstrap-worktree.test.mjs` — **29 pass** (unchanged npm behaviour)
- `tests/prepush-hook-gate.test.mjs` — **31 pass**
- `tests/bun-install-marker.test.mjs` — **7 pass** (new). Pins that a bare `node_modules/.bin` is NOT trusted, that a stale marker is rejected, and that `forceInstall` still wins.
- **The push that created this branch is itself the proof**: it ran from a bun-installed worktree with no `.package-lock.json`, and the gate passed every stage including typecheck without falling back to `npm ci`.

## Still unproven — deliberately out of scope

- **CI.** Every workflow still runs `npm ci`. Nothing here touches them, so CI on this PR exercises the npm path, which is the point: the changes must be inert.
- **`pro-test/node_modules`** is not installed by the postinstall chain (it belongs to `build:pro`), so the built-output tests were not exercised under bun.
- **Linux/CI filesystems have no APFS `clonefile`.** bun falls back to `hardlink` there, which shares differently. Unmeasured.
- **Tauri desktop and Railway seeder images** were not exercised.

## What I'd want decided

Whether the ~110 GB is worth a package-manager change at all, versus capping worktree count — the ecosystem's actual default answer is 4-10 worktrees per developer, and no guide is written for 125.

Full write-up with reproduction steps: `docs/solutions/performance-issues/worktree-node-modules-duplication-bun-spike.md`

https://claude.ai/code/session_01BmN9DZ8ZP6SaZ5BnbgqSkj
