### PR TITLE
test(portwatch): cover real ArcGIS rate-limit response

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -281,7 +281,14 @@ async function arcgisProxyRetry(url, reason, { signal } = {}) {
   return proxied;
 }
 
-async function fetchWithTimeout(url, { signal, timeoutMs = FETCH_TIMEOUT, noProxyFallback = false } = {}) {
+const defaultFetch = (...args) => globalThis.fetch(...args);
+
+async function fetchWithTimeout(url, {
+  signal,
+  timeoutMs = FETCH_TIMEOUT,
+  noProxyFallback = false,
+  fetchFn = defaultFetch,
+} = {}) {
   // Combine the per-call timeoutMs with the upstream caller signal so an
   // abort propagates into the in-flight fetch AND future pagination iterations.
   //
@@ -292,12 +299,13 @@ async function fetchWithTimeout(url, { signal, timeoutMs = FETCH_TIMEOUT, noProx
   //                       arcgisProxyRetry. Used by preflight so a degraded
   //                       upstream can't burn the container budget on
   //                       best-effort cache-invalidation probes (PR #3711 P1).
+  //   fetchFn          — optional direct transport seam for boundary tests.
   const combined = signal
     ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)])
     : AbortSignal.timeout(timeoutMs);
   let resp;
   try {
-    resp = await fetch(url, {
+    resp = await fetchFn(url, {
       headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
       signal: combined,
     });
@@ -357,7 +365,7 @@ async function fetchWithTimeout(url, { signal, timeoutMs = FETCH_TIMEOUT, noProx
     if (_bodyCaptureSuccessCount < MAX_BODY_CAPTURE_SUCCESSES
         && _bodyCaptureAttemptCount < MAX_BODY_CAPTURE_ATTEMPTS) {
       _bodyCaptureAttemptCount += 1;
-      const captured = await _captureErrorBodyAfterTimeout(url, signal);
+      const captured = await _captureErrorBodyAfterTimeout(url, signal, fetchFn);
       if (captured?.error) {
         _bodyCaptureSuccessCount += 1;
         throw new Error(`ArcGIS error: ${captured.error.message ?? captured.error.code ?? JSON.stringify(captured.error)}`);
@@ -417,13 +425,13 @@ const MAX_BODY_CAPTURE_ATTEMPTS = 0;
 // Returns `{error}` if the response body contains an ArcGIS error,
 // `{body}` if it contains a normal response, or null if the re-fetch
 // itself failed (caller falls through to proxy retry as before).
-async function _captureErrorBodyAfterTimeout(url, signal) {
+async function _captureErrorBodyAfterTimeout(url, signal, fetchFn) {
   if (signal?.aborted) return null;
   const captureSignal = signal
     ? AbortSignal.any([signal, AbortSignal.timeout(ERROR_BODY_CAPTURE_EXTRA_MS)])
     : AbortSignal.timeout(ERROR_BODY_CAPTURE_EXTRA_MS);
   try {
-    const resp = await fetch(url, {
+    const resp = await fetchFn(url, {
       headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
       signal: captureSignal,
     });
@@ -465,9 +473,9 @@ async function _captureErrorBodyAfterTimeout(url, signal) {
 // change, server-side degradation) so we don't burn the container
 // budget on doomed retries.
 let _invalidParamsErrorCount = 0;
-async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
+async function fetchWithRetryOnInvalidParams(url, { signal, fetchFn } = {}) {
   try {
-    return await fetchWithTimeout(url, { signal });
+    return await fetchWithTimeout(url, { signal, fetchFn });
   } catch (err) {
     const msg = err?.message || '';
     if (!/Invalid query parameters/i.test(msg)) throw err;
@@ -499,7 +507,7 @@ async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
     await new Promise((r) => setTimeout(r, 500));
     if (signal?.aborted) throw signal.reason ?? err;
     console.warn(`  [port-activity] retrying after "${msg}" (${_invalidParamsErrorCount}/${INVALID_PARAMS_RETRY_THRESHOLD}): ${url.slice(0, 80)}`);
-    return await fetchWithTimeout(url, { signal });
+    return await fetchWithTimeout(url, { signal, fetchFn });
   }
 }
 
@@ -507,7 +515,7 @@ async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
 // ArcGIS server-cap: advance by actual features.length, never PAGE_SIZE.
 export async function fetchAllPortRefs({
   signal,
-  fetchPage = fetchWithRetryOnInvalidParams,
+  fetchFn,
   sleepFn = waitForRetry,
 } = {}) {
   const byIso3 = new Map();
@@ -529,7 +537,10 @@ export async function fetchAllPortRefs({
     });
     const url = `${EP4_BASE}?${params}`;
     body = await retryRateLimited(
-      (attemptSignal) => fetchPage(url, { signal: attemptSignal }),
+      (attemptSignal) => fetchWithRetryOnInvalidParams(url, {
+        signal: attemptSignal,
+        fetchFn,
+      }),
       { signal, sleepFn, label: `reference page ${page}` },
     );
     const features = body.features ?? [];

--- a/tests/fixtures/portwatch-arcgis-too-many-requests.json
+++ b/tests/fixtures/portwatch-arcgis-too-many-requests.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Sanitized from Railway deployment e6458492-5b13-4cad-938b-6fc768bf6bc6 on 2026-09-01. The HTTP 200 ArcGIS error envelope and message were confirmed. Other provider fields are unconfirmed, not observed absent.",
+  "error": {
+    "message": "Unable to perform query. Too many requests."
+  }
+}

--- a/tests/portwatch-port-activity-recovery.test.mjs
+++ b/tests/portwatch-port-activity-recovery.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 import * as portwatchSeed from '../scripts/seed-portwatch-port-activity.mjs';
+import { CHROME_UA } from '../scripts/_seed-utils.mjs';
 
 const { orderColdFetchQueue } = portwatchSeed;
 const DAY = 86_400_000;
@@ -40,11 +41,13 @@ describe('PortWatch reference pagination recovery', () => {
     assert.match(arcgisRateLimitFixture._comment, /unconfirmed, not observed absent/);
 
     const requestedOffsets = [];
+    const requestedInits = [];
     const sleepCalls = [];
     let offsetOneAttempts = 0;
-    const fetchFn = async (url) => {
+    const fetchFn = async (url, init) => {
       const offset = Number(new URL(url).searchParams.get('resultOffset'));
       requestedOffsets.push(offset);
+      requestedInits.push(init);
 
       if (offset === 0) {
         return arcgisJson({
@@ -79,6 +82,17 @@ describe('PortWatch reference pagination recovery', () => {
     assert.deepEqual([...refsByIso3.get('CYP').keys()], ['cy-lca']);
     assert.equal(sleepCalls.length, 1);
     assert.equal(sleepCalls[0][0], 2_000);
+
+    // The seam is only faithful if it hands the transport what production
+    // hands it. fetchWithTimeout builds these headers and the combined abort
+    // signal itself, so without this assertion the required User-Agent or the
+    // abort wiring could be dropped and every test here would stay green.
+    assert.equal(requestedInits.length, 3);
+    for (const init of requestedInits) {
+      assert.equal(init.headers['User-Agent'], CHROME_UA);
+      assert.equal(init.headers.Accept, 'application/json');
+      assert.ok(init.signal instanceof AbortSignal);
+    }
   });
 
   it('bounds repeated HTTP 200 rate-limit errors to one same-page retry', async () => {

--- a/tests/portwatch-port-activity-recovery.test.mjs
+++ b/tests/portwatch-port-activity-recovery.test.mjs
@@ -1,10 +1,22 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 
 import * as portwatchSeed from '../scripts/seed-portwatch-port-activity.mjs';
 
 const { orderColdFetchQueue } = portwatchSeed;
 const DAY = 86_400_000;
+const arcgisRateLimitFixture = JSON.parse(await readFile(
+  new URL('./fixtures/portwatch-arcgis-too-many-requests.json', import.meta.url),
+  'utf8',
+));
+
+function arcgisJson(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
 
 function cachedCountry(iso2, cacheWrittenAt = 0) {
   return {
@@ -19,46 +31,86 @@ function cachedCountry(iso2, cacheWrittenAt = 0) {
 }
 
 describe('PortWatch reference pagination recovery', () => {
-  it('retries a rate-limited page without restarting pagination', async () => {
+  it('parses and retries a rate-limited HTTP 200 page without restarting pagination', async () => {
+    assert.equal(typeof arcgisRateLimitFixture.error, 'object');
+    assert.equal(
+      arcgisRateLimitFixture.error.message,
+      'Unable to perform query. Too many requests.',
+    );
+    assert.match(arcgisRateLimitFixture._comment, /unconfirmed, not observed absent/);
+
     const requestedOffsets = [];
     const sleepCalls = [];
     let offsetOneAttempts = 0;
-    const fetchPage = async (url) => {
+    const fetchFn = async (url) => {
       const offset = Number(new URL(url).searchParams.get('resultOffset'));
       requestedOffsets.push(offset);
 
       if (offset === 0) {
-        return {
+        return arcgisJson({
           features: [{
             attributes: { portid: 'us-lax', ISO3: 'USA', lat: 33.7, lon: -118.2 },
           }],
           exceededTransferLimit: true,
-        };
+        });
       }
 
       offsetOneAttempts += 1;
       if (offsetOneAttempts === 1) {
-        throw new Error('ArcGIS error: Unable to perform query. Too many requests.');
+        return arcgisJson(arcgisRateLimitFixture);
       }
-      return {
+      return arcgisJson({
         features: [{
           attributes: { portid: 'cy-lca', ISO3: 'CYP', lat: 34.9, lon: 33.6 },
         }],
         exceededTransferLimit: false,
-      };
+      });
     };
 
     const refsByIso3 = await portwatchSeed.fetchAllPortRefs({
-      fetchPage,
+      fetchFn,
       sleepFn: async (...args) => {
         sleepCalls.push(args);
       },
     });
 
     assert.deepEqual(requestedOffsets, [0, 1, 1]);
-    assert.ok(refsByIso3.get('USA') instanceof Map);
-    assert.ok(refsByIso3.get('CYP') instanceof Map);
+    assert.deepEqual([...refsByIso3.get('USA').keys()], ['us-lax']);
+    assert.deepEqual([...refsByIso3.get('CYP').keys()], ['cy-lca']);
     assert.equal(sleepCalls.length, 1);
+    assert.equal(sleepCalls[0][0], 2_000);
+  });
+
+  it('bounds repeated HTTP 200 rate-limit errors to one same-page retry', async () => {
+    const requestedOffsets = [];
+    const sleepCalls = [];
+    const fetchFn = async (url) => {
+      const offset = Number(new URL(url).searchParams.get('resultOffset'));
+      requestedOffsets.push(offset);
+      if (offset === 0) {
+        return arcgisJson({
+          features: [{
+            attributes: { portid: 'us-lax', ISO3: 'USA', lat: 33.7, lon: -118.2 },
+          }],
+          exceededTransferLimit: true,
+        });
+      }
+      return arcgisJson(arcgisRateLimitFixture);
+    };
+
+    await assert.rejects(
+      portwatchSeed.fetchAllPortRefs({
+        fetchFn,
+        sleepFn: async (...args) => {
+          sleepCalls.push(args);
+        },
+      }),
+      /ArcGIS error: Unable to perform query\. Too many requests\./,
+    );
+
+    assert.deepEqual(requestedOffsets, [0, 1, 1]);
+    assert.equal(sleepCalls.length, 1);
+    assert.equal(sleepCalls[0][0], 2_000);
   });
 });
 


### PR DESCRIPTION
## Summary

PortWatch reference-pagination tests now enter through the production HTTP-response parser instead of throwing the error that parser should produce. A sanitized fixture preserves the ArcGIS HTTP 200 error envelope and message confirmed in Railway, while a Fetch-compatible seam leaves the production transport and retry policy unchanged.

The regression proves that a rate-limited page retries once at the same offset, keeps rows from earlier pages, and fails after the same bounded retry when the provider repeats the error.

Related: #7520

## Validation

- Recovery produced offsets `[0, 1, 1]`, one 2,000 ms backoff, and retained both page results.
- Repeated HTTP 200 rate-limit envelopes rejected after exactly two attempts at the failed offset.
- Mutating the `body.error` classifier made both new cases fail, which proves that the tests reach the production parser branch.
- Focused recovery tests: 17 passed.
- Related PortWatch tests: 64 passed.
- Browser typecheck, API typecheck, boundary lint, Biome, and pre-push gates passed.
- Full data suite: 29,218 passed, 1 unrelated timing test failed, and 35 skipped. The failed digest timing file then passed 51/51 in isolation.

## Post-deploy monitoring

- **Window:** Check the next two scheduled Railway PortWatch seed runs.
- **Owner:** WorldMonitor operator.
- **Healthy:** A rate-limited reference page logs one retry and the run reaches `Seed complete`; no retry storm or new `PUBLISH_BLOCKED` event occurs.
- **Investigate:** Repeated attempts exceed the two-call bound at one offset, proxy traffic changes, the seed fails, or country coverage regresses.
- **Rollback:** Revert this PR if its transport seam changes production fetch behavior. The expected runtime diff is zero because production keeps the existing global Fetch default.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
