### PR TITLE
Fix general country matching for prediction markets

### DIFF
--- a/scripts/_prediction-country-index.mjs
+++ b/scripts/_prediction-country-index.mjs
@@ -10,7 +10,7 @@ export function countCountryMarkets(countryMarkets) {
 
 const PREDICTION_COUNTRY_KEYWORDS = Object.freeze({
   US: ['american', 'congress', 'white house', 'federal reserve', 'the fed', 'fed rate', 'fed chair', 'fed cut', 'fed hike', 'us recession', 'us gdp', 'us election', 'us tariff', 'us president', 'us presidency'],
-  GB: ['british', 'uk election', 'uk economy', 'uk prime minister'],
+  GB: ['british', 'uk', 'uk election', 'uk economy', 'uk prime minister'],
   KR: ['south korean'],
   KP: ['dprk'],
   AE: ['emirati'],

--- a/scripts/_prediction-country-index.mjs
+++ b/scripts/_prediction-country-index.mjs
@@ -1,4 +1,5 @@
 import countryCodes from './data/country-codes.json' with { type: 'json' };
+import predictionCountryLanguage from './shared/prediction-country-language.json' with { type: 'json' };
 import { isExpired, shouldInclude } from './_prediction-scoring.mjs';
 
 export const COUNTRY_MARKET_LIMIT = 5;
@@ -8,86 +9,7 @@ export function countCountryMarkets(countryMarkets) {
     .reduce((count, markets) => count + (Array.isArray(markets) ? markets.length : 0), 0);
 }
 
-const PREDICTION_COUNTRY_KEYWORDS = Object.freeze({
-  US: ['american', 'congress', 'white house', 'federal reserve', 'the fed', 'fed rate', 'fed chair', 'fed cut', 'fed hike', 'us recession', 'us gdp', 'us election', 'us tariff', 'us president', 'us presidency'],
-  GB: ['british', 'uk', 'uk election', 'uk economy', 'uk prime minister'],
-  KR: ['south korean'],
-  KP: ['dprk'],
-  AE: ['emirati'],
-  SA: ['saudi'],
-  CD: ['democratic republic of congo', 'democratic republic of the congo'],
-  GE: ['georgian'],
-  JO: ['jordanian'],
-  TD: ['chadian', 'n djamena'],
-});
-
-// Verified demonyms from the shared brief table (`DEMONYM_TO_NATION`).
-// Bare "korean" is omitted because it is not a specific ISO-2 country.
-const PREDICTION_COUNTRY_DEMONYMS = Object.freeze({
-  AF: ['afghan', 'afghans'],
-  AR: ['argentine', 'argentinian', 'argentinians'],
-  AT: ['austrian', 'austrians'],
-  AU: ['australian', 'australians'],
-  BE: ['belgian', 'belgians'],
-  BR: ['brazilian', 'brazilians'],
-  CA: ['canadian', 'canadians'],
-  CH: ['swiss'],
-  CN: ['chinese'],
-  CU: ['cuban', 'cubans'],
-  DE: ['german', 'germans'],
-  DK: ['danish', 'danes'],
-  EG: ['egyptian', 'egyptians'],
-  ES: ['spanish'],
-  ET: ['ethiopian', 'ethiopians'],
-  FI: ['finnish', 'finns'],
-  FR: ['french'],
-  GB: ['british', 'briton', 'britons'],
-  GR: ['greek', 'greeks'],
-  ID: ['indonesian', 'indonesians'],
-  IL: ['israeli', 'israelis'],
-  IN: ['indian', 'indians'],
-  IQ: ['iraqi', 'iraqis'],
-  IR: ['iranian', 'iranians'],
-  IT: ['italian', 'italians'],
-  JP: ['japanese'],
-  KE: ['kenyan', 'kenyans'],
-  KP: ['north korean', 'north koreans'],
-  KR: ['south korean', 'south koreans'],
-  LB: ['lebanese'],
-  MX: ['mexican', 'mexicans'],
-  NG: ['nigerian', 'nigerians'],
-  NL: ['dutch'],
-  NO: ['norwegian', 'norwegians'],
-  PH: ['filipino', 'filipinos'],
-  PK: ['pakistani', 'pakistanis'],
-  PT: ['portuguese'],
-  RU: ['russian', 'russians'],
-  SA: ['saudi', 'saudis'],
-  SE: ['swedish', 'swedes'],
-  SY: ['syrian', 'syrians'],
-  TH: ['thai', 'thais'],
-  TR: ['turkish', 'turks'],
-  UA: ['ukrainian', 'ukrainians'],
-  US: ['american', 'americans'],
-  VE: ['venezuelan', 'venezuelans'],
-  VN: ['vietnamese'],
-  YE: ['yemeni', 'yemenis'],
-});
-
-const CONTEXTUAL_COUNTRY_DEMONYMS = Object.freeze({
-  PL: ['polish election', 'polish government', 'polish president', 'polish parliament'],
-});
-
-const AMBIGUOUS_COUNTRY_KEYWORDS = Object.freeze({
-  US: new Set(['america', 'washington']),
-  CD: new Set(['congo']),
-});
-
-const REQUIRED_COUNTRY_CONTEXT = Object.freeze({
-  GE: ['tbilisi', 'georgian', 'abkhazia', 'ossetia', 'caucasus', 'saakashvili', 'ivanishvili', 'batumi', 'kutaisi'],
-  JO: ['jordanian', 'amman'],
-  TD: ['chadian', 'n djamena', 'ndjamena'],
-});
+const PREDICTION_COUNTRY_LANGUAGE = predictionCountryLanguage.countries ?? {};
 
 function normalizeSearchText(value) {
   const words = String(value)
@@ -99,36 +21,32 @@ function normalizeSearchText(value) {
   return words ? ` ${words} ` : '';
 }
 
-const COUNTRY_TERM_SHADOWS = Object.freeze({
-  CG: { term: normalizeSearchText('congo'), specificCountryCode: 'CD' },
-});
-
-const COUNTRY_DEMONYM_PHRASE_SHADOWS = Object.freeze({
-  FR: ['french hill'].map(normalizeSearchText),
-  GR: ['greek letters'].map(normalizeSearchText),
-  IN: ['indian wells'].map(normalizeSearchText),
-  NL: ['dutch bros', 'dutch auction'].map(normalizeSearchText),
-});
+const COUNTRY_TERM_SHADOWS = Object.freeze(Object.fromEntries(
+  Object.entries(predictionCountryLanguage.termShadows ?? {}).map(([countryCode, shadow]) => [
+    countryCode,
+    { ...shadow, term: normalizeSearchText(shadow.term) },
+  ]),
+));
 
 function compileCountryMatchers(countries) {
   return Object.entries(countries).map(([countryCode, country]) => {
     const name = String(country?.name ?? '').trim();
-    const ambiguous = AMBIGUOUS_COUNTRY_KEYWORDS[countryCode] ?? new Set();
+    const language = PREDICTION_COUNTRY_LANGUAGE[countryCode] ?? {};
+    const excludedBaseTerms = new Set(language.excludedBaseTerms ?? []);
     const keywords = [...new Set([
       ...(country?.keywords ?? []),
-      ...(PREDICTION_COUNTRY_KEYWORDS[countryCode] ?? []),
-      ...(PREDICTION_COUNTRY_DEMONYMS[countryCode] ?? []),
-      ...(CONTEXTUAL_COUNTRY_DEMONYMS[countryCode] ?? []),
+      ...(language.terms ?? []),
     ]
       .map((keyword) => String(keyword).trim())
       .filter((keyword) => keyword
         && keyword.toLowerCase() !== name.toLowerCase()
-        && !ambiguous.has(keyword.toLowerCase())))];
+        && !excludedBaseTerms.has(keyword.toLowerCase())))];
     return {
       countryCode,
       name: normalizeSearchText(name),
       keywords: keywords.map(normalizeSearchText),
-      requiredContext: (REQUIRED_COUNTRY_CONTEXT[countryCode] ?? []).map(normalizeSearchText),
+      requiredContext: (language.requiredContext ?? []).map(normalizeSearchText),
+      excludedPhrases: (language.excludedPhrases ?? []).map(normalizeSearchText),
     };
   });
 }
@@ -154,6 +72,7 @@ function occurrenceFallsWithin(normalizedTitle, candidate, enclosingTerm) {
 
 function countryMatches(normalizedTitle, matchers) {
   const rawMatches = [];
+  const matcherByCountryCode = new Map(matchers.map((matcher) => [matcher.countryCode, matcher]));
   for (const matcher of matchers) {
     const hasCountryContext = matcher.requiredContext.length === 0
       || matcher.requiredContext.some((term) => normalizedTitle.includes(term));
@@ -171,7 +90,8 @@ function countryMatches(normalizedTitle, matchers) {
     const shadowedByCountryContext = shadow
       && candidate.term === shadow.term
       && rawMatches.some((other) => other.countryCode === shadow.specificCountryCode);
-    const shadowedByPhrase = (COUNTRY_DEMONYM_PHRASE_SHADOWS[candidate.countryCode] ?? [])
+    const matcher = matcherByCountryCode.get(candidate.countryCode);
+    const shadowedByPhrase = (matcher?.excludedPhrases ?? [])
       .some((phrase) => occurrenceFallsWithin(normalizedTitle, candidate, phrase));
     const embeddedInSpecificCountry = rawMatches.some((other) => (
       other.countryCode !== candidate.countryCode

--- a/scripts/shared/prediction-country-language.json
+++ b/scripts/shared/prediction-country-language.json
@@ -1,0 +1,90 @@
+{
+  "countries": {
+    "AF": { "terms": ["afghan", "afghans"] },
+    "AR": { "terms": ["argentine", "argentinian", "argentinians"] },
+    "AT": { "terms": ["austrian", "austrians"] },
+    "AU": { "terms": ["australian", "australians"] },
+    "BE": { "terms": ["belgian", "belgians"] },
+    "BR": { "terms": ["brazilian", "brazilians"] },
+    "CA": { "terms": ["canadian", "canadians"] },
+    "CD": {
+      "terms": ["democratic republic of congo", "democratic republic of the congo"],
+      "excludedBaseTerms": ["congo"]
+    },
+    "CH": { "terms": ["swiss"] },
+    "CN": { "terms": ["chinese"] },
+    "CU": { "terms": ["cuban", "cubans"] },
+    "DE": { "terms": ["german", "germans"] },
+    "DK": { "terms": ["danish", "danes"] },
+    "EG": { "terms": ["egyptian", "egyptians"] },
+    "ES": { "terms": ["spanish"] },
+    "ET": { "terms": ["ethiopian", "ethiopians"] },
+    "FI": { "terms": ["finnish", "finns"] },
+    "FR": {
+      "terms": ["french"],
+      "excludedPhrases": ["french hill"]
+    },
+    "GB": {
+      "terms": ["british", "briton", "britons", "uk", "uk election", "uk economy", "uk prime minister"]
+    },
+    "GE": {
+      "terms": ["georgian"],
+      "requiredContext": ["tbilisi", "georgian", "abkhazia", "ossetia", "caucasus", "saakashvili", "ivanishvili", "batumi", "kutaisi"]
+    },
+    "GR": {
+      "terms": ["greek", "greeks"],
+      "excludedPhrases": ["greek letters"]
+    },
+    "ID": { "terms": ["indonesian", "indonesians"] },
+    "IL": { "terms": ["israeli", "israelis"] },
+    "IN": {
+      "terms": ["indian", "indians"],
+      "excludedPhrases": ["indian wells"]
+    },
+    "IQ": { "terms": ["iraqi", "iraqis"] },
+    "IR": { "terms": ["iranian", "iranians"] },
+    "IT": { "terms": ["italian", "italians"] },
+    "JO": {
+      "terms": ["jordanian"],
+      "requiredContext": ["jordanian", "amman"]
+    },
+    "JP": { "terms": ["japanese"] },
+    "KE": { "terms": ["kenyan", "kenyans"] },
+    "KP": { "terms": ["dprk", "north korean", "north koreans"] },
+    "KR": { "terms": ["south korean", "south koreans"] },
+    "LB": { "terms": ["lebanese"] },
+    "MX": { "terms": ["mexican", "mexicans"] },
+    "NG": { "terms": ["nigerian", "nigerians"] },
+    "NL": {
+      "terms": ["dutch"],
+      "excludedPhrases": ["dutch bros", "dutch auction"]
+    },
+    "NO": { "terms": ["norwegian", "norwegians"] },
+    "PH": { "terms": ["filipino", "filipinos"] },
+    "PK": { "terms": ["pakistani", "pakistanis"] },
+    "PL": { "terms": ["polish election", "polish government", "polish president", "polish parliament"] },
+    "PT": { "terms": ["portuguese"] },
+    "RU": { "terms": ["russian", "russians"] },
+    "SA": { "terms": ["saudi", "saudis"] },
+    "SE": { "terms": ["swedish", "swedes"] },
+    "SY": { "terms": ["syrian", "syrians"] },
+    "TD": {
+      "terms": ["chadian", "n djamena"],
+      "requiredContext": ["chadian", "n djamena", "ndjamena"]
+    },
+    "TH": { "terms": ["thai", "thais"] },
+    "TR": { "terms": ["turkish", "turks"] },
+    "UA": { "terms": ["ukrainian", "ukrainians"] },
+    "US": {
+      "terms": ["american", "americans", "congress", "white house", "federal reserve", "the fed", "fed rate", "fed chair", "fed cut", "fed hike", "us recession", "us gdp", "us election", "us tariff", "us president", "us presidency"],
+      "excludedBaseTerms": ["america", "washington"]
+    },
+    "VE": { "terms": ["venezuelan", "venezuelans"] },
+    "VN": { "terms": ["vietnamese"] },
+    "YE": { "terms": ["yemeni", "yemenis"] },
+    "AE": { "terms": ["emirati"] }
+  },
+  "termShadows": {
+    "CG": { "term": "congo", "specificCountryCode": "CD" }
+  }
+}

--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -25,6 +25,8 @@ const breaker = createCircuitBreaker<PredictionMarket[]>({ name: 'Polymarket', c
 const client = new PredictionServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
 
 import predictionTags from '../../../scripts/data/prediction-tags.json';
+import countryCodes from '../../../scripts/data/country-codes.json';
+import predictionCountryLanguage from '../../../scripts/shared/prediction-country-language.json';
 import { PredictionServiceClient } from '@/services/generated-rpc-clients';
 
 const GEOPOLITICAL_TAGS = predictionTags.geopolitical;
@@ -118,29 +120,95 @@ export async function fetchPredictions(opts?: { region?: string }): Promise<Pred
   return markets.slice(0, 15);
 }
 
-const COUNTRY_SEARCH_ALIASES: Record<string, string[]> = {
-  US: ['American', 'Trump', 'Biden', 'Congress', 'White House', 'Federal Reserve', 'The Fed', 'Fed rate', 'Fed chair', 'Fed cut', 'Fed hike', 'US recession', 'US GDP', 'US election', 'US tariff', 'US president', 'US presidency'],
-  GB: ['UK', 'Britain', 'British'],
-  KR: ['South Korean'],
-  KP: ['DPRK', 'Pyongyang', 'Kim Jong'],
-  AE: ['UAE', 'Dubai', 'Abu Dhabi', 'Emirati'],
-  SA: ['Saudi', 'MBS'],
-};
-
-function countrySearchTerms(country: string, countryCode: string): string[] {
-  return [country, ...(COUNTRY_SEARCH_ALIASES[countryCode] ?? [])];
+interface CountryMetadata {
+  name?: string;
+  keywords?: string[];
 }
 
-function matchesCountryTerms(title: string, terms: string[]): boolean {
-  return terms.some((term) => {
-    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`\\b${escaped}\\b`, 'i').test(title);
-  });
+interface PredictionCountryLanguage {
+  terms?: string[];
+  excludedBaseTerms?: string[];
+  requiredContext?: string[];
+  excludedPhrases?: string[];
+}
+
+interface CountrySearchMatcher {
+  names: string[];
+  terms: string[];
+  requiredContext: string[];
+  excludedPhrases: string[];
+}
+
+const COUNTRY_METADATA = countryCodes as Record<string, CountryMetadata>;
+const PREDICTION_COUNTRY_LANGUAGE = predictionCountryLanguage.countries as Record<string, PredictionCountryLanguage>;
+
+function normalizeCountryText(value: string): string {
+  const words = value
+    .normalize('NFKD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+  return words ? ` ${words} ` : '';
+}
+
+function countrySearchMatcher(country: string, countryCode: string): CountrySearchMatcher {
+  const metadata = COUNTRY_METADATA[countryCode] ?? {};
+  const language = PREDICTION_COUNTRY_LANGUAGE[countryCode] ?? {};
+  const names = [...new Set([country, metadata.name]
+    .map((name) => String(name ?? '').trim())
+    .filter(Boolean))];
+  const normalizedNames = new Set(names.map((name) => name.toLowerCase()));
+  const excludedBaseTerms = new Set(language.excludedBaseTerms ?? []);
+  const terms = [...new Set([
+    ...(metadata.keywords ?? []).filter((term) => !excludedBaseTerms.has(term.toLowerCase())),
+    ...(language.terms ?? []),
+  ]
+    .map((term) => String(term).trim())
+    .filter((term) => term && !normalizedNames.has(term.toLowerCase())))];
+
+  return {
+    names: names.map(normalizeCountryText),
+    terms: terms.map(normalizeCountryText),
+    requiredContext: (language.requiredContext ?? []).map(normalizeCountryText),
+    excludedPhrases: (language.excludedPhrases ?? []).map(normalizeCountryText),
+  };
+}
+
+function termOccursOutsideExcludedPhrase(
+  normalizedTitle: string,
+  term: string,
+  excludedPhrases: string[],
+): boolean {
+  let start = normalizedTitle.indexOf(term);
+  while (start >= 0) {
+    const end = start + term.length;
+    const excluded = excludedPhrases.some((phrase) => {
+      let phraseStart = normalizedTitle.indexOf(phrase);
+      while (phraseStart >= 0) {
+        if (phraseStart <= start && phraseStart + phrase.length >= end) return true;
+        phraseStart = normalizedTitle.indexOf(phrase, phraseStart + 1);
+      }
+      return false;
+    });
+    if (!excluded) return true;
+    start = normalizedTitle.indexOf(term, start + 1);
+  }
+  return false;
+}
+
+function matchesCountryTerms(title: string, matcher: CountrySearchMatcher): boolean {
+  const normalizedTitle = normalizeCountryText(title);
+  const hasRequiredContext = matcher.requiredContext.length === 0
+    || matcher.requiredContext.some((term) => normalizedTitle.includes(term));
+  const matchingNames = hasRequiredContext ? matcher.names : [];
+  return [...matchingNames, ...matcher.terms]
+    .some((term) => termOccursOutsideExcludedPhrase(normalizedTitle, term, matcher.excludedPhrases));
 }
 
 export async function fetchCountryMarkets(country: string, countryCode: string): Promise<PredictionMarket[]> {
   const normalizedCode = countryCode.trim().toUpperCase();
-  const terms = countrySearchTerms(country, normalizedCode);
+  const matcher = countrySearchMatcher(country, normalizedCode);
   if (/^[A-Z]{2}$/.test(normalizedCode)) {
     const response = await client.listPredictionMarkets({
       category: `country:${normalizedCode}`,
@@ -163,7 +231,7 @@ export async function fetchCountryMarkets(country: string, countryCode: string):
   if (hydrated) {
     const buckets = [...(hydrated.geopolitical ?? []), ...(hydrated.tech ?? []), ...(hydrated.finance ?? [])];
     const filtered = buckets
-      .filter(m => !isExpired(m.endDate) && matchesCountryTerms(m.title, terms))
+      .filter(m => !isExpired(m.endDate) && matchesCountryTerms(m.title, matcher))
       .filter((market, index, all) => all.findIndex((candidate) => candidate.url === market.url) === index)
       .sort((a, b) => (b.volume ?? 0) - (a.volume ?? 0))
       .slice(0, 5);

--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -25,8 +25,6 @@ const breaker = createCircuitBreaker<PredictionMarket[]>({ name: 'Polymarket', c
 const client = new PredictionServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
 
 import predictionTags from '../../../scripts/data/prediction-tags.json';
-import countryCodes from '../../../scripts/data/country-codes.json';
-import predictionCountryLanguage from '../../../scripts/shared/prediction-country-language.json';
 import { PredictionServiceClient } from '@/services/generated-rpc-clients';
 
 const GEOPOLITICAL_TAGS = predictionTags.geopolitical;
@@ -139,9 +137,6 @@ interface CountrySearchMatcher {
   excludedPhrases: string[];
 }
 
-const COUNTRY_METADATA = countryCodes as Record<string, CountryMetadata>;
-const PREDICTION_COUNTRY_LANGUAGE = predictionCountryLanguage.countries as Record<string, PredictionCountryLanguage>;
-
 function normalizeCountryText(value: string): string {
   const words = value
     .normalize('NFKD')
@@ -152,9 +147,15 @@ function normalizeCountryText(value: string): string {
   return words ? ` ${words} ` : '';
 }
 
-function countrySearchMatcher(country: string, countryCode: string): CountrySearchMatcher {
-  const metadata = COUNTRY_METADATA[countryCode] ?? {};
-  const language = PREDICTION_COUNTRY_LANGUAGE[countryCode] ?? {};
+async function countrySearchMatcher(country: string, countryCode: string): Promise<CountrySearchMatcher> {
+  const [{ default: countryCodes }, { default: predictionCountryLanguage }] = await Promise.all([
+    import('../../../scripts/data/country-codes.json'),
+    import('../../../scripts/shared/prediction-country-language.json'),
+  ]);
+  const countryMetadata = countryCodes as Record<string, CountryMetadata>;
+  const countryLanguage = predictionCountryLanguage.countries as Record<string, PredictionCountryLanguage>;
+  const metadata = countryMetadata[countryCode] ?? {};
+  const language = countryLanguage[countryCode] ?? {};
   const names = [...new Set([country, metadata.name]
     .map((name) => String(name ?? '').trim())
     .filter(Boolean))];
@@ -208,7 +209,6 @@ function matchesCountryTerms(title: string, matcher: CountrySearchMatcher): bool
 
 export async function fetchCountryMarkets(country: string, countryCode: string): Promise<PredictionMarket[]> {
   const normalizedCode = countryCode.trim().toUpperCase();
-  const matcher = countrySearchMatcher(country, normalizedCode);
   if (/^[A-Z]{2}$/.test(normalizedCode)) {
     const response = await client.listPredictionMarkets({
       category: `country:${normalizedCode}`,
@@ -221,6 +221,8 @@ export async function fetchCountryMarkets(country: string, countryCode: string):
     }
     if (response?.dataAvailable) return [];
   }
+
+  const matcher = await countrySearchMatcher(country, normalizedCode);
 
   // Fallback: search bootstrap data across all buckets. `tech` must be included
   // explicitly — until #5733 the geopolitical bucket was an unfiltered copy of

--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -130,11 +130,34 @@ interface PredictionCountryLanguage {
   excludedPhrases?: string[];
 }
 
+interface PredictionCountryLanguageFile {
+  countries?: Record<string, PredictionCountryLanguage>;
+  termShadows?: Record<string, { term: string; specificCountryCode: string }>;
+}
+
 interface CountrySearchMatcher {
+  countryCode: string;
   names: string[];
   terms: string[];
   requiredContext: string[];
   excludedPhrases: string[];
+}
+
+interface CountryTermShadow {
+  term: string;
+  specificCountryCode: string;
+}
+
+interface CountryTermOccurrence {
+  countryCode: string;
+  start: number;
+  end: number;
+  term: string;
+}
+
+interface CountrySearchIndex {
+  matchers: CountrySearchMatcher[];
+  shadows: Record<string, CountryTermShadow>;
 }
 
 function normalizeCountryText(value: string): string {
@@ -147,16 +170,13 @@ function normalizeCountryText(value: string): string {
   return words ? ` ${words} ` : '';
 }
 
-async function countrySearchMatcher(country: string, countryCode: string): Promise<CountrySearchMatcher> {
-  const [{ default: countryCodes }, { default: predictionCountryLanguage }] = await Promise.all([
-    import('../../../scripts/data/country-codes.json'),
-    import('../../../scripts/shared/prediction-country-language.json'),
-  ]);
-  const countryMetadata = countryCodes as Record<string, CountryMetadata>;
-  const countryLanguage = predictionCountryLanguage.countries as Record<string, PredictionCountryLanguage>;
-  const metadata = countryMetadata[countryCode] ?? {};
-  const language = countryLanguage[countryCode] ?? {};
-  const names = [...new Set([country, metadata.name]
+function compileCountrySearchMatcher(
+  countryCode: string,
+  displayNames: string[],
+  metadata: CountryMetadata,
+  language: PredictionCountryLanguage,
+): CountrySearchMatcher {
+  const names = [...new Set(displayNames
     .map((name) => String(name ?? '').trim())
     .filter(Boolean))];
   const normalizedNames = new Set(names.map((name) => name.toLowerCase()));
@@ -169,6 +189,7 @@ async function countrySearchMatcher(country: string, countryCode: string): Promi
     .filter((term) => term && !normalizedNames.has(term.toLowerCase())))];
 
   return {
+    countryCode,
     names: names.map(normalizeCountryText),
     terms: terms.map(normalizeCountryText),
     requiredContext: (language.requiredContext ?? []).map(normalizeCountryText),
@@ -176,35 +197,120 @@ async function countrySearchMatcher(country: string, countryCode: string): Promi
   };
 }
 
-function termOccursOutsideExcludedPhrase(
+async function loadCountrySearchIndex(country: string, countryCode: string): Promise<CountrySearchIndex> {
+  const [{ default: countryCodes }, { default: predictionCountryLanguage }] = await Promise.all([
+    import('../../../scripts/data/country-codes.json'),
+    import('../../../scripts/shared/prediction-country-language.json'),
+  ]);
+  const countryMetadata = countryCodes as Record<string, CountryMetadata>;
+  const languageFile = predictionCountryLanguage as PredictionCountryLanguageFile;
+  const countryLanguage = languageFile.countries ?? {};
+  const matchers = Object.entries(countryMetadata).map(([code, metadata]) => (
+    compileCountrySearchMatcher(
+      code,
+      code === countryCode ? [country, metadata.name ?? ''] : [metadata.name ?? ''],
+      metadata,
+      countryLanguage[code] ?? {},
+    )
+  ));
+  if (!countryMetadata[countryCode]) {
+    matchers.push(compileCountrySearchMatcher(
+      countryCode,
+      [country],
+      {},
+      countryLanguage[countryCode] ?? {},
+    ));
+  }
+  const shadows = Object.fromEntries(
+    Object.entries(languageFile.termShadows ?? {}).map(([code, shadow]) => [
+      code,
+      { specificCountryCode: shadow.specificCountryCode, term: normalizeCountryText(shadow.term) },
+    ]),
+  );
+  return { matchers, shadows };
+}
+
+function termOccurrences(
   normalizedTitle: string,
   term: string,
-  excludedPhrases: string[],
-): boolean {
+  countryCode: string,
+): CountryTermOccurrence[] {
+  if (!term) return [];
+  const matches: CountryTermOccurrence[] = [];
   let start = normalizedTitle.indexOf(term);
   while (start >= 0) {
-    const end = start + term.length;
-    const excluded = excludedPhrases.some((phrase) => {
-      let phraseStart = normalizedTitle.indexOf(phrase);
-      while (phraseStart >= 0) {
-        if (phraseStart <= start && phraseStart + phrase.length >= end) return true;
-        phraseStart = normalizedTitle.indexOf(phrase, phraseStart + 1);
-      }
-      return false;
-    });
-    if (!excluded) return true;
+    matches.push({ countryCode, start, end: start + term.length, term });
     start = normalizedTitle.indexOf(term, start + 1);
+  }
+  return matches;
+}
+
+function occurrenceFallsWithin(
+  normalizedTitle: string,
+  candidate: CountryTermOccurrence,
+  enclosingTerm: string,
+): boolean {
+  if (!enclosingTerm) return false;
+  let start = normalizedTitle.indexOf(enclosingTerm);
+  while (start >= 0) {
+    if (start <= candidate.start && start + enclosingTerm.length >= candidate.end) return true;
+    start = normalizedTitle.indexOf(enclosingTerm, start + 1);
   }
   return false;
 }
 
-function matchesCountryTerms(title: string, matcher: CountrySearchMatcher): boolean {
+function associatedCountryCodes(
+  title: string,
+  matchers: CountrySearchMatcher[],
+  shadows: Record<string, CountryTermShadow>,
+): Set<string> {
   const normalizedTitle = normalizeCountryText(title);
-  const hasRequiredContext = matcher.requiredContext.length === 0
-    || matcher.requiredContext.some((term) => normalizedTitle.includes(term));
-  const matchingNames = hasRequiredContext ? matcher.names : [];
-  return [...matchingNames, ...matcher.terms]
-    .some((term) => termOccursOutsideExcludedPhrase(normalizedTitle, term, matcher.excludedPhrases));
+  const rawMatches: CountryTermOccurrence[] = [];
+  const matcherByCountryCode = new Map(matchers.map((matcher) => [matcher.countryCode, matcher]));
+
+  for (const matcher of matchers) {
+    const hasRequiredContext = matcher.requiredContext.length === 0
+      || matcher.requiredContext.some((term) => normalizedTitle.includes(term));
+    if (hasRequiredContext) {
+      for (const name of matcher.names) {
+        rawMatches.push(...termOccurrences(normalizedTitle, name, matcher.countryCode));
+      }
+    }
+    for (const term of matcher.terms) {
+      rawMatches.push(...termOccurrences(normalizedTitle, term, matcher.countryCode));
+    }
+  }
+
+  const associated = new Set<string>();
+  for (const candidate of rawMatches) {
+    const shadow = shadows[candidate.countryCode];
+    const shadowedByCountryContext = Boolean(
+      shadow
+      && candidate.term === shadow.term
+      && rawMatches.some((other) => other.countryCode === shadow.specificCountryCode),
+    );
+    const matcher = matcherByCountryCode.get(candidate.countryCode);
+    const shadowedByPhrase = (matcher?.excludedPhrases ?? [])
+      .some((phrase) => occurrenceFallsWithin(normalizedTitle, candidate, phrase));
+    const embeddedInSpecificCountry = rawMatches.some((other) => (
+      other.countryCode !== candidate.countryCode
+      && other.term.length > candidate.term.length
+      && other.start <= candidate.start
+      && other.end >= candidate.end
+    ));
+    if (shadowedByCountryContext || shadowedByPhrase || embeddedInSpecificCountry) continue;
+    associated.add(candidate.countryCode);
+  }
+  return associated;
+}
+
+function matchesCountryTerms(
+  title: string,
+  countryCode: string,
+  matchers: CountrySearchMatcher[],
+  shadows: Record<string, CountryTermShadow>,
+): boolean {
+  return associatedCountryCodes(title, matchers, shadows).has(countryCode);
 }
 
 export async function fetchCountryMarkets(country: string, countryCode: string): Promise<PredictionMarket[]> {
@@ -222,8 +328,6 @@ export async function fetchCountryMarkets(country: string, countryCode: string):
     if (response?.dataAvailable) return [];
   }
 
-  const matcher = await countrySearchMatcher(country, normalizedCode);
-
   // Fallback: search bootstrap data across all buckets. `tech` must be included
   // explicitly — until #5733 the geopolitical bucket was an unfiltered copy of
   // every market, so omitting tech here was invisible; now the buckets are a
@@ -231,9 +335,10 @@ export async function fetchCountryMarkets(country: string, countryCode: string):
   // model line) would be unreachable without it.
   const hydrated = getHydratedData('predictions') as BootstrapPredictionData | undefined;
   if (hydrated) {
+    const { matchers, shadows } = await loadCountrySearchIndex(country, normalizedCode);
     const buckets = [...(hydrated.geopolitical ?? []), ...(hydrated.tech ?? []), ...(hydrated.finance ?? [])];
     const filtered = buckets
-      .filter(m => !isExpired(m.endDate) && matchesCountryTerms(m.title, matcher))
+      .filter(m => !isExpired(m.endDate) && matchesCountryTerms(m.title, normalizedCode, matchers, shadows))
       .filter((market, index, all) => all.findIndex((candidate) => candidate.url === market.url) === index)
       .sort((a, b) => (b.volume ?? 0) - (a.volume ?? 0))
       .slice(0, 5);

--- a/tests/prediction-country-index.test.mjs
+++ b/tests/prediction-country-index.test.mjs
@@ -49,6 +49,23 @@ describe('buildCountryMarketIndex', () => {
     assert.deepEqual(index.US.map((entry) => entry.title), [trump.title]);
   });
 
+  it('matches standalone UK terms without matching them inside other words', () => {
+    const ukMarkets = [
+      market('Next UK parliamentary by-election called by...?', 'polymarket', 20_000),
+      market('What will Mike Johnson say during his address to the UK Parliament?', 'kalshi', 10_000),
+    ];
+    const embeddedTerms = [
+      market('Will luck decide the 2027 Nobel Peace Prize?', 'polymarket', 30_000),
+      market('Will Duke Energy name a new CEO in 2027?', 'kalshi', 25_000),
+    ];
+
+    const embeddedIndex = buildCountryMarketIndex(embeddedTerms, { now: NOW });
+    assert.equal(embeddedIndex.GB, undefined);
+
+    const index = buildCountryMarketIndex(ukMarkets, { now: NOW });
+    assert.deepEqual(index.GB?.map((entry) => entry.title), ukMarkets.map((entry) => entry.title));
+  });
+
   it('ranks a nearer country alias ahead of an exact-name 2045 contract', () => {
     const distant = market(
       'Will Nick Fuentes become President of the United States before 2045?',

--- a/tests/prediction-country-index.test.mjs
+++ b/tests/prediction-country-index.test.mjs
@@ -49,11 +49,42 @@ describe('buildCountryMarketIndex', () => {
     assert.deepEqual(index.US.map((entry) => entry.title), [trump.title]);
   });
 
-  it('matches standalone UK terms without matching them inside other words', () => {
-    const ukMarkets = [
-      market('Next UK parliamentary by-election called by...?', 'polymarket', 20_000),
-      market('What will Mike Johnson say during his address to the UK Parliament?', 'kalshi', 10_000),
+  it('matches shared country language across countries and providers', () => {
+    const cases = [
+      ['FR', [
+        market('Will the French government survive the confidence vote?', 'polymarket', 20_000),
+        market('Will France hold an early election?', 'kalshi', 10_000),
+      ]],
+      ['DE', [
+        market('Will the German chancellor call an early election?', 'polymarket', 20_000),
+        market('Will Germany enter recession?', 'kalshi', 10_000),
+      ]],
+      ['SA', [
+        market('Will Saudi cut oil production this year?', 'polymarket', 20_000),
+        market('Will Saudi Arabia host the peace talks?', 'kalshi', 10_000),
+      ]],
+      ['GB', [
+        market('Next UK parliamentary by-election called by...?', 'polymarket', 20_000),
+        market('What will Mike Johnson say during his address to the UK Parliament?', 'kalshi', 10_000),
+      ]],
     ];
+    const index = buildCountryMarketIndex(cases.flatMap(([, markets]) => markets), { now: NOW });
+
+    for (const [countryCode, markets] of cases) {
+      assert.deepEqual(
+        new Set(index[countryCode]?.map((entry) => entry.title)),
+        new Set(markets.map((entry) => entry.title)),
+        countryCode,
+      );
+      assert.deepEqual(
+        new Set(index[countryCode]?.map((entry) => entry.source)),
+        new Set(['polymarket', 'kalshi']),
+        countryCode,
+      );
+    }
+  });
+
+  it('does not match a short country term inside another word', () => {
     const embeddedTerms = [
       market('Will luck decide the 2027 Nobel Peace Prize?', 'polymarket', 30_000),
       market('Will Duke Energy name a new CEO in 2027?', 'kalshi', 25_000),
@@ -61,9 +92,6 @@ describe('buildCountryMarketIndex', () => {
 
     const embeddedIndex = buildCountryMarketIndex(embeddedTerms, { now: NOW });
     assert.equal(embeddedIndex.GB, undefined);
-
-    const index = buildCountryMarketIndex(ukMarkets, { now: NOW });
-    assert.deepEqual(index.GB?.map((entry) => entry.title), ukMarkets.map((entry) => entry.title));
   });
 
   it('ranks a nearer country alias ahead of an exact-name 2045 contract', () => {

--- a/tests/prediction-country-markets-pools.test.mts
+++ b/tests/prediction-country-markets-pools.test.mts
@@ -263,4 +263,56 @@ describe('fetchCountryMarkets uses the producer country index', () => {
       assert.deepEqual(out, [], countryCode);
     }
   });
+
+  it('suppresses shadowed and embedded country names in the bootstrap fallback', async () => {
+    const cases = [
+      ['Republic of the Congo', 'CG', 'Will Democratic Republic of the Congo hold an election?'],
+      ['Republic of the Congo', 'CG', 'Will Kinshasa, Congo hold a local election?'],
+      ['Sudan', 'SD', 'Will South Sudan reach a peace agreement?'],
+      ['Guinea', 'GN', 'Will Equatorial Guinea increase oil output?'],
+    ] as const;
+
+    for (const [country, countryCode, title] of cases) {
+      globalThis.__wmCountryMarketsTestState = {
+        rpcCalls: [],
+        rpcMarketsByCategory: {},
+        hydrated: {
+          geopolitical: [bootstrapMarket(title, 2_000_000)],
+          tech: [],
+          finance: [],
+          fetchedAt: Date.now(),
+        },
+      };
+      const service = await loadPredictionService();
+      const out = await service.fetchCountryMarkets(country, countryCode);
+
+      assert.deepEqual(out, [], `${countryCode} must not claim ${title}`);
+    }
+  });
+
+  it('keeps the specific country on overlapping titles in the bootstrap fallback', async () => {
+    const cases = [
+      ['DR Congo', 'CD', 'Will Democratic Republic of the Congo hold an election?'],
+      ['DR Congo', 'CD', 'Will Kinshasa, Congo hold a local election?'],
+      ['South Sudan', 'SS', 'Will South Sudan reach a peace agreement?'],
+      ['Equatorial Guinea', 'GQ', 'Will Equatorial Guinea increase oil output?'],
+    ] as const;
+
+    for (const [country, countryCode, title] of cases) {
+      globalThis.__wmCountryMarketsTestState = {
+        rpcCalls: [],
+        rpcMarketsByCategory: {},
+        hydrated: {
+          geopolitical: [bootstrapMarket(title, 2_000_000)],
+          tech: [],
+          finance: [],
+          fetchedAt: Date.now(),
+        },
+      };
+      const service = await loadPredictionService();
+      const out = await service.fetchCountryMarkets(country, countryCode);
+
+      assert.deepEqual(out.map((m: { title: string }) => m.title), [title], countryCode);
+    }
+  });
 });

--- a/tests/prediction-country-markets-pools.test.mts
+++ b/tests/prediction-country-markets-pools.test.mts
@@ -212,22 +212,55 @@ describe('fetchCountryMarkets uses the producer country index', () => {
     ]);
   });
 
-  it('uses the UK alias when the literal country name is absent', async () => {
-    globalThis.__wmCountryMarketsTestState = {
-      rpcCalls: [],
-      rpcMarketsByCategory: {},
-      hydrated: {
-        geopolitical: [bootstrapMarket('Will the UK hold an early election?', 2_000_000)],
-        tech: [],
-        finance: [],
-        fetchedAt: Date.now(),
-      },
-    };
-    const service = await loadPredictionService();
-    const out = await service.fetchCountryMarkets('United Kingdom', 'GB');
+  it('uses the shared country vocabulary in the bootstrap fallback', async () => {
+    const cases = [
+      ['France', 'FR', 'Will the French government survive the confidence vote?'],
+      ['Germany', 'DE', 'Will the German chancellor call an early election?'],
+      ['Saudi Arabia', 'SA', 'Will Saudi cut oil production this year?'],
+      ['United Kingdom', 'GB', 'Will the UK hold an early election?'],
+    ] as const;
 
-    assert.deepEqual(out.map((m: { title: string }) => m.title), [
-      'Will the UK hold an early election?',
-    ]);
+    for (const [country, countryCode, title] of cases) {
+      globalThis.__wmCountryMarketsTestState = {
+        rpcCalls: [],
+        rpcMarketsByCategory: {},
+        hydrated: {
+          geopolitical: [bootstrapMarket(title, 2_000_000)],
+          tech: [],
+          finance: [],
+          fetchedAt: Date.now(),
+        },
+      };
+      const service = await loadPredictionService();
+      const out = await service.fetchCountryMarkets(country, countryCode);
+
+      assert.deepEqual(out.map((m: { title: string }) => m.title), [title], countryCode);
+    }
+  });
+
+  it('keeps excluded demonym phrases out of the bootstrap fallback', async () => {
+    const cases = [
+      ['France', 'FR', 'Will French Hill win reelection?'],
+      ['Netherlands', 'NL', 'Will Dutch Bros beat earnings?'],
+      ['India', 'IN', 'Will Indian Wells expand the tournament?'],
+      ['Greece', 'GR', 'Will Greek letters appear in the product name?'],
+    ] as const;
+
+    for (const [country, countryCode, title] of cases) {
+      globalThis.__wmCountryMarketsTestState = {
+        rpcCalls: [],
+        rpcMarketsByCategory: {},
+        hydrated: {
+          geopolitical: [bootstrapMarket(title, 2_000_000)],
+          tech: [],
+          finance: [],
+          fetchedAt: Date.now(),
+        },
+      };
+      const service = await loadPredictionService();
+      const out = await service.fetchCountryMarkets(country, countryCode);
+
+      assert.deepEqual(out, [], countryCode);
+    }
   });
 });


### PR DESCRIPTION
## Problem

Country Brief prediction markets could use different country associations in the authoritative producer and the browser fallback. When the country-index RPC was unavailable, the fallback could also show a market for a more specific country on a broader country page, such as South Sudan on Sudan.

## Fix

- Use one ISO-keyed country-language contract for names, demonyms, contextual terms, phrase exclusions, and ambiguity controls.
- Use that contract in both the producer index and the bootstrap fallback.
- Evaluate the full country corpus in the fallback so explicit term shadows and longer enclosing country names suppress broader matches. This covers CG/CD, SD/SS, GN/GQ, and the general overlap class.
- Load the fallback vocabulary only after the authoritative RPC index is unavailable and hydrated bootstrap data exists, so it does not increase the initial dashboard payload.
- Keep provider ranking, pool selection, and deduplication unchanged.

## Verification

- Focused producer tests: 21 passed.
- Focused fallback tests: 9 passed, including shadowed and specific-country overlap cases.
- Focused RPC contract tests: 4 passed.
- TypeScript typecheck passed.
- Import-boundary lint passed.
- Final exact-head CI: 29 checks passed, 9 checks were correctly skipped, and all 3 commit statuses passed.
- Vercel preview is ready: https://worldmonitor-git-codex-fix-uk-prediction-markets-eliewm.vercel.app
- Earlier branch verification also passed the packaging and built-output data suites and drove France, Germany, Saudi Arabia, and United Kingdom examples in the browser.

This proves the local and preview code paths. It does not claim that the change is merged or deployed to production.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
