### PR TITLE
fix(portwatch): retry rate-limited reference pages

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -214,10 +214,6 @@ const CONCURRENCY = 6;
 // run — negligible against the 570s bundle budget.
 const BATCH_BACKOFF_MS = 5_000;
 const BATCH_LOG_EVERY = 5;
-// A country-level ArcGIS request can be rate-limited even when the run has
-// ample bundle time left. Retry that country once after a short cooldown;
-// the outer per-country timeout remains the hard ceiling for the whole retry
-// sequence, so a slow upstream cannot extend the run indefinitely.
 const RATE_LIMIT_RETRY_DELAY_MS = 2_000;
 const MAX_RATE_LIMIT_RETRIES = 1;
 // Cache hygiene: force a full refetch if the cached payload is older than 7 days
@@ -512,6 +508,7 @@ async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
 export async function fetchAllPortRefs({
   signal,
   fetchPage = fetchWithRetryOnInvalidParams,
+  sleepFn = waitForRetry,
 } = {}) {
   const byIso3 = new Map();
   let offset = 0;
@@ -530,7 +527,11 @@ export async function fetchAllPortRefs({
       outSR: '4326',
       f: 'json',
     });
-    body = await fetchPage(`${EP4_BASE}?${params}`, { signal });
+    const url = `${EP4_BASE}?${params}`;
+    body = await retryRateLimited(
+      (attemptSignal) => fetchPage(url, { signal: attemptSignal }),
+      { signal, sleepFn, label: `reference page ${page}` },
+    );
     const features = body.features ?? [];
     for (const f of features) {
       const a = f.attributes;

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -509,7 +509,10 @@ async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
 
 // Fetch ALL ports globally in one paginated pass, grouped by ISO3.
 // ArcGIS server-cap: advance by actual features.length, never PAGE_SIZE.
-async function fetchAllPortRefs({ signal } = {}) {
+export async function fetchAllPortRefs({
+  signal,
+  fetchPage = fetchWithRetryOnInvalidParams,
+} = {}) {
   const byIso3 = new Map();
   let offset = 0;
   let body;
@@ -527,7 +530,7 @@ async function fetchAllPortRefs({ signal } = {}) {
       outSR: '4326',
       f: 'json',
     });
-    body = await fetchWithRetryOnInvalidParams(`${EP4_BASE}?${params}`, { signal });
+    body = await fetchPage(`${EP4_BASE}?${params}`, { signal });
     const features = body.features ?? [];
     for (const f of features) {
       const a = f.attributes;

--- a/tests/portwatch-port-activity-recovery.test.mjs
+++ b/tests/portwatch-port-activity-recovery.test.mjs
@@ -18,6 +18,50 @@ function cachedCountry(iso2, cacheWrittenAt = 0) {
   };
 }
 
+describe('PortWatch reference pagination recovery', () => {
+  it('retries a rate-limited page without restarting pagination', async () => {
+    const requestedOffsets = [];
+    const sleepCalls = [];
+    let offsetOneAttempts = 0;
+    const fetchPage = async (url) => {
+      const offset = Number(new URL(url).searchParams.get('resultOffset'));
+      requestedOffsets.push(offset);
+
+      if (offset === 0) {
+        return {
+          features: [{
+            attributes: { portid: 'us-lax', ISO3: 'USA', lat: 33.7, lon: -118.2 },
+          }],
+          exceededTransferLimit: true,
+        };
+      }
+
+      offsetOneAttempts += 1;
+      if (offsetOneAttempts === 1) {
+        throw new Error('ArcGIS error: Unable to perform query. Too many requests.');
+      }
+      return {
+        features: [{
+          attributes: { portid: 'cy-lca', ISO3: 'CYP', lat: 34.9, lon: 33.6 },
+        }],
+        exceededTransferLimit: false,
+      };
+    };
+
+    const refsByIso3 = await portwatchSeed.fetchAllPortRefs({
+      fetchPage,
+      sleepFn: async (...args) => {
+        sleepCalls.push(args);
+      },
+    });
+
+    assert.deepEqual(requestedOffsets, [0, 1, 1]);
+    assert.ok(refsByIso3.get('USA') instanceof Map);
+    assert.ok(refsByIso3.get('CYP') instanceof Map);
+    assert.equal(sleepCalls.length, 1);
+  });
+});
+
 describe('PortWatch cold-fetch recovery rotation', () => {
   it('attempts all 174 countries within six 30-country runs', () => {
     const countries = Array.from({ length: 174 }, (_, index) =>


### PR DESCRIPTION
## Why

ArcGIS can return an HTTP 200 response whose body reports `Too many requests`. `fetchAllPortRefs` sent this error past the existing rate-limit retry boundary, so the seed stopped after completed reference pages.

Apply the existing bounded rate-limit retry to each reference page. This keeps completed pages and retries only the current pagination offset.

## Scope

- Route each EP4 reference-page request through `retryRateLimited`.
- Add narrow `fetchPage` and `sleepFn` inputs to make pagination recovery deterministic in tests.
- Add a regression test that proves the request offsets are `0, 1, 1` when page 2 is rate-limited once.
- Keep the country retry path, Redis publication path, and bundle exit contract unchanged.

## Tradeoffs

A rate-limited page can add one 2-second delay and one request. A second rate-limit error still fails the seed, which keeps the retry bounded.

## Blast Radius

The change affects only the PortWatch global reference scan. It does not restart the full scan, discard completed pages, or hide persistent upstream failures.

## Verification

- Confirmed the new regression test failed before the fix with the attached `Too many requests` error.
- Passed 53 focused PortWatch tests across recovery, seed, and anchor behavior.
- Passed `npm run test:data` with 29,185 passed, 0 failed, and 35 skipped tests.
- Passed Biome on both changed files.
- Passed `git diff --check`.
