### PR TITLE
fix(corpus): differentiate microstate country pages

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -106,7 +106,7 @@ export const CHOKEPOINT_PAGE_LASTMOD_PATHS = Object.freeze([
 // families take the later of this version and their own committed source date,
 // so template changes are reflected without pretending every deploy is fresh.
 export const CORPUS_GENERATOR_CONTENT_VERSION = '2026-09-01';
-const COUNTRY_PAGE_CONTENT_VERSION = '2026-08-31';
+const COUNTRY_PAGE_CONTENT_VERSION = '2026-09-01';
 const CII_COUNTRY_PAGE_CONTENT_VERSION = '2026-09-01';
 const COUNTRIES_INDEX_CONTENT_VERSION = '2026-09-01';
 const CII_RANKING_PAGE_CONTENT_VERSION = '2026-09-01';
@@ -2258,7 +2258,7 @@ export function describeAvailableEvidence(country) {
 
 function buildMicrostateEvidenceProfile(country) {
   const dimensions = activeCountryDimensions(country);
-  const observed = dimensions
+  const supportedDimensions = dimensions
     .filter((dimension) => (
       !isCoverageGap(dimension)
       && String(dimension.imputationClass || '') === ''
@@ -2267,13 +2267,13 @@ function buildMicrostateEvidenceProfile(country) {
       && Number.isFinite(dimension.score)
     ));
   const gaps = dimensions.filter(isCoverageGap).sort(compareDimensionsByCoverageAsc);
-  const observedSources = [...new Set(observed.flatMap(dimensionSources))];
-  const gapSources = [...new Set(gaps.flatMap(dimensionSources))];
+  const supportedSourceFamilies = [...new Set(supportedDimensions.flatMap(dimensionSources))];
+  const gapSourceFamilies = [...new Set(gaps.flatMap(dimensionSources))];
   return {
-    observed,
-    observedSources,
-    gapOnlySources: gapSources.filter((source) => !observedSources.includes(source)),
-    overlappingSources: gapSources.filter((source) => observedSources.includes(source)),
+    supportedDimensions,
+    supportedSourceFamilies,
+    gapOnlySourceFamilies: gapSourceFamilies.filter((source) => !supportedSourceFamilies.includes(source)),
+    overlappingSourceFamilies: gapSourceFamilies.filter((source) => supportedSourceFamilies.includes(source)),
   };
 }
 
@@ -2289,38 +2289,38 @@ function selectMicrostateSourceExamples(sources) {
 export function describeMicrostateEvidence(country) {
   if (country.microstateTerritory !== true) return '';
   const profile = buildMicrostateEvidenceProfile(country);
-  if (profile.observed.length === 0) {
+  if (profile.supportedDimensions.length === 0) {
     return `${country.name} is in the microstate and territory cohort, but this snapshot has no observed dimension reading that can support a country-specific evidence interpretation. No overall resilience score or country rank is published.`;
   }
-  const readings = profile.observed
+  const readings = profile.supportedDimensions
     .map((dimension) => `${dimensionLabel(dimension)} ${formatScore(dimension.score)} (${formatPercent(dimension.coverage)})`);
-  const readingClause = `${country.name} has ${readings.length} observed dimension readings: ${readings.join('; ')}. Scores use a 0-100 scale; percentages show coverage.`;
-  const sourceExamples = selectMicrostateSourceExamples(profile.observedSources);
-  const observedSourceClause = sourceExamples.length > 0
-    ? ` Observed feeds: ${formatProseList(sourceExamples)}.`
+  const readingClause = `${country.name} has ${readings.length} supported dimension readings with observed inputs: ${readings.join('; ')}. Scores use a 0-100 scale; percentages show coverage.`;
+  const sourceExamples = selectMicrostateSourceExamples(profile.supportedSourceFamilies);
+  const supportedSourceClause = sourceExamples.length > 0
+    ? ` Possible dimension inputs for ${country.name}: ${formatProseList(sourceExamples)}.`
     : '';
-  const gapOnlyClause = profile.gapOnlySources.length > 0
-    ? ` Missing or unmonitored feeds: ${formatProseList(profile.gapOnlySources)}.`
+  const gapOnlyClause = profile.gapOnlySourceFamilies.length > 0
+    ? ` Inputs tied only to missing or unmonitored dimensions in ${country.name}: ${formatProseList(profile.gapOnlySourceFamilies)}.`
     : '';
-  const overlapClause = profile.overlappingSources.length > 0
-    ? ` Overlapping feeds also supply observed dimensions: ${formatProseList(profile.overlappingSources)}.`
+  const overlapClause = profile.overlappingSourceFamilies.length > 0
+    ? ` For ${country.name}, some feed families span supported and missing dimensions: ${formatProseList(profile.overlappingSourceFamilies)}.`
     : '';
-  return `This is a partial evidence snapshot. ${readingClause}${observedSourceClause}${gapOnlyClause}${overlapClause} These readings are partial evidence, not a published overall score or a country rank.`;
+  return `This is a partial evidence snapshot. ${readingClause}${supportedSourceClause}${gapOnlyClause}${overlapClause} These readings are partial evidence, not a published overall score or a country rank.`;
 }
 
 export function describeMicrostateEvidenceSummary(country) {
   const profile = buildMicrostateEvidenceProfile(country);
-  if (profile.observed.length === 0) {
+  if (profile.supportedDimensions.length === 0) {
     return `${country.name} has no observed dimension reading that can support a country-specific evidence interpretation. No overall resilience score or country rank is published.`;
   }
-  const highlightedDimensions = profile.observed
+  const highlightedDimensions = profile.supportedDimensions
     .slice(-3)
     .map(dimensionLabel);
-  const sourceExamples = profile.observedSources.slice(-3);
+  const sourceExamples = profile.supportedSourceFamilies.slice(-3);
   const feedClause = sourceExamples.length > 0
-    ? ` Observed feeds include ${formatProseList(sourceExamples)}.`
+    ? ` Possible inputs for ${country.name} include ${formatProseList(sourceExamples)}.`
     : '';
-  return `${country.name} has ${profile.observed.length} observed dimension readings, including ${formatProseList(highlightedDimensions)}.${feedClause} These readings are partial evidence, not a published overall score or a country rank.`;
+  return `${country.name} has ${profile.supportedDimensions.length} supported dimension readings with observed inputs, including ${formatProseList(highlightedDimensions)}.${feedClause} These readings are partial evidence, not a published overall score or a country rank.`;
 }
 
 export function dimensionInventoryNote(country, dimension) {

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -77,6 +77,7 @@ const OBSERVATION_PERIOD_RE = /^\d{4}-\d{2}(-\d{2})?$/;
 const MAX_LIVE_PULSE_SNAPSHOT_AGE_DAYS = 45;
 const COUNTRY_NAMES_PATH = 'shared/country-names.json';
 const COUNTRY_REGIONS_PATH = 'shared/iso2-to-region.json';
+const MICROSTATE_TERRITORIES_PATH = 'server/worldmonitor/resilience/v1/cohorts/microstate-territories.json';
 const CHOKEPOINT_REGISTRY_PATH = 'src/config/chokepoint-registry.ts';
 const TRADE_ROUTES_PATH = 'src/config/trade-routes.ts';
 const GLOSSARY_DATA_PATH = 'blog-site/src/data/glossary.ts';
@@ -1341,6 +1342,11 @@ export async function loadCorpusData({ rootDir = DEFAULT_ROOT } = {}) {
   const livePulseSnapshotPath = resolveLatestLivePulseSnapshotPath(rootDir);
   const resilience = readJson(rootDir, resilienceSnapshotPath);
   const livePulse = readJson(rootDir, livePulseSnapshotPath);
+  const microstateTerritoryCodes = new Set(
+    (readJson(rootDir, MICROSTATE_TERRITORIES_PATH).iso2 || [])
+      .map((code) => String(code || '').toUpperCase())
+      .filter((code) => /^[A-Z]{2}$/.test(code)),
+  );
   const reverseNames = reverseCountryNames(readJson(rootDir, COUNTRY_NAMES_PATH));
   const regionsByCode = readJson(rootDir, COUNTRY_REGIONS_PATH);
   const [
@@ -1375,7 +1381,10 @@ export async function loadCorpusData({ rootDir = DEFAULT_ROOT } = {}) {
     normalizeCountries(resilience, reverseNames),
     regionsByCode,
     crises,
-  );
+  ).map((country) => ({
+    ...country,
+    microstateTerritory: microstateTerritoryCodes.has(country.code),
+  }));
   const ciiRanking = buildCiiRankingEntries(countries, livePulse);
   const countryBounds = normalizeCountryBounds(countryBboxes, countries, reverseNames);
   const chokepoints = normalizeChokepoints(CHOKEPOINT_REGISTRY);
@@ -1396,6 +1405,7 @@ export async function loadCorpusData({ rootDir = DEFAULT_ROOT } = {}) {
     resilience.capturedAt,
     livePulse.capturedAt,
     gitFileLastmod(rootDir, COUNTRY_REGIONS_PATH),
+    gitFileLastmod(rootDir, MICROSTATE_TERRITORIES_PATH),
     COUNTRY_PAGE_CONTENT_VERSION,
   );
   const ciiCountriesLastmod = laterDate(
@@ -1470,6 +1480,7 @@ export async function loadCorpusData({ rootDir = DEFAULT_ROOT } = {}) {
     sources: {
       resilienceSnapshot: resilienceSnapshotPath,
       livePulseSnapshot: livePulseSnapshotPath,
+      microstateTerritories: MICROSTATE_TERRITORIES_PATH,
       countryNames: COUNTRY_NAMES_PATH,
       countryRegions: COUNTRY_REGIONS_PATH,
       chokepointRegistry: CHOKEPOINT_REGISTRY_PATH,
@@ -2239,6 +2250,73 @@ export function describeAvailableEvidence(country) {
   return `Observed evidence is present for ${formatProseList(observed.map((dimension) => `${dimensionLabel(dimension)} (${formatPercent(dimension.coverage)})`))}. Input coverage is ${formatPercent(country.dimensionCoverage)} and imputation share is ${formatPercent(country.imputationShare)}.`;
 }
 
+function buildMicrostateEvidenceProfile(country) {
+  const dimensions = activeCountryDimensions(country);
+  const observed = dimensions
+    .filter((dimension) => (
+      !isCoverageGap(dimension)
+      && String(dimension.imputationClass || '') === ''
+      && Number(dimension.coverage) >= 0.5
+      && typeof dimension.score === 'number'
+      && Number.isFinite(dimension.score)
+    ));
+  const gaps = dimensions.filter(isCoverageGap).sort(compareDimensionsByCoverageAsc);
+  const observedSources = [...new Set(observed.flatMap(dimensionSources))];
+  const gapSources = [...new Set(gaps.flatMap(dimensionSources))];
+  return {
+    observed,
+    observedSources,
+    gapOnlySources: gapSources.filter((source) => !observedSources.includes(source)),
+    overlappingSources: gapSources.filter((source) => observedSources.includes(source)),
+  };
+}
+
+function selectMicrostateSourceExamples(sources) {
+  const preferred = ['World Bank', 'UCDP'].filter((source) => sources.includes(source));
+  return [...new Set([
+    ...sources.slice(0, 3),
+    ...preferred,
+    sources.at(-1),
+  ])].filter(Boolean).slice(0, 6);
+}
+
+export function describeMicrostateEvidence(country) {
+  if (country.microstateTerritory !== true) return '';
+  const profile = buildMicrostateEvidenceProfile(country);
+  if (profile.observed.length === 0) {
+    return `${country.name} is in the microstate and territory cohort, but this snapshot has no observed dimension reading that can support a country-specific evidence interpretation. No overall resilience score or country rank is published.`;
+  }
+  const readings = profile.observed
+    .map((dimension) => `${dimensionLabel(dimension)} ${formatScore(dimension.score)} (${formatPercent(dimension.coverage)})`);
+  const readingClause = `${country.name} has ${readings.length} observed dimension readings: ${readings.join('; ')}. Scores use a 0-100 scale; percentages show coverage.`;
+  const sourceExamples = selectMicrostateSourceExamples(profile.observedSources);
+  const observedSourceClause = sourceExamples.length > 0
+    ? ` Observed feeds: ${formatProseList(sourceExamples)}.`
+    : '';
+  const gapOnlyClause = profile.gapOnlySources.length > 0
+    ? ` Missing or unmonitored feeds: ${formatProseList(profile.gapOnlySources)}.`
+    : '';
+  const overlapClause = profile.overlappingSources.length > 0
+    ? ` Overlapping feeds also supply observed dimensions: ${formatProseList(profile.overlappingSources)}.`
+    : '';
+  return `This is a partial evidence snapshot. ${readingClause}${observedSourceClause}${gapOnlyClause}${overlapClause} These readings are partial evidence, not a published overall score or a country rank.`;
+}
+
+export function describeMicrostateEvidenceSummary(country) {
+  const profile = buildMicrostateEvidenceProfile(country);
+  if (profile.observed.length === 0) {
+    return `${country.name} has no observed dimension reading that can support a country-specific evidence interpretation. No overall resilience score or country rank is published.`;
+  }
+  const highlightedDimensions = profile.observed
+    .slice(-3)
+    .map(dimensionLabel);
+  const sourceExamples = profile.observedSources.slice(-3);
+  const feedClause = sourceExamples.length > 0
+    ? ` Observed feeds include ${formatProseList(sourceExamples)}.`
+    : '';
+  return `${country.name} has ${profile.observed.length} observed dimension readings, including ${formatProseList(highlightedDimensions)}.${feedClause} These readings are partial evidence, not a published overall score or a country rank.`;
+}
+
 export function dimensionInventoryNote(country, dimension) {
   const sources = dimensionSources(dimension);
   const sourceLabel = formatProseList(sources);
@@ -2306,7 +2384,7 @@ function countryFaqs(country, capturedAt, rankedCount, ciiEntry = null) {
       },
       {
         question: `What evidence is available for ${country.name}?`,
-        answer: describeAvailableEvidence(country),
+        answer: describeCountryAvailableEvidenceFaq(country),
       },
       {
         question: `How should readers use ${country.name}'s page?`,
@@ -2335,6 +2413,18 @@ function countryFaqs(country, capturedAt, rankedCount, ciiEntry = null) {
       answer: `The 30-day reading is ${country.trend || 'unknown'}, with a change of ${formatSignedScore(country.change30d)} points. It is structural and separate from the live instability monitor.`,
     },
   ];
+}
+
+function describeCountryAvailableEvidence(country) {
+  return country.microstateTerritory === true
+    ? describeMicrostateEvidence(country)
+    : describeAvailableEvidence(country);
+}
+
+function describeCountryAvailableEvidenceFaq(country) {
+  return country.microstateTerritory === true
+    ? describeMicrostateEvidenceSummary(country)
+    : describeAvailableEvidence(country);
 }
 
 function renderCountryAnalysis({ country, capturedAt, methodologyFormula, rankedCount, ciiEntry = null }) {
@@ -2368,6 +2458,7 @@ function renderCountryAnalysis({ country, capturedAt, methodologyFormula, ranked
       : status === 'un-member'
         ? ` ${country.name} is in the rankable universe as a UN member.`
         : '';
+    const availableEvidence = describeCountryAvailableEvidence(country);
     const html = `      <article data-country-analysis>
         <h2>${escapeHtml(country.name)} resilience analysis</h2>
         <p>${escapeHtml(describeHeadlineIneligibility(country))}${escapeHtml(officialBit)}${escapeHtml(statusBit)} Ranked comparisons use ${escapeHtml(country.regionName)} peers rather than other unpublished pages. The snapshot records ${escapeHtml(country.name)} as ${escapeHtml(country.code)}.</p>
@@ -2376,7 +2467,7 @@ function renderCountryAnalysis({ country, capturedAt, methodologyFormula, ranked
         <h3>Source inventory gaps</h3>
         <p>${escapeHtml(describeCoverageGaps(country))}</p>
         <h3>What the snapshot does cover</h3>
-        <p>${escapeHtml(describeAvailableEvidence(country))}</p>
+        <p>${escapeHtml(availableEvidence)}</p>
         <h3>Dimension evidence inventory</h3>
         <ul class="routes">
 ${inventoryItems}

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -1528,6 +1528,18 @@ describe('crawlable corpus generator', () => {
 
       const corpusData = await loadCorpusData({ rootDir: repoRoot });
       const countryByCode = new Map(corpusData.countries.map((country) => [country.code, country]));
+      const microstateCohort = JSON.parse(readFileSync(
+        join(repoRoot, 'server/worldmonitor/resilience/v1/cohorts/microstate-territories.json'),
+        'utf8',
+      ));
+      const microstateCodes = new Set((microstateCohort.iso2 || []).map((code) => String(code).toUpperCase()));
+      for (const country of corpusData.countries) {
+        assert.equal(
+          country.microstateTerritory,
+          microstateCodes.has(country.code),
+          `${country.code} must match microstate cohort membership`,
+        );
+      }
       const vercelConfig = JSON.parse(readFileSync(join(repoRoot, 'vercel.json'), 'utf8'));
       const redirectPairs = new Set(
         vercelConfig.redirects.map((redirect) => `${redirect.source} -> ${redirect.destination}`),
@@ -1915,7 +1927,7 @@ describe('crawlable corpus generator', () => {
         /below the ranking threshold|input coverage is below/i,
       );
 
-      const unrankedSampleCodes = ['AD', 'SM', 'SY', 'TV', 'TW'];
+      const unrankedSampleCodes = ['AD', 'MO', 'SM', 'SY', 'TV', 'TW'];
       const unrankedArticles = [];
       const rankedNames = new Set(
         corpusData.countries.filter((country) => country.rank != null).map((country) => country.name),
@@ -1928,8 +1940,33 @@ describe('crawlable corpus generator', () => {
         const document = htmlDocument(html, `https://www.worldmonitor.app${route}`);
         const analysis = document.querySelector('[data-country-analysis]');
         assert.ok(analysis, `${route} must render unpublished analysis`);
+        const mainText = document.querySelector('main')?.textContent || '';
+        if (['TV', 'SM', 'MO'].includes(code)) {
+          const evidenceQuestion = `What evidence is available for ${country.name}?`;
+          const evidenceFaq = [...document.querySelectorAll('[data-country-faq]')]
+            .find((node) => node.querySelector('summary')?.textContent === evidenceQuestion);
+          assert.ok(evidenceFaq, `${route} must show a microstate evidence FAQ`);
+          assert.match(evidenceFaq.textContent || '', /observed dimension readings, including/);
+          const faqLabel = {
+            TV: 'State continuity',
+            SM: 'Liquid-reserve adequacy',
+            MO: 'Import concentration',
+          }[code];
+          assert.match(evidenceFaq.textContent || '', new RegExp(faqLabel));
+          assert.doesNotMatch(evidenceFaq.textContent || '', /overall score[^.]*\d|country rank[^.]*\d/i);
+          const faqPage = jsonLdObjects(html).find((entry) => entry['@type'] === 'FAQPage');
+          const faqAnswer = faqPage?.mainEntity?.find((entry) => entry.name === evidenceQuestion);
+          assert.match(faqAnswer?.acceptedAnswer?.text || '', /observed dimension readings, including/);
+          assert.match(faqAnswer?.acceptedAnswer?.text || '', new RegExp(faqLabel));
+          assert.doesNotMatch(faqAnswer?.acceptedAnswer?.text || '', /overall score[^.]*\d|country rank[^.]*\d/i);
+        }
         analysis.querySelectorAll('[data-country-faq]').forEach((node) => node.remove());
-        unrankedArticles.push({ route, text: analysis.textContent || '' });
+        unrankedArticles.push({
+          code,
+          route,
+          text: analysis.textContent || '',
+          mainText,
+        });
         assert.match(html, /Nearest ranked comparators:/);
         assert.doesNotMatch(html, new RegExp(`\\b${code} · `));
         for (const peer of country.peers) {
@@ -1939,6 +1976,28 @@ describe('crawlable corpus generator', () => {
       const syria = read(outDir, 'countries/syria/index.html');
       assert.match(syria, /Macro-fiscal position/);
       assert.match(syria, /IMF/);
+      const expectedMicrostateReadings = {
+        TV: { id: 'borderSecurity', label: 'Border security', source: 'UCDP' },
+        SM: { id: 'liquidReserveAdequacy', label: 'Liquid-reserve adequacy', source: 'World Bank' },
+        MO: { id: 'importConcentration', label: 'Import concentration', source: 'UN Comtrade' },
+      };
+      for (const code of ['TV', 'SM', 'MO']) {
+        const country = countryByCode.get(code);
+        const html = read(outDir, `countries/${country.slug}/index.html`);
+        const evidence = unpublishedHeadingParagraph(html, 'What the snapshot does cover');
+        const expected = expectedMicrostateReadings[code];
+        const dimension = country.domains
+          .flatMap((domain) => domain.dimensions || [])
+          .find((candidate) => candidate.id === expected.id);
+        assert.ok(dimension, `${code} fixture must retain ${expected.id}`);
+        const expectedReading = `${expected.label} ${Number(dimension.score).toFixed(1).replace(/\.0$/, '')} (${Math.round(Number(dimension.coverage) * 100)}%)`;
+        assert.ok(evidence.includes(expectedReading), `${code} must publish ${expectedReading}`);
+        assert.match(evidence, /observed dimension readings:/);
+        assert.match(evidence, /Scores use a 0-100 scale; percentages show coverage/);
+        assert.match(evidence, /Observed feeds:/);
+        assert.match(evidence, new RegExp(`Observed feeds:.*${expected.source}`));
+        assert.match(evidence, /not a published overall score or a country rank/);
+      }
       const andorra = read(outDir, 'countries/andorra/index.html');
       assert.doesNotMatch(andorra, /<summary>What is Andorra&#39;s Country Instability Index\?<\/summary>/);
       assert.equal(countryByCode.get('AD')?.lowConfidence, false);
@@ -1982,6 +2041,19 @@ describe('crawlable corpus generator', () => {
           assert.ok(
             share >= 0.4,
             `${unrankedArticles[left].route} and ${unrankedArticles[right].route} unranked pair must be at least 40% unique, got ${(share * 100).toFixed(1)}%`,
+          );
+        }
+      }
+      const microstateMainPages = unrankedArticles.filter(({ code }) => ['TV', 'SM', 'MO'].includes(code));
+      for (let left = 0; left < microstateMainPages.length; left += 1) {
+        for (let right = left + 1; right < microstateMainPages.length; right += 1) {
+          const share = pairwiseUniqueShare(
+            microstateMainPages[left].mainText,
+            microstateMainPages[right].mainText,
+          );
+          assert.ok(
+            share >= 0.4,
+            `${microstateMainPages[left].route} and ${microstateMainPages[right].route} main content must be at least 40% unique, got ${(share * 100).toFixed(1)}%`,
           );
         }
       }

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -1347,7 +1347,7 @@ describe('crawlable corpus generator', () => {
       assert.match(norway, /<link rel="alternate" hreflang="x-default" href="https:\/\/www\.worldmonitor\.app\/countries\/norway\/">/);
       assert.match(norway, /<link rel="alternate" hreflang="en" href="https:\/\/www\.worldmonitor\.app\/countries\/norway\/">/);
       assert.doesNotMatch(norway, /hreflang="zh/, 'English crawlable corpus pages must not advertise zh alternates');
-      assert.match(norway, /<meta name="lastmod" content="2026-08-31">/);
+      assert.match(norway, /<meta name="lastmod" content="2026-09-01">/);
       assert.ok(norway.includes(`Source: ${manifest.sources.resilienceSnapshot}`));
       assert.match(
         norway,
@@ -1412,22 +1412,13 @@ describe('crawlable corpus generator', () => {
         'only country pages with a published CII score may target Country Instability Index',
       );
       assert.equal(
-        manifest.sections.countries.routes.filter((route) => (
-          /<meta name="lastmod" content="2026-08-31">/.test(
-            read(outDir, `${route.slice(1)}index.html`),
-          )
-        )).length,
-        165,
-        'the 165 generic country pages must retain the generic content clock',
-      );
-      assert.equal(
-        ciiTargetedCountryPages.every((route) => (
+        manifest.sections.countries.routes.every((route) => (
           /<meta name="lastmod" content="2026-09-01">/.test(
             read(outDir, `${route.slice(1)}index.html`),
           )
         )),
         true,
-        'only the 31 CII-targeted country pages use the CII content clock',
+        'all country pages must use the current country content clock',
       );
 
       const ciiIndex = read(outDir, 'country-instability-index/index.html');
@@ -1953,7 +1944,8 @@ describe('crawlable corpus generator', () => {
           const evidenceFaq = [...document.querySelectorAll('[data-country-faq]')]
             .find((node) => node.querySelector('summary')?.textContent === evidenceQuestion);
           assert.ok(evidenceFaq, `${route} must show a microstate evidence FAQ`);
-          assert.match(evidenceFaq.textContent || '', /observed dimension readings, including/);
+          assert.match(evidenceFaq.textContent || '', /supported dimension readings with observed inputs, including/);
+          assert.doesNotMatch(evidenceFaq.textContent || '', /Observed feeds/);
           const faqLabel = {
             TV: 'State continuity',
             SM: 'Liquid-reserve adequacy',
@@ -1963,7 +1955,8 @@ describe('crawlable corpus generator', () => {
           assert.doesNotMatch(evidenceFaq.textContent || '', /overall score[^.]*\d|country rank[^.]*\d/i);
           const faqPage = jsonLdObjects(html).find((entry) => entry['@type'] === 'FAQPage');
           const faqAnswer = faqPage?.mainEntity?.find((entry) => entry.name === evidenceQuestion);
-          assert.match(faqAnswer?.acceptedAnswer?.text || '', /observed dimension readings, including/);
+          assert.match(faqAnswer?.acceptedAnswer?.text || '', /supported dimension readings with observed inputs, including/);
+          assert.doesNotMatch(faqAnswer?.acceptedAnswer?.text || '', /Observed feeds/);
           assert.match(faqAnswer?.acceptedAnswer?.text || '', new RegExp(faqLabel));
           assert.doesNotMatch(faqAnswer?.acceptedAnswer?.text || '', /overall score[^.]*\d|country rank[^.]*\d/i);
         }
@@ -1999,10 +1992,11 @@ describe('crawlable corpus generator', () => {
         assert.ok(dimension, `${code} fixture must retain ${expected.id}`);
         const expectedReading = `${expected.label} ${Number(dimension.score).toFixed(1).replace(/\.0$/, '')} (${Math.round(Number(dimension.coverage) * 100)}%)`;
         assert.ok(evidence.includes(expectedReading), `${code} must publish ${expectedReading}`);
-        assert.match(evidence, /observed dimension readings:/);
+        assert.match(evidence, /supported dimension readings with observed inputs:/);
         assert.match(evidence, /Scores use a 0-100 scale; percentages show coverage/);
-        assert.match(evidence, /Observed feeds:/);
-        assert.match(evidence, new RegExp(`Observed feeds:.*${expected.source}`));
+        assert.match(evidence, new RegExp(`Possible dimension inputs for ${country.name}:`));
+        assert.match(evidence, new RegExp(`Possible dimension inputs for ${country.name}:.*${expected.source}`));
+        assert.doesNotMatch(evidence, /Observed feeds/);
         assert.match(evidence, /not a published overall score or a country rank/);
       }
       const andorra = read(outDir, 'countries/andorra/index.html');
@@ -2892,7 +2886,7 @@ describe('crawlable corpus generator', () => {
     // Family lastmods use material + page versions + pulse where the HTML
     // publishes pulse values. CORPUS_GENERATOR_CONTENT_VERSION stays out
     // (#7463). Research lastmod is the report dateModified, not a rebuild stamp.
-    assert.equal(data.lastmod.countries, '2026-08-31');
+    assert.equal(data.lastmod.countries, '2026-09-01');
     assert.equal(data.lastmod.research, '2026-07-27');
     assert.equal(data.lastmod.chokepoints, '2026-09-01');
     assert.equal(

--- a/tests/crawlable-unranked-country-copy.test.mjs
+++ b/tests/crawlable-unranked-country-copy.test.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'node:url';
 
 import {
   compareUnpublishedRankedPeers,
+  describeMicrostateEvidence,
+  describeMicrostateEvidenceSummary,
   countryMetaDescription,
   describeAvailableEvidence,
   describeCoverageGaps,
@@ -25,8 +27,8 @@ const sharedSource = readFileSync(
   'utf8',
 );
 
-function dimension(id, coverage, imputationClass = '') {
-  return { id, coverage, imputationClass };
+function dimension(id, coverage, imputationClass = '', score = null) {
+  return { id, coverage, imputationClass, score };
 }
 
 function countryFixture(overrides, dimensions) {
@@ -37,6 +39,7 @@ function countryFixture(overrides, dimensions) {
     imputationShare: 0.2,
     lowConfidence: true,
     headlineEligible: false,
+    microstateTerritory: false,
     domains: [
       {
         id: 'economic',
@@ -135,6 +138,112 @@ describe('unranked country copy', () => {
     );
     assert.match(describeAvailableEvidence(country), /Input coverage is 12%/);
     assert.match(describeAvailableEvidence(country), /imputation share is 61%/);
+  });
+
+  it('explains what available dimensions show for microstate pages', () => {
+    const country = countryFixture({
+      name: 'Tuvalu',
+      code: 'TV',
+      microstateTerritory: true,
+      dimensionCoverage: 0.62,
+      imputationShare: 0.176,
+    }, [
+      dimension('borderSecurity', 1, '', 100),
+      dimension('cyberDigital', 1, '', 100),
+      dimension('education', 0.8, '', 34),
+      dimension('healthPublicService', 1, '', 65),
+      dimension('externalDebtCoverage', 0.3, 'unmonitored', 50),
+    ]);
+    const evidence = describeMicrostateEvidence(country);
+    assert.match(evidence, /Border security[^.]*100/);
+    assert.match(evidence, /Education capacity[^.]*34/);
+    assert.match(evidence, /UCDP/);
+    assert.match(evidence, /World Bank/);
+    assert.match(evidence, /not a published overall score|not a country rank/i);
+  });
+
+  it('keeps overlapping sources scoped to dimensions instead of declaring them absent', () => {
+    const country = countryFixture({
+      name: 'Overlap Isles',
+      code: 'TV',
+      microstateTerritory: true,
+    }, [
+      dimension('borderSecurity', 1, '', 72),
+      dimension('stateContinuity', 0, 'unmonitored'),
+      dimension('healthPublicService', 0, 'unmonitored'),
+    ]);
+    const evidence = describeMicrostateEvidence(country);
+    assert.match(evidence, /Overlapping feeds also supply observed dimensions: UCDP/);
+    assert.match(evidence, /Missing or unmonitored feeds: WHO/);
+    assert.doesNotMatch(evidence, /UCDP does not cover Overlap Isles|UCDP is absent/);
+  });
+
+  it('withholds scores when a microstate has no observed dimensions', () => {
+    const country = countryFixture({
+      name: 'Sparse Atoll',
+      code: 'TV',
+      microstateTerritory: true,
+    }, [
+      dimension('borderSecurity', 0, 'unmonitored', 88),
+      dimension('education', 0, 'source-failure', 41),
+    ]);
+    const evidence = describeMicrostateEvidence(country);
+    assert.match(evidence, /no observed dimension reading/);
+    assert.match(evidence, /No overall resilience score or country rank is published/);
+    assert.doesNotMatch(evidence, /88|41/);
+  });
+
+  it('does not publish a missing dimension score as an observed zero', () => {
+    const country = countryFixture({
+      name: 'Scoreless Atoll',
+      code: 'TV',
+      microstateTerritory: true,
+    }, [
+      dimension('borderSecurity', 1),
+      dimension('education', 0.8, '', 'not-a-score'),
+    ]);
+    const evidence = describeMicrostateEvidence(country);
+    assert.match(evidence, /no observed dimension reading/);
+    assert.doesNotMatch(evidence, /Border security|Education capacity/);
+  });
+
+  it('does not present stable-absence imputation as an observed reading', () => {
+    const country = countryFixture({
+      name: 'Stable Atoll',
+      code: 'TV',
+      microstateTerritory: true,
+    }, [
+      dimension('foodWater', 0.7, 'stable-absence', 88),
+    ]);
+    const evidence = describeMicrostateEvidence(country);
+    assert.match(evidence, /no observed dimension reading/);
+    assert.doesNotMatch(evidence, /Food and water security|88/);
+  });
+
+  it('requires usable coverage and observed imputation for a dimension reading', () => {
+    const country = countryFixture({
+      name: 'Partial Atoll',
+      code: 'TV',
+      microstateTerritory: true,
+    }, [
+      dimension('borderSecurity', 0.49, '', 12),
+      dimension('education', 0.7, 'not-applicable', 44),
+    ]);
+    const evidence = describeMicrostateEvidence(country);
+    assert.match(evidence, /no observed dimension reading/);
+    assert.doesNotMatch(evidence, /Border security|Education capacity|12|44/);
+  });
+
+  it('keeps the compact FAQ fallback score-free when no dimensions are observed', () => {
+    const country = countryFixture({
+      name: 'Empty Atoll',
+      code: 'TV',
+      microstateTerritory: true,
+    }, [dimension('borderSecurity', 0, 'unmonitored', 88)]);
+    const evidence = describeMicrostateEvidenceSummary(country);
+    assert.match(evidence, /no observed dimension reading/);
+    assert.match(evidence, /No overall resilience score or country rank is published/);
+    assert.doesNotMatch(evidence, /88/);
   });
 
   it('labels low-confidence unpublished meta descriptions distinctly', () => {

--- a/tests/crawlable-unranked-country-copy.test.mjs
+++ b/tests/crawlable-unranked-country-copy.test.mjs
@@ -159,6 +159,8 @@ describe('unranked country copy', () => {
     assert.match(evidence, /Education capacity[^.]*34/);
     assert.match(evidence, /UCDP/);
     assert.match(evidence, /World Bank/);
+    assert.match(evidence, /Possible dimension inputs for Tuvalu/);
+    assert.doesNotMatch(evidence, /Observed feeds/);
     assert.match(evidence, /not a published overall score|not a country rank/i);
   });
 
@@ -173,8 +175,9 @@ describe('unranked country copy', () => {
       dimension('healthPublicService', 0, 'unmonitored'),
     ]);
     const evidence = describeMicrostateEvidence(country);
-    assert.match(evidence, /Overlapping feeds also supply observed dimensions: UCDP/);
-    assert.match(evidence, /Missing or unmonitored feeds: WHO/);
+    assert.match(evidence, /For Overlap Isles, some feed families span supported and missing dimensions: UCDP/);
+    assert.match(evidence, /Inputs tied only to missing or unmonitored dimensions in Overlap Isles: WHO/);
+    assert.doesNotMatch(evidence, /Observed feeds/);
     assert.doesNotMatch(evidence, /UCDP does not cover Overlap Isles|UCDP is absent/);
   });
 


### PR DESCRIPTION
## Summary

Unpublished microstate and territory pages now explain the evidence that the snapshot can actually support, instead of repeating near-identical generic copy. The pages list observed dimension readings with coverage and source-feed context, while missing feeds remain explicit and no overall score or country rank is exposed.

The profile is derived from the existing microstate/territory cohort and resilience dimensions. The FAQ and FAQ JSON-LD paths use a compact version of the same country-specific evidence summary, so visible and structured content stay aligned.

Closes #7505

## Verification

- `node --import tsx --test tests/crawlable-unranked-country-copy.test.mjs` — 21 passed
- `node --import tsx --test tests/crawlable-corpus.test.mjs` — 39 passed
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run lint` — passed; existing repository warnings remain
- `npm run lint:unicode:staged`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Logs/search: inspect the Vercel deployment and corpus-build logs for `build-crawlable-corpus`, `microstate`, or build failures.
- Healthy signals: the deployment completes, and `/countries/tuvalu/`, `/countries/san-marino/`, and `/countries/macau/` return 200 with country-specific observed readings and no numeric overall score or country rank.
- Failure signals: corpus generation fails, a target page returns an error, or the page falls back to generic evidence copy or publishes a numeric overall score/rank. Revert the deployment or PR if this occurs.
- Validation window and owner: first production deployment plus 24 hours; the WorldMonitor maintainer owns the check.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT_5-000000)
