### PR TITLE
fix(cross-strait): accept current Taiwan MND list dates

### DIFF
--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -1261,8 +1261,8 @@ function firstHtmlElementAttribute(value, tagName, attribute) {
   return null;
 }
 
-// `className` is optional: the Taiwan MND list keys off `h5.date`, while the
-// Japan MOD homepage marks its titles with a bare `<h5>`.
+// `className` is optional: the Taiwan MND list keys off a `date` element, while
+// the Japan MOD homepage marks its titles with a bare `<h5>`.
 function extractHtmlElementBodies(value, tagNames, className = null, maxMatches = 1) {
   const source = String(value);
   const allowedTags = new Set(tagNames);
@@ -1338,7 +1338,7 @@ export function parseTaiwanMndList(html) {
   for (const anchor of scanHtmlAnchors(html)) {
     const href = quotedHtmlAttribute(anchor.openingTag, 'href');
     if (!href || !/\/News\/PLAAct\/\d+$/i.test(href)) continue;
-    const dateBody = extractHtmlElementBodies(anchor.body, ['h5'], 'date')[0];
+    const dateBody = extractHtmlElementBodies(anchor.body, ['h5', 'div'], 'date')[0];
     const publicationDay = dateBody?.includes('<') ? null : dottedDate(dateBody);
     if (!publicationDay) continue;
     let sourceUrl;
@@ -2619,6 +2619,7 @@ export async function fetchCrossStraitActivitySnapshot({
           ...(previous ? { expectedReportingDay: previous.reportingDay } : {}),
         };
       });
+      if (rows.length === 0) mndErrors.push('MND_LIST_ROWS_MISSING');
       discoveredCount += rows.length;
       for (const row of rows) {
         if (page === 1) {

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -17,6 +17,7 @@ import {
   MND_MAX_REVISION_VINTAGES_PER_DAY,
   MND_OUTBOUND_BUDGET_MS,
   MND_REFRESH_DETAIL_REQUESTS_PER_RUN,
+  MND_REQUIRED_REPORTING_DAYS,
   MND_RETENTION_REPORTING_DAYS,
   REVIEWED_JAPAN_MOD_OBSERVATIONS,
   buildCrossStraitActivitySnapshot,
@@ -198,6 +199,18 @@ describe('quantified cross-Strait activity (#5575)', () => {
         sourceUrl: 'https://www.mnd.gov.tw/en/News/PLAAct/87086',
       },
     ]);
+    assert.deepEqual(parseTaiwanMndList(`
+      <div class="date headline-h5 h5">2026.09.03</div>
+      <a href="/en/news/plaactlist/2">
+        <div class="date headline-h5 h5">2026.09.03</div>
+      </a>
+      <a href="/en/News/PLAAct/99999">
+        <h5 class="date headline-h5 h5">2026.09.02</h5>
+      </a>
+    `), [{
+      publicationDay: '2026-09-02',
+      sourceUrl: 'https://www.mnd.gov.tw/en/News/PLAAct/99999',
+    }]);
 
     const observation = parseTaiwanMndDetail(fixture('mnd-detail.html'), {
       sourceUrl: 'https://www.mnd.gov.tw/en/News/PLAAct/87151',
@@ -2531,6 +2544,42 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.deepEqual(secondJapan?.candidates, firstJapan?.candidates);
     assert.equal(secondJapan?.unreviewedCandidateCount, firstJapan?.unreviewedCandidateCount);
     assert.deepEqual(secondJapan?.shadowIndexProbe, firstJapan?.shadowIndexProbe);
+  });
+
+  it('reports a successful empty MND list response and retains last-good observations', async () => {
+    const retained = Array.from(
+      { length: MND_REQUIRED_REPORTING_DAYS },
+      (_, index) => mndObservationForDay(index + 1),
+    );
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt,
+      previousSnapshot: null,
+      mndOutcome: { ok: true, requestCount: 0, observations: retained },
+      japanOutcome: { ok: true, requestCount: 0, availableDocumentUrls: [] },
+    });
+    const mndRequests: string[] = [];
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+        mndRequests.push(url);
+        return new Response('<html><body>no activity rows</body></html>');
+      },
+      now: Date.parse('2026-09-02T08:00:00.000Z'),
+      previousSnapshot,
+      sleepFn: async () => {},
+      proxyUrl: '',
+    });
+    const mnd = snapshot.sources.find((source: { id: string }) => source.id === 'taiwan-mnd');
+
+    assert.equal(mnd?.transportStatus, 'error');
+    assert.ok(mnd?.errorCodes.includes('MND_LIST_ROWS_MISSING'));
+    assert.match(mndRequests[0] ?? '', /plaactlist/i);
+    assert.equal(mndRequests.length, 1 + MND_REFRESH_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(
+      snapshot.observations.filter((row: { sourceId: string }) => row.sourceId === 'taiwan-mnd').length,
+      MND_REQUIRED_REPORTING_DAYS,
+    );
   });
 
   it('separates the three index-presence claims by whether the index covers the series', () => {

--- a/tests/fixtures/cross-strait-activity/mnd-list.html
+++ b/tests/fixtures/cross-strait-activity/mnd-list.html
@@ -1,14 +1,14 @@
 <div class="wrap-page3">
   <a href="/en/News/PLAAct/87151" class="news_list">
-    <h5 class="date">2026.07.25</h5>
+    <div class="date headline-h5 h5">2026.07.25</div>
     <div>PLA activities in the waters and airspace around Taiwan</div>
   </a>
   <a href="/en/News/PLAAct/87105" class="news_list">
-    <h5 class="date">2026.07.24</h5>
+    <div class="date headline-h5 h5">2026.07.24</div>
     <div>PLA activities in the waters and airspace around Taiwan</div>
   </a>
   <a href="/en/News/PLAAct/87086" class="news_list">
-    <h5 class="date">2026.07.23</h5>
+    <div class="date headline-h5 h5">2026.07.23</div>
     <div>PLA activities in the waters and airspace around Taiwan</div>
   </a>
 </div>


### PR DESCRIPTION
## Why

Taiwan MND changed its list date element from `h5.date` to `div.date`. The list still returned HTTP 200, but the parser found no rows and the source stayed in `SEED_ERROR` while the snapshot retained old observations.

## Scope

- Accept the prior `h5.date` markup and the current `div.date` markup inside canonical Taiwan MND PLA activity links.
- Report `MND_LIST_ROWS_MISSING` when a successful list response contains no valid rows.
- Preserve the existing URL checks, bounded HTML parser, last-good data, request budgets, schedules, and public contracts.

## Blast Radius

This change affects only Taiwan MND list discovery and its source-health diagnostic. It does not change the seeder, retention thresholds, refresh limits, or Japan MOD collection.

## Verification

- Captured the regression first. The focused test failed because current markup returned `[]` and the empty response omitted `MND_LIST_ROWS_MISSING`.
- `./node_modules/.bin/tsx --test tests/cross-strait-activity.test.mts` passed 94 tests.
- `npm run typecheck` passed.
- `npm run typecheck:api` passed.
- `npm run lint:boundaries` passed.
- `git diff --check origin/main` passed.

## Post-Deploy Monitoring & Validation

- Owner: WorldMonitor release operator.
- Window: the first production seed after deployment and the next scheduled seed.
- Search the seed logs for `crossStraitActivityTaiwanMnd`, `MND_LIST_ROWS_MISSING`, and `SEED_ERROR`.
- Healthy signals: the Taiwan MND source reports a successful fresh read, the current publisher row appears, and public health no longer reports the seed error.
- Failure signals: the parser still discovers zero rows, the source remains in error, or an unexpected link enters the snapshot. Preserve the last-good snapshot, inspect the live markup, and roll back this change if it admits invalid rows.

Production recovery remains unproved until the deployed seed and public health checks show these healthy signals.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
