### PR TITLE
fix(seo): close structured data residue

### DIFF
--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -133,7 +133,7 @@ jobs:
           export PATH="$(go env GOPATH)/bin:$PATH"
           make install-buf
         env:
-          GOPROXY: direct
+          GOPROXY: 'https://proxy.golang.org,direct'
 
       - name: Check for breaking proto changes
         run: make breaking
@@ -200,7 +200,7 @@ jobs:
           export PATH="$(go env GOPATH)/bin:$PATH"
           make install-buf install-plugins
         env:
-          GOPROXY: direct
+          GOPROXY: 'https://proxy.golang.org,direct'
           GOPRIVATE: github.com/SebastienMelki
 
       - name: Run proto generation
@@ -398,7 +398,7 @@ jobs:
           export PATH="$(go env GOPATH)/bin:$PATH"
           make install-buf install-plugins
         env:
-          GOPROXY: direct
+          GOPROXY: 'https://proxy.golang.org,direct'
           GOPRIVATE: github.com/SebastienMelki
 
       - name: Run proto generation against merge commit

--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -128,7 +128,10 @@ jobs:
           key: buf-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
       - name: Install buf
-        run: make install-buf
+        run: |
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          make install-buf
         env:
           GOPROXY: direct
 
@@ -192,7 +195,10 @@ jobs:
           key: go-bin-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
       - name: Install buf and protoc plugins
-        run: make install-buf install-plugins
+        run: |
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          make install-buf install-plugins
         env:
           GOPROXY: direct
           GOPRIVATE: github.com/SebastienMelki
@@ -387,7 +393,10 @@ jobs:
           key: go-bin-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
       - name: Install buf and protoc plugins
-        run: make install-buf install-plugins
+        run: |
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          make install-buf install-plugins
         env:
           GOPROXY: direct
           GOPRIVATE: github.com/SebastienMelki

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ GEN_SERVER_DIR := src/generated/server
 DOCS_API_DIR := docs/api
 
 # Go install settings
-GO_PROXY := GOPROXY=direct
+# Use the public module proxy for public dependencies, with direct fallback.
+# GOPRIVATE keeps the private sebuf module off the public proxy.
+GO_PROXY := GOPROXY=https://proxy.golang.org,direct
 GO_PRIVATE := GOPRIVATE=github.com/SebastienMelki
 GO_INSTALL := $(GO_PROXY) $(GO_PRIVATE) go install
 

--- a/blog-site/src/pages/authors/elie-habib.astro
+++ b/blog-site/src/pages/authors/elie-habib.astro
@@ -21,6 +21,10 @@ const jsonLd = {
       name: 'Elie Habib — World Monitor',
       description,
       mainEntity: { '@id': personId },
+      speakable: {
+        '@type': 'SpeakableSpecification',
+        cssSelector: ['h1', '.author-page-bio'],
+      },
     },
     {
       '@type': 'Person',

--- a/index.html
+++ b/index.html
@@ -147,6 +147,55 @@
     }
     </script>
 
+    <script type="application/ld+json" nonce="wm-static-bootstrap">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "@id": "https://www.worldmonitor.app/dashboard#webpage",
+      "url": "https://www.worldmonitor.app/dashboard",
+      "name": "World Monitor — Real-Time Global Intelligence Dashboard",
+      "description": "Open-source real-time global intelligence dashboard aggregating conflicts, military movements, markets, infrastructure, and geopolitical data.",
+      "isPartOf": {
+        "@id": "https://www.worldmonitor.app/#website"
+      },
+      "publisher": {
+        "@id": "https://www.worldmonitor.app/#organization"
+      },
+      "mainEntity": {
+        "@id": "https://www.worldmonitor.app/#software"
+      },
+      "breadcrumb": {
+        "@id": "https://www.worldmonitor.app/dashboard#breadcrumb"
+      },
+      "speakable": {
+        "@type": "SpeakableSpecification",
+        "cssSelector": ["h1", ".app-seo-summary"]
+      }
+    }
+    </script>
+
+    <script type="application/ld+json" nonce="wm-static-bootstrap">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "@id": "https://www.worldmonitor.app/dashboard#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "World Monitor",
+          "item": "https://www.worldmonitor.app/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Dashboard",
+          "item": "https://www.worldmonitor.app/dashboard"
+        }
+      ]
+    }
+    </script>
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/pro-test/index.html
+++ b/pro-test/index.html
@@ -214,7 +214,7 @@
       },
       "speakable": {
         "@type": "SpeakableSpecification",
-        "cssSelector": ["h1", "#pricing"]
+        "cssSelector": ["h1", "main > p:first-of-type"]
       }
     }
     </script>

--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -172,6 +172,13 @@
         "https://discord.gg/re63kWKxaz",
         "https://www.wired.com/story/world-monitor-elie-habib/"
       ],
+      "interactionStatistic": {
+        "@type": "InteractionCounter",
+        "interactionType": "https://schema.org/LikeAction",
+        "userInteractionCount": 85288,
+        "name": "GitHub stars",
+        "url": "https://github.com/koala73/worldmonitor/stargazers"
+      },
       "contactPoint": {
         "@type": "ContactPoint",
         "contactType": "customer support",

--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -172,13 +172,6 @@
         "https://discord.gg/re63kWKxaz",
         "https://www.wired.com/story/world-monitor-elie-habib/"
       ],
-      "interactionStatistic": {
-        "@type": "InteractionCounter",
-        "interactionType": "https://schema.org/LikeAction",
-        "userInteractionCount": 85288,
-        "name": "GitHub stars",
-        "url": "https://github.com/koala73/worldmonitor/stargazers"
-      },
       "contactPoint": {
         "@type": "ContactPoint",
         "contactType": "customer support",

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -3094,6 +3094,7 @@ function renderCrisisPage({
   // the Dataset description while temporalCoverage silently drops to undefined.
   const hasPulse = pulse != null && OBSERVATION_PERIOD_RE.test(String(pulse.referencePeriod ?? ''));
   const publishedPeriod = hasPulse ? datasetTemporalCoverage(pulse.referencePeriod) : undefined;
+  const publishedDate = hasPulse ? pulseDateOnly(livePulse.capturedAt, undefined) : undefined;
   const liveState = hasPulse ? pulse.state : 'loading';
   const liveStatus = hasPulse
     ? (pulse.state === 'partial' ? 'Published partial pulse' : 'Published pulse')
@@ -3241,7 +3242,7 @@ ${snapshotSection}
           identifier: `crisis-tracker-${crisis.slug}`,
           creator: { ...WORLD_MONITOR_ORG },
           license: DATASET_LICENSE,
-          datePublished: publishedPeriod,
+          datePublished: publishedDate,
           dateModified: laterDate(
             hasPulse ? pulseDateOnly(pulse.asOf, lastmod) : lastmod,
             DATASET_SCHEMA_CONTENT_VERSION.crisis,
@@ -3683,6 +3684,7 @@ function buildManifest({ data, baseUrl, changelogPageCount }) {
         count: crisisRoutes.length,
         index: '/crises/',
         routes: crisisRoutes,
+        sourceCapturedAt: data.livePulse.capturedAt,
       },
       tools: {
         count: toolRoutes.length,

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -133,11 +133,11 @@ const SOURCES_PAGE_CONTENT_VERSION = '2026-08-20';
 // contract (#7391), so their recrawl signal is COUNTRY_PAGE_CONTENT_VERSION.
 const DATASET_SCHEMA_CONTENT_VERSION = {
   chokepoint: '2026-08-31',
-  crisis: '2026-08-31',
-  tools: '2026-08-31',
+  crisis: '2026-09-01',
+  tools: '2026-09-01',
 };
-const CRISIS_PAGE_CONTENT_VERSION = '2026-08-31';
-const TOOLS_PAGE_CONTENT_VERSION = '2026-08-30';
+const CRISIS_PAGE_CONTENT_VERSION = '2026-09-01';
+const TOOLS_PAGE_CONTENT_VERSION = '2026-09-01';
 const DATASET_LICENSE = {
   '@type': 'CreativeWork',
   name: 'World Monitor Terms of Service (27 July 2026)',
@@ -614,7 +614,7 @@ function pulseTotals(pulse) {
   };
 }
 
-function crisisDatasetDownload(crisis, pulse = null) {
+function crisisDatasetDownload(crisis, pulse = null, numericTotals = null) {
   return stableJson({
     dataset: 'crisis-tracker',
     slug: crisis.slug,
@@ -629,10 +629,11 @@ function crisisDatasetDownload(crisis, pulse = null) {
       maintainedPulse: {
         state: pulse.state,
         // The pulse carries Intl-formatted display strings ("9,824"); a Dataset
-        // download must be machine-readable, so re-derive the totals from the
-        // raw per-country rows. `eventsTotal === null` stays the marker for
+        // The build loop shares numeric totals with the page schema. The pulse
+        // carries Intl-formatted display strings, so these values stay
+        // machine-readable; `eventsTotal === null` remains the marker for
         // "reference periods differ, combined total withheld".
-        ...pulseTotals(pulse),
+        ...numericTotals,
         referencePeriod: pulse.referencePeriod,
         asOf: pulse.asOf,
         missingCountries: pulse.missingCountries,
@@ -1025,7 +1026,9 @@ function normalizeCountry(item, sourceStatus, seen, reverseNames) {
     identity: {
       commonName,
       officialName,
-      alternateNames: [...new Set(identity.alternateNames || [])],
+      alternateNames: [...new Set((identity.alternateNames || []).map((name) => (
+        name === 'Macao S A R' ? 'Macao SAR' : name
+      )))],
       sameAs,
     },
     rank: sourceStatus === 'ranked' ? Number(item.rank) : null,
@@ -1911,6 +1914,7 @@ ${ciiRanking.entries.map((entry) => `            <tr data-cii-country="${escapeH
 function renderCountriesIndex({ countries, ciiRanking, baseUrl, capturedAt, lastmod, snapshotPath }) {
   const path = '/countries/';
   const description = `Browse World Monitor country risk pages with structural resilience across ${countries.length} countries and high-frequency instability scores for ${ciiRanking.entries.length} Tier-1 countries.`;
+  const datasetId = `${absoluteUrl(baseUrl, path)}#dataset`;
   const rankedCountries = countries
     .filter((country) => Number.isInteger(country.rank))
     .sort((a, b) => a.rank - b.rank);
@@ -1988,6 +1992,7 @@ ${countries.map((country) => {
         description,
         url: absoluteUrl(baseUrl, path),
         inLanguage: 'en-US',
+        mainEntity: { '@id': datasetId },
       },
       {
         '@context': 'https://schema.org',
@@ -2009,6 +2014,7 @@ ${countries.map((country) => {
       {
         '@context': 'https://schema.org',
         '@type': 'Dataset',
+        '@id': datasetId,
         name: `World Monitor Country Resilience Index snapshot for ${capturedAt}`,
         description,
         url: absoluteUrl(baseUrl, path),
@@ -3071,7 +3077,14 @@ ${crises.map((crisis) => `        <a class="card" href="/crises/${escapeHtml(cri
   });
 }
 
-function renderCrisisPage({ crisis, baseUrl, lastmod, livePulse = null, livePulseSnapshotPath = null }) {
+function renderCrisisPage({
+  crisis,
+  baseUrl,
+  lastmod,
+  livePulse = null,
+  livePulseSnapshotPath = null,
+  publishedTotals,
+}) {
   const path = `/crises/${crisis.slug}/`;
   const dashboardUrl = withUtmSource(absoluteUrl(baseUrl, crisis.dashboardPath), 'seo-crisis');
   const pulse = livePulse?.crises?.[crisis.slug] || null;
@@ -3080,6 +3093,7 @@ function renderCrisisPage({ crisis, baseUrl, lastmod, livePulse = null, livePuls
   // HAPI months; publishing that as a period would put it in the page prose and
   // the Dataset description while temporalCoverage silently drops to undefined.
   const hasPulse = pulse != null && OBSERVATION_PERIOD_RE.test(String(pulse.referencePeriod ?? ''));
+  const publishedPeriod = hasPulse ? datasetTemporalCoverage(pulse.referencePeriod) : undefined;
   const liveState = hasPulse ? pulse.state : 'loading';
   const liveStatus = hasPulse
     ? (pulse.state === 'partial' ? 'Published partial pulse' : 'Published pulse')
@@ -3162,19 +3176,44 @@ ${snapshotSection}
   const distribution = [
     dataDownload(absoluteUrl(baseUrl, datasetDownloadHref(path, CRISIS_DATASET_DOWNLOAD))),
   ];
-  const variableMeasured = hasPulse
-    ? [
-        'Tracker scope',
-        'Covered countries',
-        'Recorded conflict events',
-        'Recorded fatalities',
-        'Political violence events',
-        'Humanitarian reference period',
-      ]
-    : [
-        'Tracker scope',
-        'Covered countries',
-      ];
+  const variableMeasured = [
+    {
+      '@type': 'PropertyValue',
+      name: 'Tracker scope',
+      value: crisis.shortTitle || crisis.title,
+    },
+    {
+      '@type': 'PropertyValue',
+      name: 'Covered countries',
+      value: crisis.coverage.length,
+      unitText: 'countries',
+    },
+    ...(hasPulse ? [
+      {
+        '@type': 'PropertyValue',
+        name: 'Recorded conflict events',
+        value: publishedTotals.eventsTotal ?? 'Unavailable',
+        unitText: 'events',
+      },
+      {
+        '@type': 'PropertyValue',
+        name: 'Recorded fatalities',
+        value: publishedTotals.fatalities ?? 'Unavailable',
+        unitText: 'fatalities',
+      },
+      {
+        '@type': 'PropertyValue',
+        name: 'Political violence events',
+        value: publishedTotals.politicalViolenceEvents ?? 'Unavailable',
+        unitText: 'events',
+      },
+      {
+        '@type': 'PropertyValue',
+        name: 'Humanitarian reference period',
+        value: pulse.referencePeriod,
+      },
+    ] : []),
+  ];
   const datasetDescription = hasPulse
     ? `A bounded World Monitor crisis tracker for ${crisis.title}, with the maintained ${pulse.referencePeriod} HAPI/HDX country summaries across ${crisis.coverage.map((country) => country.name).join(', ')}.`
     : `A bounded World Monitor crisis tracker reference for ${crisis.title}, defining the maintained geographic scope across ${crisis.coverage.map((country) => country.name).join(', ')}.`;
@@ -3195,18 +3234,23 @@ ${snapshotSection}
         about: coveragePlaces,
         mainEntity: {
           '@type': 'Dataset',
+          '@id': `${absoluteUrl(baseUrl, path)}#crisis-dataset`,
           name: `World Monitor crisis tracker reference: ${crisis.shortTitle || crisis.title}`,
           description: datasetDescription,
+          url: absoluteUrl(baseUrl, path),
+          identifier: `crisis-tracker-${crisis.slug}`,
           creator: { ...WORLD_MONITOR_ORG },
           license: DATASET_LICENSE,
+          datePublished: publishedPeriod,
           dateModified: laterDate(
             hasPulse ? pulseDateOnly(pulse.asOf, lastmod) : lastmod,
             DATASET_SCHEMA_CONTENT_VERSION.crisis,
           ),
-          temporalCoverage: hasPulse ? datasetTemporalCoverage(pulse.referencePeriod) : undefined,
+          temporalCoverage: publishedPeriod,
           isAccessibleForFree: true,
           includedInDataCatalog: includedInDataCatalog(baseUrl),
           variableMeasured,
+          measurementTechnique: 'Monthly country-level HAPI/HDX humanitarian conflict summaries; combined totals are published only when covered countries share a reference period.',
           spatialCoverage: coverageSpatial.length === 1 ? coverageSpatial[0] : coverageSpatial,
           distribution,
         },
@@ -3268,6 +3312,8 @@ function renderSignalConvergencePage({ signalConvergence, baseUrl, lastmod, snap
   const metricName = signalConvergence.metricName || 'Geographic Convergence Score';
   const description = `World Monitor's ${metricName} (0-100) names when protests, military flights, naval vessels, and earthquakes co-occur in the same 1° cell.`;
   const downloadHref = datasetDownloadHref(path, CONVERGENCE_DATASET_DOWNLOAD);
+  const datasetUrl = absoluteUrl(baseUrl, path);
+  const datasetId = `${datasetUrl}#signal-convergence-dataset`;
   const examples = (signalConvergence.referenceExamples || []).map((example) => (
     `        <article class="card">
           <p class="eyebrow">${escapeHtml(example.kind === 'methodology-example' ? 'Methodology example' : 'Reference')}</p>
@@ -3325,24 +3371,30 @@ ${examples}
         inLanguage: 'en-US',
         mainEntity: {
           '@type': 'Dataset',
+          '@id': datasetId,
           name: `World Monitor ${metricName} reference`,
           description,
+          url: datasetUrl,
+          identifier: `signal-convergence-${signalConvergence.capturedAt || 'reference'}`,
           creator: { ...WORLD_MONITOR_ORG },
           license: DATASET_LICENSE,
-          // This reference is a formula plus documentation-derived examples --
-          // it has no observation window, so it carries no temporalCoverage and
-          // is dated from its content version, not the freeze wall clock. The
-          // family schema stamp rides alongside so a Dataset-shape change signals
+          // This reference is a formula plus documentation-derived examples. It
+          // has no observation window, so it carries no temporalCoverage; when
+          // available, datePublished identifies the source snapshot. The family
+          // schema stamp rides alongside so a Dataset-shape change signals
           // recrawl without dragging the page lastmod with it (#7382).
+          datePublished: datasetTemporalCoverage(signalConvergence.capturedAt),
           dateModified: laterDate(lastmod, DATASET_SCHEMA_CONTENT_VERSION.tools),
+          spatialCoverage: 'Worldwide',
           isAccessibleForFree: true,
           includedInDataCatalog: includedInDataCatalog(baseUrl),
           variableMeasured: [
-            { '@type': 'PropertyValue', name: metricName, minValue: 0, maxValue: 100 },
-            'Default minimum domains',
-            'Alert priority thresholds',
+            { '@type': 'PropertyValue', name: metricName, minValue: 0, maxValue: 100, unitText: 'score points' },
+            { '@type': 'PropertyValue', name: 'Default minimum domains', value: signalConvergence.defaultMinDomains ?? 3, minValue: 1 },
+            { '@type': 'PropertyValue', name: 'Alert priority thresholds', value: signalConvergence.thresholds?.length ?? 0, unitText: 'thresholds' },
           ],
           measurementTechnique: 'type_score = event_types × 25; count_boost = min(25, total_events × 2); convergence_score = min(100, type_score + count_boost)',
+          citation: absoluteUrl(baseUrl, '/docs/geographic-convergence'),
           distribution: [dataDownload(absoluteUrl(baseUrl, downloadHref))],
         },
       },
@@ -3875,6 +3927,7 @@ export async function buildCorpus({
   for (const crisis of data.crises) {
     const pagePath = `/crises/${crisis.slug}/`;
     const crisisPulse = data.livePulse.crises?.[crisis.slug] || null;
+    const crisisPulseTotals = crisisPulse ? pulseTotals(crisisPulse) : null;
     writeGeneratedFile(
       outDir,
       routeFile(pagePath),
@@ -3884,12 +3937,13 @@ export async function buildCorpus({
         lastmod: data.lastmod.crises,
         livePulse: data.livePulse,
         livePulseSnapshotPath: data.sources.livePulseSnapshot,
+        publishedTotals: crisisPulseTotals,
       }),
     );
     writeGeneratedFile(
       outDir,
       datasetDownloadFile(pagePath, CRISIS_DATASET_DOWNLOAD),
-      crisisDatasetDownload(crisis, crisisPulse),
+      crisisDatasetDownload(crisis, crisisPulse, crisisPulseTotals),
     );
   }
 

--- a/scripts/build-use-cases.mjs
+++ b/scripts/build-use-cases.mjs
@@ -131,31 +131,6 @@ function stepUrl(pageUrl, name) {
   return `${pageUrl}#${stepSlug(name)}`;
 }
 
-function itemListLd(name, pageUrl, steps) {
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'ItemList',
-    name,
-    numberOfItems: steps.length,
-    itemListElement: steps.map((step, index) => {
-      const url = stepUrl(pageUrl, step.name);
-      return {
-        '@type': 'ListItem',
-        position: index + 1,
-        name: step.name,
-        url,
-        description: step.text,
-        item: {
-          '@type': 'HowToStep',
-          name: step.name,
-          url,
-          text: step.text,
-        },
-      };
-    }),
-  };
-}
-
 function howToLd({ name, description, url, steps }) {
   return {
     '@context': 'https://schema.org',
@@ -409,7 +384,6 @@ function renderCountryRiskUseCase({ tpl, baseUrl, lastmod }) {
         url: pageUrl,
         steps: workflowSteps,
       }),
-      itemListLd('Country-risk end-to-end workflow', pageUrl, workflowSteps),
     ],
     breadcrumbs: breadcrumbLd(baseUrl, [
       { name: 'Home', path: '/' },
@@ -601,7 +575,6 @@ function renderVerifyBreakingNewsUseCase({ tpl, baseUrl, lastmod }) {
         url: pageUrl,
         steps: workflowSteps,
       }),
-      itemListLd('Breaking-news verification workflow', pageUrl, workflowSteps),
     ],
     breadcrumbs: breadcrumbLd(baseUrl, [
       { name: 'Home', path: '/' },
@@ -814,7 +787,6 @@ function renderSupplyChainDisruptionsUseCase({ tpl, baseUrl, lastmod }) {
         url: pageUrl,
         steps: workflowSteps,
       }),
-      itemListLd('Supply-chain disruption monitoring steps', pageUrl, workflowSteps),
     ],
     breadcrumbs: breadcrumbLd(baseUrl, [
       { name: 'Home', path: '/' },

--- a/scripts/freeze-resilience-ranking.mjs
+++ b/scripts/freeze-resilience-ranking.mjs
@@ -351,7 +351,8 @@ function normalizeCountryIdentity(code, identity, legacyName, fallbackName) {
   const officialName = identity?.officialName || identity?.commonName || commonName;
   const legacyNames = legacyName && legacyName !== commonName ? [legacyName] : [];
   const alternateNames = [...new Set([legacyName, identity?.commonName, officialName]
-    .filter((name) => name && name !== commonName))];
+    .filter((name) => name && name !== commonName)
+    .map((name) => name === 'Macao S A R' ? 'Macao SAR' : name))];
   return {
     commonName,
     officialName,

--- a/src/config/variant-dashboard-html.ts
+++ b/src/config/variant-dashboard-html.ts
@@ -153,21 +153,24 @@ function variantBreadcrumbJsonLd(meta: VariantMeta): string {
   });
 }
 
-function removeJsonLdType(html: string, expectedType: string): string {
-  let count = 0;
+function removeJsonLdTypes(html: string, expectedTypes: readonly string[]): string {
+  const counts = new Map(expectedTypes.map((type) => [type, 0]));
   const result = html.replace(
     /[ \t]*<script\b(?=[^>]*\btype=["']application\/ld\+json["'])[^>]*>\s*([\s\S]*?)\s*<\/script>\s*/gi,
     (script, json: string) => {
       const type = JSON.parse(json)['@type'];
-      if (type !== expectedType) return script;
-      count += 1;
+      if (!counts.has(type)) return script;
+      counts.set(type, counts.get(type)! + 1);
       return '';
     },
   );
-  if (count !== 1) {
-    throw new Error(
-      `[variant-dashboard-html] JSON-LD type "${expectedType}" matched ${count} time(s), expected 1`,
-    );
+  for (const expectedType of expectedTypes) {
+    const count = counts.get(expectedType)!;
+    if (count !== 1) {
+      throw new Error(
+        `[variant-dashboard-html] JSON-LD type "${expectedType}" matched ${count} time(s), expected 1`,
+      );
+    }
   }
   return result;
 }
@@ -268,7 +271,7 @@ export function renderVariantDashboardHtml(fullDashboardHtml: string, variant: s
     'WebApplication featureList',
   );
 
-  html = removeJsonLdType(html, 'WebSite');
+  html = removeJsonLdTypes(html, ['WebSite', 'WebPage', 'BreadcrumbList']);
 
   // Variants stay on their own canonical URL but must not be entity-orphaned:
   // join the canonical Organization/WebSite via WebPage + breadcrumbs + speakable

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -1599,6 +1599,10 @@ describe('crawlable corpus generator', () => {
       assert.equal(macau.slug, 'macau');
       assert.ok(existsSync(join(outDir, 'countries/macau/index.html')));
       assert.ok(!existsSync(join(outDir, 'countries/macao-s-a-r/index.html')));
+      const macauPage = jsonLdObjects(read(outDir, 'countries/macau/index.html'))
+        .find((entry) => entry['@type'] === 'WebPage');
+      assert.deepEqual(macauPage?.about?.alternateName, ['Macao SAR']);
+      assert.doesNotMatch(JSON.stringify(macauPage), /Macao S A R/);
 
       const countriesIndex = read(outDir, 'countries/index.html');
       const countriesDocument = htmlDocument(countriesIndex, 'https://www.worldmonitor.app/countries/');
@@ -1616,6 +1620,7 @@ describe('crawlable corpus generator', () => {
       assert.equal(countryCollection?.name, 'Country risk, instability and resilience by country');
       assert.equal(countryCollection?.['@id'], 'https://www.worldmonitor.app/countries/#webpage');
       assertDefaultSpeakable(countryCollection, 'countries hub CollectionPage');
+      assert.equal(countryDataset?.['@id'], 'https://www.worldmonitor.app/countries/#dataset');
       assert.deepEqual(countryCollection?.breadcrumb, {
         '@id': 'https://www.worldmonitor.app/countries/#breadcrumb',
       });
@@ -2620,19 +2625,19 @@ describe('crawlable corpus generator', () => {
       });
       assert.equal(
         redSeaDataset.dateModified,
-        '2026-08-31',
+        '2026-09-01',
         'changed crisis Dataset schema must advance only the crisis family stamp',
       );
       assert.equal(
         pageLastmod(redSea),
-        '2026-08-31',
+        '2026-09-01',
         'crisis page lastmod must advance with its changed Dataset schema',
       );
       assert.equal(
         sitemapEntries.find((entry) => (
           new URL(entry.loc).pathname === '/crises/red-sea-security/'
         ))?.lastmod,
-        '2026-08-31',
+        '2026-09-01',
         'crisis sitemap lastmod must advance with its changed Dataset schema',
       );
       assert.equal(redSeaDataset.isAccessibleForFree, true);
@@ -2664,13 +2669,18 @@ describe('crawlable corpus generator', () => {
         'maintainedPulse.eventsTotal must equal the sum of its published rows',
       );
       assert.deepEqual(redSeaDataset.variableMeasured, [
-        'Tracker scope',
-        'Covered countries',
-        'Recorded conflict events',
-        'Recorded fatalities',
-        'Political violence events',
-        'Humanitarian reference period',
+        { '@type': 'PropertyValue', name: 'Tracker scope', value: 'Red Sea security' },
+        { '@type': 'PropertyValue', name: 'Covered countries', value: 4, unitText: 'countries' },
+        { '@type': 'PropertyValue', name: 'Recorded conflict events', value: redSeaReference.maintainedPulse.eventsTotal, unitText: 'events' },
+        { '@type': 'PropertyValue', name: 'Recorded fatalities', value: redSeaReference.maintainedPulse.fatalities, unitText: 'fatalities' },
+        { '@type': 'PropertyValue', name: 'Political violence events', value: redSeaReference.maintainedPulse.politicalViolenceEvents, unitText: 'events' },
+        { '@type': 'PropertyValue', name: 'Humanitarian reference period', value: redSeaReference.maintainedPulse.referencePeriod },
       ]);
+      assert.equal(redSeaDataset['@id'], 'https://www.worldmonitor.app/crises/red-sea-security/#crisis-dataset');
+      assert.equal(redSeaDataset.url, 'https://www.worldmonitor.app/crises/red-sea-security/');
+      assert.equal(redSeaDataset.identifier, 'crisis-tracker-red-sea-security');
+      assert.equal(redSeaDataset.datePublished, redSeaReference.maintainedPulse.referencePeriod);
+      assert.match(redSeaDataset.measurementTechnique, /HAPI\/HDX/);
       assertDataCatalogPresent(redSea, '/crises/red-sea-security/');
 
       const toolsIndex = read(outDir, 'tools/index.html');
@@ -2705,6 +2715,15 @@ describe('crawlable corpus generator', () => {
       assert.match(convergence, /<strong>87<\/strong>/);
       assert.match(convergence, /href="\/docs\/geographic-convergence"/);
       assert.doesNotMatch(convergence, /id="app"/);
+      const convergencePage = jsonLdObjects(convergence).find((entry) => entry['@type'] === 'WebPage');
+      const convergenceDataset = collectDatasets(convergencePage)[0];
+      assert.equal(convergenceDataset['@id'], 'https://www.worldmonitor.app/tools/signal-convergence/#signal-convergence-dataset');
+      assert.equal(convergenceDataset.url, 'https://www.worldmonitor.app/tools/signal-convergence/');
+      assert.equal(convergenceDataset.identifier, 'signal-convergence-2026-08-30');
+      assert.equal(convergenceDataset.datePublished, '2026-08-30');
+      assert.equal(convergenceDataset.spatialCoverage, 'Worldwide');
+      assert.equal(convergenceDataset.variableMeasured[1].value, 3);
+      assert.equal(convergenceDataset.variableMeasured[2].value, 3);
 
       const hazard = read(outDir, 'tools/natural-hazard-pulse/index.html');
       assert.match(hazard, /data-natural-hazard-tool/);

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -751,6 +751,7 @@ function assertSourceDerivedTemporalCoverage(dataset, {
   observationInterval,
   lastmod,
   index = 1,
+  publishedDate,
 } = {}) {
   const expected = datasetTemporalCoverage(observationInterval);
   assert.equal(
@@ -779,8 +780,8 @@ function assertSourceDerivedTemporalCoverage(dataset, {
   if (dataset.datePublished) {
     assert.equal(
       dataset.datePublished,
-      expected,
-      `${route} Dataset ${index} datePublished must match the same observation interval`,
+      publishedDate ?? expected,
+      `${route} Dataset ${index} datePublished must match the published snapshot date`,
     );
   }
 }
@@ -1294,6 +1295,7 @@ describe('crawlable corpus generator', () => {
             assertSourceDerivedTemporalCoverage(dataset, {
               route,
               observationInterval: tracker.maintainedPulse?.referencePeriod,
+              publishedDate: manifest.sections.crises.sourceCapturedAt,
               lastmod: pageLastmod(html),
               index: index + 1,
             });
@@ -2621,6 +2623,7 @@ describe('crawlable corpus generator', () => {
       assertSourceDerivedTemporalCoverage(redSeaDataset, {
         route: '/crises/red-sea-security/',
         observationInterval: redSeaReference.maintainedPulse?.referencePeriod,
+        publishedDate: corpus.livePulse.capturedAt,
         lastmod: pageLastmod(redSea),
       });
       assert.equal(
@@ -2679,7 +2682,7 @@ describe('crawlable corpus generator', () => {
       assert.equal(redSeaDataset['@id'], 'https://www.worldmonitor.app/crises/red-sea-security/#crisis-dataset');
       assert.equal(redSeaDataset.url, 'https://www.worldmonitor.app/crises/red-sea-security/');
       assert.equal(redSeaDataset.identifier, 'crisis-tracker-red-sea-security');
-      assert.equal(redSeaDataset.datePublished, redSeaReference.maintainedPulse.referencePeriod);
+      assert.equal(redSeaDataset.datePublished, corpus.livePulse.capturedAt);
       assert.match(redSeaDataset.measurementTechnique, /HAPI\/HDX/);
       assertDataCatalogPresent(redSea, '/crises/red-sea-security/');
 

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -128,6 +128,9 @@ function probePlaywrightWebMcpEnvironment(overrides = {}) {
   return probe;
 }
 
+const HTML_ENTRY_BROWSER_CACHE = 'public, max-age=0, must-revalidate';
+const HTML_ENTRY_EDGE_CACHE = 'public, s-maxage=600, stale-while-revalidate=60';
+
 const getCacheHeaderValue = (sourcePath) => {
   let value = null;
   for (const rule of vercelConfig.headers.filter((entry) => entry.source === sourcePath)) {
@@ -249,6 +252,43 @@ const effectiveCacheControl = (path) => {
     if (header) value = header.value;
   }
   return value;
+};
+
+const effectiveHeader = (path, key) => {
+  let value = null;
+  for (const entry of vercelConfig.headers) {
+    if (!sourceToRegExp(entry.source).test(path)) continue;
+    const header = entry.headers?.find((h) => h.key.toLowerCase() === key.toLowerCase());
+    if (header) value = header.value;
+  }
+  return value;
+};
+
+const assertPublicHtmlEntryCache = (route) => {
+  assert.equal(
+    effectiveCacheControl(route),
+    HTML_ENTRY_BROWSER_CACHE,
+    `${route} must keep a browser-only revalidation policy after all matching rules apply`,
+  );
+  assert.ok(
+    !effectiveCacheControl(route).includes('no-store'),
+    'HTML must not set no-store — it disables bfcache',
+  );
+  assert.doesNotMatch(
+    effectiveCacheControl(route),
+    /\bs-maxage\b/,
+    `${route} Cache-Control must not carry s-maxage; Vercel consumes it and forwards max-age=0 to Cloudflare`,
+  );
+  assert.equal(
+    effectiveHeader(route, 'CDN-Cache-Control'),
+    HTML_ENTRY_EDGE_CACHE,
+    `${route} must advertise the 600s Cloudflare TTL on CDN-Cache-Control`,
+  );
+  assert.equal(
+    effectiveHeader(route, 'Vercel-CDN-Cache-Control'),
+    HTML_ENTRY_EDGE_CACHE,
+    `${route} must advertise the 600s Vercel TTL on Vercel-CDN-Cache-Control`,
+  );
 };
 
 const getHeaderValueForSource = (sourcePath, key) => {
@@ -744,19 +784,16 @@ describe('deploy/cache configuration guardrails', () => {
     // path-to-regexp source-pattern parser rejects `(?:...)` in `source` fields
     // (deploy-fail PR #3646 round-2 review).
     //
-    // The header uses `public, max-age=0, s-maxage=600,
-    // stale-while-revalidate=60` for static HTML entry routes: browsers still
-    // revalidate while shared caches can serve the immutable shell quickly.
-    // `no-store` remains forbidden — it disables Chrome bfcache (#3993/#4004).
+    // Stacked-CDN HTML entries keep browser `Cache-Control` at max-age=0
+    // (must-revalidate, never no-store — #3993/#4004) and put the 600s TTL on
+    // CDN-Cache-Control + Vercel-CDN-Cache-Control. A combined Cache-Control
+    // value lets Vercel consume s-maxage and forward max-age=0 to Cloudflare,
+    // which then refuses to cache HTML.
     const spaNoCache = getCacheHeaderValue(SPA_HTML_CACHE_SOURCE);
     assert.equal(spaNoCache, 'private, no-cache, must-revalidate');
     assert.ok(!spaNoCache.includes('no-store'), 'HTML must not set no-store — it disables bfcache');
     for (const route of ['/', '/dashboard', '/dashboard.html']) {
-      assert.equal(
-        effectiveCacheControl(route),
-        'public, max-age=0, s-maxage=600, stale-while-revalidate=60',
-        `${route} must keep the public revalidation policy after all matching rules apply`,
-      );
+      assertPublicHtmlEntryCache(route);
     }
   });
 
@@ -1153,21 +1190,15 @@ describe('welcome landing page routing', () => {
   });
 
   it('requires revalidation for /dashboard HTML without disabling bfcache', () => {
-    const dashboardCache = getCacheHeaderValue('/dashboard');
-    assert.equal(dashboardCache, 'public, max-age=0, s-maxage=600, stale-while-revalidate=60');
-    assert.ok(!dashboardCache.includes('no-store'), 'HTML must not set no-store — it disables bfcache');
+    assertPublicHtmlEntryCache('/dashboard');
   });
 
   it('requires revalidation for root welcome HTML without disabling bfcache', () => {
-    const welcomeCache = getCacheHeaderValue('/');
-    assert.equal(welcomeCache, 'public, max-age=0, s-maxage=600, stale-while-revalidate=60');
-    assert.ok(!welcomeCache.includes('no-store'), 'HTML must not set no-store — it disables bfcache');
+    assertPublicHtmlEntryCache('/');
   });
 
   it('requires revalidation for direct dashboard.html without disabling bfcache', () => {
-    const dashboardCache = getCacheHeaderValue('/dashboard.html');
-    assert.equal(dashboardCache, 'public, max-age=0, s-maxage=600, stale-while-revalidate=60');
-    assert.ok(!dashboardCache.includes('no-store'), 'HTML must not set no-store — it disables bfcache');
+    assertPublicHtmlEntryCache('/dashboard.html');
   });
 
   it('redirects bare /api to the docs API reference hub (#7382)', () => {
@@ -4581,9 +4612,9 @@ describe('variant-host canonicalization (#6833–#6836)', () => {
     const catchAllHeader = vercelConfig.headers.find((r) => r.source === SPA_HTML_CACHE_SOURCE);
     assert.ok(catchAllHeader, 'expected the pinned SPA cache-header rule');
     assert.equal(getCacheHeaderValue(SPA_HTML_CACHE_SOURCE), 'private, no-cache, must-revalidate');
-    // Explicit /dashboard entry uses public revalidate (#7382); other SPA
+    // Explicit /dashboard entry uses the stacked public HTML policy; other SPA
     // pretty-URLs still inherit the catch-all private policy.
-    assert.equal(effectiveCacheControl('/dashboard'), 'public, max-age=0, s-maxage=600, stale-while-revalidate=60');
+    assertPublicHtmlEntryCache('/dashboard');
     for (const path of ['/stocks', '/stocks/AAPL', '/story']) {
       assert.equal(effectiveCacheControl(path), 'private, no-cache, must-revalidate', path + ' must stay no-cache');
     }

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -744,9 +744,9 @@ describe('deploy/cache configuration guardrails', () => {
     // path-to-regexp source-pattern parser rejects `(?:...)` in `source` fields
     // (deploy-fail PR #3646 round-2 review).
     //
-    // The header uses `public, max-age=0, must-revalidate` for HTML entry
-    // routes (issue #7382): CDN-cacheable with always-revalidate, which cuts
-    // shared-cache TTFB vs `private` while still revalidating on navigation.
+    // The header uses `public, max-age=0, s-maxage=600,
+    // stale-while-revalidate=60` for static HTML entry routes: browsers still
+    // revalidate while shared caches can serve the immutable shell quickly.
     // `no-store` remains forbidden — it disables Chrome bfcache (#3993/#4004).
     const spaNoCache = getCacheHeaderValue(SPA_HTML_CACHE_SOURCE);
     assert.equal(spaNoCache, 'private, no-cache, must-revalidate');
@@ -754,7 +754,7 @@ describe('deploy/cache configuration guardrails', () => {
     for (const route of ['/', '/dashboard', '/dashboard.html']) {
       assert.equal(
         effectiveCacheControl(route),
-        'public, max-age=0, must-revalidate',
+        'public, max-age=0, s-maxage=600, stale-while-revalidate=60',
         `${route} must keep the public revalidation policy after all matching rules apply`,
       );
     }
@@ -1154,19 +1154,19 @@ describe('welcome landing page routing', () => {
 
   it('requires revalidation for /dashboard HTML without disabling bfcache', () => {
     const dashboardCache = getCacheHeaderValue('/dashboard');
-    assert.equal(dashboardCache, 'public, max-age=0, must-revalidate');
+    assert.equal(dashboardCache, 'public, max-age=0, s-maxage=600, stale-while-revalidate=60');
     assert.ok(!dashboardCache.includes('no-store'), 'HTML must not set no-store — it disables bfcache');
   });
 
   it('requires revalidation for root welcome HTML without disabling bfcache', () => {
     const welcomeCache = getCacheHeaderValue('/');
-    assert.equal(welcomeCache, 'public, max-age=0, must-revalidate');
+    assert.equal(welcomeCache, 'public, max-age=0, s-maxage=600, stale-while-revalidate=60');
     assert.ok(!welcomeCache.includes('no-store'), 'HTML must not set no-store — it disables bfcache');
   });
 
   it('requires revalidation for direct dashboard.html without disabling bfcache', () => {
     const dashboardCache = getCacheHeaderValue('/dashboard.html');
-    assert.equal(dashboardCache, 'public, max-age=0, must-revalidate');
+    assert.equal(dashboardCache, 'public, max-age=0, s-maxage=600, stale-while-revalidate=60');
     assert.ok(!dashboardCache.includes('no-store'), 'HTML must not set no-store — it disables bfcache');
   });
 
@@ -4583,7 +4583,7 @@ describe('variant-host canonicalization (#6833–#6836)', () => {
     assert.equal(getCacheHeaderValue(SPA_HTML_CACHE_SOURCE), 'private, no-cache, must-revalidate');
     // Explicit /dashboard entry uses public revalidate (#7382); other SPA
     // pretty-URLs still inherit the catch-all private policy.
-    assert.equal(effectiveCacheControl('/dashboard'), 'public, max-age=0, must-revalidate');
+    assert.equal(effectiveCacheControl('/dashboard'), 'public, max-age=0, s-maxage=600, stale-while-revalidate=60');
     for (const path of ['/stocks', '/stocks/AAPL', '/story']) {
       assert.equal(effectiveCacheControl(path), 'private, no-cache, must-revalidate', path + ' must stay no-cache');
     }

--- a/tests/makefile-generate-plugin-path.test.mjs
+++ b/tests/makefile-generate-plugin-path.test.mjs
@@ -39,6 +39,19 @@ function extractGenerateRecipe() {
 describe('Makefile generate target — plugin path resolution', () => {
   const recipe = extractGenerateRecipe();
 
+  test('uses the public Go module proxy while keeping sebuf private', () => {
+    assert.match(
+      MAKEFILE,
+      /^GO_PROXY := GOPROXY=https:\/\/proxy\.golang\.org,direct$/m,
+      'Go installs must use proxy.golang.org for public modules with a direct fallback',
+    );
+    assert.match(
+      MAKEFILE,
+      /^GO_PRIVATE := GOPRIVATE=github\.com\/SebastienMelki$/m,
+      'private sebuf modules must bypass the public Go module proxy',
+    );
+  });
+
   test('resolves buf via command -v before invoking it', () => {
     // `command -v buf` must appear before the PATH override so the
     // caller's buf is captured first. Any version pinned by PATH

--- a/tests/schema-graph-contract.test.mts
+++ b/tests/schema-graph-contract.test.mts
@@ -377,13 +377,7 @@ describe('canonical schema graph', () => {
         `${path} disambiguation must disclaim the similarly named mobile applications`,
       );
       assert.equal(organization.alternateName, 'WorldMonitor');
-      assert.deepEqual(organization.interactionStatistic, {
-        '@type': 'InteractionCounter',
-        interactionType: 'https://schema.org/LikeAction',
-        userInteractionCount: 85288,
-        name: 'GitHub stars',
-        url: 'https://github.com/koala73/worldmonitor/stargazers',
-      });
+      assert.equal(organization.interactionStatistic, undefined);
     }
   });
 

--- a/tests/schema-graph-contract.test.mts
+++ b/tests/schema-graph-contract.test.mts
@@ -128,6 +128,33 @@ describe('canonical schema graph', () => {
     assert.deepEqual(sourceCode.targetProduct, { '@id': SOFTWARE_ID });
   });
 
+  it('connects the canonical dashboard page to its product graph and visible SEO content', () => {
+    const blocks = jsonLdBlocks(read('index.html'));
+    const application = blocksOfType(blocks, 'WebApplication')[0];
+    const webSite = blocksOfType(blocks, 'WebSite')[0];
+    const webPage = blocksOfType(blocks, 'WebPage')[0];
+    const crumbs = blocksOfType(blocks, 'BreadcrumbList')[0];
+    const dashboardUrl = 'https://www.worldmonitor.app/dashboard';
+
+    assert.equal(application['@id'], SOFTWARE_ID);
+    assert.equal(webSite['@id'], WEBSITE_ID);
+    assert.equal(webPage['@id'], `${dashboardUrl}#webpage`);
+    assert.equal(webPage.url, dashboardUrl);
+    assert.deepEqual(webPage.mainEntity, { '@id': SOFTWARE_ID });
+    assert.deepEqual(webPage.isPartOf, { '@id': WEBSITE_ID });
+    assert.deepEqual(webPage.publisher, { '@id': ORGANIZATION_ID });
+    assert.deepEqual(webPage.speakable, {
+      '@type': 'SpeakableSpecification',
+      cssSelector: ['h1', '.app-seo-summary'],
+    });
+    assert.deepEqual(webPage.breadcrumb, { '@id': `${dashboardUrl}#breadcrumb` });
+    assert.equal(crumbs['@id'], `${dashboardUrl}#breadcrumb`);
+    assert.deepEqual(crumbs.itemListElement, [
+      { '@type': 'ListItem', position: 1, name: 'World Monitor', item: CANONICAL_ORIGIN },
+      { '@type': 'ListItem', position: 2, name: 'Dashboard', item: dashboardUrl },
+    ]);
+  });
+
   it('binds every canonical product surface to the World Monitor Wikidata item (#7373)', () => {
     const dashboardBlocks = jsonLdBlocks(read('index.html'));
     const proBlocks = jsonLdBlocks(read('pro-test/index.html'));
@@ -170,6 +197,8 @@ describe('canonical schema graph', () => {
 
       const webPage = blocksOfType(renderedBlocks, 'WebPage')[0];
       const crumbs = blocksOfType(renderedBlocks, 'BreadcrumbList')[0];
+      assert.equal(blocksOfType(renderedBlocks, 'WebPage').length, 1, `${variant} must replace the canonical WebPage`);
+      assert.equal(blocksOfType(renderedBlocks, 'BreadcrumbList').length, 1, `${variant} must replace the canonical BreadcrumbList`);
       assert.ok(webPage, `${variant} must declare a WebPage that joins the canonical graph`);
       assert.equal(webPage['@id'], `${VARIANT_META[variant].url}#webpage`);
       assert.deepEqual(webPage.isPartOf, { '@id': WEBSITE_ID });
@@ -205,8 +234,15 @@ describe('canonical schema graph', () => {
     assert.equal(webPage['@id'], 'https://www.worldmonitor.app/pro#webpage');
     assert.deepEqual(webPage.isPartOf, { '@id': WEBSITE_ID });
     assert.deepEqual(webPage.mainEntity, { '@id': SOFTWARE_ID });
-    assert.equal(webPage.speakable?.['@type'], 'SpeakableSpecification');
-    assert.ok(webPage.speakable.cssSelector.includes('h1'));
+    assert.deepEqual(webPage.speakable, {
+      '@type': 'SpeakableSpecification',
+      cssSelector: ['h1', 'main > p:first-of-type'],
+    });
+    assert.match(
+      read('pro-test/index.html'),
+      /<main[^>]*>\s*<p>/,
+      'the Pro speakable paragraph selector must match the static main content',
+    );
     assert.deepEqual(webPage.breadcrumb, { '@id': 'https://www.worldmonitor.app/pro#breadcrumb' });
     const crumbs = blocksOfType(blocks, 'BreadcrumbList')[0];
     assert.equal(crumbs['@id'], 'https://www.worldmonitor.app/pro#breadcrumb');
@@ -222,7 +258,13 @@ describe('canonical schema graph', () => {
       assert.doesNotMatch(source, /['"]@type['"]:\s*['"]Organization['"]/, `${path} must not redeclare Organization`);
       assert.match(source, new RegExp(`['"]@id['"]:\\s*['"]${ORGANIZATION_ID.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`));
     }
-    assert.match(read('blog-site/src/pages/authors/elie-habib.astro'), /['"]@type['"]:\s*['"]BreadcrumbList['"]/);
+    const authorPage = read('blog-site/src/pages/authors/elie-habib.astro');
+    assert.match(authorPage, /['"]@type['"]:\s*['"]BreadcrumbList['"]/);
+    assert.match(
+      authorPage,
+      /'@type': 'ProfilePage',[\s\S]*?speakable: \{\s*'@type': 'SpeakableSpecification',\s*cssSelector: \['h1', '\.author-page-bio'\]/,
+      'the author ProfilePage must target its static h1 and biography content',
+    );
   });
 
   it('overrides Mintlify publisher metadata with the canonical Organization', () => {
@@ -335,6 +377,13 @@ describe('canonical schema graph', () => {
         `${path} disambiguation must disclaim the similarly named mobile applications`,
       );
       assert.equal(organization.alternateName, 'WorldMonitor');
+      assert.deepEqual(organization.interactionStatistic, {
+        '@type': 'InteractionCounter',
+        interactionType: 'https://schema.org/LikeAction',
+        userInteractionCount: 85288,
+        name: 'GitHub stars',
+        url: 'https://github.com/koala73/worldmonitor/stargazers',
+      });
     }
   });
 

--- a/tests/use-cases-corpus.test.mjs
+++ b/tests/use-cases-corpus.test.mjs
@@ -296,7 +296,7 @@ describe('use-cases corpus (#6849, #6850, #6851)', () => {
       const types = new Set(objects.map((ld) => ld['@type']));
       assert.ok(types.has('WebPage'), `${label} missing WebPage JSON-LD`);
       assert.ok(types.has('FAQPage'), `${label} missing FAQPage JSON-LD for AI extraction (#7381)`);
-      assert.ok(types.has('ItemList'), `${label} missing ItemList JSON-LD for AI extraction (#7381)`);
+      assert.equal(types.has('ItemList'), false, `${label} must not duplicate its HowTo steps in ItemList JSON-LD (#7506)`);
       assert.ok(types.has('HowTo'), `${label} missing HowTo JSON-LD for AI extraction (#7462)`);
       const faq = objects.find((ld) => ld['@type'] === 'FAQPage');
       assert.deepEqual(faq.mainEntity, expected.faq, `${label} FAQPage questions`);
@@ -314,34 +314,20 @@ describe('use-cases corpus (#6849, #6850, #6851)', () => {
       assert.equal(howto['@id'], `${pageUrl}#howto`);
       assert.equal(howto.name, expected.itemListName);
       assert.equal(howto.step.length, expected.steps.length);
-      const list = objects.find((ld) => ld['@type'] === 'ItemList');
-      assert.equal(list.name, expected.itemListName, `${label} ItemList name`);
-      assert.equal(list.numberOfItems, expected.steps.length, `${label} ItemList numberOfItems`);
-      assert.equal(list.itemListElement.length, expected.steps.length);
       assert.deepEqual(
         visibleWorkflowStepNames(html),
         expected.steps,
-        `${label} visible workflow steps must match ItemList names`,
+        `${label} visible workflow steps must match HowTo names`,
       );
       for (const [index, name] of expected.steps.entries()) {
         const url = `${pageUrl}#${stepSlug(name)}`;
-        const el = list.itemListElement[index];
         const step = howto.step[index];
-        assert.equal(el['@type'], 'ListItem');
-        assert.equal(el.position, index + 1);
-        assert.equal(el.name, name);
-        assert.equal(el.url, url);
-        assert.match(el.description, /\S/, `${label} ItemList ${name} needs a description`);
-        assert.ok(html.includes(el.description), `${label} ItemList ${name} description must match visible copy`);
-        assert.equal(el.item['@type'], 'HowToStep');
-        assert.equal(el.item.name, name);
-        assert.equal(el.item.url, url);
-        assert.equal(el.item.text, el.description);
         assert.equal(step['@type'], 'HowToStep');
         assert.equal(step.position, index + 1);
         assert.equal(step.name, name);
         assert.equal(step.url, url);
-        assert.equal(step.text, el.description);
+        assert.match(step.text, /\S/, `${label} HowTo ${name} needs a description`);
+        assert.ok(html.includes(step.text), `${label} HowTo ${name} text must match visible copy`);
         assert.ok(html.includes(`id="${stepSlug(name)}"`), `${label} missing visible step id ${stepSlug(name)}`);
       }
     }

--- a/tests/variant-dashboard-html.test.mts
+++ b/tests/variant-dashboard-html.test.mts
@@ -64,6 +64,45 @@ const fixture = `<!doctype html>
       "publisher": { "@id": "https://www.worldmonitor.app/#organization" }
     }
     </script>
+    <script type="application/ld+json" nonce="wm-static-bootstrap">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "@id": "https://www.worldmonitor.app/dashboard#webpage",
+      "url": "https://www.worldmonitor.app/dashboard",
+      "name": "World Monitor — Real-Time Global Intelligence Dashboard",
+      "description": "Open-source real-time global intelligence dashboard aggregating conflicts, military movements, markets, infrastructure, and geopolitical data.",
+      "isPartOf": { "@id": "https://www.worldmonitor.app/#website" },
+      "publisher": { "@id": "https://www.worldmonitor.app/#organization" },
+      "mainEntity": { "@id": "https://www.worldmonitor.app/#software" },
+      "breadcrumb": { "@id": "https://www.worldmonitor.app/dashboard#breadcrumb" },
+      "speakable": {
+        "@type": "SpeakableSpecification",
+        "cssSelector": ["h1", ".app-seo-summary"]
+      }
+    }
+    </script>
+    <script type="application/ld+json" nonce="wm-static-bootstrap">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "@id": "https://www.worldmonitor.app/dashboard#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "World Monitor",
+          "item": "https://www.worldmonitor.app/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Dashboard",
+          "item": "https://www.worldmonitor.app/dashboard"
+        }
+      ]
+    }
+    </script>
   </head>
   <body>
     <h1 class="app-heading">World Monitor — Real-Time Global Intelligence Dashboard</h1>

--- a/vercel.json
+++ b/vercel.json
@@ -687,14 +687,18 @@
     {
       "source": "/",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=600, stale-while-revalidate=60" },
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" },
+        { "key": "CDN-Cache-Control", "value": "public, s-maxage=600, stale-while-revalidate=60" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "public, s-maxage=600, stale-while-revalidate=60" },
         { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/mcp/docs-server-card.json>; rel=\"mcp-server-card\"; anchor=\"/docs/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\", </api-versioning.md>; rel=\"deprecation\"; type=\"text/markdown\"" }
       ]
     },
     {
       "source": "/dashboard.html",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=600, stale-while-revalidate=60" },
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" },
+        { "key": "CDN-Cache-Control", "value": "public, s-maxage=600, stale-while-revalidate=60" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "public, s-maxage=600, stale-while-revalidate=60" },
         { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/mcp/docs-server-card.json>; rel=\"mcp-server-card\"; anchor=\"/docs/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\", </api-versioning.md>; rel=\"deprecation\"; type=\"text/markdown\"" }
       ]
     },
@@ -731,7 +735,9 @@
     {
       "source": "/dashboard",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=600, stale-while-revalidate=60" },
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" },
+        { "key": "CDN-Cache-Control", "value": "public, s-maxage=600, stale-while-revalidate=60" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "public, s-maxage=600, stale-while-revalidate=60" },
         { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/mcp/docs-server-card.json>; rel=\"mcp-server-card\"; anchor=\"/docs/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\", </api-versioning.md>; rel=\"deprecation\"; type=\"text/markdown\"" }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -687,14 +687,14 @@
     {
       "source": "/",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" },
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=600, stale-while-revalidate=60" },
         { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/mcp/docs-server-card.json>; rel=\"mcp-server-card\"; anchor=\"/docs/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\", </api-versioning.md>; rel=\"deprecation\"; type=\"text/markdown\"" }
       ]
     },
     {
       "source": "/dashboard.html",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" },
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=600, stale-while-revalidate=60" },
         { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/mcp/docs-server-card.json>; rel=\"mcp-server-card\"; anchor=\"/docs/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\", </api-versioning.md>; rel=\"deprecation\"; type=\"text/markdown\"" }
       ]
     },
@@ -731,7 +731,7 @@
     {
       "source": "/dashboard",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" },
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=600, stale-while-revalidate=60" },
         { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/mcp/docs-server-card.json>; rel=\"mcp-server-card\"; anchor=\"/docs/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\", </api-versioning.md>; rel=\"deprecation\"; type=\"text/markdown\"" }
       ]
     },


### PR DESCRIPTION
## Summary

Public SEO pages no longer publish duplicate or inconsistent structured-data residue, so crawlers can identify one coherent page graph and machine-readable datasets. Crisis and signal-convergence datasets now expose stable identifiers, publication metadata, and explicit measured values; country aliases, dashboard schema, author speakability, and cache behavior now match the rendered public surfaces.

Fixes #7506.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Public SEO and structured data

## Validation

- [x] `npm run typecheck`
- [x] `npm run --silent lint:boundaries`
- [x] Focused crawlable-corpus, use-cases, and schema contract tests: 56 passed, 1 skipped
- [x] No API keys or secrets committed
- [ ] Browser verification: not run; this change is covered by static schema and contract checks
- [ ] Full deploy-config suite: 237 passed, 3 unrelated OAuth failures because `api/_agent-metadata` is missing in this checkout, 6 skipped

## Documentation Alignment Checklist

- [x] N/A — this PR does not publish or change project documentation claims.

## Screenshots

Not applicable for static SEO and deployment metadata changes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/GPT_5-000000?logoColor=white)