### PR TITLE
fix(climate): preserve Open-Meteo fallback budget

### DIFF
--- a/scripts/_open-meteo-archive.mjs
+++ b/scripts/_open-meteo-archive.mjs
@@ -204,9 +204,11 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
   if (connectProxyAuth) {
     try {
       console.log(`  [OPEN_METEO] direct failed on ${label} (${lastDirectError?.message ?? 'unknown'}); trying proxy (CONNECT)`);
+      const connectTimeoutMs = routeTimeoutMs();
       const { buffer } = await _proxyFetcher(url, connectProxyAuth, {
         accept: 'application/json',
-        timeoutMs: routeTimeoutMs(),
+        timeoutMs: connectTimeoutMs,
+        signal: AbortSignal.timeout(connectTimeoutMs),
       });
       ensureBeforeDeadline();
       const data = normalizeArchiveBatchResponse(JSON.parse(buffer.toString('utf8')));

--- a/scripts/_open-meteo-archive.mjs
+++ b/scripts/_open-meteo-archive.mjs
@@ -21,7 +21,15 @@ export const _PROXY_DEFAULTS = Object.freeze({
 });
 
 const MAX_RETRY_AFTER_MS = 60_000;
+const CURL_PROXY_TIMEOUT_MS = 15_000;
 const RETRYABLE_STATUSES = new Set([429, 503]);
+export const OPEN_METEO_DEADLINE_CODE = 'OPEN_METEO_DEADLINE';
+
+function createDeadlineError(label) {
+  return Object.assign(new Error(`Open-Meteo deadline exhausted for ${label}`), {
+    code: OPEN_METEO_DEADLINE_CODE,
+  });
+}
 
 export function chunkItems(items, size) {
   const chunks = [];
@@ -60,9 +68,10 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
     timeoutMs = 30_000,
     maxRetries = 3,
     retryBaseMs = 2_000,
+    deadlineAtMs = Number.POSITIVE_INFINITY,
     label = zones.map((zone) => zone.name).join(', '),
     // Test hooks. Production callers leave these unset; the helper uses the
-    // real proxy resolvers + fetchers from _seed-utils.mjs (see _PROXY_DEFAULTS).
+    // real clock, sleeper, proxy resolvers, and fetchers.
     // Tests inject mocks to exercise the cascade without spinning up real
     // Decodo tunnels. Keep these undocumented in PR descriptions — they are
     // implementation-only seams, not a public API surface.
@@ -75,6 +84,8 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
     _curlProxyResolver = _PROXY_DEFAULTS.curlProxyResolver,
     _proxyFetcher = _PROXY_DEFAULTS.connectFetcher,
     _proxyCurlFetcher = _PROXY_DEFAULTS.curlFetcher,
+    _now = Date.now,
+    _sleep = sleep,
   } = opts;
 
   const params = new URLSearchParams({
@@ -93,20 +104,50 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
   // upstream error (timeout, ECONNRESET, HTTP status code) that triggered
   // the fallback path.
   let lastDirectError = null;
+  let proxyAuthResolved = false;
+  let connectProxyAuth = null;
+  let curlProxyAuth = null;
+
+  const resolveProxyAuth = () => {
+    if (!proxyAuthResolved) {
+      connectProxyAuth = _connectProxyResolver();
+      curlProxyAuth = _curlProxyResolver();
+      proxyAuthResolved = true;
+    }
+    return Boolean(connectProxyAuth || curlProxyAuth);
+  };
+
+  const routeTimeoutMs = (routeLimitMs = timeoutMs) => {
+    const remainingMs = deadlineAtMs - _now();
+    if (!(remainingMs > 0)) throw createDeadlineError(label);
+    return Math.max(1, Math.min(routeLimitMs, Math.floor(remainingMs)));
+  };
+
+  const ensureBeforeDeadline = () => {
+    if (!(deadlineAtMs - _now() > 0)) throw createDeadlineError(label);
+  };
+
+  const waitForDirectRetry = async (retryMs) => {
+    if (retryMs >= deadlineAtMs - _now()) throw createDeadlineError(label);
+    await _sleep(retryMs);
+    ensureBeforeDeadline();
+  };
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     let resp;
     try {
       resp = await fetch(url, {
         headers: { 'User-Agent': CHROME_UA },
-        signal: AbortSignal.timeout(timeoutMs),
+        signal: AbortSignal.timeout(routeTimeoutMs()),
       });
+      ensureBeforeDeadline();
     } catch (err) {
+      if (err?.code === OPEN_METEO_DEADLINE_CODE) throw err;
       lastDirectError = err;
       if (attempt < maxRetries) {
         const retryMs = retryBaseMs * 2 ** attempt;
         console.log(`  [OPEN_METEO] ${err?.message ?? err} for ${label}; retrying batch in ${Math.round(retryMs / 1000)}s`);
-        await sleep(retryMs);
+        await waitForDirectRetry(retryMs);
         continue;
       }
       // Final direct attempt threw (timeout, ECONNRESET, DNS, etc.). Fall
@@ -127,9 +168,10 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
     lastDirectError = new Error(`HTTP ${resp.status}`);
 
     if (RETRYABLE_STATUSES.has(resp.status) && attempt < maxRetries) {
+      if (resolveProxyAuth()) break;
       const retryMs = parseRetryAfterMs(resp.headers.get('retry-after')) ?? (retryBaseMs * 2 ** attempt);
       console.log(`  [OPEN_METEO] ${resp.status} for ${label}; retrying batch in ${Math.round(retryMs / 1000)}s`);
-      await sleep(retryMs);
+      await waitForDirectRetry(retryMs);
       continue;
     }
 
@@ -142,9 +184,9 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
   }
 
   // Proxy fallback — same pattern as fredFetchJson / imfFetchJson in
-  // _seed-utils.mjs. Decodo gateway gets a different egress IP that is not
-  // (yet) on Open-Meteo's per-IP throttle. Skip silently if no proxy is
-  // configured (preserves existing behavior in non-Railway envs).
+  // _seed-utils.mjs. A retryable direct status transfers control here before
+  // another same-IP wait when a proxy is configured. Non-proxy environments
+  // keep the direct retry loop above.
   //
   // Two-attempt cascade: CONNECT path first (pure-Node, faster, no curl
   // dependency), curl fallback second. Decodo's CONNECT and curl egress
@@ -155,18 +197,18 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
   // be a single point of failure if Decodo rebalances pools. The curl
   // attempt costs an exec only when CONNECT also failed, so steady-state
   // overhead is zero.
-  const connectProxyAuth = _connectProxyResolver();
-  const curlProxyAuth = _curlProxyResolver();
+  resolveProxyAuth();
   let lastProxyError = null;
 
   // CONNECT leg via gate.decodo.com pool.
   if (connectProxyAuth) {
     try {
-      console.log(`  [OPEN_METEO] direct exhausted on ${label} (${lastDirectError?.message ?? 'unknown'}); trying proxy (CONNECT)`);
+      console.log(`  [OPEN_METEO] direct failed on ${label} (${lastDirectError?.message ?? 'unknown'}); trying proxy (CONNECT)`);
       const { buffer } = await _proxyFetcher(url, connectProxyAuth, {
         accept: 'application/json',
-        timeoutMs,
+        timeoutMs: routeTimeoutMs(),
       });
+      ensureBeforeDeadline();
       const data = normalizeArchiveBatchResponse(JSON.parse(buffer.toString('utf8')));
       if (data.length !== zones.length) {
         throw new Error(`Open-Meteo proxy batch size mismatch for ${label}: expected ${zones.length}, got ${data.length}`);
@@ -174,6 +216,7 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
       console.log(`  [OPEN_METEO] proxy (CONNECT) succeeded for ${label}`);
       return data;
     } catch (proxyErr) {
+      if (proxyErr?.code === OPEN_METEO_DEADLINE_CODE) throw proxyErr;
       lastProxyError = proxyErr;
       console.warn(`  [OPEN_METEO] proxy (CONNECT) failed for ${label}: ${proxyErr?.message ?? proxyErr}${curlProxyAuth ? '; trying proxy (curl)' : ''}`);
     }
@@ -189,7 +232,13 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
       // Promise.resolve + await keeps the call future-safe: if curlFetch is
       // ever refactored to async, this line silently keeps working instead
       // of returning an unhandled Promise to JSON.parse.
-      const text = await Promise.resolve(_proxyCurlFetcher(url, curlProxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' }));
+      const text = await Promise.resolve(_proxyCurlFetcher(
+        url,
+        curlProxyAuth,
+        { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+        { timeoutMs: routeTimeoutMs(Math.min(timeoutMs, CURL_PROXY_TIMEOUT_MS)) },
+      ));
+      ensureBeforeDeadline();
       const data = normalizeArchiveBatchResponse(JSON.parse(text));
       if (data.length !== zones.length) {
         throw new Error(`Open-Meteo proxy (curl) batch size mismatch for ${label}: expected ${zones.length}, got ${data.length}`);
@@ -197,6 +246,7 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
       console.log(`  [OPEN_METEO] proxy (curl) succeeded for ${label}`);
       return data;
     } catch (curlErr) {
+      if (curlErr?.code === OPEN_METEO_DEADLINE_CODE) throw curlErr;
       lastProxyError = curlErr;
       console.warn(`  [OPEN_METEO] proxy (curl) failed for ${label}: ${curlErr?.message ?? curlErr}`);
     }

--- a/scripts/seed-climate-zone-normals.mjs
+++ b/scripts/seed-climate-zone-normals.mjs
@@ -16,6 +16,15 @@ const NORMALS_BATCH_SIZE = 2;
 const NORMALS_BATCH_DELAY_MS = 3_000;
 export const NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS = 225_000;
 
+function createNormalsFailure(message, deadlineExhausted) {
+  const error = new Error(message);
+  if (deadlineExhausted) {
+    error.code = OPEN_METEO_DEADLINE_CODE;
+    error.nonRetryable = true;
+  }
+  return error;
+}
+
 function round(value, decimals = 2) {
   const scale = 10 ** decimals;
   return Math.round(value * scale) / scale;
@@ -103,10 +112,12 @@ export async function fetchClimateZoneNormals({
   const normals = [];
   const batches = chunkItems(CLIMATE_ZONES, NORMALS_BATCH_SIZE);
   const deadlineAtMs = runStartedAtMs + NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS;
+  let deadlineExhausted = false;
 
   for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
     const batch = batches[batchIndex];
     if (_now() >= deadlineAtMs) {
+      deadlineExhausted = true;
       break;
     }
 
@@ -127,7 +138,10 @@ export async function fetchClimateZoneNormals({
       normals.push(...batchNormals);
     } catch (err) {
       console.log(`  [CLIMATE_NORMALS] ${err?.message ?? err}`);
-      if (err?.code === OPEN_METEO_DEADLINE_CODE) break;
+      if (err?.code === OPEN_METEO_DEADLINE_CODE) {
+        deadlineExhausted = true;
+        break;
+      }
     }
 
     if (batchIndex < batches.length - 1) {
@@ -139,10 +153,13 @@ export async function fetchClimateZoneNormals({
 
   if (normals.length < MIN_CLIMATE_ZONE_COUNT) {
     const failures = CLIMATE_ZONES.length - normals.length;
-    throw new Error(`Only ${normals.length}/${CLIMATE_ZONES.length} zones returned normals (${failures} errors)`);
+    throw createNormalsFailure(
+      `Only ${normals.length}/${CLIMATE_ZONES.length} zones returned normals (${failures} errors)`,
+      deadlineExhausted,
+    );
   }
   if (!hasRequiredClimateZones(normals, (zone) => zone.zone)) {
-    throw new Error('Missing one or more required climate-specific zone normals');
+    throw createNormalsFailure('Missing one or more required climate-specific zone normals', deadlineExhausted);
   }
 
   return {

--- a/scripts/seed-climate-zone-normals.mjs
+++ b/scripts/seed-climate-zone-normals.mjs
@@ -94,19 +94,24 @@ export function buildZoneNormalsFromBatch(zones, batchPayloads) {
   });
 }
 
-export async function fetchClimateZoneNormals({ runStartedAtMs = Date.now() } = {}) {
+export async function fetchClimateZoneNormals({
+  runStartedAtMs = Date.now(),
+  _now = Date.now,
+  _sleep = sleep,
+  _fetchArchiveBatch = fetchOpenMeteoArchiveBatch,
+} = {}) {
   const normals = [];
   const batches = chunkItems(CLIMATE_ZONES, NORMALS_BATCH_SIZE);
   const deadlineAtMs = runStartedAtMs + NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS;
 
   for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
     const batch = batches[batchIndex];
-    if (Date.now() >= deadlineAtMs) {
+    if (_now() >= deadlineAtMs) {
       break;
     }
 
     try {
-      const payloads = await fetchOpenMeteoArchiveBatch(batch, {
+      const payloads = await _fetchArchiveBatch(batch, {
         startDate: NORMALS_START,
         endDate: NORMALS_END,
         daily: ['temperature_2m_mean', 'precipitation_sum'],
@@ -114,6 +119,8 @@ export async function fetchClimateZoneNormals({ runStartedAtMs = Date.now() } = 
         maxRetries: 4,
         retryBaseMs: 5_000,
         deadlineAtMs,
+        _now,
+        _sleep,
         label: `normals batch (${batch.map((zone) => zone.name).join(', ')})`,
       });
       const batchNormals = buildZoneNormalsFromBatch(batch, payloads);
@@ -124,9 +131,9 @@ export async function fetchClimateZoneNormals({ runStartedAtMs = Date.now() } = 
     }
 
     if (batchIndex < batches.length - 1) {
-      const remainingMs = deadlineAtMs - Date.now();
+      const remainingMs = deadlineAtMs - _now();
       if (remainingMs <= 0) break;
-      await sleep(Math.min(NORMALS_BATCH_DELAY_MS, remainingMs));
+      await _sleep(Math.min(NORMALS_BATCH_DELAY_MS, remainingMs));
     }
   }
 
@@ -140,7 +147,7 @@ export async function fetchClimateZoneNormals({ runStartedAtMs = Date.now() } = 
 
   return {
     referencePeriod: '1991-2020',
-    fetchedAt: Date.now(),
+    fetchedAt: _now(),
     normals,
   };
 }

--- a/scripts/seed-climate-zone-normals.mjs
+++ b/scripts/seed-climate-zone-normals.mjs
@@ -3,7 +3,7 @@
 import { pathToFileURL } from 'node:url';
 import { loadEnvFile, runSeed, sleep } from './_seed-utils.mjs';
 import { CLIMATE_ZONES, MIN_CLIMATE_ZONE_COUNT, hasRequiredClimateZones } from './_climate-zones.mjs';
-import { chunkItems, fetchOpenMeteoArchiveBatch } from './_open-meteo-archive.mjs';
+import { OPEN_METEO_DEADLINE_CODE, chunkItems, fetchOpenMeteoArchiveBatch } from './_open-meteo-archive.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -14,6 +14,7 @@ const NORMALS_START = '1991-01-01';
 const NORMALS_END = '2020-12-31';
 const NORMALS_BATCH_SIZE = 2;
 const NORMALS_BATCH_DELAY_MS = 3_000;
+export const NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS = 225_000;
 
 function round(value, decimals = 2) {
   const scale = 10 ** decimals;
@@ -93,11 +94,17 @@ export function buildZoneNormalsFromBatch(zones, batchPayloads) {
   });
 }
 
-export async function fetchClimateZoneNormals() {
+export async function fetchClimateZoneNormals({ runStartedAtMs = Date.now() } = {}) {
   const normals = [];
-  let failures = 0;
+  const batches = chunkItems(CLIMATE_ZONES, NORMALS_BATCH_SIZE);
+  const deadlineAtMs = runStartedAtMs + NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS;
 
-  for (const batch of chunkItems(CLIMATE_ZONES, NORMALS_BATCH_SIZE)) {
+  for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
+    const batch = batches[batchIndex];
+    if (Date.now() >= deadlineAtMs) {
+      break;
+    }
+
     try {
       const payloads = await fetchOpenMeteoArchiveBatch(batch, {
         startDate: NORMALS_START,
@@ -106,19 +113,25 @@ export async function fetchClimateZoneNormals() {
         timeoutMs: 30_000,
         maxRetries: 4,
         retryBaseMs: 5_000,
+        deadlineAtMs,
         label: `normals batch (${batch.map((zone) => zone.name).join(', ')})`,
       });
       const batchNormals = buildZoneNormalsFromBatch(batch, payloads);
       normals.push(...batchNormals);
-      failures += Math.max(0, batch.length - batchNormals.length);
     } catch (err) {
       console.log(`  [CLIMATE_NORMALS] ${err?.message ?? err}`);
-      failures += batch.length;
+      if (err?.code === OPEN_METEO_DEADLINE_CODE) break;
     }
-    await sleep(NORMALS_BATCH_DELAY_MS);
+
+    if (batchIndex < batches.length - 1) {
+      const remainingMs = deadlineAtMs - Date.now();
+      if (remainingMs <= 0) break;
+      await sleep(Math.min(NORMALS_BATCH_DELAY_MS, remainingMs));
+    }
   }
 
   if (normals.length < MIN_CLIMATE_ZONE_COUNT) {
+    const failures = CLIMATE_ZONES.length - normals.length;
     throw new Error(`Only ${normals.length}/${CLIMATE_ZONES.length} zones returned normals (${failures} errors)`);
   }
   if (!hasRequiredClimateZones(normals, (zone) => zone.zone)) {

--- a/tests/open-meteo-proxy-fallback.test.mjs
+++ b/tests/open-meteo-proxy-fallback.test.mjs
@@ -135,11 +135,15 @@ test('non-retryable status (500): falls through to proxy attempt without extra r
 test('429 + proxy configured + proxy succeeds: returns proxy data, never throws', async () => {
   const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
 
-  globalThis.fetch = async () => ({
-    ok: false, status: 429,
-    headers: { get: () => null },
-    json: async () => ({}),
-  });
+  let directCalls = 0;
+  globalThis.fetch = async () => {
+    directCalls += 1;
+    return {
+      ok: false, status: 429,
+      headers: { get: () => null },
+      json: async () => ({}),
+    };
+  };
 
   let proxyCalls = 0;
   let receivedProxyAuth = null;
@@ -155,10 +159,131 @@ test('429 + proxy configured + proxy succeeds: returns proxy data, never throws'
     },
   });
 
+  assert.equal(directCalls, 1, 'a configured proxy should own the next attempt after a throttle');
   assert.equal(proxyCalls, 1);
   assert.equal(receivedProxyAuth, 'user:pass@gate.decodo.com:7000');
   assert.equal(result.length, 2);
   assert.equal(result[1].latitude, 80);
+});
+
+test('multiple throttled batches transfer directly to CONNECT without retry waits', async () => {
+  const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
+
+  let status = 429;
+  let directCalls = 0;
+  globalThis.fetch = async () => {
+    directCalls += 1;
+    return {
+      ok: false, status,
+      headers: { get: () => null },
+      json: async () => ({}),
+    };
+  };
+
+  let nowMs = 0;
+  let connectCalls = 0;
+  const retryWaits = [];
+  for (const throttleStatus of [429, 503, 429]) {
+    status = throttleStatus;
+    const result = await fetchOpenMeteoArchiveBatch(ZONES, {
+      ...ARCHIVE_OPTS,
+      maxRetries: 4,
+      retryBaseMs: 1,
+      deadlineAtMs: 225_000,
+      _now: () => nowMs,
+      _sleep: async (waitMs) => {
+        retryWaits.push(waitMs);
+        nowMs += waitMs;
+      },
+      _connectProxyResolver: () => 'user:pass@gate.decodo.com:7000',
+      _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
+      _proxyFetcher: async () => {
+        connectCalls += 1;
+        nowMs += 1_000;
+        return { buffer: Buffer.from(JSON.stringify(VALID_PAYLOAD), 'utf8'), contentType: 'application/json' };
+      },
+    });
+    assert.equal(result.length, ZONES.length);
+  }
+
+  assert.equal(directCalls, 3, 'each batch should make one direct attempt');
+  assert.equal(connectCalls, 3, 'each throttled batch should reach CONNECT');
+  assert.deepEqual(retryWaits, [], 'the helper should not wait before changing egress routes');
+  assert.ok(nowMs < 225_000, 'the proxy cascade should finish inside the shared soft deadline');
+});
+
+test('shared deadline clamps CONNECT and rejects a response that finishes after expiry', async () => {
+  const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
+
+  let nowMs = 5;
+  globalThis.fetch = async () => ({
+    ok: false, status: 503,
+    headers: { get: () => null },
+    json: async () => ({}),
+  });
+
+  let connectCalls = 0;
+  await assert.rejects(
+    () => fetchOpenMeteoArchiveBatch(ZONES, {
+      ...ARCHIVE_OPTS,
+      deadlineAtMs: 100,
+      _now: () => nowMs,
+      _connectProxyResolver: () => 'user:pass@gate.decodo.com:7000',
+      _curlProxyResolver: () => null,
+      _proxyFetcher: async (_url, _proxyAuth, options) => {
+        connectCalls += 1;
+        assert.equal(options.timeoutMs, 95);
+        nowMs = 101;
+        return { buffer: Buffer.from(JSON.stringify(VALID_PAYLOAD), 'utf8'), contentType: 'application/json' };
+      },
+    }),
+    (err) => {
+      assert.equal(err.code, 'OPEN_METEO_DEADLINE');
+      return true;
+    },
+  );
+  assert.equal(connectCalls, 1);
+});
+
+test('shared deadline gives CONNECT failure time to reach the curl route', async () => {
+  const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
+
+  let nowMs = 100;
+  let directCalls = 0;
+  globalThis.fetch = async () => {
+    directCalls += 1;
+    return {
+      ok: false, status: 429,
+      headers: { get: () => null },
+      json: async () => ({}),
+    };
+  };
+
+  let connectCalls = 0;
+  let curlCalls = 0;
+  const result = await fetchOpenMeteoArchiveBatch(ZONES, {
+    ...ARCHIVE_OPTS,
+    deadlineAtMs: 1_000,
+    _now: () => nowMs,
+    _connectProxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
+    _proxyFetcher: async (_url, _proxyAuth, options) => {
+      connectCalls += 1;
+      assert.equal(options.timeoutMs, 900);
+      nowMs = 400;
+      throw new Error('CONNECT 502');
+    },
+    _proxyCurlFetcher: (_url, _proxyAuth, _headers, options) => {
+      curlCalls += 1;
+      assert.equal(options.timeoutMs, 600);
+      return JSON.stringify(VALID_PAYLOAD);
+    },
+  });
+
+  assert.equal(directCalls, 1);
+  assert.equal(connectCalls, 1);
+  assert.equal(curlCalls, 1);
+  assert.equal(result.length, ZONES.length);
 });
 
 test('thrown fetch error (timeout/ECONNRESET) on final direct attempt → proxy fallback runs (P1 fix)', async () => {

--- a/tests/open-meteo-proxy-fallback.test.mjs
+++ b/tests/open-meteo-proxy-fallback.test.mjs
@@ -354,6 +354,69 @@ test('normals caller stops launching batches when the soft deadline expires', as
   assert.equal(batchCalls, 1);
 });
 
+test('normals deadline failure stops the outer seed retry loop', async () => {
+  const { OPEN_METEO_DEADLINE_CODE } = await import('../scripts/_open-meteo-archive.mjs');
+  const { withRetry } = await import('../scripts/_seed-utils.mjs');
+  const { fetchClimateZoneNormals } = await import(`../scripts/seed-climate-zone-normals.mjs?t=${Date.now()}`);
+
+  let batchCalls = 0;
+  await assert.rejects(
+    () => withRetry(
+      () => fetchClimateZoneNormals({
+        runStartedAtMs: 0,
+        _now: () => 1,
+        _sleep: async () => {},
+        _fetchArchiveBatch: async () => {
+          batchCalls += 1;
+          throw Object.assign(new Error('deadline'), { code: OPEN_METEO_DEADLINE_CODE });
+        },
+      }),
+      3,
+      0,
+    ),
+    (err) => {
+      assert.equal(err.code, OPEN_METEO_DEADLINE_CODE);
+      assert.equal(err.nonRetryable, true);
+      return true;
+    },
+  );
+  assert.equal(batchCalls, 1);
+});
+
+test('normals pre-batch deadline check is non-retryable', async () => {
+  const {
+    NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS,
+    fetchClimateZoneNormals,
+  } = await import(`../scripts/seed-climate-zone-normals.mjs?t=${Date.now()}`);
+  const { OPEN_METEO_DEADLINE_CODE } = await import('../scripts/_open-meteo-archive.mjs');
+  const { withRetry } = await import('../scripts/_seed-utils.mjs');
+
+  const runStartedAtMs = 10_000;
+  let fetchCalls = 0;
+  await assert.rejects(
+    () => withRetry(
+      () => {
+        fetchCalls += 1;
+        return fetchClimateZoneNormals({
+          runStartedAtMs,
+          _now: () => runStartedAtMs + NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS,
+          _fetchArchiveBatch: async () => {
+            throw new Error('must not start a batch');
+          },
+        });
+      },
+      3,
+      0,
+    ),
+    (err) => {
+      assert.equal(err.code, OPEN_METEO_DEADLINE_CODE);
+      assert.equal(err.nonRetryable, true);
+      return true;
+    },
+  );
+  assert.equal(fetchCalls, 1);
+});
+
 test('thrown fetch error (timeout/ECONNRESET) on final direct attempt → proxy fallback runs (P1 fix)', async () => {
   // Pre-fix bug: the catch block did `throw err` after the final direct retry,
   // which silently bypassed proxy fallback for thrown-error cases (timeout,

--- a/tests/open-meteo-proxy-fallback.test.mjs
+++ b/tests/open-meteo-proxy-fallback.test.mjs
@@ -239,6 +239,7 @@ test('shared deadline clamps CONNECT and rejects a response that finishes after 
       _proxyFetcher: async (_url, _proxyAuth, options) => {
         connectCalls += 1;
         assert.equal(options.timeoutMs, 95);
+        assert.ok(options.signal instanceof AbortSignal, 'CONNECT should share one abort signal across tunnel and response work');
         nowMs = 101;
         return { buffer: Buffer.from(JSON.stringify(VALID_PAYLOAD), 'utf8'), contentType: 'application/json' };
       },

--- a/tests/open-meteo-proxy-fallback.test.mjs
+++ b/tests/open-meteo-proxy-fallback.test.mjs
@@ -22,6 +22,12 @@ const VALID_PAYLOAD = ZONES.map((z) => ({
   daily: { time: ['2020-01-01'], temperature_2m_mean: [10] },
 }));
 
+const VALID_NORMALS_DAILY = {
+  time: Array.from({ length: 12 }, (_, index) => `2020-${String(index + 1).padStart(2, '0')}-15`),
+  temperature_2m_mean: Array(12).fill(10),
+  precipitation_sum: Array(12).fill(1),
+};
+
 const ARCHIVE_OPTS = {
   startDate: '2020-01-01',
   endDate: '2020-01-02',
@@ -284,6 +290,67 @@ test('shared deadline gives CONNECT failure time to reach the curl route', async
   assert.equal(connectCalls, 1);
   assert.equal(curlCalls, 1);
   assert.equal(result.length, ZONES.length);
+});
+
+test('normals caller shares one run-anchored deadline across every batch', async () => {
+  const { CLIMATE_ZONES } = await import('../scripts/_climate-zones.mjs');
+  const {
+    NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS,
+    fetchClimateZoneNormals,
+  } = await import(`../scripts/seed-climate-zone-normals.mjs?t=${Date.now()}`);
+
+  const runStartedAtMs = 10_000;
+  let nowMs = runStartedAtMs;
+  const deadlines = [];
+  const result = await fetchClimateZoneNormals({
+    runStartedAtMs,
+    _now: () => nowMs,
+    _sleep: async (waitMs) => { nowMs += waitMs; },
+    _fetchArchiveBatch: async (batch, options) => {
+      deadlines.push(options.deadlineAtMs);
+      nowMs += 100;
+      return batch.map((zone) => ({
+        latitude: zone.lat,
+        longitude: zone.lon,
+        daily: VALID_NORMALS_DAILY,
+      }));
+    },
+  });
+
+  const expectedDeadlineAtMs = runStartedAtMs + NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS;
+  assert.equal(deadlines.length, Math.ceil(CLIMATE_ZONES.length / 2));
+  assert.ok(deadlines.every((deadlineAtMs) => deadlineAtMs === expectedDeadlineAtMs));
+  assert.equal(result.normals.length, CLIMATE_ZONES.length);
+  assert.ok(result.fetchedAt < expectedDeadlineAtMs);
+});
+
+test('normals caller stops launching batches when the soft deadline expires', async () => {
+  const {
+    NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS,
+    fetchClimateZoneNormals,
+  } = await import(`../scripts/seed-climate-zone-normals.mjs?t=${Date.now()}`);
+
+  const runStartedAtMs = 20_000;
+  let nowMs = runStartedAtMs;
+  let batchCalls = 0;
+  await assert.rejects(
+    () => fetchClimateZoneNormals({
+      runStartedAtMs,
+      _now: () => nowMs,
+      _sleep: async (waitMs) => { nowMs += waitMs; },
+      _fetchArchiveBatch: async (batch) => {
+        batchCalls += 1;
+        nowMs = runStartedAtMs + NORMALS_FETCH_PHASE_SOFT_DEADLINE_MS;
+        return batch.map((zone) => ({
+          latitude: zone.lat,
+          longitude: zone.lon,
+          daily: VALID_NORMALS_DAILY,
+        }));
+      },
+    }),
+    /Only 2\/25 zones returned normals \(23 errors\)/,
+  );
+  assert.equal(batchCalls, 1);
 });
 
 test('thrown fetch error (timeout/ECONNRESET) on final direct attempt → proxy fallback runs (P1 fix)', async () => {

--- a/tests/open-meteo-proxy-fallback.test.mjs
+++ b/tests/open-meteo-proxy-fallback.test.mjs
@@ -213,7 +213,7 @@ test('multiple throttled batches transfer directly to CONNECT without retry wait
 });
 
 test('shared deadline clamps CONNECT and rejects a response that finishes after expiry', async () => {
-  const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
+  const { OPEN_METEO_DEADLINE_CODE, fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
 
   let nowMs = 5;
   globalThis.fetch = async () => ({
@@ -238,7 +238,7 @@ test('shared deadline clamps CONNECT and rejects a response that finishes after 
       },
     }),
     (err) => {
-      assert.equal(err.code, 'OPEN_METEO_DEADLINE');
+      assert.equal(err.code, OPEN_METEO_DEADLINE_CODE);
       return true;
     },
   );


### PR DESCRIPTION
## Why

Repeated 429 and 503 responses from direct Open-Meteo requests could use the full 240-second seed deadline on same-IP retries. The configured Decodo CONNECT and curl routes then had no useful time, so `climateZoneNormals` could remain stale.

This change keeps the direct request first. On a retryable throttle, it transfers control to Decodo at once and applies one 225-second soft deadline across every normals batch and route. The soft deadline leaves time before the `runSeed` hard deadline.

## Scope

- Bound direct requests, retry waits, CONNECT, and curl by the same remaining deadline.
- Keep direct retry behavior when no proxy is configured.
- Stop new normals batches after the shared deadline.
- Retain payload-size checks, 25-zone completeness checks, required-zone checks, monthly validation, TTL, and the freshness budget.
- Leave other provider clients and retry systems unchanged.

## Blast Radius

The change is limited to the shared Open-Meteo archive helper, the climate zone normals caller, and its regression tests. The climate anomalies seed also uses the helper; it does not pass the new deadline, so only the immediate proxy transfer after a configured 429 or 503 applies there.

## Verification

- `node --test tests/open-meteo-proxy-fallback.test.mjs`: 19 passed. This covers multi-batch throttling with proxy success, CONNECT-to-curl transfer, proxy exhaustion, deadline expiry, one run-wide caller deadline, and stop-after-expiry behavior.
- `node --test tests/climate-seeds.test.mjs`: 35 passed. This confirms the adjacent seed contracts and archive retry behavior.
- `npm run test:data`: 29,266 passed before the final caller-test follow-up; the changed focused tests passed again after that follow-up.
- `npm run typecheck:all`: passed.
- `npm run lint`: passed. Existing warnings remain outside the changed files.
- `git diff --check origin/main...HEAD`: passed.

## Post-Deploy Monitoring & Validation

- Owner: the production operator for the first scheduled or manual climate normals seed run after deployment.
- Window: watch the full run and the public health response for 15 minutes after it completes.
- Logs: search for `[OPEN_METEO] direct failed`, `proxy (CONNECT) succeeded`, `proxy (curl) succeeded`, `deadline exhausted`, `Only`, and `FATAL`.
- Healthy result: the seed completes in less than 240 seconds, writes all 25 zone normals to `climate:zone-normals:v1`, updates its seed metadata, and public health no longer reports `climateZoneNormals` as `STALE_SEED`.
- Failure result: the run reaches the hard deadline, both proxy routes fail, validation rejects a partial result, or health stays stale.
- Mitigation: keep the previous cached value, inspect the direct and proxy error sequence, and revert this PR if the new route transfer causes a regression.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
