### PR TITLE
fix(seeds): complete SIPRI supplier sweeps

### DIFF
--- a/scripts/_arms-suppliers-sweep.mjs
+++ b/scripts/_arms-suppliers-sweep.mjs
@@ -1,0 +1,63 @@
+// The SIPRI arms-supplier sweep's entry point, extracted from the seeder so it
+// can be executed by a test.
+//
+// scripts/seed-defense-industrial-suppliers.mjs ends in a top-level
+// `await runSeed(...)`, so importing it runs a seed — which is why the wiring
+// and read-failure guards there could only ever assert on the seeder's SOURCE
+// TEXT. A regex cannot observe whether a read failure actually propagates, and
+// one stayed green while it did not (#7524 review). Everything the tests need to
+// drive lives here instead, with its dependencies injected.
+
+import {
+  buildSipriSupplierSnapshot,
+  fetchSipriSupplierDependencies,
+  SIPRI_SWEEP_CHUNK,
+} from './_defense-industrial-source.mjs';
+
+export const ARMS_SUPPLIERS_KEY = 'military:arms-suppliers:v1';
+export const ARMS_SUPPLIERS_COMPLETE_KEY = 'military:arms-suppliers:complete:v1';
+
+export function validateArmsSuppliers(data) {
+  return data && Object.keys(data.importers || {}).length > 0;
+}
+
+export function supplierContentMeta(data) {
+  const endYears = Object.values(data.importers || {})
+    .map((entry) => entry?.window?.endYear)
+    .filter(Number.isInteger);
+  if (endYears.length === 0) return null;
+  return {
+    newestItemAt: Date.UTC(Math.max(...endYears), 11, 31, 23, 59, 59),
+    oldestItemAt: Date.UTC(Math.min(...endYears), 0, 1),
+  };
+}
+
+/**
+ * One sweep tick: read the published snapshot, refresh the oldest slice, and
+ * merge. A read failure MUST propagate — a snapshot that reads as absent is
+ * indistinguishable from a first run, and a first run republishes one 56-row
+ * slice over the ~200-row canonical key.
+ *
+ * @param {object} deps
+ * @param {(key: string) => Promise<any>} deps.readCanonical strict canonical reader
+ */
+export async function fetchSupplierSnapshot({
+  readCanonical,
+  buildSnapshot = buildSipriSupplierSnapshot,
+  fetchSipri = fetchSipriSupplierDependencies,
+  maxSweepImporters = SIPRI_SWEEP_CHUNK,
+} = {}) {
+  const previousSnapshot = await readCanonical(ARMS_SUPPLIERS_KEY);
+  const previous = previousSnapshot || {};
+  return buildSnapshot({
+    previousSnapshot: previous,
+    // One SLICE per tick. The full ~200-importer catalog needs ~800s at the
+    // measured 31.8s/request and Railway kills the container at 600s, so a
+    // whole-catalog pass cannot be made to fit at any deadline.
+    fetchSipri: (options) => fetchSipri({
+      ...options,
+      previousSnapshot: previous,
+      maxSweepImporters,
+    }),
+  });
+}

--- a/scripts/_defense-industrial-source.mjs
+++ b/scripts/_defense-industrial-source.mjs
@@ -301,12 +301,20 @@ export async function fetchSipriSupplierDependencies({
   concurrency = 8,
   delayMs = 150,
   logger = console,
-  // The slice this tick is allowed to refresh. Undefined = every mapped
-  // importer, which is the shape the unit tests and any one-shot manual run use.
-  selectImporters = null,
+  previousSnapshot,
+  maxSweepImporters,
   softBudgetMs = SIPRI_SWEEP_SOFT_BUDGET_MS,
   now = () => Date.now(),
 } = {}) {
+  const hasPreviousSnapshot = previousSnapshot !== undefined;
+  const hasMaxSweepImporters = maxSweepImporters !== undefined;
+  if (hasPreviousSnapshot !== hasMaxSweepImporters) {
+    throw new Error('previousSnapshot and maxSweepImporters must be provided together');
+  }
+  if (hasMaxSweepImporters && (!Number.isSafeInteger(maxSweepImporters) || maxSweepImporters < 1)) {
+    throw new Error('maxSweepImporters must be a positive safe integer');
+  }
+
   const [maxYearValue, catalog] = await Promise.all([
     fetchJson(`${baseUrl}/trades/getMaxYear`, undefined, fetchFn),
     fetchJson(`${baseUrl}/countries/getAllCountriesTrimmed`, undefined, fetchFn),
@@ -337,29 +345,32 @@ export async function fetchSipriSupplierDependencies({
     importerByIso2.set(importer.iso2, importer);
   }
   const catalogImporters = [...importerByIso2.values()];
-  // selectImporters returns the slice owed a refresh; everything it leaves out
-  // keeps its previously published row via buildSipriSupplierSnapshot.
-  const uniqueImporters = typeof selectImporters === 'function'
-    ? selectImporters(catalogImporters, maxYear)
+  const staleImporters = hasPreviousSnapshot
+    ? selectSweepImporters(catalogImporters, previousSnapshot, maxYear, now())
     : catalogImporters;
-  const sweepPending = catalogImporters.length - uniqueImporters.length;
+  const selectedImporters = hasPreviousSnapshot
+    ? staleImporters.slice(0, maxSweepImporters)
+    : staleImporters;
+  const deferredByCap = staleImporters.length - selectedImporters.length;
   const output = {};
   const unmapped = new Map();
   const failedImporters = [];
   let cursor = 0;
+  let attempted = 0;
 
   const fetchStartedAt = now();
   let budgetStoppedAt = 0;
   async function worker() {
-    while (cursor < uniqueImporters.length) {
+    while (cursor < selectedImporters.length) {
       // Check BEFORE taking work, not after: the outer fetchPhaseTimeoutMs
       // aborts and discards the entire phase, so a worker that starts a 37s
       // request it cannot finish costs every row this tick already paid for.
       if (softBudgetMs > 0 && now() - fetchStartedAt > softBudgetMs) {
-        budgetStoppedAt = uniqueImporters.length - cursor;
+        budgetStoppedAt = selectedImporters.length - cursor;
         return;
       }
-      const importer = uniqueImporters[cursor++];
+      const importer = selectedImporters[cursor++];
+      attempted += 1;
       try {
         const body = sipriFilters(importer.EntityId, startYear, maxYear);
         const json = await fetchJson(`${baseUrl}/trades/import-export-csv/`, {
@@ -399,7 +410,7 @@ export async function fetchSipriSupplierDependencies({
       .join(', ');
     logger.warn(`  SIPRI importer requests failed (${failedImporters.length}): ${preview}`);
   }
-  const unfetched = budgetStoppedAt + sweepPending;
+  const unfetched = budgetStoppedAt + deferredByCap;
   if (budgetStoppedAt > 0) {
     logger.warn(
       `  SIPRI soft budget reached after ${Math.round((now() - fetchStartedAt) / 1000)}s — `
@@ -412,7 +423,7 @@ export async function fetchSipriSupplierDependencies({
     windowEndYear: maxYear,
     sweep: {
       catalogCount: catalogImporters.length,
-      attempted: uniqueImporters.length,
+      attempted,
       fetched: Object.keys(output).length,
       // Sections this tick did not even attempt: deliberately deferred by the
       // slice, plus any the soft budget cut off.

--- a/scripts/_defense-industrial-source.mjs
+++ b/scripts/_defense-industrial-source.mjs
@@ -76,6 +76,15 @@ export const SIPRI_SWEEP_SOFT_BUDGET_MS = 220_000;
 // nothing.
 export const SIPRI_SWEEP_HORIZON_MS = 10 * 24 * 3600 * 1000;
 
+// A structurally valid CSV parses to zero suppliers two ways: the importer
+// genuinely had no major-weapon transfers in the window, or every positive
+// transfer came from an entity mapSipriEntityToIso2 does not know. Nothing at
+// the parse boundary can tell those apart, so the cohort decides: a few
+// importers going to zero is ordinary drift, most of a slice doing it at once
+// is upstream degradation. Below this count the signal is too small to act on,
+// and withholding would strand genuinely-zero importers as permanently stale.
+export const SIPRI_ZERO_REGRESSION_MIN = 5;
+
 /**
  * Importers still owed a refresh this sweep, oldest first.
  *
@@ -301,6 +310,11 @@ export async function fetchSipriSupplierDependencies({
   concurrency = 8,
   delayMs = 150,
   logger = console,
+  // Sweep mode is opt-in and these two travel together: pass NEITHER for a
+  // whole-catalog pass (the shape the unit tests and any one-shot manual run
+  // use), or BOTH to refresh one capped slice and let buildSipriSupplierSnapshot
+  // carry the rest forward. Splitting them across the caller boundary is what
+  // let the cap and the accounting disagree (#7522).
   previousSnapshot,
   maxSweepImporters,
   softBudgetMs = SIPRI_SWEEP_SOFT_BUDGET_MS,
@@ -352,9 +366,11 @@ export async function fetchSipriSupplierDependencies({
     ? staleImporters.slice(0, maxSweepImporters)
     : staleImporters;
   const deferredByCap = staleImporters.length - selectedImporters.length;
+  const previousImporters = previousSnapshot?.importers || {};
   const output = {};
   const unmapped = new Map();
   const failedImporters = [];
+  const zeroedRegressions = [];
   let cursor = 0;
   let attempted = 0;
 
@@ -386,7 +402,17 @@ export async function fetchSipriSupplierDependencies({
           windowStartYear: startYear,
           windowEndYear: maxYear,
         });
-        output[importer.iso2] = parsed;
+        // A row that HELD suppliers and now parses to none is held back until
+        // the whole slice is in: alone it is a real zero-transfer refresh, but
+        // en masse it is upstream drift that would wipe last-good data AND
+        // report the sweep complete. Rows that were already empty, or absent,
+        // publish immediately -- that is the zero-transfer fix from #7524.
+        if (parsed.suppliers.length === 0
+          && (previousImporters[importer.iso2]?.suppliers?.length || 0) > 0) {
+          zeroedRegressions.push({ iso2: importer.iso2, parsed });
+        } else {
+          output[importer.iso2] = parsed;
+        }
         for (const entity of parsed.unmappedEntities) unmapped.set(entity, (unmapped.get(entity) || 0) + 1);
       } catch (error) {
         failedImporters.push({
@@ -398,6 +424,29 @@ export async function fetchSipriSupplierDependencies({
     }
   }
   await Promise.all(Array.from({ length: Math.max(1, Math.min(concurrency, 8)) }, () => worker()));
+
+  // Cohort verdict on the withheld zero-supplier rows. When most of the slice
+  // lost every supplier at once, treat them as failures: their previous rows
+  // stay retained and stale, selectSweepImporters picks them up next tick, and
+  // failures.length > 0 keeps stage.status at 'partial' so no completion marker
+  // is written on wiped data. Otherwise they are real zero-transfer refreshes
+  // and publish as current, which is what stops them being selected forever.
+  const cohortCollapsed = zeroedRegressions.length >= SIPRI_ZERO_REGRESSION_MIN
+    && zeroedRegressions.length * 2 > attempted;
+  for (const { iso2, parsed } of zeroedRegressions) {
+    if (cohortCollapsed) {
+      failedImporters.push({ iso2, message: 'all suppliers dropped across the cohort; withheld pending retry' });
+    } else {
+      output[iso2] = parsed;
+    }
+  }
+  if (cohortCollapsed) {
+    logger.warn(
+      `  SIPRI zero-supplier cohort collapse: ${zeroedRegressions.length}/${attempted} importers lost every `
+      + 'supplier — withholding the slice and retaining last-good rows',
+    );
+  }
+
   if (unmapped.size > 0) {
     const preview = [...unmapped.entries()].slice(0, 25)
       .map(([name, count]) => `${String(name).replace(/[\u0000-\u001f\u007f]/g, ' ')} (${count})`)
@@ -487,10 +536,16 @@ export async function buildSipriSupplierSnapshot({
     .filter((importer) => Array.isArray(importer?.suppliers) && importer.suppliers.length > 0)
     .length;
   if (failures.length === 0 && positiveImporterCount < minimumCompleteImporterCount) {
-    throw new Error(
+    // Non-retryable: runSeed wraps the fetcher in withRetry, so an untagged
+    // throw re-runs the entire ~56-importer slice against a throttled host
+    // shared with seed-defense-industrial, and fetchPhaseTimeoutMs aborts the
+    // second attempt partway anyway. Fail fast into the graceful-failure path.
+    const error = new Error(
       `SIPRI snapshot holds only ${positiveImporterCount} positive importer rows; `
       + `minimum is ${minimumCompleteImporterCount}`,
     );
+    error.nonRetryable = true;
+    throw error;
   }
 
   // 'ok' is what writes the completion marker, and the marker is what stops the

--- a/scripts/_defense-industrial-source.mjs
+++ b/scripts/_defense-industrial-source.mjs
@@ -386,7 +386,7 @@ export async function fetchSipriSupplierDependencies({
           windowStartYear: startYear,
           windowEndYear: maxYear,
         });
-        if (parsed.suppliers.length > 0) output[importer.iso2] = parsed;
+        output[importer.iso2] = parsed;
         for (const entity of parsed.unmappedEntities) unmapped.set(entity, (unmapped.get(entity) || 0) + 1);
       } catch (error) {
         failedImporters.push({
@@ -483,10 +483,12 @@ export async function buildSipriSupplierSnapshot({
   // The floor applies to the MERGED snapshot, never to one tick's slice. Judging
   // a chunk by it would reject every healthy sweep tick, since a slice is
   // smaller than the floor by design.
-  const mergedImporterCount = Object.keys(importers).length;
-  if (failures.length === 0 && mergedImporterCount < minimumCompleteImporterCount) {
+  const positiveImporterCount = Object.values(importers)
+    .filter((importer) => Array.isArray(importer?.suppliers) && importer.suppliers.length > 0)
+    .length;
+  if (failures.length === 0 && positiveImporterCount < minimumCompleteImporterCount) {
     throw new Error(
-      `SIPRI snapshot holds only ${mergedImporterCount} positive importer rows; `
+      `SIPRI snapshot holds only ${positiveImporterCount} positive importer rows; `
       + `minimum is ${minimumCompleteImporterCount}`,
     );
   }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -408,13 +408,19 @@ export async function redisCommand(url, token, command, options = {}) {
   return parseRedisCommandResponse(resp, label);
 }
 
-async function redisGet(url, token, key) {
+async function redisGet(url, token, key, options = {}) {
   // Retry transient failures (timeout / network tear / 5xx / 429) with the
   // redisCommand tagging contract. A single unretried blip here silently read
   // as "key missing", which killed seed-gdelt-intel's cache-merge fallback for
   // 21h while the canonical key was healthy (issue #5437). The external
   // contract is unchanged: HTTP failures still degrade to null (now loudly),
   // thrown failures still propagate — both only after retries.
+  //
+  // `options.strict` opts a single caller out of the HTTP degrade. Degrading is
+  // right for a cache-merge reader that can proceed without the value, and
+  // wrong for one whose next step reads "no value" as a first run — the arms
+  // sweep republished a 56-row slice over its ~200-row canonical key that way.
+  // Default false keeps every existing caller byte-identical.
   let data;
   try {
     data = await withRetry(async () => {
@@ -436,7 +442,7 @@ async function redisGet(url, token, key) {
       return resp.json();
     }, SEED_REDIS_RETRY_ATTEMPTS - 1, SEED_REDIS_RETRY_BASE_MS);
   } catch (err) {
-    if (err.httpStatus == null) throw err;
+    if (err.httpStatus == null || options.strict) throw err;
     console.warn(`  Redis GET ${key}: degraded to null (${err.message})`);
     return null;
   }
@@ -1003,9 +1009,9 @@ export function logSeedResult(domain, count, durationMs, extra = {}) {
  * payload for contract-mode writes; passes legacy bare-shape values through
  * unchanged. Callers MUST NOT parse the envelope themselves.
  */
-export async function readCanonicalValue(key) {
+export async function readCanonicalValue(key, options = {}) {
   const { url, token } = getRedisCredentials();
-  return redisGet(url, token, key);
+  return redisGet(url, token, key, options);
 }
 
 export async function verifySeedKey(key) {
@@ -1131,6 +1137,13 @@ export async function writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKey
 // keys so callers that publish per-key health can distinguish a confirmed
 // EXPIRE no-op from a successful extension and from a pipeline result that
 // could not be confirmed at all.
+//
+// `options.allowMissingKeys` is LOG-ONLY: it suppresses the "manual seed
+// required" warning for keys whose absence is expected (an optional marker that
+// has never been written), but `missingKeys` still lists them and `allExtended`
+// is still false. A caller that needs "absent is fine" must branch on
+// missingKeys — the boolean deliberately keeps its #5364 meaning, where a
+// no-op is a real data condition rather than a transient error.
 export async function extendExistingTtlDetailed(keys, ttlSeconds = 600, options = {}) {
   const requestedKeys = Array.isArray(keys) ? keys : [];
   const allowMissingKeys = new Set(
@@ -1222,8 +1235,8 @@ export async function extendExistingTtlDetailed(keys, ttlSeconds = 600, options 
 // proof the data is still alive (e.g. a market-closed skip that then reports
 // fresh) MUST gate on this boolean and fall back to a real fetch on false —
 // otherwise a silent extension failure looks green while the key expires.
-export async function extendExistingTtl(keys, ttlSeconds = 600) {
-  const result = await extendExistingTtlDetailed(keys, ttlSeconds);
+export async function extendExistingTtl(keys, ttlSeconds = 600, options = {}) {
+  const result = await extendExistingTtlDetailed(keys, ttlSeconds, options);
   return result.allExtended;
 }
 
@@ -2003,6 +2016,12 @@ export function parseYahooChart(data, symbol) {
  * instead of clobbering a good cached payload with an empty recordCount=0 one on
  * a partial upstream fetch. The canonical key is already guarded by validateFn;
  * this closes the same gap for extra keys. Pure function — extracted for tests.
+ *
+ * A companion extra-key option, `allowMissingOnSkip: true`, marks a key whose
+ * ABSENCE is expected rather than alarming — a completion marker that is not
+ * written until the final tick of a multi-tick sweep. It downgrades the
+ * "manual seed required" warning to an info line on every preservation path,
+ * and is meaningless without `skipWhenEmpty`.
  */
 export function shouldSkipEmptyExtraKey(ek, recordCount) {
   return Boolean(ek && ek.skipWhenEmpty) && recordCount === 0;
@@ -2222,6 +2241,17 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     ...preserveKeys,
   ].filter((key) => typeof key === 'string' && key.length > 0))];
 
+  // Extra keys whose absence is expected rather than alarming (see
+  // shouldSkipEmptyExtraKey). Threaded into EVERY preservation call, not just
+  // the empty-skip branch: the fetch-failure, SIGTERM, contract-RETRY,
+  // atomic-publish-failure and validation-skip paths all preserve the same key
+  // set, and warning "manual seed required" for a marker that is not supposed
+  // to exist yet is the false alarm allowMissingOnSkip exists to remove.
+  const optionalPreservationKeys = (extraKeys || [])
+    .filter((ek) => ek && ek.allowMissingOnSkip)
+    .map((ek) => ek.key)
+    .filter((key) => typeof key === 'string' && key.length > 0);
+
   // Single preservation seam for fetch failure, fetch-phase SIGTERM, contract
   // RETRY, validation skip, and per-extra-key empty skips. Grouping keys by TTL
   // keeps one Redis pipeline per TTL while allowing explicit declarations to
@@ -2241,7 +2271,9 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       keysByTtl.get(targetTtl).push(key);
     }
     const results = await Promise.all(
-      [...keysByTtl].map(([targetTtl, keys]) => extendExistingTtl(keys, targetTtl)),
+      [...keysByTtl].map(([targetTtl, keys]) => extendExistingTtl(keys, targetTtl, {
+        allowMissingKeys: optionalPreservationKeys,
+      })),
     );
     return results.every(Boolean);
   };
@@ -2668,7 +2700,11 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
           // Opt-in skip-empty: don't overwrite a good cached extra-key payload
           // with a recordCount=0 write on a partial fetch (e.g. a token panel
           // whose IDs the upstream dropped this cycle). Preserve last-good by
-          // extending the existing key's TTL instead.
+          // extending the existing key's TTL instead. Three outcomes, reported
+          // distinctly because they mean different things to an operator:
+          // preserved (EXPIRE confirmed), expected-absent (an
+          // allowMissingOnSkip key that has not been written yet), or a real
+          // preservation failure / unconfirmed pipeline result.
           if (shouldSkipEmptyExtraKey(ek, ekCount)) {
             const preservation = await extendExistingTtlDetailed(
               [ek.key],

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1131,8 +1131,11 @@ export async function writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKey
 // keys so callers that publish per-key health can distinguish a confirmed
 // EXPIRE no-op from a successful extension and from a pipeline result that
 // could not be confirmed at all.
-export async function extendExistingTtlDetailed(keys, ttlSeconds = 600) {
+export async function extendExistingTtlDetailed(keys, ttlSeconds = 600, options = {}) {
   const requestedKeys = Array.isArray(keys) ? keys : [];
+  const allowMissingKeys = new Set(
+    Array.isArray(options?.allowMissingKeys) ? options.allowMissingKeys : [],
+  );
   if (requestedKeys.length === 0) {
     return {
       allExtended: true,
@@ -1192,7 +1195,8 @@ export async function extendExistingTtlDetailed(keys, ttlSeconds = 600) {
       }
     }
     if (extendedKeys.length > 0) console.log(`  Extended TTL on ${extendedKeys.length} key(s) (${ttlSeconds}s)`);
-    if (missingKeys.length > 0) console.warn(`  WARNING: ${missingKeys.length} key(s) were expired/missing — EXPIRE was a no-op; manual seed required`);
+    const strictMissingKeys = missingKeys.filter((key) => !allowMissingKeys.has(key));
+    if (strictMissingKeys.length > 0) console.warn(`  WARNING: ${strictMissingKeys.length} key(s) were expired/missing — EXPIRE was a no-op; manual seed required`);
     if (unconfirmedKeys.length > 0) console.warn(`  WARNING: TTL extension result was unconfirmed for ${unconfirmedKeys.length} key(s)`);
     return {
       allExtended: extendedKeys.length === requestedKeys.length,
@@ -2666,11 +2670,18 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
           // whose IDs the upstream dropped this cycle). Preserve last-good by
           // extending the existing key's TTL instead.
           if (shouldSkipEmptyExtraKey(ek, ekCount)) {
-            await preserveExistingKeys([{
-              key: ek.key,
-              ttlSeconds: ek.ttl || ttlSeconds || 600,
-            }]);
-            console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, extended TTL to preserve last-good`);
+            const preservation = await extendExistingTtlDetailed(
+              [ek.key],
+              ek.ttl || ttlSeconds || 600,
+              { allowMissingKeys: ek.allowMissingOnSkip ? [ek.key] : [] },
+            );
+            if (preservation.allExtended) {
+              console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, extended TTL to preserve last-good`);
+            } else if (ek.allowMissingOnSkip && preservation.missingKeys.includes(ek.key)) {
+              console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, optional last-good key was absent`);
+            } else {
+              console.warn(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, TTL preservation failed or was unconfirmed`);
+            }
             continue;
           }
           ekEnvelope = {

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1138,12 +1138,18 @@ export async function writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKey
 // EXPIRE no-op from a successful extension and from a pipeline result that
 // could not be confirmed at all.
 //
-// `options.allowMissingKeys` is LOG-ONLY: it suppresses the "manual seed
-// required" warning for keys whose absence is expected (an optional marker that
-// has never been written), but `missingKeys` still lists them and `allExtended`
-// is still false. A caller that needs "absent is fine" must branch on
-// missingKeys — the boolean deliberately keeps its #5364 meaning, where a
-// no-op is a real data condition rather than a transient error.
+// `options.allowMissingKeys` names keys whose absence is EXPECTED (an optional
+// marker that has not been written yet). For those keys a confirmed EXPIRE
+// no-op stops being a failure: the "manual seed required" warning is suppressed
+// and `allExtended` forgives them. That second half is load-bearing --
+// `allExtended` gates runSeed's RETRY exit(1) and its preservationSucceeded
+// diagnostic, so treating an expected-absent marker as a preservation failure
+// would crash-loop a seeder over a key that is not supposed to exist yet.
+//
+// The #5364 contract is otherwise intact: a no-op on any key NOT in this list is
+// still a real data condition, an unconfirmed result is still a failure even for
+// a listed key, and `missingKeys` still reports every no-op for callers that
+// need per-key truth.
 export async function extendExistingTtlDetailed(keys, ttlSeconds = 600, options = {}) {
   const requestedKeys = Array.isArray(keys) ? keys : [];
   const allowMissingKeys = new Set(
@@ -1212,7 +1218,16 @@ export async function extendExistingTtlDetailed(keys, ttlSeconds = 600, options 
     if (strictMissingKeys.length > 0) console.warn(`  WARNING: ${strictMissingKeys.length} key(s) were expired/missing — EXPIRE was a no-op; manual seed required`);
     if (unconfirmedKeys.length > 0) console.warn(`  WARNING: TTL extension result was unconfirmed for ${unconfirmedKeys.length} key(s)`);
     return {
-      allExtended: extendedKeys.length === requestedKeys.length,
+      // An allowed-missing key is EXCLUDED from this verdict, not just from the
+      // warning: `allExtended` gates runSeed's RETRY exit(1) and its
+      // preservationSucceeded diagnostic, so counting an expected-absent marker
+      // as a preservation failure would crash-loop a seeder over a key that is
+      // not supposed to exist yet. The second clause requires a CONFIRMED no-op
+      // -- an allowed-missing key whose EXPIRE result could not be read is still
+      // a failure, because "we could not tell" is not "expectedly absent".
+      allExtended: requestedKeys.every((key) => (
+        extendedKeys.includes(key) || (allowMissingKeys.has(key) && missingKeys.includes(key))
+      )),
       extendedKeys,
       missingKeys,
       unconfirmedKeys,
@@ -2711,7 +2726,10 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
               ek.ttl || ttlSeconds || 600,
               { allowMissingKeys: ek.allowMissingOnSkip ? [ek.key] : [] },
             );
-            if (preservation.allExtended) {
+            // Per-key truth, not allExtended: that verdict now forgives an
+            // allowed-missing key, so it would report a preserved TTL for a key
+            // that is simply absent.
+            if (preservation.extendedKeys.includes(ek.key)) {
               console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, extended TTL to preserve last-good`);
             } else if (ek.allowMissingOnSkip && preservation.missingKeys.includes(ek.key)) {
               console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, optional last-good key was absent`);

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -349,6 +349,7 @@
       ]
     ],
     "watchPatterns": [
+      "scripts/_arms-suppliers-sweep.mjs",
       "scripts/_bundle-runner.mjs",
       "scripts/_static-ref-heavy-order.mjs",
       "scripts/_defense-industrial-source.mjs",

--- a/scripts/seed-defense-industrial-suppliers.mjs
+++ b/scripts/seed-defense-industrial-suppliers.mjs
@@ -3,49 +3,29 @@
 import { loadEnvFile, readCanonicalValue, runSeed } from './_seed-utils.mjs';
 import {
   buildArmsSupplierCompletion,
-  buildSipriSupplierSnapshot,
   DEFENSE_INDUSTRIAL_TTL_SECONDS,
-  fetchSipriSupplierDependencies,
-  SIPRI_SWEEP_CHUNK,
 } from './_defense-industrial-source.mjs';
+import {
+  ARMS_SUPPLIERS_COMPLETE_KEY,
+  ARMS_SUPPLIERS_KEY,
+  fetchSupplierSnapshot,
+  supplierContentMeta,
+  validateArmsSuppliers,
+} from './_arms-suppliers-sweep.mjs';
 
 loadEnvFile(import.meta.url, { only: ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN', 'SIPRI_ARMS_API_BASE_URL'] });
 
-export const ARMS_SUPPLIERS_KEY = 'military:arms-suppliers:v1';
-export const ARMS_SUPPLIERS_COMPLETE_KEY = 'military:arms-suppliers:complete:v1';
+export { ARMS_SUPPLIERS_COMPLETE_KEY, ARMS_SUPPLIERS_KEY };
 
-export function validateArmsSuppliers(data) {
-  return data && Object.keys(data.importers || {}).length > 0;
-}
+// strict: an Upstash HTTP error must NOT read as an absent key here. redisGet
+// degrades HTTP failures to null by default, which would make a transient 5xx
+// look like a first run and republish one 56-importer slice over the ~200-row
+// canonical key.
+const readSnapshot = (key) => readCanonicalValue(key, { strict: true });
 
-export function supplierContentMeta(data) {
-  const endYears = Object.values(data.importers || {})
-    .map((entry) => entry?.window?.endYear)
-    .filter(Number.isInteger);
-  if (endYears.length === 0) return null;
-  return {
-    newestItemAt: Date.UTC(Math.max(...endYears), 11, 31, 23, 59, 59),
-    oldestItemAt: Date.UTC(Math.min(...endYears), 0, 1),
-  };
-}
-
-async function fetchSupplierSnapshot() {
-  const previousSnapshot = await readCanonicalValue(ARMS_SUPPLIERS_KEY);
-  const previous = previousSnapshot || {};
-  return buildSipriSupplierSnapshot({
-    previousSnapshot: previous,
-    // One SLICE per tick. The full ~200-importer catalog needs ~800s at the
-    // measured 31.8s/request and Railway kills the container at 600s, so a
-    // whole-catalog pass cannot be made to fit at any deadline.
-    fetchSipri: (options) => fetchSipriSupplierDependencies({
-      ...options,
-      previousSnapshot: previous,
-      maxSweepImporters: SIPRI_SWEEP_CHUNK,
-    }),
-  });
-}
-
-await runSeed('military', 'arms-suppliers', ARMS_SUPPLIERS_KEY, fetchSupplierSnapshot, {
+await runSeed('military', 'arms-suppliers', ARMS_SUPPLIERS_KEY, () => fetchSupplierSnapshot({
+  readCanonical: readSnapshot,
+}), {
   validateFn: validateArmsSuppliers,
   ttlSeconds: DEFENSE_INDUSTRIAL_TTL_SECONDS,
   lockTtlMs: 7 * 60 * 1000,

--- a/scripts/seed-defense-industrial-suppliers.mjs
+++ b/scripts/seed-defense-industrial-suppliers.mjs
@@ -6,7 +6,6 @@ import {
   buildSipriSupplierSnapshot,
   DEFENSE_INDUSTRIAL_TTL_SECONDS,
   fetchSipriSupplierDependencies,
-  selectSweepImporters,
   SIPRI_SWEEP_CHUNK,
 } from './_defense-industrial-source.mjs';
 
@@ -31,7 +30,7 @@ export function supplierContentMeta(data) {
 }
 
 async function fetchSupplierSnapshot() {
-  const previousSnapshot = await readCanonicalValue(ARMS_SUPPLIERS_KEY).catch(() => null);
+  const previousSnapshot = await readCanonicalValue(ARMS_SUPPLIERS_KEY);
   const previous = previousSnapshot || {};
   return buildSipriSupplierSnapshot({
     previousSnapshot: previous,
@@ -40,11 +39,8 @@ async function fetchSupplierSnapshot() {
     // whole-catalog pass cannot be made to fit at any deadline.
     fetchSipri: (options) => fetchSipriSupplierDependencies({
       ...options,
-      selectImporters: (candidates, windowEndYear) => selectSweepImporters(
-        candidates,
-        previous,
-        windowEndYear,
-      ).slice(0, SIPRI_SWEEP_CHUNK),
+      previousSnapshot: previous,
+      maxSweepImporters: SIPRI_SWEEP_CHUNK,
     }),
   });
 }
@@ -77,6 +73,7 @@ await runSeed('military', 'arms-suppliers', ARMS_SUPPLIERS_KEY, fetchSupplierSna
       transform: buildArmsSupplierCompletion,
       declareRecords: (data) => data.completedAt ? 1 : 0,
       skipWhenEmpty: true,
+      allowMissingOnSkip: true,
       metaKey: 'seed-meta:military:arms-suppliers-complete',
       metaTtlSeconds: DEFENSE_INDUSTRIAL_TTL_SECONDS,
       metaExtra: (data) => ({

--- a/shared/defense-industrial-response.ts
+++ b/shared/defense-industrial-response.ts
@@ -110,7 +110,13 @@ export function buildDefenseIndustrialResponse(
 ): DefenseIndustrialResponseValue {
   const country = industrial?.countries?.[countryCode];
   const dependency = dependencies?.importers?.[countryCode];
-  if (!country && !dependency) return emptyResponse(countryCode);
+  // Presence is not content. Since the sweep began recording zero-transfer
+  // importers, a row can exist carrying no suppliers at all; treating that as
+  // `available` renders an all-"Not available" panel where a clean empty
+  // response belongs, because the shape has no way to say "checked, genuinely
+  // zero". Gate on supplier content instead.
+  const hasDependency = (dependency?.suppliers?.length || 0) > 0;
+  if (!country && !hasDependency) return emptyResponse(countryCode);
   const suppliers = (dependency?.suppliers || [])
     .filter((entry) => (
       /^[A-Z]{2}$/.test(String(entry.supplierIso2 || ''))

--- a/tests/get-defense-industrial-base.test.mts
+++ b/tests/get-defense-industrial-base.test.mts
@@ -49,6 +49,39 @@ describe('get-defense-industrial-base response mapping', () => {
     assert.equal(response.supplierRetained, true);
   });
 
+  it('does not report a zero-transfer importer row as available', () => {
+    // The sweep now records importers whose window held no major-weapon
+    // transfers, so a row can exist carrying no suppliers. Row presence must not
+    // read as availability -- that renders an all-"Not available" panel where a
+    // clean empty response belongs.
+    const response = buildDefenseIndustrialResponse('ZZ', { countries: {} }, {
+      importers: { ZZ: {
+        suppliers: [],
+        supplierHhi: 0,
+        window: { startYear: 2021, endYear: 2025 },
+        fetchedAt: '2026-07-01T00:00:00.000Z',
+        retained: false,
+      } },
+      fetchedAt: '2026-08-12T00:00:00.000Z',
+    });
+
+    assert.equal(response.available, false);
+    assert.equal(response.countryCode, 'ZZ');
+  });
+
+  it('still reports a zero-transfer importer that has World Bank data', () => {
+    const response = buildDefenseIndustrialResponse('UA', {
+      fetchedAt: '2026-08-12T00:00:00.000Z',
+      countries: { UA: { expenditurePctGdp: { value: 34.5, year: 2024, source: 'World Bank' } } },
+    }, {
+      importers: { UA: { suppliers: [], window: { startYear: 2021, endYear: 2025 } } },
+      fetchedAt: '2026-08-12T00:00:00.000Z',
+    });
+
+    assert.equal(response.available, true);
+    assert.deepEqual(response.suppliers, []);
+  });
+
   it('returns an explicit unavailable response for a missing country', () => {
     const response = buildDefenseIndustrialResponse('ZZ', { countries: {} }, { importers: {} });
     assert.equal(response.available, false);

--- a/tests/seed-defense-industrial.test.mjs
+++ b/tests/seed-defense-industrial.test.mjs
@@ -115,7 +115,16 @@ describe('defense-industrial source parsing', () => {
   it('rejects an all-empty complete SIPRI cohort and does not create a completion marker', async () => {
     await assert.rejects(
       () => buildSipriSupplierSnapshot({
-        fetchSipri: async () => ({ importers: {}, failedImporters: [], windowEndYear: 2025 }),
+        fetchSipri: async () => ({
+          importers: {
+            UA: {
+              suppliers: [],
+              window: { startYear: 2021, endYear: 2025 },
+            },
+          },
+          failedImporters: [],
+          windowEndYear: 2025,
+        }),
         minimumCompleteImporterCount: 1,
       }),
       /holds only 0 positive importer rows/,
@@ -476,7 +485,11 @@ describe('SIPRI chunked sweep (#6806)', () => {
     // would reject every healthy sweep tick.
     const previous = {
       importers: Object.fromEntries(
-        Array.from({ length: 30 }, (_, i) => [`X${i}`, { suppliers: [], window: { endYear: 2025 }, fetchedAt: iso(NOW - 3600_000) }]),
+        Array.from({ length: 30 }, (_, i) => [`X${i}`, {
+          suppliers: [{ supplierIso2: 'US', tivShare: 1 }],
+          window: { endYear: 2025 },
+          fetchedAt: iso(NOW - 3600_000),
+        }]),
       ),
     };
     const snapshot = await buildSipriSupplierSnapshot({
@@ -484,7 +497,12 @@ describe('SIPRI chunked sweep (#6806)', () => {
       minimumCompleteImporterCount: 25,
       now: () => new Date(NOW),
       fetchSipri: async () => ({
-        importers: { FR: { suppliers: [], window: { endYear: 2025 } } },
+        importers: {
+          FR: {
+            suppliers: [{ supplierIso2: 'US', tivShare: 1 }],
+            window: { endYear: 2025 },
+          },
+        },
         failedImporters: [],
         windowEndYear: 2025,
         sweep: { catalogCount: 31, attempted: 1, fetched: 1, unfetched: 30 },
@@ -676,6 +694,44 @@ describe('SIPRI chunked sweep (#6806)', () => {
       selectSweepImporters([{ iso2: importerCodes[0] }], snapshot, 2025, NOW)
         .map((importer) => importer.iso2),
       [importerCodes[0]],
+    );
+  });
+
+  it('records a successful zero-transfer importer as current before completing the sweep', async () => {
+    const previous = previousSnapshot(1);
+    const headerOnlyCsv = 'Supplier,2021-2025\n';
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch({
+        importerResponse: () => new Response(JSON.stringify({
+          bytes: Buffer.from(headerOnlyCsv).toString('base64'),
+        })),
+      }),
+      previousSnapshot: previous,
+      maxSweepImporters: 56,
+      concurrency: 1,
+      delayMs: 0,
+      now: () => NOW,
+    });
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      fetchSipri: async () => result,
+      now: () => new Date(NOW),
+    });
+    const importerIso2 = importerCodes[0];
+
+    assert.deepEqual(result.importers[importerIso2].suppliers, []);
+    assert.equal(result.sweep.fetched, 1);
+    assert.equal(result.sweep.unfetched, 0);
+    assert.deepEqual(snapshot.importers[importerIso2].suppliers, []);
+    assert.equal(snapshot.importers[importerIso2].retained, false);
+    assert.equal(snapshot.importers[importerIso2].fetchedAt, iso(NOW));
+    assert.deepEqual(
+      selectSweepImporters([{ iso2: importerIso2 }], snapshot, 2025, NOW),
+      [],
+    );
+    assert.deepEqual(
+      buildArmsSupplierCompletion(snapshot),
+      { completedAt: iso(NOW), windowEndYear: 2025 },
     );
   });
 

--- a/tests/seed-defense-industrial.test.mjs
+++ b/tests/seed-defense-industrial.test.mjs
@@ -765,6 +765,23 @@ describe('SIPRI chunked sweep (#6806)', () => {
     );
   });
 
+  it('tags a floor rejection non-retryable so withRetry cannot re-run the slice', async () => {
+    // runSeed wraps the fetcher in withRetry; an untagged throw re-runs all 56
+    // POSTs against a throttled host shared with seed-defense-industrial, and
+    // fetchPhaseTimeoutMs aborts the second attempt partway anyway.
+    await assert.rejects(
+      () => buildSipriSupplierSnapshot({
+        fetchSipri: async () => ({
+          importers: { UA: { suppliers: [], window: { endYear: 2025 } } },
+          failedImporters: [],
+          windowEndYear: 2025,
+        }),
+        minimumCompleteImporterCount: 1,
+      }),
+      (error) => error.nonRetryable === true && /positive importer rows/.test(error.message),
+    );
+  });
+
   it('withholds a collapsed zero-supplier cohort instead of publishing wiped rows', async () => {
     // Every attempted importer previously HAD suppliers and now parses clean
     // with none. That is upstream degradation, not 56 countries simultaneously

--- a/tests/seed-defense-industrial.test.mjs
+++ b/tests/seed-defense-industrial.test.mjs
@@ -11,10 +11,13 @@ import {
   fetchSipriSupplierDependencies,
   mapSipriEntityToIso2,
   selectSweepImporters,
+  SIPRI_SWEEP_CHUNK,
   SIPRI_SWEEP_HORIZON_MS,
+  SIPRI_ZERO_REGRESSION_MIN,
   parseSipriSupplierCsv,
   parseWbIndicatorPage,
 } from '../scripts/_defense-industrial-source.mjs';
+import { fetchSupplierSnapshot } from '../scripts/_arms-suppliers-sweep.mjs';
 
 const wbFixture = JSON.parse(readFileSync(new URL('./fixtures/defense-industrial/wb-ms-mil.json', import.meta.url), 'utf8'));
 const sipriFixture = readFileSync(new URL('./fixtures/defense-industrial/sipri-importer.csv', import.meta.url), 'utf8');
@@ -181,29 +184,56 @@ describe('defense-industrial deployment wiring', () => {
     assert.match(supplierSeeder, /maxContentAgeMin:\s*800 \* 24 \* 60/);
   });
 
-  it('passes both production sweep inputs without the callback contract', () => {
-    const root = join(dirname(fileURLToPath(import.meta.url)), '..');
-    const supplierSeeder = readFileSync(join(root, 'scripts/seed-defense-industrial-suppliers.mjs'), 'utf8');
+  it('passes both production sweep inputs without the callback contract', async () => {
+    // Executed, not regex-matched: a positional source regex reds on a
+    // behaviour-identical property reorder and stays green if the caller passes
+    // the pair and then ignores it.
+    let received = null;
+    await fetchSupplierSnapshot({
+      readCanonical: async () => ({ importers: { FR: { suppliers: [], window: { endYear: 2025 } } } }),
+      buildSnapshot: async ({ fetchSipri }) => { await fetchSipri({ fetchFn: async () => new Response('{}') }); return {}; },
+      fetchSipri: async (options) => { received = options; return { importers: {} }; },
+    });
 
     assert.deepEqual({
-      pairedInputs: /fetchSipriSupplierDependencies\(\{\s*\.\.\.options,\s*previousSnapshot:\s*previous,\s*maxSweepImporters:\s*SIPRI_SWEEP_CHUNK,?\s*\}\)/s
-        .test(supplierSeeder),
-      selectImporters: /selectImporters:/.test(supplierSeeder),
+      previousSnapshot: received.previousSnapshot,
+      maxSweepImporters: received.maxSweepImporters,
     }, {
-      pairedInputs: true,
-      selectImporters: false,
+      previousSnapshot: { importers: { FR: { suppliers: [], window: { endYear: 2025 } } } },
+      maxSweepImporters: SIPRI_SWEEP_CHUNK,
     });
   });
 
-  it('propagates a previous-snapshot read failure', () => {
+  it('does not reintroduce the removed selectImporters callback', () => {
+    const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+    for (const file of ['scripts/seed-defense-industrial-suppliers.mjs', 'scripts/_arms-suppliers-sweep.mjs']) {
+      assert.equal(
+        /selectImporters:/.test(readFileSync(join(root, file), 'utf8')),
+        false,
+        `${file} must not pass the removed selectImporters callback`,
+      );
+    }
+  });
+
+  it('propagates a previous-snapshot read failure instead of sweeping as a first run', async () => {
+    // The failure this names is the one redisGet's default degrade-to-null hides:
+    // a snapshot that reads as absent is indistinguishable from a first run, and
+    // a first run republishes one 56-row slice over the ~200-row canonical key.
+    let sweepStarted = false;
+    await assert.rejects(
+      () => fetchSupplierSnapshot({
+        readCanonical: async () => { throw new Error('Redis GET failed: HTTP 503'); },
+        buildSnapshot: async () => { sweepStarted = true; return {}; },
+      }),
+      /HTTP 503/,
+    );
+    assert.equal(sweepStarted, false, 'no sweep may start when the previous snapshot could not be read');
+  });
+
+  it('reads the canonical snapshot in strict mode so an HTTP error cannot look absent', () => {
     const root = join(dirname(fileURLToPath(import.meta.url)), '..');
     const supplierSeeder = readFileSync(join(root, 'scripts/seed-defense-industrial-suppliers.mjs'), 'utf8');
-
-    assert.equal(
-      /const previousSnapshot = await readCanonicalValue\(ARMS_SUPPLIERS_KEY\);/.test(supplierSeeder),
-      true,
-      'readCanonicalValue failure must propagate out of fetchSupplierSnapshot',
-    );
+    assert.match(supplierSeeder, /readCanonicalValue\(key,\s*\{\s*strict:\s*true\s*\}\)/);
   });
 });
 
@@ -733,6 +763,89 @@ describe('SIPRI chunked sweep (#6806)', () => {
       buildArmsSupplierCompletion(snapshot),
       { completedAt: iso(NOW), windowEndYear: 2025 },
     );
+  });
+
+  it('withholds a collapsed zero-supplier cohort instead of publishing wiped rows', async () => {
+    // Every attempted importer previously HAD suppliers and now parses clean
+    // with none. That is upstream degradation, not 56 countries simultaneously
+    // ceasing arms imports, so the slice must be withheld and retried.
+    const previous = previousSnapshot(importerCodes.length);
+    const headerOnlyCsv = 'Supplier,2021-2025\n';
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch({
+        importerResponse: () => new Response(JSON.stringify({
+          bytes: Buffer.from(headerOnlyCsv).toString('base64'),
+        })),
+      }),
+      previousSnapshot: previous,
+      maxSweepImporters: 56,
+      concurrency: 1,
+      delayMs: 0,
+      now: () => NOW,
+    });
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      fetchSipri: async () => result,
+      now: () => new Date(NOW),
+    });
+
+    assert.deepEqual({
+      published: Object.keys(result.importers).length,
+      failed: result.failedImporters.length,
+      status: snapshot.stage.status,
+      completion: buildArmsSupplierCompletion(snapshot),
+    }, {
+      published: 0,
+      failed: 56,
+      status: 'partial',
+      completion: {},
+    });
+    // Last-good data survived and the withheld importers stay selectable.
+    assert.deepEqual(snapshot.importers[importerCodes[0]].suppliers, [{ supplierIso2: 'US', tivShare: 1 }]);
+    assert.equal(snapshot.importers[importerCodes[0]].retained, true);
+    assert.equal(
+      selectSweepImporters([{ iso2: importerCodes[0] }], snapshot, 2025, NOW).length,
+      1,
+    );
+  });
+
+  it('still publishes a zero-transfer refresh below the cohort-collapse floor', async () => {
+    // The counterpart to the test above: a handful of genuine zero-transfer
+    // importers must still become current, or the #7524 fix regresses and they
+    // stay stale forever.
+    const staleCount = SIPRI_ZERO_REGRESSION_MIN - 1;
+    const previous = previousSnapshot(staleCount);
+    const headerOnlyCsv = 'Supplier,2021-2025\n';
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch({
+        importerResponse: () => new Response(JSON.stringify({
+          bytes: Buffer.from(headerOnlyCsv).toString('base64'),
+        })),
+      }),
+      previousSnapshot: previous,
+      maxSweepImporters: 56,
+      concurrency: 1,
+      delayMs: 0,
+      now: () => NOW,
+    });
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      fetchSipri: async () => result,
+      now: () => new Date(NOW),
+    });
+
+    assert.deepEqual({
+      published: Object.keys(result.importers).length,
+      failed: result.failedImporters.length,
+      unfetched: result.sweep.unfetched,
+      completion: buildArmsSupplierCompletion(snapshot),
+    }, {
+      published: staleCount,
+      failed: 0,
+      unfetched: 0,
+      completion: { completedAt: iso(NOW), windowEndYear: 2025 },
+    });
+    assert.equal(snapshot.importers[importerCodes[0]].retained, false);
   });
 
   it('the soft budget returns partial progress instead of losing the tick', async () => {

--- a/tests/seed-defense-industrial.test.mjs
+++ b/tests/seed-defense-industrial.test.mjs
@@ -324,13 +324,19 @@ describe('SIPRI chunked sweep (#6806)', () => {
       Name: importerCodes[index % count],
     }),
   );
-  const makeSipriFetch = ({ importerCount = importerCodes.length, onImporter = () => {} } = {}) => async (url) => {
+  const makeSipriFetch = ({
+    importerCount = importerCodes.length,
+    onImporter = () => {},
+    importerResponse = () => new Response(JSON.stringify({
+      bytes: Buffer.from(sipriFixture).toString('base64'),
+    })),
+  } = {}) => async (url) => {
     if (String(url).includes('getMaxYear')) return new Response('2025');
     if (String(url).includes('getAllCountriesTrimmed')) {
       return new Response(JSON.stringify(importerCatalog(importerCount)));
     }
     onImporter();
-    return new Response(JSON.stringify({ bytes: Buffer.from(sipriFixture).toString('base64') }));
+    return importerResponse();
   };
   const previousSnapshot = (staleCount) => ({
     importers: Object.fromEntries(importerCodes.map((iso2, index) => [iso2, {
@@ -515,6 +521,53 @@ describe('SIPRI chunked sweep (#6806)', () => {
     });
   });
 
+  it('a fully current production sweep starts no requests and completes', async () => {
+    let served = 0;
+    const previous = previousSnapshot(0);
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch({ onImporter: () => { served += 1; } }),
+      previousSnapshot: previous,
+      maxSweepImporters: 56,
+      now: () => NOW,
+    });
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      fetchSipri: async () => result,
+      now: () => new Date(NOW),
+    });
+
+    assert.deepEqual({
+      served,
+      attempted: result.sweep.attempted,
+      unfetched: result.sweep.unfetched,
+      completion: buildArmsSupplierCompletion(snapshot),
+    }, {
+      served: 0,
+      attempted: 0,
+      unfetched: 0,
+      completion: { completedAt: iso(NOW), windowEndYear: 2025 },
+    });
+  });
+
+  it('selects exactly the cap without reporting a deferred importer', async () => {
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch(),
+      previousSnapshot: previousSnapshot(56),
+      maxSweepImporters: 56,
+      concurrency: 1,
+      delayMs: 0,
+      now: () => NOW,
+    });
+
+    assert.deepEqual({
+      attempted: result.sweep.attempted,
+      unfetched: result.sweep.unfetched,
+    }, {
+      attempted: 56,
+      unfetched: 0,
+    });
+  });
+
   it('reports stale importers deferred above the sweep limit', async () => {
     const result = await fetchSipriSupplierDependencies({
       fetchFn: makeSipriFetch(),
@@ -551,9 +604,22 @@ describe('SIPRI chunked sweep (#6806)', () => {
     });
   }
 
-  it('counts only importer requests started before the soft budget', async () => {
+  for (const maxSweepImporters of [-1, 0, 1.5, Number.POSITIVE_INFINITY]) {
+    it(`rejects an invalid sweep cap of ${maxSweepImporters}`, async () => {
+      await assert.rejects(
+        () => fetchSipriSupplierDependencies({
+          fetchFn: makeSipriFetch(),
+          previousSnapshot: {},
+          maxSweepImporters,
+        }),
+        /maxSweepImporters must be a positive safe integer/,
+      );
+    });
+  }
+
+  it('counts cap deferrals and only requests started before the soft budget', async () => {
     let served = 0;
-    let clock = 0;
+    let clock = NOW;
     const result = await fetchSipriSupplierDependencies({
       fetchFn: makeSipriFetch({
         onImporter: () => {
@@ -561,6 +627,8 @@ describe('SIPRI chunked sweep (#6806)', () => {
           clock += 10_000;
         },
       }),
+      previousSnapshot: previousSnapshot(importerCodes.length),
+      maxSweepImporters: 56,
       concurrency: 1,
       delayMs: 0,
       softBudgetMs: 15_000,
@@ -576,6 +644,39 @@ describe('SIPRI chunked sweep (#6806)', () => {
       attempted: 2,
       unfetched: 58,
     });
+  });
+
+  it('keeps a started request failure separate from unfetched and eligible for retry', async () => {
+    const previous = previousSnapshot(1);
+    const malformedCsv = 'Supplier,2021-2025\n"United States,10';
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch({
+        importerResponse: () => new Response(JSON.stringify({
+          bytes: Buffer.from(malformedCsv).toString('base64'),
+        })),
+      }),
+      previousSnapshot: previous,
+      maxSweepImporters: 56,
+      concurrency: 1,
+      delayMs: 0,
+      now: () => NOW,
+    });
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      fetchSipri: async () => result,
+      now: () => new Date(NOW),
+    });
+
+    assert.equal(result.sweep.attempted, 1);
+    assert.equal(result.sweep.unfetched, 0);
+    assert.equal(result.failedImporters.length, 1);
+    assert.equal(snapshot.stage.status, 'partial');
+    assert.deepEqual(buildArmsSupplierCompletion(snapshot), {});
+    assert.deepEqual(
+      selectSweepImporters([{ iso2: importerCodes[0] }], snapshot, 2025, NOW)
+        .map((importer) => importer.iso2),
+      [importerCodes[0]],
+    );
   });
 
   it('the soft budget returns partial progress instead of losing the tick', async () => {

--- a/tests/seed-defense-industrial.test.mjs
+++ b/tests/seed-defense-industrial.test.mjs
@@ -171,6 +171,31 @@ describe('defense-industrial deployment wiring', () => {
     assert.match(supplierSeeder, /transform:\s*buildArmsSupplierCompletion/);
     assert.match(supplierSeeder, /maxContentAgeMin:\s*800 \* 24 \* 60/);
   });
+
+  it('passes both production sweep inputs without the callback contract', () => {
+    const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+    const supplierSeeder = readFileSync(join(root, 'scripts/seed-defense-industrial-suppliers.mjs'), 'utf8');
+
+    assert.deepEqual({
+      pairedInputs: /fetchSipriSupplierDependencies\(\{\s*\.\.\.options,\s*previousSnapshot:\s*previous,\s*maxSweepImporters:\s*SIPRI_SWEEP_CHUNK,?\s*\}\)/s
+        .test(supplierSeeder),
+      selectImporters: /selectImporters:/.test(supplierSeeder),
+    }, {
+      pairedInputs: true,
+      selectImporters: false,
+    });
+  });
+
+  it('propagates a previous-snapshot read failure', () => {
+    const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+    const supplierSeeder = readFileSync(join(root, 'scripts/seed-defense-industrial-suppliers.mjs'), 'utf8');
+
+    assert.equal(
+      /const previousSnapshot = await readCanonicalValue\(ARMS_SUPPLIERS_KEY\);/.test(supplierSeeder),
+      true,
+      'readCanonicalValue failure must propagate out of fetchSupplierSnapshot',
+    );
+  });
 });
 
 describe('SIPRI importer fan-out fits its fetch deadline (#6799, #6806)', () => {
@@ -289,6 +314,31 @@ describe('SIPRI chunked sweep (#6806)', () => {
   const candidates = [{ iso2: 'FR' }, { iso2: 'DE' }, { iso2: 'JP' }, { iso2: 'BR' }];
 
   const DAY = 24 * 3600_000;
+  const importerCodes = [...new Set(Object.values(JSON.parse(
+    readFileSync(new URL('../scripts/shared/country-names.json', import.meta.url), 'utf8'),
+  )))].slice(0, 60);
+  const importerCatalog = (count = importerCodes.length) => Array.from(
+    { length: Math.max(150, count * 3) },
+    (_, index) => ({
+      EntityId: 1000 + (index % count),
+      Name: importerCodes[index % count],
+    }),
+  );
+  const makeSipriFetch = ({ importerCount = importerCodes.length, onImporter = () => {} } = {}) => async (url) => {
+    if (String(url).includes('getMaxYear')) return new Response('2025');
+    if (String(url).includes('getAllCountriesTrimmed')) {
+      return new Response(JSON.stringify(importerCatalog(importerCount)));
+    }
+    onImporter();
+    return new Response(JSON.stringify({ bytes: Buffer.from(sipriFixture).toString('base64') }));
+  };
+  const previousSnapshot = (staleCount) => ({
+    importers: Object.fromEntries(importerCodes.map((iso2, index) => [iso2, {
+      suppliers: [{ supplierIso2: 'US', tivShare: 1 }],
+      window: { startYear: 2021, endYear: 2025 },
+      fetchedAt: iso(NOW - (index < staleCount ? 11 * DAY : DAY)),
+    }])),
+  });
 
   it('selects only rows outside the horizon, oldest first, and never a current one', () => {
     const previous = {
@@ -436,6 +486,96 @@ describe('SIPRI chunked sweep (#6806)', () => {
     });
     assert.equal(Object.keys(snapshot.importers).length, 31);
     assert.equal(snapshot.stage.status, 'partial');
+  });
+
+  it('the final stale set below the cap completes the sweep and writes the marker', async () => {
+    const previous = previousSnapshot(2);
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch(),
+      previousSnapshot: previous,
+      maxSweepImporters: 56,
+      concurrency: 1,
+      delayMs: 0,
+      now: () => NOW,
+    });
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      fetchSipri: async () => result,
+      now: () => new Date(NOW),
+    });
+
+    assert.deepEqual({
+      attempted: result.sweep.attempted,
+      unfetched: result.sweep.unfetched,
+      completion: buildArmsSupplierCompletion(snapshot),
+    }, {
+      attempted: 2,
+      unfetched: 0,
+      completion: { completedAt: iso(NOW), windowEndYear: 2025 },
+    });
+  });
+
+  it('reports stale importers deferred above the sweep limit', async () => {
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch(),
+      previousSnapshot: previousSnapshot(importerCodes.length),
+      maxSweepImporters: 56,
+      concurrency: 1,
+      delayMs: 0,
+      now: () => NOW,
+    });
+
+    assert.deepEqual({
+      attempted: result.sweep.attempted,
+      unfetched: result.sweep.unfetched,
+    }, {
+      attempted: 56,
+      unfetched: 4,
+    });
+  });
+
+  for (const [missing, sweepOptions] of [
+    ['previousSnapshot', { maxSweepImporters: 56 }],
+    ['maxSweepImporters', { previousSnapshot: {} }],
+  ]) {
+    it(`rejects production sweep inputs without ${missing}`, async () => {
+      await assert.rejects(
+        () => fetchSipriSupplierDependencies({
+          fetchFn: makeSipriFetch(),
+          concurrency: 1,
+          delayMs: 0,
+          ...sweepOptions,
+        }),
+        /previousSnapshot.*maxSweepImporters.*together/,
+      );
+    });
+  }
+
+  it('counts only importer requests started before the soft budget', async () => {
+    let served = 0;
+    let clock = 0;
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn: makeSipriFetch({
+        onImporter: () => {
+          served += 1;
+          clock += 10_000;
+        },
+      }),
+      concurrency: 1,
+      delayMs: 0,
+      softBudgetMs: 15_000,
+      now: () => clock,
+    });
+
+    assert.deepEqual({
+      served,
+      attempted: result.sweep.attempted,
+      unfetched: result.sweep.unfetched,
+    }, {
+      served: 2,
+      attempted: 2,
+      unfetched: 58,
+    });
   });
 
   it('the soft budget returns partial progress instead of losing the tick', async () => {

--- a/tests/seed-utils-canonical-read-strict.test.mjs
+++ b/tests/seed-utils-canonical-read-strict.test.mjs
@@ -1,0 +1,62 @@
+// readCanonicalValue's opt-in strict mode (#7524 review).
+//
+// redisGet degrades HTTP failures to null after retries, which is right for a
+// cache-merge reader that can proceed without the value and wrong for one whose
+// next step reads "no value" as a first run. The SIPRI arms sweep is the latter:
+// a degraded read made it republish one 56-importer slice over its ~200-row
+// canonical key. `strict` opts that single caller out.
+//
+// The third case is the one that keeps strict honest: a genuinely ABSENT key is
+// an HTTP 200 carrying a null result, not a failure, and must still return null
+// so a real first run can bootstrap.
+
+import { test, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { readCanonicalValue } = await import('../scripts/_seed-utils.mjs');
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+const originalWarn = console.warn;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+  console.warn = originalWarn;
+});
+
+// Collapse the retry backoff ladder so exhausting it does not sleep for real.
+function collapseBackoffs() {
+  globalThis.setTimeout = (cb, ms, ...args) => originalSetTimeout(cb, ms > 0 && ms <= 8000 ? 0 : ms, ...args);
+}
+
+test('a persistent Redis HTTP failure still degrades to null by default', async () => {
+  const warns = [];
+  console.warn = (...args) => { warns.push(args.join(' ')); };
+  collapseBackoffs();
+  globalThis.fetch = async () => new Response('upstream error', { status: 503 });
+
+  assert.equal(await readCanonicalValue('test:strict-read:v1'), null);
+  assert.match(warns.join('\n'), /degraded to null/);
+});
+
+test('strict mode propagates the same failure instead of reading as a first run', async () => {
+  collapseBackoffs();
+  globalThis.fetch = async () => new Response('upstream error', { status: 503 });
+
+  await assert.rejects(
+    () => readCanonicalValue('test:strict-read:v1', { strict: true }),
+    /HTTP 503/,
+  );
+});
+
+test('strict mode still returns null for a genuinely absent key', async () => {
+  // HTTP 200 + null result is "no such key", not a failure. If strict threw
+  // here it would hard-fail every legitimate first run.
+  globalThis.fetch = async () => new Response(JSON.stringify({ result: null }), { status: 200 });
+
+  assert.equal(await readCanonicalValue('test:strict-read:v1', { strict: true }), null);
+});

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -365,6 +365,50 @@ test('allowMissingOnSkip keeps a failed expiry warning and does not claim preser
   assert.doesNotMatch(logs.join('\n'), /extended TTL to preserve last-good/);
 });
 
+test('allowMissingOnSkip also silences the warning on the fetch-failure preservation path', async () => {
+  // The empty-skip branch is only one of six preservation paths. The others
+  // (fetch failure, SIGTERM, contract RETRY, atomic-publish failure, validation
+  // skip) all go through preserveExistingKeys, which preserves the same extra
+  // keys -- so without threading the allowance there, the optional completion
+  // marker still triggers "manual seed required" on every failed tick.
+  // Every key in this fixture is absent, so the canonical key and its seed-meta
+  // warn legitimately. What must change is the COUNT: the optional completion
+  // marker is excluded, and the strict control below proves the difference is
+  // the allowance and not the fixture.
+  const runFetchFailure = (resource, extraKeyOptions) => {
+    expireResult = 0;
+    return captureSeedLogs(() => runWithExitTrap(() => runSeed(
+      'test',
+      resource,
+      `test:${resource}:v1`,
+      async () => { throw new Error('upstream down'); },
+      {
+        validateFn: (data) => Array.isArray(data?.events),
+        ttlSeconds: 3600,
+        sourceVersion: 'test-v1',
+        schemaVersion: 1,
+        maxStaleMin: 120,
+        declareRecords: (data) => data.events.length,
+        extraKeys: [{
+          key: `test:${resource}:completion`,
+          transform: (data) => data.completion,
+          declareRecords: (completion) => completion.length,
+          skipWhenEmpty: true,
+          ...extraKeyOptions,
+        }],
+      },
+    )));
+  };
+
+  const optional = await runFetchFailure('optional-extra-fetch-fail', { allowMissingOnSkip: true });
+  const strict = await runFetchFailure('strict-extra-fetch-fail', {});
+
+  assert.equal(optional.exitCode, 75);
+  assert.equal(strict.exitCode, 75);
+  assert.match(optional.warnings.join('\n'), /WARNING: 2 key\(s\) were expired\/missing/);
+  assert.match(strict.warnings.join('\n'), /WARNING: 3 key\(s\) were expired\/missing/);
+});
+
 test('skipWhenEmpty remains strict for a missing extra key without allowMissingOnSkip', async () => {
   expireResult = 0;
   const { exitCode, logs, warnings } = await runSkippedExtraKey('strict-extra-missing');

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -20,19 +20,21 @@ const ORIGINAL_SIGTERM_LISTENERS = new Set(process.rawListeners('SIGTERM'));
 
 let recordedCalls;
 let expireResult;
+let expirePipelineStatus;
 
 beforeEach(() => {
   process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example.com';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
   recordedCalls = [];
   expireResult = 0;
+  expirePipelineStatus = 200;
 
   globalThis.fetch = async (url, opts = {}) => {
     const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
     recordedCalls.push({ url: String(url), method: opts?.method || 'GET', body });
     // Lock acquire: SET NX returns OK. Pipeline (EXPIRE) returns array. Default: OK.
     if (Array.isArray(body) && Array.isArray(body[0])) {
-      return new Response(JSON.stringify(body.map(() => ({ result: expireResult }))), { status: 200 });
+      return new Response(JSON.stringify(body.map(() => ({ result: expireResult }))), { status: expirePipelineStatus });
     }
     return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
   };
@@ -105,6 +107,50 @@ function runEmptyContractRetry(resource, opts = {}) {
       ...opts,
     }),
   );
+}
+
+async function captureSeedLogs(fn) {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const logs = [];
+  const warnings = [];
+  const errors = [];
+  console.log = (...args) => logs.push(args.join(' '));
+  console.warn = (...args) => warnings.push(args.join(' '));
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    const exitCode = await fn();
+    return { exitCode, logs, warnings, errors };
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+}
+
+function runSkippedExtraKey(resource, extraKeyOptions = {}) {
+  return captureSeedLogs(() => runWithExitTrap(() => runSeed(
+    'test',
+    resource,
+    `test:${resource}:v1`,
+    async () => ({ events: [{ id: 'canonical' }], completion: [] }),
+    {
+      validateFn: (data) => Array.isArray(data?.events),
+      ttlSeconds: 3600,
+      sourceVersion: 'test-v1',
+      schemaVersion: 1,
+      maxStaleMin: 120,
+      declareRecords: (data) => data.events.length,
+      extraKeys: [{
+        key: `test:${resource}:completion`,
+        transform: (data) => data.completion,
+        declareRecords: (completion) => completion.length,
+        skipWhenEmpty: true,
+        ...extraKeyOptions,
+      }],
+    },
+  )));
 }
 
 test('fetch failure extends existing TTL and exits with graceful-failure code', async () => {
@@ -265,6 +311,67 @@ test('skipWhenEmpty preserves the last-good extra key without refreshing its see
     expireKeys().includes('test:extra-meta-empty:warnings'),
     'the skipped extra key must have its TTL extended to preserve last-good data',
   );
+});
+
+test('allowMissingOnSkip suppresses missing-key warnings and does not claim TTL preservation', async () => {
+  expireResult = 0;
+  const { exitCode, logs, warnings } = await runSkippedExtraKey('optional-extra-missing', {
+    allowMissingOnSkip: true,
+  });
+
+  assert.equal(exitCode, 0);
+  assert.doesNotMatch(
+    warnings.join('\n'),
+    /manual seed required/,
+    'an opted-in optional extra key may be absent when its empty write is skipped',
+  );
+  assert.doesNotMatch(
+    logs.join('\n'),
+    /extended TTL to preserve last-good/,
+    'EXPIRE 0 must not be reported as a successful TTL extension',
+  );
+});
+
+test('allowMissingOnSkip reports preservation only when EXPIRE confirms it', async () => {
+  expireResult = 1;
+  const { exitCode, logs, warnings } = await runSkippedExtraKey('optional-extra-preserved', {
+    allowMissingOnSkip: true,
+  });
+
+  assert.equal(exitCode, 0);
+  assert.match(logs.join('\n'), /skipped write, extended TTL to preserve last-good/);
+  assert.doesNotMatch(warnings.join('\n'), /manual seed required/);
+});
+
+test('allowMissingOnSkip keeps an unconfirmed expiry warning and does not claim preservation', async () => {
+  expireResult = null;
+  const { exitCode, logs, warnings } = await runSkippedExtraKey('optional-extra-unconfirmed', {
+    allowMissingOnSkip: true,
+  });
+
+  assert.equal(exitCode, 0);
+  assert.match(warnings.join('\n'), /unconfirmed/i);
+  assert.doesNotMatch(logs.join('\n'), /extended TTL to preserve last-good/);
+});
+
+test('allowMissingOnSkip keeps a failed expiry warning and does not claim preservation', async () => {
+  expirePipelineStatus = 401;
+  const { exitCode, logs, warnings, errors } = await runSkippedExtraKey('optional-extra-failed', {
+    allowMissingOnSkip: true,
+  });
+
+  assert.equal(exitCode, 0);
+  assert.match([...warnings, ...errors].join('\n'), /TTL.*failed|failed.*TTL/i);
+  assert.doesNotMatch(logs.join('\n'), /extended TTL to preserve last-good/);
+});
+
+test('skipWhenEmpty remains strict for a missing extra key without allowMissingOnSkip', async () => {
+  expireResult = 0;
+  const { exitCode, logs, warnings } = await runSkippedExtraKey('strict-extra-missing');
+
+  assert.equal(exitCode, 0);
+  assert.match(warnings.join('\n'), /manual seed required/);
+  assert.doesNotMatch(logs.join('\n'), /extended TTL to preserve last-good/);
 });
 
 // PR #3582: When validateFn rejects a transient blip but canonical key still

--- a/tests/seed-utils-extend-ttl-confirms.test.mjs
+++ b/tests/seed-utils-extend-ttl-confirms.test.mjs
@@ -154,3 +154,43 @@ test('extendExistingTtl: does NOT retry when response is OK but a key is missing
   assert.equal(ok, false);
   assert.equal(calls, 1, 'missing-key no-op is a real condition, not a transient error');
 });
+
+// allowMissingKeys (#7524 review). `allExtended` gates runSeed's RETRY exit(1)
+// and its preservationSucceeded diagnostic, so a key whose absence is EXPECTED
+// -- a completion marker not written until a multi-tick sweep finishes -- must
+// not read as a preservation failure. The #5364 contract still holds for every
+// key outside the list, and for an unconfirmed result even inside it.
+
+test('allowMissingKeys: a confirmed no-op on a listed key does not fail the verdict', async () => {
+  mockPipeline([{ result: 1 }, { result: 0 }]);
+  const result = await extendExistingTtlDetailed(['alive', 'optional'], 1800, {
+    allowMissingKeys: ['optional'],
+  });
+  assert.equal(result.allExtended, true);
+  assert.deepEqual(result.extendedKeys, ['alive']);
+  assert.deepEqual(result.missingKeys, ['optional']);
+});
+
+test('allowMissingKeys: a no-op on an UNLISTED key still fails the verdict', async () => {
+  mockPipeline([{ result: 0 }, { result: 0 }]);
+  const result = await extendExistingTtlDetailed(['required', 'optional'], 1800, {
+    allowMissingKeys: ['optional'],
+  });
+  assert.equal(result.allExtended, false);
+});
+
+test('allowMissingKeys: an UNCONFIRMED result on a listed key still fails the verdict', async () => {
+  // "We could not read the result" is not "it is expectedly absent".
+  mockPipeline([{ result: 1 }, { result: null }]);
+  const result = await extendExistingTtlDetailed(['alive', 'optional'], 1800, {
+    allowMissingKeys: ['optional'],
+  });
+  assert.equal(result.allExtended, false);
+  assert.deepEqual(result.unconfirmedKeys, ['optional']);
+});
+
+test('allowMissingKeys: omitting the option keeps the strict #5364 contract', async () => {
+  mockPipeline([{ result: 1 }, { result: 0 }]);
+  const result = await extendExistingTtlDetailed(['alive', 'optional'], 1800);
+  assert.equal(result.allExtended, false);
+});


### PR DESCRIPTION
## Why

The SIPRI supplier sweep could publish valid data but never reach its completion marker. The seeder capped each tick before the fetcher calculated remaining work, so the fetcher counted every importer outside that capped slice as unfinished even after earlier ticks refreshed it.

This fix makes one boundary own stale selection, per-tick capping, and sweep accounting. A completed sweep can now report `unfetched: 0`.

## Scope

- Pass the previous snapshot and the 56-importer cap into `fetchSipriSupplierDependencies()` as one validated pair.
- Count importers that are stale, selected, started, deferred by the cap, and stopped by the soft budget as separate states.
- Record a genuinely zero-transfer importer as current so it stops being selected forever, while withholding a whole cohort that loses its suppliers at once.
- Make the canonical snapshot read strict, so an Upstash HTTP error cannot read as a first run.
- Treat the absent optional completion key as expected on every preservation path, but keep strict warnings for required keys and unconfirmed TTL updates.
- Add boundary coverage for all-current, below-cap, exact-cap, above-cap, soft-budget, request-failure, invalid-cap, paired-input, cohort-collapse, strict-read, and Redis TTL-result cases.

**This PR does change the canonical empty-result policy**: an importer whose window holds no positive transfers is now persisted as a row with `suppliers: []`, where previously it was omitted. That is the point of the fix — an omitted row never became current, so the sweep could never finish — but it means the snapshot's importer set grows and consumers must gate on supplier content rather than row presence (done here for `get_defense_industrial_base`).

This PR does not change Redis schemas, the Railway schedule, or request concurrency.

## Blast Radius

The runtime change covers the SIPRI arms-supplier seed path, the shared empty-extra-key TTL reporting path, the opt-in strict canonical read (used only by this seeder; every other `readCanonicalValue` caller keeps degrade-to-null), and the `get_defense_industrial_base` availability gate. Existing callers keep whole-catalog behavior unless they provide both sweep options. Missing required keys and unconfirmed Redis results still warn.

## Review fixes (post-review, commits `92f5127f`, `18e4c141`, `cc099985`)

A multi-reviewer code review of the original three commits found the completion fix opened two ways for the sweep to go green on bad data:

1. **A parse-clean all-zero cohort could wipe last-good rows and complete the sweep.** `parseSipriSupplierCsv` returns `suppliers: []` both when an importer genuinely had no transfers and when every positive transfer came from an entity `mapSipriEntityToIso2` does not know. A row that held suppliers and now parses to none is withheld until the slice is in; if most of the cohort did that, those importers are reported as failures so previous rows stay retained and the sweep stays `partial`. Individual zero-transfer refreshes still publish.
2. **The canonical read was not actually strict.** `redisGet` degrades HTTP failures to null, so dropping `.catch(() => null)` did not cover the dominant failure mode — an Upstash 5xx still read as a first run and republished one 56-importer slice over the ~200-row canonical key. `redisGet`/`readCanonicalValue` now take an opt-in `strict` flag.

Also: zero-supplier rows no longer flip `get_defense_industrial_base` to `available: true` with an all-"Not available" panel; the minimum-importer floor error is tagged `nonRetryable` so a rejection does not re-run all 56 POSTs against a throttled shared host; `allowMissingOnSkip` is threaded through `preserveExistingKeys` so the optional marker stops warning "manual seed required" on the fetch-failure, SIGTERM, contract-RETRY, atomic-publish and validation-skip paths; and `fetchSupplierSnapshot` moved to `scripts/_arms-suppliers-sweep.mjs` so the wiring and read-failure guards execute the code instead of regex-matching the seeder's source.

## Verification

- Full data suite: 29,220 passed, 0 failed, 35 skipped.
- `npm run typecheck`, `npm run typecheck:api`, `npm run lint:boundaries`: passed.
- Biome on all changed files: passed.
- Each new guard mutation-tested: reverting the cohort check, the `strict` flag, or the supplier-content gate turns exactly its own test red.

## Post-deploy monitoring and validation

On the next complete `seed-bundle-static-ref-heavy` sweep cycle, check Railway logs for `SIPRI soft budget`, `SIPRI zero-supplier cohort collapse`, `arms-suppliers`, `[extraKey] military:arms-suppliers:complete:v1`, `manual seed required`, `extended TTL to preserve last-good`, and `seed_complete`.

Healthy behavior: partial ticks report the true remaining stale count; the final tick writes the completion key and metadata; later health checks see the current marker. Failure behavior: `sweep.unfetched` does not decrease across eligible runs, the completion key remains absent after a full sweep, a snapshot read fails, or Redis reports an unconfirmed/failed TTL update. A `zero-supplier cohort collapse` warning means upstream returned empty parses for most of a slice — data was deliberately withheld and will retry, which is working as intended, but a repeat across consecutive cycles is a real upstream problem.

`scripts/railway-services.json` gained a watch path for the new module; the manifest describes the desired state, so the live Railway watch paths still need `audit-railway-watch-paths.mjs --apply` to match.

The WorldMonitor operator or PR author owns this check. If it fails, roll back this change and retain the prior canonical snapshot; do not run a manual seed without separate authorization.

Fixes #7522.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

https://claude.ai/code/session_01THGWRDH2JuP3S2dcewBQDb
