### PR TITLE
fix(sentry): close marketing-surface filter gaps from the 2026-09-02 triage

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -221,6 +221,70 @@ export const MARKETING_IGNORE_ERRORS: RegExp[] = [
   // `/pro/assets/*.js` frame. `tests/pro-sentry-filter-policy.test.mts` pins
   // both the suppression and the bare-identifier scan that licenses it.
   /^jQuery is not defined$/,
+  // A synthetic `unhandledrejection` CustomEvent, dispatched by injected script
+  // and swept up by Sentry's global rejection handler. WORLDMONITOR-11S is the
+  // shape: Safari 26.6.2 / macOS on `/pro`, zero frames, and
+  // `extra.__serialized__` = `{type: 'unhandledrejection', isTrusted: false,
+  // target: '[object Window]', currentTarget: '[object Window]', detail: null}`.
+  // `isTrusted: false` is the browser saying the Event was constructed and
+  // dispatched by script — a browser-fired `unhandledrejection` is always
+  // trusted — so the page was handed a fake rejection event.
+  //
+  // The licence is the CONSTRUCTOR, not the frame: Sentry only writes
+  // ``Event `CustomEvent` … captured as promise rejection`` when the rejected
+  // value is a real `CustomEvent` instance, and the marketing surface never
+  // constructs one — `CustomEvent` appears in neither `pro-test/src`, the
+  // `shared/` leaves it imports, nor either inline script (the dashboard DOES
+  // construct them, e.g. `WM_SESSION_DEGRADED_EVENT`, which is why its own copy
+  // of this entry is separately argued). Frame-blind suppression is the only
+  // option available anyway: the event carries `stacktrace: null`, so
+  // `marketingBeforeSend`'s `!hasFirstParty` gate has nothing to act on.
+  //
+  // Anchored to the whole synthetic sentence rather than copying the
+  // dashboard's bare `/Event `CustomEvent`.*captured as promise rejection/`,
+  // for the reason the `Error invoking` entry above spells out. Sibling of the
+  // dashboard's `ProgressEvent` entry (WORLDMONITOR-SQ).
+  /^Event `CustomEvent` \(type=[\w-]+\) captured as promise rejection$/,
+  // javascript-obfuscator's hex-suffixed identifier scheme. WORLDMONITOR-11P is
+  // the shape: `ReferenceError: _0x58c9 is not defined` on Chrome 152 /
+  // Windows at `/`, whose only frames are three `<anonymous>:1` — an injected
+  // userscript or extension bundle referencing its own obfuscated global before
+  // define. Same class as the `mainWorldSdk` / `extDomain` / `crusoe` entries
+  // the dashboard carries.
+  //
+  // Matched on the identifier so BOTH engine phrasings are covered from one
+  // entry — Chromium says `<name> is not defined`, WebKit says `Can't find
+  // variable: <name>` — and on the SHAPE rather than the one observed name,
+  // because the hex suffix is regenerated on every obfuscation run. `_0x`
+  // followed by four or more hex digits is javascript-obfuscator's output
+  // convention and nothing else: Vite's esbuild/terser minifier emits
+  // single-letter and `$`-prefixed names, never a `_0x` prefix, and the literal
+  // appears nowhere in `pro-test/src`, `shared/`, or either inline script.
+  //
+  // The dashboard has carried only the WebKit half (`/Can't find variable:
+  // _0x/`) since #4005; this pass adds the same shape there alongside it.
+  /\b_0x[0-9a-f]{4,}\b/,
+  // WebAuthn on a shell that has no authenticator. WORLDMONITOR-11Q is the
+  // shape: `NotSupportedError: The user agent does not support public key
+  // credentials.` (`DOMException.code: 9`) on Electron 33.4.11 / Windows at
+  // `/pro`, arriving via `onunhandledrejection` with zero frames, breadcrumbs
+  // ending at Clerk's `POST /v1/client/sign_ins`.
+  //
+  // The sentence is emitted by the browser's own `navigator.credentials`
+  // implementation, so only a WebAuthn CALLER can raise it — and the marketing
+  // surface has none: neither `navigator.credentials` nor
+  // `PublicKeyCredential` appears in `pro-test/src`, the `shared/` leaves, or
+  // either inline script. The only passkey on this surface is Clerk's own
+  // sign-in UI (the `Passkey sign-in` string in `locales/*.json` is marketing
+  // copy for it), so the throw belongs to the Clerk SDK on an Electron shell
+  // that ships no authenticator — the same disposition as the `ClerkJS:
+  // Network error` and `[clerk] failed to load` entries on the dashboard.
+  //
+  // Anchored to the whole sentence: bare `NotSupportedError` is generic enough
+  // that our own bundle could raise it (the dashboard keeps it behind a
+  // `!hasFirstParty` gate for exactly that reason), so only the WebAuthn
+  // wording — which no first-party call site can reach — is suppressed here.
+  /^(?:Error: )?NotSupportedError: The user agent does not support public key credentials\.$/,
 ];
 
 /** Sentry's own hashed SDK chunk — infrastructure, never evidence of our code. */
@@ -244,6 +308,14 @@ const MODULE_LOAD_FAILURE =
  * infinitely, and suppressing this by message alone would hide it.
  */
 const STACK_OVERFLOW = /Maximum call stack size exceeded|too much recursion/i;
+/**
+ * A fetch cancelled by a bare `AbortController.abort()`, in the engine's own
+ * default wording. Deliberately NOT in `MARKETING_IGNORE_ERRORS`: this bundle
+ * aborts fetches itself (`createTimeoutSignal`, the checkout transport, the
+ * entitlement poll), so suppressing the message alone would hide a first-party
+ * abort that genuinely escaped a `.catch`.
+ */
+const LEAKED_ABORT = /^(?:AbortError: )?The user aborted a request\.?$/;
 /**
  * A marketing document frame: `/`, `/pro`, or an absolute URL on any production,
  * preview, or custom host with one of those paths. Query strings, hashes, and a
@@ -359,6 +431,27 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // loop in this bundle — the realistic first-party cause — still pages
   // (WORLDMONITOR-103).
   if (!hasFirstParty && STACK_OVERFLOW.test(msg)) return null;
+
+  // A leaked fetch cancellation. WORLDMONITOR-11M is the shape: `AbortError:
+  // The user aborted a request.` (`DOMException.code: 20`) on Chrome 151 /
+  // macOS at `/`, via `onunhandledrejection` with zero frames.
+  //
+  // The wording is what a bare `controller.abort()` produces — no reason
+  // argument. This bundle's own aborts do not look like that and do not escape:
+  // `createTimeoutSignal` aborts with an explicit `TimeoutError` DOMException
+  // (see `./timeout-signal.ts`, and Chrome's native `AbortSignal.timeout` says
+  // `signal timed out`), and every fetch that carries one — the pricing
+  // catalog, the teaser loaders, the entitlement poll, the checkout transport —
+  // sits inside a `catch`. So on this surface a bare-abort rejection reaching
+  // the global handler comes from the Clerk SDK or an injected script.
+  //
+  // Gated on `!hasFirstParty` rather than suppressed by message, because that
+  // census is a fact about today's call sites, not an invariant: a future
+  // first-party `controller.abort()` that escapes its chain must still page,
+  // and it would ride a `/pro/assets/*.js` frame. Dashboard-side this class is
+  // covered by the standing `(?:AbortError: )?The user aborted a request` entry
+  // in `src/bootstrap/sentry-init.ts`.
+  if (!hasFirstParty && LEAKED_ABORT.test(msg)) return null;
 
   // Safari-masked injected script. The observed event (WORLDMONITOR-110,
   // `TypeError: Attempting to change value of a readonly property.` on iOS

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -146,6 +146,24 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /objectStoreNames/,
       /Unexpected identifier 'https'/,
       /Can't find variable: _0x/,
+      // The Chromium/Gecko half of the entry above. javascript-obfuscator names
+      // its identifiers `_0x<hex>`, and a userscript or extension bundle that
+      // reads its own obfuscated global before define throws
+      // `_0x58c9 is not defined` there and `Can't find variable: _0x58c9` on
+      // WebKit — so the entry above has covered only Safari since #4005.
+      // WORLDMONITOR-11P is the other half leaking through (Chrome 152 /
+      // Windows, three `<anonymous>:1` frames and nothing else); it landed on
+      // the marketing surface, which runs a separate Sentry client, and the
+      // same hole exists here.
+      //
+      // Added ALONGSIDE the WebKit entry rather than replacing it: keying on
+      // four-or-more hex digits is what makes the identifier unmistakably
+      // obfuscator output, but it would drop a non-hex `_0x…` name that the
+      // broader Safari-phrasing entry has been suppressing for months. Neither
+      // pattern subsumes the other. Vite's esbuild/terser minifier emits
+      // single-letter and `$`-prefixed names, never a `_0x` prefix, and the
+      // literal appears nowhere in src/, api/, shared/, public/ or index.html.
+      /\b_0x[0-9a-f]{4,}\b/,
       /Can't find variable: video/,
       /hackLocationFailed is not defined/,
       /userScripts is not defined/,

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -904,3 +904,110 @@ describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () =
     }
   });
 });
+
+// ─── 2026-09-02 triage: marketing-surface gaps the dashboard has covered ──────
+//
+// Four production issues, all `sentry.javascript.react` with a null release and
+// all fired by the browser's own global handlers (`onunhandledrejection` /
+// `onerror`), so no first-party catch was involved and no frame gate had
+// anything to act on. Each is a class `src/bootstrap/sentry-init.ts` has
+// suppressed for months; the two surfaces run separate Sentry clients, which is
+// the same gap that let WORLDMONITOR-15/-102/-107/-108/-10N/-10T/-117/-11F
+// through before it.
+
+describe('marketing ignoreErrors — injected-script classes (2026-09-02 triage)', () => {
+  it('drops a synthetic CustomEvent rejected into onunhandledrejection (WORLDMONITOR-11S)', () => {
+    // Verbatim production value: Safari 26.6.2 / macOS on `/pro`, whose
+    // `extra.__serialized__` was `{type: 'unhandledrejection', isTrusted: false,
+    // target: '[object Window]', …}` — a script-dispatched Event object, not a
+    // browser-fired one.
+    assert.equal(
+      isIgnored('CustomEvent', 'Event `CustomEvent` (type=unhandledrejection) captured as promise rejection'),
+      true,
+    );
+  });
+
+  it('keeps a first-party message that merely mentions CustomEvent', () => {
+    assert.equal(isIgnored('Error', 'CustomEvent listener for wm-session-degraded threw'), false);
+  });
+
+  it('pins the marketing surface as CustomEvent-free, which is what licenses the rule', () => {
+    const offenders = marketingFirstPartySources()
+      .filter((f) => !f.rel.includes('sentry-filter-policy'))
+      .filter((f) => /\bCustomEvent\b/.test(f.code))
+      .map((f) => f.rel);
+    assert.deepEqual(offenders, [],
+      'the marketing surface now constructs a CustomEvent — re-derive the WORLDMONITOR-11S rule');
+  });
+
+  it('drops a javascript-obfuscator `_0x` identifier in both engine phrasings (WORLDMONITOR-11P)', () => {
+    // Verbatim production value: Chrome 152 / Windows on `/`, three
+    // `<anonymous>:1` frames and nothing else.
+    assert.equal(isIgnored('ReferenceError', '_0x58c9 is not defined'), true);
+    // WebKit phrasing of the same missing global — the dashboard has carried
+    // only this half since #4005.
+    assert.equal(isIgnored('ReferenceError', "Can't find variable: _0x4f2a1b"), true);
+  });
+
+  it('keeps a name that merely starts with an underscore-zero-ex prefix', () => {
+    assert.equal(isIgnored('ReferenceError', '_0xy is not defined'), false);
+    assert.equal(isIgnored('ReferenceError', '_0 is not defined'), false);
+  });
+
+  it('pins the marketing surface as `_0x`-free, which is what licenses the rule', () => {
+    const offenders = marketingFirstPartySources()
+      .filter((f) => !f.rel.includes('sentry-filter-policy'))
+      .filter((f) => /_0x[0-9a-f]{4,}/.test(f.code))
+      .map((f) => f.rel);
+    assert.deepEqual(offenders, []);
+  });
+
+  it('drops the WebAuthn unsupported-agent rejection (WORLDMONITOR-11Q)', () => {
+    // Verbatim production value: Electron 33.4.11 / Windows on `/pro`,
+    // `DOMException.code: 9`, breadcrumbs ending at Clerk's
+    // `POST /v1/client/sign_ins`. Clerk's own sign-in UI offers passkeys; the
+    // Electron shell ships no `PublicKeyCredential`.
+    assert.equal(
+      isIgnored('Error', 'NotSupportedError: The user agent does not support public key credentials.'),
+      true,
+    );
+  });
+
+  it('keeps other NotSupportedError messages so a real one still reports', () => {
+    assert.equal(isIgnored('Error', 'NotSupportedError: The operation is not supported.'), false);
+  });
+
+  it('pins the marketing surface as WebAuthn-free, which is what licenses the rule', () => {
+    const offenders = marketingFirstPartySources()
+      .filter((f) => !f.rel.includes('sentry-filter-policy'))
+      .filter((f) => /navigator\.credentials|PublicKeyCredential/.test(f.code))
+      .map((f) => f.rel);
+    assert.deepEqual(offenders, [],
+      'the marketing surface now calls WebAuthn — re-derive the WORLDMONITOR-11Q rule');
+  });
+});
+
+describe('marketingBeforeSend — leaked fetch abort (WORLDMONITOR-11M)', () => {
+  const ABORTED = 'AbortError: The user aborted a request.';
+
+  it('drops the zero-frame abort rejection', () => {
+    assert.equal(marketingBeforeSend(event(ABORTED)), null);
+    // Chrome also reports it without the type prefix in `value`.
+    assert.equal(marketingBeforeSend(event('The user aborted a request.')), null);
+  });
+
+  it('keeps the same message when a marketing-bundle frame is present', () => {
+    const kept = event(ABORTED, ['/pro/assets/main-Ab12Cd.js']);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  it('keeps the same message when a source-mapped frame is present', () => {
+    const kept = event(ABORTED, ['src/services/checkout.ts']);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  it('keeps an unrelated abort-flavoured message', () => {
+    const kept = event('Checkout aborted a request to Dodo');
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+});


### PR DESCRIPTION
## Summary

`/` and `/pro` render from `pro-test/`, which runs its own `@sentry/react` client — `src/bootstrap/sentry-init.ts` never executes there. Today's triage found **all six** new error-level issues sitting in that gap, four of them classes the dashboard has suppressed for months. This closes those four.

All four arrived as `sentry.javascript.react` with a null release, fired by the browser's own `onunhandledrejection` / `onerror`, carrying zero frames or `<anonymous>` only. So no first-party catch was involved, and `marketingBeforeSend`'s frame gates had nothing to act on for three of them.

| Issue | Message | Lands in | What licenses it |
|---|---|---|---|
| `WORLDMONITOR-11S` | `Event \`CustomEvent\` (type=unhandledrejection) captured as promise rejection` | `MARKETING_IGNORE_ERRORS` | Sentry writes that sentence only for a real `CustomEvent` instance, and the surface constructs none. `isTrusted: false` — script-dispatched, not browser-fired. |
| `WORLDMONITOR-11P` | `_0x58c9 is not defined` | `MARKETING_IGNORE_ERRORS` | `_0x<hex>` is javascript-obfuscator's identifier scheme; esbuild/terser emit single-letter and `$`-prefixed names. Absent from both bundles. |
| `WORLDMONITOR-11Q` | `NotSupportedError: The user agent does not support public key credentials.` | `MARKETING_IGNORE_ERRORS` | Browser-native WebAuthn wording, so only a `navigator.credentials` caller can raise it — the surface has none. Clerk's passkey UI on an Electron 33 shell with no authenticator. |
| `WORLDMONITOR-11M` | `AbortError: The user aborted a request.` | `marketingBeforeSend`, `!hasFirstParty` | **Not** message-level: this bundle aborts fetches itself, so "every abort here is caught" is a census of today's call sites, not an invariant. A future escaped first-party abort must still page, and it rides a `/pro/assets/*.js` frame. |

The three message-level entries are anchored to the whole sentence rather than copied as substrings from the dashboard, and each one's premise — "no first-party call site can reach this" — is turned into a source scan the suite runs, so the licence fails loudly if the surface ever gains a `CustomEvent`, a `_0x` name, or a WebAuthn call.

## The dashboard's `_0x` entry

Its `/Can't find variable: _0x/` is the WebKit phrasing only, so the same hole exists there — Chromium and Gecko say `_0x58c9 is not defined`. The identifier-shape pattern is added **alongside** it, not as a replacement: neither subsumes the other, and swapping would have dropped a non-hex `_0x…` name that entry has been suppressing since #4005.

## Deliberately left unfiltered

Two of the six are noise by evidence but have no sound structural discriminator, so they stay open rather than get a wording-based suppressor:

- `WORLDMONITOR-11R` — `Object captured as promise rejection with keys: [object has no keys]`. The existing plain-object rule keys on the JSON-RPC reserved code range; an empty payload offers nothing equivalent.
- `WORLDMONITOR-10D` — the same shape with `{code: 400, message: 'TOKEN_EXPIRED', status: 'INVALID_ARGUMENT'}`. Its breadcrumbs name a Chrome extension (`[extensionService]`, `/chrome-storage-local-get`), but breadcrumb-gating is not a sound licence.

Both could reach Sentry through `services/clerk.ts`'s rejection forwarding, so a message-only rule there would be the blind spot this file exists to avoid.

## Validation

The four suppression tests were written first and confirmed **red** against the pre-fix policy, then green. Eight further tests are positive controls and source scans — delete a gate and a KEEP case goes red rather than the suite passing on absence.

```
tests/pro-sentry-filter-policy.test.mts   84/84   (was 72)
tests/sentry-beforesend.test.mjs         296/296
npx tsc --noEmit                         clean
pre-push gates                           all passed
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_01AaFMdBw39ftNSpQx9pKZ1r
