### PR TITLE
fix(seeds): let SIPRI supplier sweep reach completion

### DIFF
--- a/scripts/_defense-industrial-source.mjs
+++ b/scripts/_defense-industrial-source.mjs
@@ -304,6 +304,10 @@ export async function fetchSipriSupplierDependencies({
   // The slice this tick is allowed to refresh. Undefined = every mapped
   // importer, which is the shape the unit tests and any one-shot manual run use.
   selectImporters = null,
+  // When set, only the first N stale candidates are attempted this tick; the
+  // remainder stay deferred and count toward sweep.unfetched. Production passes
+  // SIPRI_SWEEP_CHUNK here AFTER selectImporters returns the full stale set.
+  maxImporters = null,
   softBudgetMs = SIPRI_SWEEP_SOFT_BUDGET_MS,
   now = () => Date.now(),
 } = {}) {
@@ -337,12 +341,18 @@ export async function fetchSipriSupplierDependencies({
     importerByIso2.set(importer.iso2, importer);
   }
   const catalogImporters = [...importerByIso2.values()];
-  // selectImporters returns the slice owed a refresh; everything it leaves out
-  // keeps its previously published row via buildSipriSupplierSnapshot.
-  const uniqueImporters = typeof selectImporters === 'function'
+  // selectImporters returns every importer still owed a refresh this sweep.
+  // maxImporters applies the production chunk AFTER that full stale set is known,
+  // so current catalog rows are not mistaken for unfinished work (#7522).
+  const staleCandidates = typeof selectImporters === 'function'
     ? selectImporters(catalogImporters, maxYear)
     : catalogImporters;
-  const sweepPending = catalogImporters.length - uniqueImporters.length;
+  const deferredByLimit = Number.isInteger(maxImporters) && maxImporters > 0 && staleCandidates.length > maxImporters
+    ? staleCandidates.length - maxImporters
+    : 0;
+  const uniqueImporters = deferredByLimit > 0
+    ? staleCandidates.slice(0, maxImporters)
+    : staleCandidates;
   const output = {};
   const unmapped = new Map();
   const failedImporters = [];
@@ -399,11 +409,16 @@ export async function fetchSipriSupplierDependencies({
       .join(', ');
     logger.warn(`  SIPRI importer requests failed (${failedImporters.length}): ${preview}`);
   }
-  const unfetched = budgetStoppedAt + sweepPending;
+  const unfetched = deferredByLimit + budgetStoppedAt;
   if (budgetStoppedAt > 0) {
     logger.warn(
       `  SIPRI soft budget reached after ${Math.round((now() - fetchStartedAt) / 1000)}s — `
       + `${budgetStoppedAt} importer(s) left for the next tick`,
+    );
+  }
+  if (deferredByLimit > 0) {
+    logger.warn(
+      `  SIPRI chunk limit deferred ${deferredByLimit} stale importer(s) to a later tick`,
     );
   }
   return {
@@ -415,8 +430,10 @@ export async function fetchSipriSupplierDependencies({
       attempted: uniqueImporters.length,
       fetched: Object.keys(output).length,
       // Sections this tick did not even attempt: deliberately deferred by the
-      // slice, plus any the soft budget cut off.
+      // chunk limit, plus any the soft budget cut off.
       unfetched,
+      deferredByLimit,
+      budgetStoppedAt,
     },
   };
 }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1131,8 +1131,9 @@ export async function writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKey
 // keys so callers that publish per-key health can distinguish a confirmed
 // EXPIRE no-op from a successful extension and from a pipeline result that
 // could not be confirmed at all.
-export async function extendExistingTtlDetailed(keys, ttlSeconds = 600) {
+export async function extendExistingTtlDetailed(keys, ttlSeconds = 600, { optionalKeys = [] } = {}) {
   const requestedKeys = Array.isArray(keys) ? keys : [];
+  const optional = new Set(Array.isArray(optionalKeys) ? optionalKeys : []);
   if (requestedKeys.length === 0) {
     return {
       allExtended: true,
@@ -1192,10 +1193,14 @@ export async function extendExistingTtlDetailed(keys, ttlSeconds = 600) {
       }
     }
     if (extendedKeys.length > 0) console.log(`  Extended TTL on ${extendedKeys.length} key(s) (${ttlSeconds}s)`);
-    if (missingKeys.length > 0) console.warn(`  WARNING: ${missingKeys.length} key(s) were expired/missing — EXPIRE was a no-op; manual seed required`);
+    const requiredMissing = missingKeys.filter((key) => !optional.has(key));
+    if (requiredMissing.length > 0) {
+      console.warn(`  WARNING: ${requiredMissing.length} key(s) were expired/missing — EXPIRE was a no-op; manual seed required`);
+    }
     if (unconfirmedKeys.length > 0) console.warn(`  WARNING: TTL extension result was unconfirmed for ${unconfirmedKeys.length} key(s)`);
+    const requiredKeys = requestedKeys.filter((key) => !optional.has(key));
     return {
-      allExtended: extendedKeys.length === requestedKeys.length,
+      allExtended: requiredKeys.every((key) => extendedKeys.includes(key)),
       extendedKeys,
       missingKeys,
       unconfirmedKeys,
@@ -1218,8 +1223,8 @@ export async function extendExistingTtlDetailed(keys, ttlSeconds = 600) {
 // proof the data is still alive (e.g. a market-closed skip that then reports
 // fresh) MUST gate on this boolean and fall back to a real fetch on false —
 // otherwise a silent extension failure looks green while the key expires.
-export async function extendExistingTtl(keys, ttlSeconds = 600) {
-  const result = await extendExistingTtlDetailed(keys, ttlSeconds);
+export async function extendExistingTtl(keys, ttlSeconds = 600, options = {}) {
+  const result = await extendExistingTtlDetailed(keys, ttlSeconds, options);
   return result.allExtended;
 }
 
@@ -2206,7 +2211,11 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       process.exit(1);
     }
     declaredTtlByKey.set(key, declaredTtl);
-    normalizedPreserveKeyTtls.push({ key, ttlSeconds: declaredTtl });
+    normalizedPreserveKeyTtls.push({
+      key,
+      ttlSeconds: declaredTtl,
+      ...(declaration?.optional === true ? { optional: true } : {}),
+    });
   }
   const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const startMs = Date.now();
@@ -2224,11 +2233,18 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
   // override a key that also appears in the default canonical-TTL cohort.
   const preserveExistingKeys = async (targets) => {
     const ttlByKey = new Map();
+    const optionalKeys = new Set();
     if (targets) {
-      for (const target of targets) ttlByKey.set(target.key, target.ttlSeconds);
+      for (const target of targets) {
+        ttlByKey.set(target.key, target.ttlSeconds);
+        if (target.optional) optionalKeys.add(target.key);
+      }
     } else {
       for (const key of defaultPreservationKeys) ttlByKey.set(key, defaultPreservationTtl);
-      for (const target of normalizedPreserveKeyTtls) ttlByKey.set(target.key, target.ttlSeconds);
+      for (const target of normalizedPreserveKeyTtls) {
+        ttlByKey.set(target.key, target.ttlSeconds);
+        if (target.optional) optionalKeys.add(target.key);
+      }
     }
 
     const keysByTtl = new Map();
@@ -2236,8 +2252,9 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       if (!keysByTtl.has(targetTtl)) keysByTtl.set(targetTtl, []);
       keysByTtl.get(targetTtl).push(key);
     }
+    const optionalKeyList = [...optionalKeys];
     const results = await Promise.all(
-      [...keysByTtl].map(([targetTtl, keys]) => extendExistingTtl(keys, targetTtl)),
+      [...keysByTtl].map(([targetTtl, keys]) => extendExistingTtl(keys, targetTtl, { optionalKeys: optionalKeyList })),
     );
     return results.every(Boolean);
   };
@@ -2666,11 +2683,17 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
           // whose IDs the upstream dropped this cycle). Preserve last-good by
           // extending the existing key's TTL instead.
           if (shouldSkipEmptyExtraKey(ek, ekCount)) {
-            await preserveExistingKeys([{
-              key: ek.key,
-              ttlSeconds: ek.ttl || ttlSeconds || 600,
-            }]);
-            console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, extended TTL to preserve last-good`);
+            const ttl = ek.ttl || ttlSeconds || 600;
+            const detail = await extendExistingTtlDetailed([ek.key], ttl, {
+              optionalKeys: ek.preserveOptional ? [ek.key] : [],
+            });
+            if (detail.extendedKeys.includes(ek.key)) {
+              console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, extended TTL to preserve last-good`);
+            } else if (ek.preserveOptional && detail.missingKeys.includes(ek.key)) {
+              console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write; optional key absent (expected before first completion)`);
+            } else {
+              console.warn(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, but last-good preservation failed`);
+            }
             continue;
           }
           ekEnvelope = {

--- a/scripts/seed-defense-industrial-suppliers.mjs
+++ b/scripts/seed-defense-industrial-suppliers.mjs
@@ -31,7 +31,7 @@ export function supplierContentMeta(data) {
 }
 
 async function fetchSupplierSnapshot() {
-  const previousSnapshot = await readCanonicalValue(ARMS_SUPPLIERS_KEY).catch(() => null);
+  const previousSnapshot = await readCanonicalValue(ARMS_SUPPLIERS_KEY);
   const previous = previousSnapshot || {};
   return buildSipriSupplierSnapshot({
     previousSnapshot: previous,
@@ -40,11 +40,12 @@ async function fetchSupplierSnapshot() {
     // whole-catalog pass cannot be made to fit at any deadline.
     fetchSipri: (options) => fetchSipriSupplierDependencies({
       ...options,
+      maxImporters: SIPRI_SWEEP_CHUNK,
       selectImporters: (candidates, windowEndYear) => selectSweepImporters(
         candidates,
         previous,
         windowEndYear,
-      ).slice(0, SIPRI_SWEEP_CHUNK),
+      ),
     }),
   });
 }
@@ -77,6 +78,7 @@ await runSeed('military', 'arms-suppliers', ARMS_SUPPLIERS_KEY, fetchSupplierSna
       transform: buildArmsSupplierCompletion,
       declareRecords: (data) => data.completedAt ? 1 : 0,
       skipWhenEmpty: true,
+      preserveOptional: true,
       metaKey: 'seed-meta:military:arms-suppliers-complete',
       metaTtlSeconds: DEFENSE_INDUSTRIAL_TTL_SECONDS,
       metaExtra: (data) => ({
@@ -87,7 +89,7 @@ await runSeed('military', 'arms-suppliers', ARMS_SUPPLIERS_KEY, fetchSupplierSna
     },
   ],
   preserveKeyTtls: [
-    { key: ARMS_SUPPLIERS_COMPLETE_KEY, ttlSeconds: DEFENSE_INDUSTRIAL_TTL_SECONDS },
+    { key: ARMS_SUPPLIERS_COMPLETE_KEY, ttlSeconds: DEFENSE_INDUSTRIAL_TTL_SECONDS, optional: true },
     { key: 'seed-meta:military:arms-suppliers-complete', ttlSeconds: DEFENSE_INDUSTRIAL_TTL_SECONDS },
   ],
 });

--- a/tests/seed-defense-industrial.test.mjs
+++ b/tests/seed-defense-industrial.test.mjs
@@ -467,3 +467,149 @@ describe('SIPRI chunked sweep (#6806)', () => {
     );
   });
 });
+
+describe('SIPRI sweep completion vs production chunk limit (#7522)', () => {
+  const names = ['Ukraine', 'Poland', 'Japan', 'Egypt', 'India', 'Brazil', 'Norway', 'Chile'];
+  const catalog = Array.from({ length: 160 }, (_, i) => ({
+    EntityId: 1000 + (i % names.length),
+    Name: names[i % names.length],
+  }));
+
+  function fetchFnFactory({ post } = {}) {
+    return async (url) => {
+      if (String(url).includes('getMaxYear')) return new Response('2025');
+      if (String(url).includes('getAllCountriesTrimmed')) return new Response(JSON.stringify(catalog));
+      if (typeof post === 'function') return post(url);
+      return new Response(JSON.stringify({ bytes: '' }));
+    };
+  }
+
+  function syntheticStale(count) {
+    return Array.from({ length: count }, (_, i) => ({
+      EntityId: 5000 + i,
+      Name: `Synthetic ${i}`,
+      iso2: `C${i}`,
+    }));
+  }
+
+  it('below-limit: only deferred stale importers count as unfetched, not fresh catalog rows', async () => {
+    // Production used to subtract the chunked selection from the FULL mapped
+    // catalog, so every current importer inflated sweep.unfetched and a final
+    // tick could never write the completion marker.
+    const sipriBytes = Buffer.from(sipriFixture).toString('base64');
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: fetchFnFactory({
+        post: async () => new Response(JSON.stringify({ bytes: sipriBytes })),
+      }),
+      delayMs: 0,
+      softBudgetMs: 0,
+      maxImporters: 56,
+      selectImporters: (candidates) => candidates.slice(0, 3),
+    });
+    assert.equal(result.sweep.attempted, 3);
+    assert.equal(result.sweep.unfetched, 0, 'fresh catalog rows must not block sweep completion');
+    assert.equal(result.failedImporters.length, 0);
+  });
+
+  it('exact-limit: selecting exactly the chunk size with no deferred stale leaves unfetched at 0', async () => {
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: fetchFnFactory(),
+      delayMs: 0,
+      softBudgetMs: 0,
+      maxImporters: 56,
+      selectImporters: () => syntheticStale(56),
+    });
+    assert.equal(result.sweep.attempted, 56);
+    assert.equal(result.sweep.unfetched, 0);
+  });
+
+  it('above-limit: deferred stale beyond the chunk remain unfetched', async () => {
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: fetchFnFactory(),
+      delayMs: 0,
+      softBudgetMs: 0,
+      maxImporters: 56,
+      selectImporters: () => syntheticStale(80),
+    });
+    assert.equal(result.sweep.attempted, 56);
+    assert.equal(result.sweep.unfetched, 24, 'only the deferred stale tail is unfinished work');
+  });
+
+  it('soft-budget stops add to unfetched on top of deferred stale', async () => {
+    let clock = 0;
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: fetchFnFactory({
+        post: async () => {
+          clock += 10_000;
+          return new Response(JSON.stringify({ bytes: '' }));
+        },
+      }),
+      delayMs: 0,
+      softBudgetMs: 30_000,
+      maxImporters: 56,
+      selectImporters: () => syntheticStale(80),
+      now: () => clock,
+    });
+    // 24 deferred by the chunk + whatever the soft budget left inside the chunk.
+    assert.ok(result.sweep.unfetched >= 24);
+    assert.ok(result.sweep.attempted === 56 || result.sweep.unfetched > 24);
+  });
+
+  it('failed requests stay out of unfetched and still block the completion marker', async () => {
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: fetchFnFactory({
+        post: async () => new Response('boom', { status: 500 }),
+      }),
+      delayMs: 0,
+      softBudgetMs: 0,
+      maxImporters: 56,
+      selectImporters: (candidates) => candidates.slice(0, 2),
+    });
+    assert.equal(result.sweep.unfetched, 0, 'attempted failures are retried later, not counted unfetched');
+    assert.ok(result.failedImporters.length > 0);
+
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: { importers: {} },
+      minimumCompleteImporterCount: 1,
+      fetchSipri: async () => result,
+    });
+    assert.equal(snapshot.stage.status, 'partial');
+    assert.deepEqual(buildArmsSupplierCompletion(snapshot), {});
+  });
+
+  it('default full-catalog path with no maxImporters still reports budget-stopped work', async () => {
+    let served = 0;
+    let clock = 0;
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: fetchFnFactory({
+        post: async () => {
+          served += 1;
+          clock += 10_000;
+          return new Response(JSON.stringify({ bytes: '' }));
+        },
+      }),
+      delayMs: 0,
+      softBudgetMs: 30_000,
+      now: () => clock,
+    });
+    assert.ok(served > 0);
+    assert.ok(result.sweep.unfetched > 0);
+  });
+
+  it('the suppliers seeder applies the chunk after selecting the full stale set', () => {
+    const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+    const src = readFileSync(join(root, 'scripts/seed-defense-industrial-suppliers.mjs'), 'utf8');
+    assert.match(src, /maxImporters:\s*SIPRI_SWEEP_CHUNK/);
+    assert.doesNotMatch(
+      src,
+      /selectSweepImporters\([\s\S]*?\)\.slice\(0,\s*SIPRI_SWEEP_CHUNK\)/,
+      'slicing inside selectImporters hides deferred stale from the fetcher',
+    );
+    assert.doesNotMatch(
+      src,
+      /readCanonicalValue\(ARMS_SUPPLIERS_KEY\)\.catch\(\s*\(\)\s*=>\s*null\s*\)/,
+      'a snapshot read failure must abort, not pretend the key was empty',
+    );
+    assert.match(src, /optional:\s*true/);
+  });
+});

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -267,6 +267,53 @@ test('skipWhenEmpty preserves the last-good extra key without refreshing its see
   );
 });
 
+test('skipWhenEmpty on an optional extra key does not claim TTL extension when EXPIRE is a no-op', async () => {
+  expireResult = 0;
+  const logs = [];
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  console.log = (...args) => { logs.push(args.join(' ')); originalLog(...args); };
+  console.warn = (...args) => { logs.push(args.join(' ')); originalWarn(...args); };
+
+  try {
+    const exitCode = await runWithExitTrap(() => runSeed('test', 'extra-meta-optional-empty', 'test:extra-meta-optional-empty:v1', async () => ({
+      events: [{ id: 'canonical' }],
+      warnings: [],
+    }), {
+      validateFn: (data) => Array.isArray(data?.events),
+      ttlSeconds: 3600,
+      sourceVersion: 'test-v1',
+      schemaVersion: 1,
+      maxStaleMin: 120,
+      declareRecords: (data) => data.events.length,
+      extraKeys: [{
+        key: 'test:extra-meta-optional-empty:warnings',
+        transform: (data) => data.warnings,
+        declareRecords: (warnings) => warnings.length,
+        skipWhenEmpty: true,
+        preserveOptional: true,
+      }],
+    }));
+
+    assert.equal(exitCode, 0);
+    assert.ok(
+      logs.some((line) => line.includes('optional key absent')),
+      'missing optional completion marker must not claim last-good TTL extension',
+    );
+    assert.ok(
+      !logs.some((line) => line.includes('extended TTL to preserve last-good')),
+      'EXPIRE 0 must not print a false preservation success message',
+    );
+    assert.ok(
+      !logs.some((line) => line.includes('manual seed required')),
+      'optional EXPIRE no-op must not fire manual-seed alarm',
+    );
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+  }
+});
+
 // PR #3582: When validateFn rejects a transient blip but canonical key still
 // holds a contract-mode envelope with recordCount > 0, seed-meta should mirror
 // the canonical's (fetchedAt, recordCount) rather than overwrite with zero.

--- a/tests/seed-utils-extend-ttl-confirms.test.mjs
+++ b/tests/seed-utils-extend-ttl-confirms.test.mjs
@@ -47,6 +47,25 @@ test('extendExistingTtl: returns false when any key is missing/expired (EXPIRE n
   assert.equal(ok, false);
 });
 
+test('extendExistingTtl: treats optional missing keys as success without manual-seed alarm', async () => {
+  let warned = false;
+  const originalWarn = console.warn;
+  console.warn = (...args) => {
+    warned = true;
+    originalWarn(...args);
+  };
+  try {
+    mockPipeline([{ result: 1 }, { result: 0 }]);
+    const ok = await extendExistingTtl(['required', 'optional-complete'], 1800, {
+      optionalKeys: ['optional-complete'],
+    });
+    assert.equal(ok, true);
+    assert.equal(warned, false, 'optional EXPIRE no-op must not fire manual-seed alarm');
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
 test('extendExistingTtlDetailed: preserves mixed per-key EXPIRE outcomes', async () => {
   mockPipeline([{ result: 1 }, { result: 0 }, { result: null }]);
   const result = await extendExistingTtlDetailed(['alive', 'missing', 'unknown'], 1800);

--- a/tests/seed-utils-preserve-key-ttls.test.mjs
+++ b/tests/seed-utils-preserve-key-ttls.test.mjs
@@ -108,3 +108,29 @@ test('preserveKeyTtls rejects malformed declarations before acquiring the Redis 
   assert.equal(exitCode, 1);
   assert.equal(calls.length, 0, 'configuration failure must happen before any Redis operation');
 });
+
+test('optional preserveKeyTtls entries do not fail preservation when EXPIRE is a no-op', async () => {
+  globalThis.fetch = async (url, opts = {}) => {
+    const body = opts.body ? JSON.parse(opts.body) : null;
+    calls.push({ url: String(url), body });
+    if (Array.isArray(body) && Array.isArray(body[0])) {
+      return Response.json(body.map((command) => ({
+        result: command[1] === 'test:optional-marker:v1' ? 0 : 1,
+      })));
+    }
+    return Response.json({ result: 'OK' });
+  };
+
+  const exitCode = await trapExit(() =>
+    runSeed('test', 'optional-marker', 'test:optional-marker:v1', async () => {
+      throw Object.assign(new Error('upstream failed'), { nonRetryable: true });
+    }, {
+      ttlSeconds: 3600,
+      preserveKeyTtls: [
+        { key: 'test:optional-marker:v1', ttlSeconds: 3600, optional: true },
+      ],
+    }),
+  );
+
+  assert.equal(exitCode, GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #7522 — the Arms-Suppliers SIPRI sweep could never finish because `sweep.unfetched` counted fresh catalog rows as unfinished work after the production chunk limit was applied inside `selectImporters`. A final chunk could therefore never reach `unfetched === 0`, so `military:arms-suppliers:complete:v1` was never written.

Also fixes misleading preservation logs when the optional completion marker does not exist yet (`EXPIRE 0`).

## Changes

- **`fetchSipriSupplierDependencies`**: compute the full stale set first, then apply `maxImporters` (production chunk). `unfetched` now counts only deferred-by-limit and soft-budget stops — not fresh importers or failed requests.
- **`seed-defense-industrial-suppliers`**: pass `maxImporters: SIPRI_SWEEP_CHUNK` instead of slicing inside `selectImporters`; stop swallowing snapshot read failures.
- **`runSeed` / TTL preservation**: support `optional: true` on `preserveKeyTtls` and `preserveOptional` on `skipWhenEmpty` extra keys; suppress manual-seed alarms for optional missing keys; only log TTL preservation success when Redis returns `EXPIRE 1`.

## Verification

- `node --test tests/seed-defense-industrial.test.mjs tests/seed-utils-empty-data-failure.test.mjs tests/seed-utils-extend-ttl-confirms.test.mjs tests/seed-utils-preserve-key-ttls.test.mjs` — 58/58 pass
- `npm run test:data` — exit 0

## Post-Deploy Monitoring & Validation

- Watch Railway logs for `seed-bundle-static-ref-heavy` / **Arms-Suppliers** on the next eligible tick:
  - Expect `SIPRI chunk limit deferred N stale importer(s)` only when stale > 56
  - Expect `sweep.unfetched === 0` on the final chunk of a sweep
  - Expect first write of `military:arms-suppliers:complete:v1` after a completed sweep
  - Expect **no** `manual seed required` warning for the optional completion marker when it has never existed
- Health: `/api/health` key `military:arms-suppliers-complete` should transition from absent/EMPTY to OK after the first successful sweep completion.
- Validation window: one full sweep cycle (~8 days) after deploy; owner: platform/data on-call.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e991a68a-3fe0-4621-87f6-062cf3c6e1ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e991a68a-3fe0-4621-87f6-062cf3c6e1ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

