### PR TITLE
fix(schema): bind schema.org on every top-level JSON-LD block

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -1589,6 +1589,19 @@ function withPrimaryImage(entry, image) {
   };
 }
 
+// Every top-level JSON-LD block binds its own vocabulary. A root node without
+// `@context` is not a lenient block — it has no vocabulary at all, so `@type`
+// resolves to nothing and schema.org consumers discard it silently rather than
+// erroring. Stamping here rather than at each call site is deliberate: #7502
+// shipped 62 unparseable blocks across the 31 CII-covered country pages because
+// two hand-written sibling Datasets were promoted out of a `@context`'d parent
+// and nobody re-declared it. A builder that forgets can no longer produce one.
+// Nested nodes inherit the root context and are left untouched.
+function withSchemaContext(entry) {
+  if (!entry || typeof entry !== 'object' || entry['@context']) return entry;
+  return { '@context': SCHEMA_ORG_CONTEXT_URL, ...entry };
+}
+
 function pageDocument({
   baseUrl,
   path,
@@ -1623,7 +1636,8 @@ function pageDocument({
   ]
     .filter(Boolean)
     .map((entry) => withPrimaryImage(entry, pageImage))
-    .map((entry) => withSpeakableAndGraph(entry, { canonical, breadcrumbId }));
+    .map((entry) => withSpeakableAndGraph(entry, { canonical, breadcrumbId }))
+    .map((entry) => withSchemaContext(entry));
   const renderedNav = headerNav || `        <a href="/">World Monitor</a>
         <a href="/sources/">Sources</a>
         <a href="/countries/">Countries</a>

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -1592,14 +1592,21 @@ function withPrimaryImage(entry, image) {
 // Every top-level JSON-LD block binds its own vocabulary. A root node without
 // `@context` is not a lenient block — it has no vocabulary at all, so `@type`
 // resolves to nothing and schema.org consumers discard it silently rather than
-// erroring. Stamping here rather than at each call site is deliberate: #7502
-// shipped 62 unparseable blocks across the 31 CII-covered country pages because
-// two hand-written sibling Datasets were promoted out of a `@context`'d parent
-// and nobody re-declared it. A builder that forgets can no longer produce one.
+// erroring. Stamping here rather than at each call site is deliberate: #7491
+// shipped 62 unparseable blocks across the 31 CII-covered country pages (found
+// in #7502) because two hand-written sibling Datasets were promoted out of a
+// `@context`'d parent and nobody re-declared it. A builder that forgets can no
+// longer produce one.
 // Nested nodes inherit the root context and are left untouched.
-function withSchemaContext(entry) {
-  if (!entry || typeof entry !== 'object' || entry['@context']) return entry;
-  return { '@context': SCHEMA_ORG_CONTEXT_URL, ...entry };
+export function withSchemaContext(entry) {
+  if (!entry || typeof entry !== 'object') return entry;
+  // A deliberate `@context` is preserved; a missing OR empty one is replaced.
+  // Destructure the dead key out rather than spreading `entry` over the stamp,
+  // or `'@context': null` would be re-applied on top of it and the "cannot
+  // forget" invariant above would hold only for the absent case.
+  if (entry['@context']) return entry;
+  const { '@context': unusable, ...rest } = entry;
+  return { '@context': SCHEMA_ORG_CONTEXT_URL, ...rest };
 }
 
 function pageDocument({

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -36,7 +36,10 @@ function read(outDir, path) {
 }
 
 function jsonLdObjects(html) {
-  return [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+  // Tolerate attributes on the open tag (`nonce`, `id`). The corpus emits none
+  // today, but a bare-literal match would silently skip an attributed block
+  // rather than fail -- and skipping blocks is the #7502 defect class.
+  return [...html.matchAll(/<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g)]
     .map(([, raw]) => JSON.parse(raw));
 }
 
@@ -693,6 +696,14 @@ function assertJsonLdContexts(html, route) {
       jsonLdContextIsResolvable(block['@context']),
       `${route} JSON-LD block ${index + 1} (${label}) must declare a schema.org @context; without one @type binds to no vocabulary and consumers discard the block silently`,
     );
+    // A context binds a vocabulary; a type is what binds an entity. Now that
+    // the context is stamped unconditionally, a typeless node (a bare `@id`
+    // reference, or an array flattened into an object) would sail through the
+    // check above while still describing nothing.
+    assert.ok(
+      typeof type === 'string' && type.length > 0,
+      `${route} JSON-LD block ${index + 1} (${label}) must declare an @type; a context without one binds a vocabulary but no entity`,
+    );
   }
   // Returned so the caller can prove the sweep actually ran: a loop that never
   // executes is indistinguishable from one where every page passed.
@@ -802,6 +813,20 @@ describe('JSON-LD @context guard', () => {
 
   it('rejects a top-level block whose @context resolves to a non-schema.org vocabulary', () => {
     const html = ldBlock({ '@context': 'https://example.invalid/vocab', '@type': 'Dataset' });
+    assert.throws(() => assertJsonLdContexts(html, route), /must declare a schema\.org @context/);
+  });
+
+  it('rejects a block that binds a vocabulary but no entity', () => {
+    const html = ldBlock({ '@context': 'https://schema.org', '@id': 'https://www.worldmonitor.app/countries/taiwan/#cii-dataset' });
+    assert.throws(() => assertJsonLdContexts(html, route), /must declare an @type/);
+  });
+
+  it('sees a block whose open tag carries attributes', () => {
+    // A bare-literal tag match would return zero blocks here and pass by
+    // vacuity if the "at least one block" floor were ever relaxed.
+    const html = '<script type="application/ld+json" nonce="wm-static-bootstrap">'
+      + JSON.stringify({ '@type': 'Dataset' })
+      + '</script>';
     assert.throws(() => assertJsonLdContexts(html, route), /must declare a schema\.org @context/);
   });
 
@@ -1195,9 +1220,14 @@ describe('crawlable corpus generator', () => {
       // #7502: sweep every page the build wrote, including the paginated
       // changelog pages the manifest's route list omits.
       const writtenRoutes = generatedPageRoutes(outDir);
-      assert.ok(
-        writtenRoutes.length >= generatedRoutes.size,
-        `the @context sweep must cover at least every manifest route (wrote ${writtenRoutes.length}, manifest lists ${generatedRoutes.size})`,
+      // Membership, not count: a walk that returned the right NUMBER of wrong
+      // pages would satisfy a `>=` comparison while leaving real routes unswept.
+      const sweptRoutes = new Set(writtenRoutes);
+      const missedRoutes = [...generatedRoutes].filter((route) => !sweptRoutes.has(route));
+      assert.deepEqual(
+        missedRoutes,
+        [],
+        `the @context sweep skipped manifest routes: ${missedRoutes.join(', ')}`,
       );
       let sweptPages = 0;
       let sweptBlocks = 0;

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -22,6 +22,7 @@ import {
   resolveChokepointObservation,
   SOURCE_CATALOG_LASTMOD_PATHS,
   sourcePageLastmod,
+  withSchemaContext,
 } from '../scripts/build-crawlable-corpus.mjs';
 import { buildSitemapEntries } from '../scripts/build-sitemap.mjs';
 import { buildSourceCatalog, sourceProviderDisplayName } from '../scripts/crawlable-sources-page.mjs';
@@ -666,11 +667,11 @@ function assertDataCatalogPresent(html, route) {
 
 // A root JSON-LD node with no `@context` has no vocabulary binding: `@type`
 // resolves to nothing, and every schema.org consumer discards the block
-// silently rather than erroring. #7502 shipped 62 such blocks across the 31
-// CII-covered country pages, which undid the Dataset/DataCatalog work from
-// #7379 on exactly the highest-intent pages and was invisible to every
-// existing assertion. Nested nodes inherit the root context, so only the
-// top-level block of each script tag is checked.
+// silently rather than erroring. #7491 shipped 62 such blocks across the 31
+// CII-covered country pages (found in #7502), which undid the
+// Dataset/DataCatalog work from #7379 on exactly the highest-intent pages and
+// was invisible to every existing assertion. Nested nodes inherit the root
+// context, so only the top-level block of each script tag is checked.
 const SCHEMA_ORG_CONTEXT_URLS = new Set(['https://schema.org', 'http://schema.org']);
 
 function jsonLdContextIsResolvable(context) {
@@ -693,6 +694,9 @@ function assertJsonLdContexts(html, route) {
       `${route} JSON-LD block ${index + 1} (${label}) must declare a schema.org @context; without one @type binds to no vocabulary and consumers discard the block silently`,
     );
   }
+  // Returned so the caller can prove the sweep actually ran: a loop that never
+  // executes is indistinguishable from one where every page passed.
+  return blocks.length;
 }
 
 // Walk what the build actually wrote, not the manifest's route list. The two
@@ -803,6 +807,26 @@ describe('JSON-LD @context guard', () => {
 
   it('rejects a page that emits no JSON-LD at all', () => {
     assert.throws(() => assertJsonLdContexts('<html><body>no structured data</body></html>', route), /must emit at least one JSON-LD block/);
+  });
+
+  it('stamps a missing or unusable @context and preserves a deliberate one', () => {
+    // The stamp is what makes the defect unreproducible, so both branches are
+    // pinned: forgetting the key gets it back, and choosing a vocabulary keeps
+    // it. `null`/`''` count as forgetting -- they bind no vocabulary either.
+    assert.deepEqual(
+      withSchemaContext({ '@type': 'Dataset', name: 'CII' }),
+      { '@context': 'https://schema.org', '@type': 'Dataset', name: 'CII' },
+    );
+    for (const unusable of [null, '', undefined]) {
+      assert.equal(
+        withSchemaContext({ '@context': unusable, '@type': 'Dataset' })['@context'],
+        'https://schema.org',
+        `a ${JSON.stringify(unusable)} @context binds no vocabulary and must be replaced`,
+      );
+    }
+    const deliberate = { '@context': 'https://example.invalid/vocab', '@type': 'Dataset' };
+    assert.deepEqual(withSchemaContext(deliberate), deliberate);
+    assert.equal(withSchemaContext(null), null);
   });
 
   it('accepts schema.org string, array, and @vocab contexts', () => {
@@ -1175,9 +1199,24 @@ describe('crawlable corpus generator', () => {
         writtenRoutes.length >= generatedRoutes.size,
         `the @context sweep must cover at least every manifest route (wrote ${writtenRoutes.length}, manifest lists ${generatedRoutes.size})`,
       );
+      let sweptPages = 0;
+      let sweptBlocks = 0;
       for (const route of writtenRoutes) {
-        assertJsonLdContexts(read(outDir, `${route.slice(1)}index.html`), route);
+        sweptBlocks += assertJsonLdContexts(read(outDir, `${route.slice(1)}index.html`), route);
+        sweptPages += 1;
       }
+      // Without this the sweep is an absence assertion that also passes when it
+      // is unwired: delete the loop above and every per-page check silently
+      // stops running. Tallying makes the wiring itself falsifiable.
+      assert.equal(
+        sweptPages,
+        writtenRoutes.length,
+        `the @context sweep must inspect every written page (swept ${sweptPages} of ${writtenRoutes.length})`,
+      );
+      assert.ok(
+        sweptBlocks >= sweptPages * 3,
+        `every corpus page carries at least a page node, DataCatalog and BreadcrumbList (swept ${sweptBlocks} blocks across ${sweptPages} pages)`,
+      );
 
       for (const route of generatedRoutes) {
         const html = read(outDir, `${route.slice(1)}index.html`);

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -664,6 +664,54 @@ function assertDataCatalogPresent(html, route) {
   return catalog;
 }
 
+// A root JSON-LD node with no `@context` has no vocabulary binding: `@type`
+// resolves to nothing, and every schema.org consumer discards the block
+// silently rather than erroring. #7502 shipped 62 such blocks across the 31
+// CII-covered country pages, which undid the Dataset/DataCatalog work from
+// #7379 on exactly the highest-intent pages and was invisible to every
+// existing assertion. Nested nodes inherit the root context, so only the
+// top-level block of each script tag is checked.
+const SCHEMA_ORG_CONTEXT_URLS = new Set(['https://schema.org', 'http://schema.org']);
+
+function jsonLdContextIsResolvable(context) {
+  if (typeof context === 'string') {
+    return SCHEMA_ORG_CONTEXT_URLS.has(context.replace(/\/$/, ''));
+  }
+  if (Array.isArray(context)) return context.some((entry) => jsonLdContextIsResolvable(entry));
+  if (context && typeof context === 'object') return jsonLdContextIsResolvable(context['@vocab']);
+  return false;
+}
+
+function assertJsonLdContexts(html, route) {
+  const blocks = jsonLdObjects(html);
+  assert.ok(blocks.length > 0, `${route} must emit at least one JSON-LD block`);
+  for (const [index, block] of blocks.entries()) {
+    const type = Array.isArray(block['@type']) ? block['@type'].join('+') : block['@type'];
+    const label = block['@id'] || type || `block ${index + 1}`;
+    assert.ok(
+      jsonLdContextIsResolvable(block['@context']),
+      `${route} JSON-LD block ${index + 1} (${label}) must declare a schema.org @context; without one @type binds to no vocabulary and consumers discard the block silently`,
+    );
+  }
+}
+
+// Walk what the build actually wrote, not the manifest's route list. The two
+// disagree: `manifest.sections.changelog` reports one route for fourteen
+// published pages, so a manifest-driven sweep silently skips the thirteen
+// `/reference/changelog/page/N/` pages (229 of 242 covered). A structured-data
+// guard that skips pages is the defect class it exists to catch.
+function generatedPageRoutes(outDir) {
+  const routes = [];
+  const visit = (relative) => {
+    for (const entry of readdirSync(join(outDir, relative), { withFileTypes: true })) {
+      if (entry.isDirectory()) visit(join(relative, entry.name));
+      else if (entry.name === 'index.html') routes.push(`/${relative === '.' ? '' : `${relative}/`}`);
+    }
+  };
+  visit('.');
+  return routes.sort();
+}
+
 function decodeHtmlAttribute(value) {
   return value
     .replaceAll('&#39;', "'")
@@ -731,6 +779,42 @@ function productionScriptNonce() {
   assert.ok(nonce, 'production CSP must declare a strict-dynamic script nonce');
   return nonce;
 }
+
+// The corpus-wide @context sweep is an absence assertion — it stays green if
+// the rule is deleted, weakened, or never sees a block. These controls prove it
+// still rejects each way the defect can present.
+describe('JSON-LD @context guard', () => {
+  const ldBlock = (value) => `<script type="application/ld+json">${JSON.stringify(value)}</script>`;
+  const route = '/countries/taiwan/';
+
+  it('rejects a top-level block with no @context (the #7502 shape)', () => {
+    const html = ldBlock({ '@context': 'https://schema.org', '@type': 'WebPage' })
+      + ldBlock({ '@type': 'Dataset', '@id': 'https://www.worldmonitor.app/countries/taiwan/#cii-dataset' });
+    assert.throws(
+      () => assertJsonLdContexts(html, route),
+      /block 2 \(https:\/\/www\.worldmonitor\.app\/countries\/taiwan\/#cii-dataset\) must declare a schema\.org @context/,
+    );
+  });
+
+  it('rejects a top-level block whose @context resolves to a non-schema.org vocabulary', () => {
+    const html = ldBlock({ '@context': 'https://example.invalid/vocab', '@type': 'Dataset' });
+    assert.throws(() => assertJsonLdContexts(html, route), /must declare a schema\.org @context/);
+  });
+
+  it('rejects a page that emits no JSON-LD at all', () => {
+    assert.throws(() => assertJsonLdContexts('<html><body>no structured data</body></html>', route), /must emit at least one JSON-LD block/);
+  });
+
+  it('accepts schema.org string, array, and @vocab contexts', () => {
+    assert.doesNotThrow(() => assertJsonLdContexts(
+      ldBlock({ '@context': 'https://schema.org', '@type': 'Dataset' })
+      + ldBlock({ '@context': 'https://schema.org/', '@type': 'Dataset' })
+      + ldBlock({ '@context': ['https://schema.org', { wm: 'https://www.worldmonitor.app/#' }], '@type': 'Dataset' })
+      + ldBlock({ '@context': { '@vocab': 'https://schema.org/' }, '@type': 'Dataset' }),
+      route,
+    ));
+  });
+});
 
 describe('crawlable corpus generator', () => {
   it('requires the exact shared Tier-1 country set for CII publication', async () => {
@@ -1084,6 +1168,17 @@ describe('crawlable corpus generator', () => {
       const countryObservationRoutes = new Set(manifest.sections.countries.routes);
       const liveObservationRoutes = new Set(manifest.sections.chokepoints.routes);
       const crisisObservationRoutes = new Set(manifest.sections.crises.routes);
+      // #7502: sweep every page the build wrote, including the paginated
+      // changelog pages the manifest's route list omits.
+      const writtenRoutes = generatedPageRoutes(outDir);
+      assert.ok(
+        writtenRoutes.length >= generatedRoutes.size,
+        `the @context sweep must cover at least every manifest route (wrote ${writtenRoutes.length}, manifest lists ${generatedRoutes.size})`,
+      );
+      for (const route of writtenRoutes) {
+        assertJsonLdContexts(read(outDir, `${route.slice(1)}index.html`), route);
+      }
+
       for (const route of generatedRoutes) {
         const html = read(outDir, `${route.slice(1)}index.html`);
         assertDatasetGoogleProperties(
@@ -1639,6 +1734,18 @@ describe('crawlable corpus generator', () => {
         taiwanResilienceDataset?.description ?? '',
         /below the ranking threshold|input coverage is below/i,
       );
+      // #7502: on CII-covered pages both Datasets are siblings of the WebPage
+      // rather than nested under it, so each must bind its own vocabulary or it
+      // parses as nothing at all.
+      for (const fragment of ['#cii-dataset', '#resilience-dataset']) {
+        const block = jsonLdObjects(taiwan).find((entry) => entry['@id']?.endsWith(fragment));
+        assert.ok(block, `taiwan must emit a top-level ${fragment} block`);
+        assert.equal(block['@type'], 'Dataset', `taiwan ${fragment} must be a Dataset`);
+        assert.ok(
+          jsonLdContextIsResolvable(block['@context']),
+          `taiwan ${fragment} must bind schema.org so it parses as a Dataset`,
+        );
+      }
 
       for (const slug of ['taiwan', 'palau', 'san-marino']) {
         const html = read(outDir, `countries/${slug}/index.html`);


### PR DESCRIPTION
## Summary

Google, Dataset Search, and AI crawlers were silently discarding two structured-data blocks on the 31 highest-intent country pages. They now parse.

CII-covered country pages emitted `#cii-dataset` and `#resilience-dataset` as top-level `<script type="application/ld+json">` blocks with **no `@context`**. A root JSON-LD node without one binds no vocabulary at all, so `@type: "Dataset"` resolves to nothing and every schema.org consumer drops the block — without erroring, without a warning, indistinguishable from a page that never emitted it. 62 blocks across 31 countries, including US, China, Taiwan, Ukraine, India, and the UK.

It was a net loss rather than a missed opportunity: Taiwan previously served a *valid* `#resilience-dataset` nested inside its `@context`'d `#webpage` node. Promoting the Datasets to siblings in #7491 left it with zero parseable Datasets.

## Why the fix is at `pageDocument`, not the two literals

The obvious patch is two `'@context'` keys on the Dataset object literals. That fixes today's 62 blocks and leaves the trap armed.

The regression happened because two hand-written Datasets were **promoted out of** a `@context`'d parent and nobody re-declared the context on the way out. Nothing in the build noticed, because nothing was looking. Stamping at `pageDocument` — the single seam every generated page's JSON-LD passes through — means a builder that forgets can no longer produce an unparseable block:

```js
// A deliberate @context is preserved; a missing OR empty one is replaced.
if (entry['@context']) return entry;
const { '@context': unusable, ...rest } = entry;
return { '@context': SCHEMA_ORG_CONTEXT_URL, ...rest };
```

Nested nodes inherit the root context and are untouched, so the 165 non-CII country pages are byte-identical — their Dataset stays nested under `WebPage.mainEntity` exactly as before.

## The guard is the interesting half

The issue asked for a test, because this defect class is invisible without one. A naive sweep is an absence assertion, which is the weakest kind of test — it passes when the rule is deleted, when it is weakened, and when it never runs. Three holes were found and closed, each proven by mutation rather than argued:

| Hole | Consequence | Proven closed by |
|---|---|---|
| Swept `manifest.sections[*].routes` | Covered 229 of 242 written pages — `changelog` lists 1 route for 14 published pages, so `/reference/changelog/page/2..14/` were never checked | Breaking only the paginated pages → red on `/page/10/` |
| Sweep passed when **unwired** | Deleting the loop left all controls green and the corpus unguarded | Deleting the loop → `swept 0 of 242` |
| Coverage asserted by **count** | A walk returning the right *number* of wrong pages passed | Membership check now names skipped routes |

The sweep therefore walks what the build actually wrote rather than what the manifest claims, tallies the pages and blocks it inspected so the wiring itself is falsifiable, and asserts `@type` alongside `@context` — now that the context is stamped unconditionally, a typeless node would otherwise bind a vocabulary but no entity. Five positive controls cover the missing, foreign-vocabulary, typeless, attributed-tag, and zero-block shapes.

Related: #7502

## Validation

Measured against a full corpus build, not inferred:

| | Blocks | Missing `@context` |
|---|---|---|
| Before | 989 | **62** (31 pages x 2) |
| After | 989 | **0** |

- Taiwan's `#cii-dataset` and `#resilience-dataset` both parse as `Dataset` again; Nigeria (non-CII control) unchanged at 4 blocks.
- The failing test was observed red first, on the real defect: `/countries/japan/ JSON-LD block 2 ... must declare a schema.org @context`.
- 39/39 `crawlable-corpus` tests, plus 72 adjacent SEO/sitemap/schema tests.
- All 989 shipped blocks verified to carry `@type`, and 0 to use an attributed open tag, before those assertions were added — so both are behaviour-preserving today and load-bearing later.

Closing #7502 manually after a production re-measure, since its acceptance was stated against live pages rather than the build.

## Known residuals

- `jsonLdContextIsResolvable` accepts a `@context` array on first match, so a later entry shadowing schema.org would pass. Latent only — all 989 blocks emit the plain string; modelling full JSON-LD context precedence in a test helper is not worth it.
- Glossary pages (`generatedBy: 'blog-site Astro build'`) are covered by neither sweep. They are written by a different build and never enter this script's output directory. Real gap, wrong PR.
- ~20 hand-written `'@context'` literals elsewhere in the file are now redundant. Deliberately kept: they are inert, and deleting them would make correctness depend entirely on the stamping, on the exact surface that just regressed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
