### PR TITLE
fix(ci): normalize line endings in source attribution and skills index for cross-platform parity

### DIFF
--- a/scripts/build-agent-skills-index.mjs
+++ b/scripts/build-agent-skills-index.mjs
@@ -24,7 +24,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { basename, resolve, dirname, join } from 'node:path';
+import { basename, resolve, dirname, join, extname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import yaml from 'js-yaml';
 
@@ -106,6 +106,19 @@ export function buildResourceContent(content, mimeType) {
   return isTextMimeType(mimeType)
     ? { mimeType, text: content.toString('utf-8') }
     : { mimeType, blob: content.toString('base64') };
+}
+
+const TEXT_EXTENSIONS = new Set(['.json', '.md', '.html', '.yaml', '.yml', '.txt']);
+
+function getPlatformAgnosticContent(file) {
+  const ext = extname(file).toLowerCase();
+  const raw = readFileSync(file);
+  if (TEXT_EXTENSIONS.has(ext)) {
+    const text = raw.toString('utf-8');
+    const normalized = text.replace(/\r\n/g, '\n');
+    return Buffer.from(normalized, 'utf-8');
+  }
+  return raw;
 }
 
 // Agent Plugins 1.0.0 requires skills/<name>/SKILL.md to resolve to a regular
@@ -296,10 +309,10 @@ export function collectSkills() {
       type: 'skill-md',
       description: fm.description,
       url: `${PUBLIC_BASE}/.well-known/agent-skills/${name}/SKILL.md`,
-      digest: `sha256:${sha256Hex(bytes)}`,
+      digest: `sha256:${sha256Hex(Buffer.from(lfMd, 'utf-8'))}`,
       frontmatter: fm,
       resources: files.map((file) => {
-        const content = readFileSync(file);
+        const content = getPlatformAgnosticContent(file);
         const relativePath = file.slice(skillDir.length + 1).split('\\').join('/');
         const mimeType = relativePath.endsWith('.md') ? 'text/markdown' : 'application/octet-stream';
         return {

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -26,7 +26,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 // can never observe the probe. null means the real ROOT.
 let rootOverride = null;
 const rootOf = () => rootOverride ?? ROOT;
-const read = (p) => readFileSync(join(rootOf(), p), 'utf8');
+const read = (p) => readFileSync(join(rootOf(), p), 'utf8').replace(/\r\n/g, '\n');
 const dirsIn = (p) =>
   readdirSync(join(rootOf(), p), { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name);
 const filesIn = (p) =>

--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -964,7 +964,7 @@ const EXCLUDED_HOSTS = new Set([
 ]);
 
 function read(rootDir, path) {
-  return readFileSync(join(rootDir, path), 'utf8');
+  return readFileSync(join(rootDir, path), 'utf8').replace(/\r\n/g, '\n');
 }
 
 function readdirPresentSync(absoluteDir) {
@@ -1702,7 +1702,7 @@ export function matchGeneratedAttributionSection(docs) {
 
 function updateDocs(rootDir, section) {
   const path = join(rootDir, DOCS_PATH);
-  const current = readFileSync(path, 'utf8');
+  const current = readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
   const markerPattern = inventoryMarkerPattern(true);
   const updated = markerPattern.test(current)
     // Function replacement: `section` is generated from manifest text that can
@@ -1754,10 +1754,10 @@ export function checkSourceAttribution(rootDir = ROOT) {
     declarations,
     geography: loadSourceGeography(rootDir),
   }));
-  if (readFileSync(manifestPath, 'utf8') !== rebuilt) {
+  if (readFileSync(manifestPath, 'utf8').replace(/\r\n/g, '\n') !== rebuilt) {
     return { errors: [`${MANIFEST_PATH} is out of date; ${REGENERATE_HINT}`] };
   }
-  const actual = matchGeneratedAttributionSection(readFileSync(docsPath, 'utf8'));
+  const actual = matchGeneratedAttributionSection(readFileSync(docsPath, 'utf8').replace(/\r\n/g, '\n'));
   if (actual !== renderAttributionSection(inventory, previous)) {
     return { errors: [`${DOCS_PATH} is out of date; ${REGENERATE_HINT}`] };
   }

--- a/tests/source-attribution.test.mjs
+++ b/tests/source-attribution.test.mjs
@@ -79,7 +79,7 @@ test('source inventory has complete metadata and matches the generated catalog',
   const manifest = loadManifest(rootDir);
   assert.deepEqual(validateManifest(inventory, manifest), []);
 
-  const docs = readFileSync(join(rootDir, 'docs/source-attribution.mdx'), 'utf8');
+  const docs = readFileSync(join(rootDir, 'docs/source-attribution.mdx'), 'utf8').replace(/\r\n/g, '\n');
   const generated = renderAttributionSection(inventory, manifest);
   const actual = matchGeneratedAttributionSection(docs);
   assert.equal(actual, generated, 'docs/source-attribution.mdx must contain exactly the generated attribution section');


### PR DESCRIPTION
### Summary of Changes

This PR resolves source-attribution and agent-skills CI gate failures caused by platform-specific line ending discrepancies (CRLF on Windows vs LF on Linux).

1. **Source Attribution & Docs Stats ([scripts/source-attribution.mjs](cci:7://file:///d:/MONITOR-WORLD/worldmonitor/scripts/source-attribution.mjs:0:0-0:0), [scripts/docs-stats.mjs](cci:7://file:///d:/MONITOR-WORLD/worldmonitor/scripts/docs-stats.mjs:0:0-0:0))**:
   - Added line-ending normalization (`.replace(/\r\n/g, '\n')`) when reading source files during lexical scanning and contract verification.
   - Prevents character sliding-window mismatches for keyword hints on Windows checkouts.

2. **Agent-Skills Index ([scripts/build-agent-skills-index.mjs](cci:7://file:///d:/MONITOR-WORLD/worldmonitor/scripts/build-agent-skills-index.mjs:0:0-0:0), [tests/source-attribution.test.mjs](cci:7://file:///d:/MONITOR-WORLD/worldmonitor/tests/source-attribution.test.mjs:0:0-0:0))**:
   - Normalized markdown content to LF before computing SHA-256 digests and reading documentation sections in test assertions.

3. **Verification**:
   - `node scripts/source-attribution.mjs --check` — PASSED
   - `node scripts/docs-stats.mjs --check` — PASSED
   - `node scripts/build-agent-skills-index.mjs --check` — PASSED
   - `103 / 103` unit tests passing cleanly locally.
