### PR TITLE
fix(electricity): recover ENTSO-E through Decodo

### DIFF
--- a/scripts/seed-electricity-prices.mjs
+++ b/scripts/seed-electricity-prices.mjs
@@ -5,9 +5,11 @@ import {
   CHROME_UA,
   extendExistingTtl,
   getRedisCredentials,
+  httpsProxyFetchRaw,
   loadEnvFile,
   logSeedResult,
   releaseLock,
+  resolveProxyForConnect,
   withRetry,
 } from './_seed-utils.mjs';
 
@@ -110,7 +112,15 @@ async function redisPipeline(commands) {
 
 // ── ENTSO-E fetcher ───────────────────────────────────────────────────────────
 
-async function fetchEntsoERegion(region, token, today, yesterday) {
+export function meetsEntsoPublicationFloor(regionCount) {
+  return regionCount >= MIN_ENTSO_REGIONS;
+}
+
+export async function fetchEntsoERegion(region, token, today, yesterday, {
+  fetchFn = globalThis.fetch,
+  proxyAuth = resolveProxyForConnect(),
+  proxyFetcher = httpsProxyFetchRaw,
+} = {}) {
   const params = new URLSearchParams({
     documentType: 'A44',
     in_Domain: region.eic,
@@ -119,22 +129,38 @@ async function fetchEntsoERegion(region, token, today, yesterday) {
     periodEnd: `${isoDate(today).replace(/-/g, '')}2300`,
     securityToken: token,
   });
+  const url = `https://web-api.tp.entsoe.eu/api?${params.toString()}`;
 
   try {
-    const resp = await withRetry(
-      () =>
-        fetch(`https://web-api.tp.entsoe.eu/api?${params.toString()}`, {
-          headers: { 'User-Agent': CHROME_UA, Accept: 'application/xml' },
-          signal: AbortSignal.timeout(20_000),
-        }).then((r) => {
-          if (!r.ok) throw new Error(`ENTSO-E ${region.region} HTTP ${r.status}`);
-          return r.text();
-        }),
-      2,
-      500,
-    );
+    let xml;
+    try {
+      xml = await withRetry(
+        () =>
+          fetchFn(url, {
+            headers: { 'User-Agent': CHROME_UA, Accept: 'application/xml' },
+            signal: AbortSignal.timeout(20_000),
+          }).then((r) => {
+            if (!r.ok) throw new Error(`ENTSO-E ${region.region} HTTP ${r.status}`);
+            return r.text();
+          }),
+        2,
+        500,
+      );
+    } catch (directErr) {
+      if (!proxyAuth) throw directErr;
+      console.warn(`[electricity] ENTSO-E ${region.region} direct failed (${directErr.message}); retrying via proxy`);
+      try {
+        const { buffer } = await proxyFetcher(url, proxyAuth, {
+          accept: 'application/xml',
+          timeoutMs: 20_000,
+        });
+        xml = buffer.toString('utf8');
+      } catch (proxyErr) {
+        throw new Error(`direct=${directErr.message}; proxy=${proxyErr.message}`);
+      }
+    }
 
-    const price = parseEntsoEPrice(resp);
+    const price = parseEntsoEPrice(xml);
     if (price == null) {
       console.warn(`[electricity] ENTSO-E ${region.region}: no price.amount in response`);
       return null;
@@ -288,7 +314,7 @@ export async function main() {
     }
 
     // Check EU coverage threshold — preserve EU snapshot but still write US data
-    if (entsoToken && entsoResults.length < MIN_ENTSO_REGIONS) {
+    if (!meetsEntsoPublicationFloor(entsoResults.length)) {
       const euKeys = ENTSO_E_REGIONS.map((r) => r.region);
       await preservePreviousSnapshot(
         `Only ${entsoResults.length} ENTSO-E regions returned valid prices (min: ${MIN_ENTSO_REGIONS})`,

--- a/scripts/seed-electricity-prices.mjs
+++ b/scripts/seed-electricity-prices.mjs
@@ -324,7 +324,11 @@ export async function main() {
         const usCommands = eiaResults.map((entry) => [
           'SET', `${ELECTRICITY_KEY_PREFIX}${entry.region}`, JSON.stringify(entry), 'EX', ELECTRICITY_TTL_SECONDS,
         ]);
-        await redisPipeline(usCommands);
+        const results = await redisPipeline(usCommands);
+        const failures = results.filter((r) => r?.error || r?.result === 'ERR');
+        if (failures.length > 0) {
+          throw new Error(`Redis pipeline: ${failures.length}/${usCommands.length} commands failed`);
+        }
         console.log(`[electricity] EU below threshold but wrote ${eiaResults.length} US regions`);
       }
       return;

--- a/scripts/seed-electricity-prices.mjs
+++ b/scripts/seed-electricity-prices.mjs
@@ -147,7 +147,12 @@ export async function fetchEntsoERegion(region, token, today, yesterday, {
         500,
       );
     } catch (directErr) {
-      if (!proxyAuth) throw directErr;
+      if (!proxyAuth) {
+        // Without PROXY_URL the fallback is inert; say so, or the log line is
+        // byte-identical to the pre-fallback outage and reads as "proxy blocked too".
+        console.warn(`[electricity] ENTSO-E ${region.region} direct failed (${directErr.message}); no proxy configured (PROXY_URL unset), skipping proxy fallback`);
+        throw directErr;
+      }
       console.warn(`[electricity] ENTSO-E ${region.region} direct failed (${directErr.message}); retrying via proxy`);
       try {
         const { buffer } = await proxyFetcher(url, proxyAuth, {
@@ -316,10 +321,10 @@ export async function main() {
     // Check EU coverage threshold — preserve EU snapshot but still write US data
     if (!meetsEntsoPublicationFloor(entsoResults.length)) {
       const euKeys = ENTSO_E_REGIONS.map((r) => r.region);
-      await preservePreviousSnapshot(
-        `Only ${entsoResults.length} ENTSO-E regions returned valid prices (min: ${MIN_ENTSO_REGIONS})`,
-        euKeys,
-      );
+      const reason = entsoToken
+        ? `Only ${entsoResults.length} ENTSO-E regions returned valid prices (min: ${MIN_ENTSO_REGIONS})`
+        : `ENTSO_E_TOKEN not set — ENTSO-E skipped, floor of ${MIN_ENTSO_REGIONS} regions cannot be met`;
+      await preservePreviousSnapshot(reason, euKeys);
       if (eiaResults.length > 0) {
         const usCommands = eiaResults.map((entry) => [
           'SET', `${ELECTRICITY_KEY_PREFIX}${entry.region}`, JSON.stringify(entry), 'EX', ELECTRICITY_TTL_SECONDS,
@@ -334,11 +339,8 @@ export async function main() {
       return;
     }
 
+    // The publication floor above guarantees allRegions.length >= MIN_ENTSO_REGIONS here.
     const allRegions = [...entsoResults, ...eiaResults];
-    if (allRegions.length === 0) {
-      console.warn('[electricity] No data from any source — skipping write');
-      return;
-    }
 
     const index = buildElectricityIndex(entsoResults, dateStr);
     const metaPayload = {

--- a/tests/electricity-prices-seed.test.mjs
+++ b/tests/electricity-prices-seed.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
+import * as electricitySeed from '../scripts/seed-electricity-prices.mjs';
 import {
   parseEntsoEPrice,
   buildElectricityIndex,
@@ -10,6 +11,14 @@ import {
   ELECTRICITY_TTL_SECONDS,
   fetchEiaRegion,
 } from '../scripts/seed-electricity-prices.mjs';
+
+const ENTSO_REGION = { region: 'DE', eic: '10Y1001A1001A82H', name: 'Germany' };
+const ENTSO_TODAY = new Date('2026-09-02T00:00:00Z');
+const ENTSO_YESTERDAY = new Date('2026-09-01T00:00:00Z');
+
+function entsoXml(price) {
+  return `<TimeSeries><Period><Point><price.amount>${price}</price.amount></Point></Period></TimeSeries>`;
+}
 
 // ── parseEntsoEPrice ──────────────────────────────────────────────────────────
 
@@ -47,6 +56,94 @@ describe('parseEntsoEPrice', () => {
   it('handles all-negative prices', () => {
     const xml = '<price.amount>-5.00</price.amount><price.amount>-15.00</price.amount>';
     assert.equal(parseEntsoEPrice(xml), -10);
+  });
+});
+
+describe('fetchEntsoERegion transport recovery', () => {
+  it('returns direct XML without calling the proxy', async () => {
+    let proxyCalls = 0;
+    const result = await electricitySeed.fetchEntsoERegion(
+      ENTSO_REGION,
+      'test-token',
+      ENTSO_TODAY,
+      ENTSO_YESTERDAY,
+      {
+        fetchFn: async () => ({ ok: true, text: async () => entsoXml('87.30') }),
+        proxyAuth: 'proxy-auth',
+        proxyFetcher: async () => {
+          proxyCalls += 1;
+          return { buffer: Buffer.from(entsoXml('90.00')) };
+        },
+      },
+    );
+
+    assert.equal(proxyCalls, 0);
+    assert.equal(result.region, 'DE');
+    assert.equal(result.source, 'entso-e');
+    assert.equal(result.priceMwhEur, 87.3);
+  });
+
+  it('uses the proxy once after retryable direct failures', async () => {
+    let directCalls = 0;
+    let proxyCalls = 0;
+    const result = await electricitySeed.fetchEntsoERegion(
+      ENTSO_REGION,
+      'test-token',
+      ENTSO_TODAY,
+      ENTSO_YESTERDAY,
+      {
+        fetchFn: async () => {
+          directCalls += 1;
+          return { ok: false, status: 503 };
+        },
+        proxyAuth: 'proxy-auth',
+        proxyFetcher: async () => {
+          proxyCalls += 1;
+          return { buffer: Buffer.from(entsoXml('91.20')) };
+        },
+      },
+    );
+
+    assert.equal(directCalls, 3, 'must exhaust the existing direct retry path');
+    assert.equal(proxyCalls, 1, 'proxy fallback must stay bounded');
+    assert.equal(result.priceMwhEur, 91.2);
+  });
+
+  it('keeps proxy failure visible when both routes fail', async () => {
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      const result = await electricitySeed.fetchEntsoERegion(
+        ENTSO_REGION,
+        'test-token',
+        ENTSO_TODAY,
+        ENTSO_YESTERDAY,
+        {
+          fetchFn: async () => ({ ok: false, status: 503 }),
+          proxyAuth: 'proxy-auth',
+          proxyFetcher: async () => {
+            throw new Error('proxy unavailable');
+          },
+        },
+      );
+
+      assert.equal(result, null);
+      assert.ok(
+        warnings.some((message) => message.includes('proxy unavailable')),
+        `expected proxy failure in warnings, got: ${warnings.join('\n')}`,
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+describe('ENTSO-E full-snapshot publication floor', () => {
+  it('does not accept an EIA-only result as full-snapshot coverage', () => {
+    const eiaOnlyCount = EIA_REGIONS.length;
+    assert.equal(eiaOnlyCount, 7, 'fixture must represent the complete EIA cohort');
+    assert.equal(electricitySeed.meetsEntsoPublicationFloor(0), false);
   });
 });
 

--- a/tests/electricity-prices-seed.test.mjs
+++ b/tests/electricity-prices-seed.test.mjs
@@ -1,7 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import * as electricitySeed from '../scripts/seed-electricity-prices.mjs';
 import {
   parseEntsoEPrice,
   buildElectricityIndex,
@@ -10,6 +9,8 @@ import {
   ELECTRICITY_KEY_PREFIX,
   ELECTRICITY_TTL_SECONDS,
   fetchEiaRegion,
+  fetchEntsoERegion,
+  meetsEntsoPublicationFloor,
 } from '../scripts/seed-electricity-prices.mjs';
 
 const ENTSO_REGION = { region: 'DE', eic: '10Y1001A1001A82H', name: 'Germany' };
@@ -62,7 +63,7 @@ describe('parseEntsoEPrice', () => {
 describe('fetchEntsoERegion transport recovery', () => {
   it('returns direct XML without calling the proxy', async () => {
     let proxyCalls = 0;
-    const result = await electricitySeed.fetchEntsoERegion(
+    const result = await fetchEntsoERegion(
       ENTSO_REGION,
       'test-token',
       ENTSO_TODAY,
@@ -86,7 +87,7 @@ describe('fetchEntsoERegion transport recovery', () => {
   it('uses the proxy once after retryable direct failures', async () => {
     let directCalls = 0;
     let proxyCalls = 0;
-    const result = await electricitySeed.fetchEntsoERegion(
+    const result = await fetchEntsoERegion(
       ENTSO_REGION,
       'test-token',
       ENTSO_TODAY,
@@ -114,7 +115,7 @@ describe('fetchEntsoERegion transport recovery', () => {
     const originalWarn = console.warn;
     console.warn = (...args) => warnings.push(args.join(' '));
     try {
-      const result = await electricitySeed.fetchEntsoERegion(
+      const result = await fetchEntsoERegion(
         ENTSO_REGION,
         'test-token',
         ENTSO_TODAY,
@@ -143,7 +144,7 @@ describe('ENTSO-E full-snapshot publication floor', () => {
   it('does not accept an EIA-only result as full-snapshot coverage', () => {
     const eiaOnlyCount = EIA_REGIONS.length;
     assert.equal(eiaOnlyCount, 7, 'fixture must represent the complete EIA cohort');
-    assert.equal(electricitySeed.meetsEntsoPublicationFloor(0), false);
+    assert.equal(meetsEntsoPublicationFloor(0), false);
   });
 });
 

--- a/tests/electricity-prices-seed.test.mjs
+++ b/tests/electricity-prices-seed.test.mjs
@@ -7,9 +7,11 @@ import {
   EIA_REGIONS,
   ELECTRICITY_INDEX_KEY,
   ELECTRICITY_KEY_PREFIX,
+  ELECTRICITY_META_KEY,
   ELECTRICITY_TTL_SECONDS,
   fetchEiaRegion,
   fetchEntsoERegion,
+  main,
   meetsEntsoPublicationFloor,
 } from '../scripts/seed-electricity-prices.mjs';
 
@@ -138,14 +140,111 @@ describe('fetchEntsoERegion transport recovery', () => {
       console.warn = originalWarn;
     }
   });
+
+  it('contains direct failure when no proxy is configured', async () => {
+    let directCalls = 0;
+    let proxyCalls = 0;
+    const result = await fetchEntsoERegion(
+      ENTSO_REGION,
+      'test-token',
+      ENTSO_TODAY,
+      ENTSO_YESTERDAY,
+      {
+        fetchFn: async () => {
+          directCalls += 1;
+          return { ok: false, status: 503 };
+        },
+        proxyAuth: null,
+        proxyFetcher: async () => {
+          proxyCalls += 1;
+          return { buffer: Buffer.from(entsoXml('90.00')) };
+        },
+      },
+    );
+
+    assert.equal(directCalls, 3);
+    assert.equal(proxyCalls, 0);
+    assert.equal(result, null);
+  });
 });
 
 describe('ENTSO-E full-snapshot publication floor', () => {
-  it('does not accept an EIA-only result as full-snapshot coverage', () => {
-    const eiaOnlyCount = EIA_REGIONS.length;
-    assert.equal(eiaOnlyCount, 7, 'fixture must represent the complete EIA cohort');
-    assert.equal(meetsEntsoPublicationFloor(0), false);
+  it('requires at least seven ENTSO-E regions', () => {
+    assert.equal(meetsEntsoPublicationFloor(6), false);
+    assert.equal(meetsEntsoPublicationFloor(7), true);
   });
+
+  it('preserves full-snapshot freshness and rejects a failed degraded EIA write', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalEnv = {
+      ENTSO_E_TOKEN: process.env.ENTSO_E_TOKEN,
+      EIA_API_KEY: process.env.EIA_API_KEY,
+      UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+      UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+    };
+    const pipelines = [];
+
+    delete process.env.ENTSO_E_TOKEN;
+    process.env.EIA_API_KEY = 'test-key';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    globalThis.fetch = async (url, init = {}) => {
+      const href = String(url);
+      if (href.startsWith('https://api.eia.gov/')) {
+        return new Response(JSON.stringify({ response: { data: [{ value: 10_000 }] } }), {
+          status: 200,
+        });
+      }
+
+      const command = JSON.parse(init.body);
+      if (href.endsWith('/pipeline')) {
+        pipelines.push(command);
+        if (command[0]?.[0] === 'SET') {
+          return new Response(JSON.stringify([
+            { error: 'ERR write failed' },
+            ...command.slice(1).map(() => ({ result: 'OK' })),
+          ]), { status: 200 });
+        }
+        return new Response(JSON.stringify(command.map(() => ({ result: 1 }))), { status: 200 });
+      }
+
+      return new Response(JSON.stringify({ result: command[0] === 'SET' ? 'OK' : 1 }), {
+        status: 200,
+      });
+    };
+
+    try {
+      await assert.rejects(main(), /Redis pipeline: 1\/7 commands failed/);
+    } finally {
+      globalThis.fetch = originalFetch;
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value == null) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+
+    const setPipeline = pipelines.find((pipeline) => pipeline[0]?.[0] === 'SET');
+    assert.ok(setPipeline, 'expected a degraded EIA write');
+    const setKeys = setPipeline.map((command) => command[1]);
+    assert.equal(EIA_REGIONS.length, 7, 'fixture must represent the complete EIA cohort');
+    assert.deepEqual(
+      setKeys,
+      EIA_REGIONS.map((region) => `${ELECTRICITY_KEY_PREFIX}${region.region}`),
+    );
+    assert.equal(setKeys.includes(ELECTRICITY_INDEX_KEY), false);
+    assert.equal(setKeys.includes(ELECTRICITY_META_KEY), false);
+    assert.ok(
+      pipelines.some((pipeline) => {
+        const expireKeys = pipeline
+          .filter((command) => command[0] === 'EXPIRE')
+          .map((command) => command[1]);
+        return expireKeys.includes(ELECTRICITY_INDEX_KEY)
+          && expireKeys.includes(ELECTRICITY_META_KEY);
+      }),
+      'expected the prior full snapshot and freshness metadata to retain their TTL',
+    );
+  });
+
 });
 
 // ── buildElectricityIndex ─────────────────────────────────────────────────────

--- a/tests/electricity-prices-seed.test.mjs
+++ b/tests/electricity-prices-seed.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
@@ -15,6 +15,19 @@ import {
   meetsEntsoPublicationFloor,
 } from '../scripts/seed-electricity-prices.mjs';
 
+// The transport-recovery cases drive withRetry to exhaustion. Cap the idle
+// wait between attempts — attempt count and the logged wait stay real (see
+// the WM_SEED_RETRY_DELAY_MS comment in scripts/_seed-utils.mjs withRetry).
+const originalRetryDelay = process.env.WM_SEED_RETRY_DELAY_MS;
+beforeEach(() => {
+  process.env.WM_SEED_RETRY_DELAY_MS = '0';
+});
+afterEach(() => {
+  if (originalRetryDelay === undefined) delete process.env.WM_SEED_RETRY_DELAY_MS;
+  else process.env.WM_SEED_RETRY_DELAY_MS = originalRetryDelay;
+});
+
+const ENTSO_API_PREFIX = 'https://web-api.tp.entsoe.eu/api?';
 const ENTSO_REGION = { region: 'DE', eic: '10Y1001A1001A82H', name: 'Germany' };
 const ENTSO_TODAY = new Date('2026-09-02T00:00:00Z');
 const ENTSO_YESTERDAY = new Date('2026-09-01T00:00:00Z');
@@ -65,13 +78,17 @@ describe('parseEntsoEPrice', () => {
 describe('fetchEntsoERegion transport recovery', () => {
   it('returns direct XML without calling the proxy', async () => {
     let proxyCalls = 0;
+    const directCalls = [];
     const result = await fetchEntsoERegion(
       ENTSO_REGION,
       'test-token',
       ENTSO_TODAY,
       ENTSO_YESTERDAY,
       {
-        fetchFn: async () => ({ ok: true, text: async () => entsoXml('87.30') }),
+        fetchFn: async (url, init) => {
+          directCalls.push({ url, init });
+          return { ok: true, text: async () => entsoXml('87.30') };
+        },
         proxyAuth: 'proxy-auth',
         proxyFetcher: async () => {
           proxyCalls += 1;
@@ -81,6 +98,18 @@ describe('fetchEntsoERegion transport recovery', () => {
     );
 
     assert.equal(proxyCalls, 0);
+    assert.equal(directCalls.length, 1);
+    const [{ url, init }] = directCalls;
+    assert.ok(url.startsWith(ENTSO_API_PREFIX), `unexpected ENTSO-E URL: ${url}`);
+    const params = new URL(url).searchParams;
+    assert.equal(params.get('documentType'), 'A44');
+    assert.equal(params.get('in_Domain'), ENTSO_REGION.eic);
+    assert.equal(params.get('out_Domain'), ENTSO_REGION.eic);
+    assert.equal(params.get('securityToken'), 'test-token');
+    assert.equal(params.get('periodStart'), '202609010000');
+    assert.equal(params.get('periodEnd'), '202609022300');
+    assert.match(init.headers['User-Agent'], /Mozilla\/5\.0/, 'direct leg must send CHROME_UA');
+    assert.equal(init.headers.Accept, 'application/xml');
     assert.equal(result.region, 'DE');
     assert.equal(result.source, 'entso-e');
     assert.equal(result.priceMwhEur, 87.3);
@@ -88,7 +117,7 @@ describe('fetchEntsoERegion transport recovery', () => {
 
   it('uses the proxy once after retryable direct failures', async () => {
     let directCalls = 0;
-    let proxyCalls = 0;
+    const proxyCalls = [];
     const result = await fetchEntsoERegion(
       ENTSO_REGION,
       'test-token',
@@ -100,15 +129,21 @@ describe('fetchEntsoERegion transport recovery', () => {
           return { ok: false, status: 503 };
         },
         proxyAuth: 'proxy-auth',
-        proxyFetcher: async () => {
-          proxyCalls += 1;
+        proxyFetcher: async (url, auth, opts) => {
+          proxyCalls.push({ url, auth, opts });
           return { buffer: Buffer.from(entsoXml('91.20')) };
         },
       },
     );
 
     assert.equal(directCalls, 3, 'must exhaust the existing direct retry path');
-    assert.equal(proxyCalls, 1, 'proxy fallback must stay bounded');
+    assert.equal(proxyCalls.length, 1, 'proxy fallback must stay bounded');
+    const [{ url, auth, opts }] = proxyCalls;
+    assert.ok(url.startsWith(ENTSO_API_PREFIX), `proxy leg must request the same ENTSO-E URL, got: ${url}`);
+    assert.equal(new URL(url).searchParams.get('securityToken'), 'test-token');
+    assert.equal(auth, 'proxy-auth', 'proxy leg must use the resolved CONNECT auth string');
+    assert.equal(opts.accept, 'application/xml');
+    assert.equal(opts.timeoutMs, 20_000);
     assert.equal(result.priceMwhEur, 91.2);
   });
 
@@ -142,29 +177,51 @@ describe('fetchEntsoERegion transport recovery', () => {
   });
 
   it('contains direct failure when no proxy is configured', async () => {
+    // resolveProxyForConnect() returns '' when PROXY_URL is unset. The
+    // fallback must stay inert AND say so — otherwise the log line is
+    // identical to the pre-fallback outage and reads as "proxy blocked too".
     let directCalls = 0;
     let proxyCalls = 0;
-    const result = await fetchEntsoERegion(
-      ENTSO_REGION,
-      'test-token',
-      ENTSO_TODAY,
-      ENTSO_YESTERDAY,
-      {
-        fetchFn: async () => {
-          directCalls += 1;
-          return { ok: false, status: 503 };
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      const result = await fetchEntsoERegion(
+        ENTSO_REGION,
+        'test-token',
+        ENTSO_TODAY,
+        ENTSO_YESTERDAY,
+        {
+          fetchFn: async () => {
+            directCalls += 1;
+            return { ok: false, status: 503 };
+          },
+          proxyAuth: '',
+          proxyFetcher: async () => {
+            proxyCalls += 1;
+            return { buffer: Buffer.from(entsoXml('90.00')) };
+          },
         },
-        proxyAuth: null,
-        proxyFetcher: async () => {
-          proxyCalls += 1;
-          return { buffer: Buffer.from(entsoXml('90.00')) };
-        },
-      },
-    );
+      );
 
-    assert.equal(directCalls, 3);
-    assert.equal(proxyCalls, 0);
-    assert.equal(result, null);
+      assert.equal(directCalls, 3, 'direct retries still run without a proxy');
+      assert.equal(proxyCalls, 0, 'proxy must not be attempted without auth');
+      assert.equal(result, null);
+      assert.ok(
+        warnings.some((message) => /ENTSO-E DE failed: ENTSO-E DE HTTP 503$/.test(message)),
+        `direct error must surface unchanged, got: ${warnings.join('\n')}`,
+      );
+      assert.ok(
+        warnings.some((message) => message.includes('no proxy configured')),
+        `skipped fallback must be visible, got: ${warnings.join('\n')}`,
+      );
+      assert.ok(
+        !warnings.some((message) => message.includes('proxy=')),
+        `no proxy error fragment expected, got: ${warnings.join('\n')}`,
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });
 
@@ -245,6 +302,138 @@ describe('ENTSO-E full-snapshot publication floor', () => {
     );
   });
 
+});
+
+// ── main() publication gate ───────────────────────────────────────────────────
+//
+// Drives the real main() with fetch mocked for Upstash, ENTSO-E and EIA-930
+// (same shape as tests/seed-comtrade-bilateral-main.test.mjs) and asserts the
+// commands that actually reach Redis. The degraded-write case above covers the
+// failure path; these pin the three success shapes of the publication gate so
+// a regression in how main() consumes the floor predicate (e.g. restoring the
+// old `entsoToken &&` conjunct) cannot ship green.
+
+describe('main() publication gate', () => {
+  const REDIS_URL = 'https://fake-upstash.test';
+  const ENV_KEYS = ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN', 'ENTSO_E_TOKEN', 'EIA_API_KEY', 'PROXY_URL'];
+  const ORIGINAL_FETCH = globalThis.fetch;
+  const ORIGINAL_ERROR = console.error;
+  const ORIGINAL_ENV = {};
+  let redisCommands;
+  let errors;
+  let entsoCalls;
+  let entsoStatus;
+
+  function respond(body) {
+    return new Response(JSON.stringify(body), { status: 200 });
+  }
+
+  function runCommand(cmd) {
+    redisCommands.push(cmd);
+    switch (cmd[0]) {
+      case 'SET': return { result: 'OK' };
+      case 'EXPIRE': return { result: 1 };
+      case 'EVAL': return { result: 1 };
+      default: return { result: null };
+    }
+  }
+
+  function setsFor(key) {
+    return redisCommands.filter((c) => c[0] === 'SET' && c[1] === key);
+  }
+
+  function expiredKeys() {
+    return redisCommands.filter((c) => c[0] === 'EXPIRE').map((c) => c[1]);
+  }
+
+  beforeEach(() => {
+    redisCommands = [];
+    errors = [];
+    entsoCalls = 0;
+    entsoStatus = 200;
+    for (const key of ENV_KEYS) ORIGINAL_ENV[key] = process.env[key];
+    process.env.UPSTASH_REDIS_REST_URL = REDIS_URL;
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+    process.env.EIA_API_KEY = 'eia-key';
+    delete process.env.ENTSO_E_TOKEN;
+    delete process.env.PROXY_URL;
+    console.error = (...args) => errors.push(args.join(' '));
+
+    globalThis.fetch = async (input, init) => {
+      const href = String(input);
+      if (href.startsWith(REDIS_URL)) {
+        const body = JSON.parse(String(init?.body ?? '[]'));
+        // The bare URL takes a single command; /pipeline takes an array of them.
+        if (href.endsWith('/pipeline')) return respond(body.map(runCommand));
+        return respond(runCommand(body));
+      }
+      if (href.startsWith('https://api.eia.gov/')) {
+        return respond({ response: { data: [{ period: '2026-09-02T05', value: 10271, type: 'D' }] } });
+      }
+      if (href.startsWith(ENTSO_API_PREFIX)) {
+        entsoCalls += 1;
+        if (entsoStatus !== 200) return new Response('', { status: entsoStatus });
+        return new Response(entsoXml('80.00'), { status: 200 });
+      }
+      throw new Error(`unexpected fetch to ${href}`);
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    console.error = ORIGINAL_ERROR;
+    for (const key of ENV_KEYS) {
+      if (ORIGINAL_ENV[key] === undefined) delete process.env[key];
+      else process.env[key] = ORIGINAL_ENV[key];
+    }
+  });
+
+  it('EIA-only run (no ENTSO_E_TOKEN) writes US keys but withholds the index and fresh seed meta', async () => {
+    await main();
+
+    assert.equal(entsoCalls, 0);
+    for (const { region } of EIA_REGIONS) {
+      assert.equal(setsFor(`${ELECTRICITY_KEY_PREFIX}${region}`).length, 1, `expected SET for ${region}`);
+    }
+    assert.equal(setsFor(ELECTRICITY_INDEX_KEY).length, 0, 'EIA-only run must not publish the EU index');
+    assert.equal(setsFor(ELECTRICITY_META_KEY).length, 0, 'EIA-only run must not mark the seed fresh');
+    assert.ok(expiredKeys().includes(ELECTRICITY_INDEX_KEY), 'previous index TTL must be extended');
+    assert.ok(expiredKeys().includes(ELECTRICITY_META_KEY), 'previous seed meta TTL must be extended');
+    assert.ok(
+      errors.some((message) => message.includes('ENTSO_E_TOKEN not set')),
+      `preserve reason must name the missing token, got: ${errors.join('\n')}`,
+    );
+  });
+
+  it('full ENTSO-E outage with no proxy preserves the snapshot instead of publishing', async () => {
+    process.env.ENTSO_E_TOKEN = 'entso-token';
+    entsoStatus = 503;
+
+    await main();
+
+    assert.equal(entsoCalls, 30, '10 regions x 3 direct attempts, no proxy leg');
+    assert.equal(setsFor(ELECTRICITY_INDEX_KEY).length, 0);
+    assert.equal(setsFor(ELECTRICITY_META_KEY).length, 0);
+    assert.equal(setsFor(`${ELECTRICITY_KEY_PREFIX}CISO`).length, 1, 'US keys still refresh below the floor');
+    assert.ok(
+      errors.some((message) => message.includes('Only 0 ENTSO-E regions returned valid prices')),
+      `preserve reason must report the ENTSO-E shortfall, got: ${errors.join('\n')}`,
+    );
+  });
+
+  it('publishes the index and fresh seed meta once the ENTSO-E floor is met', async () => {
+    process.env.ENTSO_E_TOKEN = 'entso-token';
+
+    await main();
+
+    assert.equal(entsoCalls, 10, 'every ENTSO-E region fetched once on direct success');
+    assert.equal(setsFor(ELECTRICITY_INDEX_KEY).length, 1);
+    const meta = setsFor(ELECTRICITY_META_KEY);
+    assert.equal(meta.length, 1, 'a full publish must write fresh seed meta');
+    assert.equal(JSON.parse(meta[0][2]).recordCount, 17, '10 ENTSO-E + 7 EIA regions');
+    assert.equal(expiredKeys().length, 0, 'a full publish does not fall back to TTL extension');
+    assert.equal(errors.length, 0, `no preserve path expected, got: ${errors.join('\n')}`);
+  });
 });
 
 // ── buildElectricityIndex ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The production `electricityPrices` seed stayed stale after Railway returned HTTP 503 responses and timeouts for all ENTSO-E regions. Direct ENTSO-E requests remain the first route. A region can now use one Decodo CONNECT request after its direct retries fail.

## Scope

Both routes feed the existing XML parser and return the existing region record. The change also makes the seven-region ENTSO-E floor the only condition that permits a full snapshot and fresh seed metadata. Seven EIA results alone can update their US region keys, but they cannot mark the full electricity seed as fresh.

The PR does not change the EIA fetcher, region definitions, Redis keys, TTLs, health limits, or shared proxy helpers.

## Blast Radius

The runtime change applies only to failed ENTSO-E region requests in `seed-electricity-prices`. Direct success does not call the proxy. Proxy failure remains visible, and the existing last-good retention path stays active when fewer than seven ENTSO-E regions succeed.

## Verification

- `node --test tests/electricity-prices-seed.test.mjs`: 25 passed, 0 failed.
- `npm run test:data`: 29,399 passed, 0 failed, 35 skipped.
- `npm run typecheck`: passed.
- `npm run lint:boundaries`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Pre-fix production evidence: the latest scheduled run returned 0 of 10 ENTSO-E regions and 7 of 7 EIA regions, then preserved the prior snapshot. Public health still reported `STALE_SEED` before this branch was deployed.

## Post-Deploy Monitoring & Validation

The deploy operator owns validation during the first scheduled Railway run and for 30 minutes after it completes.

- Search the `seed-electricity-prices` logs for `ENTSO-E`, `retrying via proxy`, `Preserving previous snapshot`, and `Seeded`.
- The healthy result has at least 7 valid ENTSO-E regions, writes fresh seed metadata, and clears `electricityPrices` from `STALE_SEED` in `/api/health?compact=1`.
- A failure is fewer than 7 ENTSO-E regions, a visible proxy error, a retained old `fetchedAt`, or continued `STALE_SEED` health.
- If the proxy route causes new failures or unsafe logs, revert this PR. The existing last-good retention path limits data loss while the operator investigates.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
