### PR TITLE
fix(maritime): parse current NGA warning envelope

### DIFF
--- a/server/_shared/nga-broadcast-warnings.ts
+++ b/server/_shared/nga-broadcast-warnings.ts
@@ -1,0 +1,43 @@
+export interface NgaBroadcastWarning {
+  msgYear: string | number;
+  msgNumber: string | number;
+  navArea: string | number;
+  subregion: string | number;
+  text: string;
+  issueDate: string;
+  authority: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringOrNumber(value: unknown): string | number {
+  return typeof value === 'string' || typeof value === 'number' ? value : '';
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+export function parseNgaBroadcastWarnings(data: unknown): NgaBroadcastWarning[] | null {
+  const rawWarnings = Array.isArray(data)
+    ? data
+    : isRecord(data)
+      ? data['broadcast-warn'] ?? data.broadcast_warn ?? data.warnings
+      : null;
+
+  if (!Array.isArray(rawWarnings) || rawWarnings.some((warning) => !isRecord(warning))) {
+    return null;
+  }
+
+  return rawWarnings.map((warning) => ({
+    msgYear: stringOrNumber(warning.msgYear),
+    msgNumber: stringOrNumber(warning.msgNumber),
+    navArea: stringOrNumber(warning.navArea),
+    subregion: stringOrNumber(warning.subregion),
+    text: stringValue(warning.text),
+    issueDate: stringValue(warning.issueDate),
+    authority: stringValue(warning.authority),
+  }));
+}

--- a/server/worldmonitor/infrastructure/v1/get-cable-health.ts
+++ b/server/worldmonitor/infrastructure/v1/get-cable-health.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/infrastructure/v1/service_server';
 
 import { cachedFetchJson, setCachedJson } from '../../../_shared/redis';
+import { parseNgaBroadcastWarnings, type NgaBroadcastWarning } from '../../../_shared/nga-broadcast-warnings';
 import { UPSTREAM_TIMEOUT_MS } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
 
@@ -27,13 +28,7 @@ let fallbackCache: GetCableHealthResponse | null = null;
 // NGA warning types
 // ========================================================================
 
-interface NgaWarning {
-  text?: string;
-  issueDate?: string;
-  navArea?: string;
-  msgYear?: number;
-  msgNumber?: number;
-}
+type NgaWarning = Partial<Pick<NgaBroadcastWarning, 'text' | 'issueDate'>>;
 
 // ========================================================================
 // Cable keywords and patterns
@@ -176,7 +171,7 @@ async function fetchNgaWarnings(): Promise<NgaWarning[] | null> {
     );
     if (!res.ok) return null; // fetch failed — don't cache, let sentinel TTL govern retry
     const data = await res.json();
-    return Array.isArray(data) ? data : (data as { warnings?: NgaWarning[] })?.warnings ?? [];
+    return parseNgaBroadcastWarnings(data);
   } catch {
     return null; // network error — don't poison NGA cache with empty data
   }

--- a/server/worldmonitor/infrastructure/v1/get-cable-health.ts
+++ b/server/worldmonitor/infrastructure/v1/get-cable-health.ts
@@ -18,7 +18,7 @@ import { CHROME_UA } from '../../../_shared/constants';
 
 const CACHE_KEY = 'cable-health-v1';
 const CACHE_TTL = 1800; // 30 min — matches warm-ping interval; ensures recencyWeight decay is recomputed each cycle
-const NGA_CACHE_KEY = 'cable-health-nga-warnings-v1';
+const NGA_CACHE_KEY = 'cable-health-nga-warnings-v2';
 const NGA_CACHE_TTL = 86400; // 24h — raw NGA warnings are stable; long TTL survives relay downtime without hammering upstream
 
 // In-memory fallback: serves stale data when both Redis and NGA are down

--- a/server/worldmonitor/maritime/v1/list-navigational-warnings.ts
+++ b/server/worldmonitor/maritime/v1/list-navigational-warnings.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/maritime/v1/service_server';
 
 import { CHROME_UA } from '../../../_shared/constants';
+import { parseNgaBroadcastWarnings } from '../../../_shared/nga-broadcast-warnings';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'maritime:navwarnings:v2';
@@ -44,16 +45,10 @@ async function fetchNgaWarnings(area?: string): Promise<NavigationalWarning[] | 
     if (!response.ok) return null;
 
     const data = await response.json();
-    const rawWarnings: any[] | null = Array.isArray(data)
-      ? data
-      : Array.isArray(data?.broadcast_warn)
-        ? data.broadcast_warn
-        : null;
-    if (rawWarnings === null || rawWarnings.some((warning) => !warning || typeof warning !== 'object')) {
-      return null;
-    }
+    const rawWarnings = parseNgaBroadcastWarnings(data);
+    if (rawWarnings === null) return null;
 
-    let warnings: NavigationalWarning[] = rawWarnings.map((w: any): NavigationalWarning => ({
+    let warnings: NavigationalWarning[] = rawWarnings.map((w): NavigationalWarning => ({
       id: `${w.navArea || ''}-${w.msgYear || ''}-${w.msgNumber || ''}`,
       title: `NAVAREA ${w.navArea || ''} ${w.msgNumber || ''}/${w.msgYear || ''}`,
       text: w.text || '',

--- a/tests/chokepoint-source-availability.test.mts
+++ b/tests/chokepoint-source-availability.test.mts
@@ -71,13 +71,15 @@ describe('chokepoint source availability', () => {
   it('uses append-only proto fields and the private NGA v2 cache key', async () => {
     const maritimeProto = await readFile('proto/worldmonitor/maritime/v1/list_navigational_warnings.proto', 'utf8');
     const supplyChainProto = await readFile('proto/worldmonitor/supply_chain/v1/supply_chain_data.proto', 'utf8');
-    const handler = await readFile('server/worldmonitor/maritime/v1/list-navigational-warnings.ts', 'utf8');
+    const maritimeHandler = await readFile('server/worldmonitor/maritime/v1/list-navigational-warnings.ts', 'utf8');
+    const cableHealthHandler = await readFile('server/worldmonitor/infrastructure/v1/get-cable-health.ts', 'utf8');
 
     assert.match(maritimeProto, /bool data_available = 3;/);
     assert.match(supplyChainProto, /bool navigational_warnings_available = 17;/);
     assert.match(supplyChainProto, /bool ais_snapshot_available = 18;/);
     assert.match(supplyChainProto, /"normal" is an observed AIS level/);
-    assert.match(handler, /maritime:navwarnings:v2/);
+    assert.match(maritimeHandler, /maritime:navwarnings:v2/);
+    assert.match(cableHealthHandler, /cable-health-nga-warnings-v2/);
   });
 
   it('marks a successful empty NGA response available and caches it', async () => {

--- a/tests/chokepoint-source-availability.test.mts
+++ b/tests/chokepoint-source-availability.test.mts
@@ -135,6 +135,7 @@ describe('chokepoint source availability', () => {
   it('marks malformed NGA payloads unavailable instead of treating them as empty', async () => {
     const malformedPayloads = [
       { area: 'malformed-envelope', body: { broadcast_warn: {} } },
+      { area: 'malformed-live-envelope', body: { 'broadcast-warn': {} } },
       { area: 'malformed-entry', body: [null] },
     ];
 
@@ -266,6 +267,48 @@ describe('chokepoint source availability', () => {
     const meta = JSON.parse(harness.values.get('seed-meta:supply_chain:chokepoints') || '{}');
     assert.equal(meta.recordCount, 0, 'health must count rows with complete source coverage');
     assert.equal(meta.uncoveredChokepoints?.length, 13);
+  });
+
+  it('reports complete health coverage for the live NGA response envelope', async () => {
+    const harness = redisHarness(async (url) => {
+      if (url.includes('msi.nga.mil')) {
+        return Response.json({
+          'broadcast-warn': [{
+            msgYear: 2026,
+            msgNumber: 321,
+            navArea: 'P',
+            subregion: '62',
+            text: 'PERSIAN GULF. STRAIT OF HORMUZ. NAVIGATIONAL HAZARD.',
+            issueDate: '021200Z SEP 2026',
+            authority: 'NGA NAVSAFETY',
+          }],
+        });
+      }
+      if (url.startsWith('https://relay.test/ais/snapshot')) {
+        return Response.json({
+          density: [],
+          disruptions: [],
+          snapshotAt: Date.now(),
+          status: { connected: true, vessels: 10, messages: 20 },
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    harness.values.set('supply_chain:transit-summaries:v1', JSON.stringify({
+      summaries: completeTransitSummaries(),
+    }));
+    globalThis.fetch = harness.fetchImpl as typeof fetch;
+
+    const response = await getChokepointStatus({} as never, {});
+
+    assert.equal(response.chokepoints.length, 13);
+    assert.equal(response.upstreamUnavailable, false);
+    assert.ok(response.chokepoints.every((row) => row.navigationalWarningsAvailable === true));
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const meta = JSON.parse(harness.values.get('seed-meta:supply_chain:chokepoints') || '{}');
+    assert.equal(meta.recordCount, 13);
+    assert.equal(meta.uncoveredChokepoints, undefined);
   });
 
   it('qualifies quiet rows that are missing from a partial transit payload', async () => {

--- a/tests/chokepoint-source-availability.test.mts
+++ b/tests/chokepoint-source-availability.test.mts
@@ -100,6 +100,29 @@ describe('chokepoint source availability', () => {
     assert.ok(harness.values.has('maritime:navwarnings:v2:all'));
   });
 
+  it('accepts the live NGA broadcast-warn response envelope', async () => {
+    const harness = redisHarness(async () => Response.json({
+      'broadcast-warn': [{
+        msgYear: 2026,
+        msgNumber: 321,
+        navArea: 'P',
+        subregion: '62',
+        text: 'PERSIAN GULF. STRAIT OF HORMUZ. NAVIGATIONAL HAZARD.',
+        issueDate: '021200Z SEP 2026',
+        authority: 'NGA NAVSAFETY',
+      }],
+    }));
+    globalThis.fetch = harness.fetchImpl as typeof fetch;
+
+    const response = await listNavigationalWarnings({} as never, { area: '', pageSize: 0, cursor: '' });
+
+    assert.equal(response.dataAvailable, true);
+    assert.equal(response.warnings.length, 1);
+    assert.equal(response.warnings[0]?.id, 'P-2026-321');
+    assert.equal(response.warnings[0]?.area, 'P 62');
+    assert.equal(response.warnings[0]?.text, 'PERSIAN GULF. STRAIT OF HORMUZ. NAVIGATIONAL HAZARD.');
+  });
+
   it('marks an NGA fetch failure unavailable', async () => {
     const harness = redisHarness(async () => new Response('unavailable', { status: 503 }));
     globalThis.fetch = harness.fetchImpl as typeof fetch;

--- a/tests/empty-200-degradation-handlers.test.mts
+++ b/tests/empty-200-degradation-handlers.test.mts
@@ -159,7 +159,9 @@ describe('empty 200 degraded handler responses', () => {
     assert.equal(response.summary, undefined);
   });
 
-  it('marks chokepoint status cache misses with the documented empty fetchedAt sentinel', async () => {
+  it('marks chokepoint cache and upstream misses with the documented empty fetchedAt sentinel', async () => {
+    globalThis.fetch = async () => new Response('upstream unavailable', { status: 503 });
+
     const response = await getChokepointStatus({} as never, {});
 
     assert.deepEqual(response, {


### PR DESCRIPTION
## Why

NGA returns active warnings in a `broadcast-warn` array. `listNavigationalWarnings` accepted a top-level array or `broadcast_warn`, so the valid HTTP 200 response became `dataAvailable: false`. Chokepoint health then stayed `EMPTY_ON_DEMAND` after #7538 preserved the partial rows.

This repair parses the current NGA envelope at the shared server boundary.

## Scope

- Add `parseNgaBroadcastWarnings()` for the current envelope and the existing legacy forms.
- Use the shared parser in chokepoint navigational warnings and cable health.
- Keep malformed payloads unavailable. Keep the current cache keys, timeouts, response types, and partial-row behavior.
- Add regression coverage for the live envelope and the 13-row complete-health result.

## Tradeoffs

The parser keeps the legacy top-level, `broadcast_warn`, and `warnings` forms. This small compatibility cost keeps alternate or cached NGA responses valid while one function owns the external shape.

## Blast Radius

The change affects two server-side NGA consumers. It does not change a proto, a generated client, a cache key, or the user interface. A true NGA error or malformed payload still fails closed.

## Verification

- Live NGA request returned HTTP 200. The new parser accepted 386 warnings.
- The regression test failed before the fix with `false !== true` for `dataAvailable`.
- Chokepoint source tests passed 10 of 10. The complete-health case wrote `recordCount: 13`.
- Cable-health and shared handler tests passed 84 of 84.
- The full data suite passed 29,410 tests with 35 skips and no failures.
- `npm run typecheck:api`, `npm run lint:boundaries`, and Biome checks passed.
