### PR TITLE
fix(panels): stop dropping async panel-call rejections

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1,6 +1,6 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import { getRpcBaseUrl } from '@/services/rpc-client';
-import { enqueuePanelCall } from '@/app/pending-panel-data';
+import { enqueuePanelCall, invokePanelMethod } from '@/app/pending-panel-data';
 import { markLcpDebug } from '@/utils/lcp-debug';
 import { runHydrationTier, type HydrationTask } from '@/app/hydration-scheduler';
 import { yieldToMain } from '@/utils/after-paint';
@@ -450,13 +450,10 @@ export class DataLoaderManager implements AppModule {
   public updateSearchIndex: () => void = () => {};
 
   private callPanel(key: string, method: string, ...args: unknown[]): void {
-    const panel = this.ctx.panels[key];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const obj = panel as any;
-    if (obj && typeof obj[method] === 'function') {
-      obj[method](...args);
-      return;
-    }
+    // Panel update methods are async; invokePanelMethod keeps a rejection
+    // observable instead of letting it escape to onunhandledrejection
+    // (WORLDMONITOR-11N).
+    if (invokePanelMethod(this.ctx.panels[key], key, method, args)) return;
     enqueuePanelCall(key, method, args);
   }
 

--- a/src/app/pending-panel-data.ts
+++ b/src/app/pending-panel-data.ts
@@ -1,4 +1,57 @@
+import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
+
 const pendingCalls = new Map<string, Map<string, unknown[]>>();
+
+export type PanelCallFailureReporter = (key: string, method: string, error: unknown) => void;
+
+/**
+ * Default sink for a rejected panel update.
+ *
+ * Swallowing the rejection silently would trade an unhandled rejection for an
+ * invisible failure, so the panel that failed and the error are reported.
+ */
+export function reportPanelCallFailure(key: string, method: string, error: unknown): void {
+  console.error(`[panel-call] ${key}.${method}() rejected:`, error);
+  enqueueSentryCall((s) => {
+    s.captureException(error instanceof Error ? error : new Error(String(error)), {
+      tags: { kind: 'panel_call_rejected', panel: key, method },
+    });
+  });
+}
+
+/**
+ * Dispatch a panel method directly, keeping an async rejection observable.
+ *
+ * WORLDMONITOR-11N: `DataLoader.callPanel` called `obj[method](...args)` and
+ * discarded the result. Panel update methods are `async` and can reject —
+ * `InsightsPanel.updateInsights` awaits `updateFromServer`, whose catch handler
+ * awaits `updateFromClient` outside any try — so the rejection had no handler
+ * and escaped to `onunhandledrejection`. Production reported it as the insights
+ * loader's shared abort reason (`TimeoutError: signal timed out`) carrying that
+ * loader's async stack, even though the loader itself always catches.
+ *
+ * Returns whether the call was dispatched, so the caller can queue it otherwise.
+ * A synchronous throw still propagates, matching the previous direct call.
+ */
+export function invokePanelMethod(
+  panel: unknown,
+  key: string,
+  method: string,
+  args: unknown[],
+  report: PanelCallFailureReporter = reportPanelCallFailure,
+): boolean {
+  const obj = panel as Record<string, unknown> | null | undefined;
+  const fn = obj?.[method];
+  if (typeof fn !== 'function') return false;
+  const result = (fn as (...a: unknown[]) => unknown).apply(obj, args);
+  if (result && typeof (result as { then?: unknown }).then === 'function') {
+    void (result as Promise<unknown>).catch((error: unknown) => {
+      // A throwing reporter must not re-reject and recreate the leak.
+      try { report(key, method, error); } catch { /* reporting is best-effort */ }
+    });
+  }
+  return true;
+}
 
 export function enqueuePanelCall(key: string, method: string, args: unknown[]): void {
   let methods = pendingCalls.get(key);

--- a/tests/panel-call-rejection.test.mts
+++ b/tests/panel-call-rejection.test.mts
@@ -1,0 +1,126 @@
+/**
+ * WORLDMONITOR-11N regression.
+ *
+ * `DataLoader.callPanel` dispatched panel methods as `obj[method](...args)` and
+ * discarded the return value. Panel update methods are `async` — `InsightsPanel
+ * .updateInsights` awaits `updateFromServer`, whose own catch handler awaits
+ * `updateFromClient` outside any try — so a rejection there had no handler and
+ * escaped to `onunhandledrejection`. In production that surfaced as
+ * `TimeoutError: signal timed out`, the abort reason from the insights loader's
+ * shared controller, reported with the loader's async stack even though the
+ * loader itself catches (verified: `fetchServerInsights` never rejects).
+ *
+ * A dropped panel rejection must become an observable, reported error instead.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { invokePanelMethod } from '../src/app/pending-panel-data';
+
+/** Let queued microtasks and one macrotask turn so a leak would be flagged. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+describe('invokePanelMethod — async panel rejections must not escape', () => {
+  let unhandled: unknown[] = [];
+  let onUnhandled: (reason: unknown) => void;
+
+  beforeEach(() => {
+    unhandled = [];
+    onUnhandled = (reason: unknown) => { unhandled.push(reason); };
+    process.on('unhandledRejection', onUnhandled);
+  });
+
+  afterEach(() => {
+    process.off('unhandledRejection', onUnhandled);
+  });
+
+  it('does not leak an unhandled rejection when an async panel method rejects', async () => {
+    const panel = {
+      updateInsights: async () => { throw new Error('boom'); },
+    };
+
+    invokePanelMethod(panel, 'insights', 'updateInsights', [], () => {});
+    await settle();
+
+    assert.deepEqual(unhandled, [], 'a rejected panel update must not reach onunhandledrejection');
+  });
+
+  it('reports the rejection so the failure stays observable', async () => {
+    const seen: Array<{ key: string; method: string; error: unknown }> = [];
+    const boom = new Error('boom');
+    const panel = { updateInsights: async () => { throw boom; } };
+
+    invokePanelMethod(panel, 'insights', 'updateInsights', [], (key, method, error) => {
+      seen.push({ key, method, error });
+    });
+    await settle();
+
+    assert.equal(seen.length, 1, 'exactly one report per rejected call');
+    assert.equal(seen[0]?.key, 'insights');
+    assert.equal(seen[0]?.method, 'updateInsights');
+    assert.equal(seen[0]?.error, boom, 'the original error must reach the reporter');
+  });
+
+  it('preserves the abort reason a shared signal rejects with', async () => {
+    const reason = new DOMException('signal timed out', 'TimeoutError');
+    const panel = { updateInsights: async () => { throw reason; } };
+    const seen: unknown[] = [];
+
+    invokePanelMethod(panel, 'insights', 'updateInsights', [], (_k, _m, error) => { seen.push(error); });
+    await settle();
+
+    assert.deepEqual(unhandled, [], 'the 11N signature must not escape');
+    assert.equal(seen[0], reason);
+  });
+
+  it('does not re-leak when the reporter itself throws', async () => {
+    const panel = { updateInsights: async () => { throw new Error('boom'); } };
+
+    invokePanelMethod(panel, 'insights', 'updateInsights', [], () => {
+      throw new Error('reporter exploded');
+    });
+    await settle();
+
+    assert.deepEqual(unhandled, [], 'a throwing reporter must not recreate the unhandled rejection');
+  });
+
+  it('does not report anything when the async method resolves', async () => {
+    const seen: unknown[] = [];
+    const panel = { updateInsights: async () => 'ok' };
+
+    const dispatched = invokePanelMethod(panel, 'insights', 'updateInsights', [], (_k, _m, e) => { seen.push(e); });
+    await settle();
+
+    assert.equal(dispatched, true);
+    assert.deepEqual(seen, [], 'a successful update must stay silent');
+  });
+});
+
+describe('invokePanelMethod — dispatch contract callPanel depends on', () => {
+  it('returns true and forwards arguments for a synchronous method', () => {
+    const calls: unknown[][] = [];
+    const panel = { setData: (...args: unknown[]) => { calls.push(args); } };
+
+    const dispatched = invokePanelMethod(panel, 'giving', 'setData', [1, 'two'], () => {});
+
+    assert.equal(dispatched, true);
+    assert.deepEqual(calls, [[1, 'two']]);
+  });
+
+  it('returns false when the panel is missing so the caller can queue the call', () => {
+    assert.equal(invokePanelMethod(undefined, 'insights', 'updateInsights', [], () => {}), false);
+    assert.equal(invokePanelMethod(null, 'insights', 'updateInsights', [], () => {}), false);
+  });
+
+  it('returns false when the method is absent so the caller can queue the call', () => {
+    assert.equal(invokePanelMethod({}, 'insights', 'updateInsights', [], () => {}), false);
+  });
+
+  it('lets a synchronous throw propagate, matching the previous direct-call behavior', () => {
+    const panel = { setData: () => { throw new Error('sync boom'); } };
+
+    assert.throws(() => invokePanelMethod(panel, 'giving', 'setData', [], () => {}), /sync boom/);
+  });
+});


### PR DESCRIPTION
## Summary

A dashboard panel whose update failed used to fail silently. `DataLoader.callPanel` invoked panel methods and discarded the returned promise, so an async update that rejected had no handler at all: the failure was never attributed to the panel that caused it, and the rejection escaped to the browser's global `onunhandledrejection`. A failed panel update is now reported with the panel and method that failed, and no longer surfaces as an anonymous global rejection.

The reachable path is real rather than theoretical. `InsightsPanel.updateInsights` awaits `updateFromServer`, whose own catch handler awaits `updateFromClient` outside any try, and `updateFromClient` runs unguarded code before its try.

## Why the reported stack pointed somewhere innocent

This is the fix for Sentry `WORLDMONITOR-11N` (`TimeoutError: signal timed out`), and the diagnosis is worth one paragraph because the evidence argues for a different culprit than the real one.

That message is the insights loader's own abort reason, and the reported stack ended inside `fetchServerInsights`' inner function at its `await fetch(...)`. Byte-attributing the deployed chunk showed that await sits inside `try { ... } catch { return null }`, so the reported path cannot be where anything escaped. An abort rejects every promise on the signal with the *same* `DOMException`, and the engine attaches the async stack of the chain it propagated through — so the chain that catches ends up owning the stack while an unawaited promise elsewhere is what actually leaks.

The loader was then ruled out by experiment, not by reading: a probe that rejected a stubbed `fetch` with `signal.reason` showed zero unhandled rejections across single-caller, shared-in-flight, and join-after-abort scenarios. So no change was made there.

## Risk

The dispatch contract `callPanel` depends on is unchanged and covered by tests: the helper still reports whether it dispatched, so a not-yet-mounted panel still queues its call, and a synchronous throw still propagates to the caller. The behavioral change is limited to what previously had no handler.

A rejected update is reported rather than swallowed, so this can newly surface panel failures that were previously invisible. That is the intent; if a noisy one appears, it is a real failure that was already happening.

## Validation

`tests/panel-call-rejection.test.mts` was written against the pre-fix behavior first and failed for the right reason — three tests red, one of them with the exact production signature escaping as an unhandled rejection. All nine pass after the fix.

Both guards were mutation-tested: removing the reporter's `try`/`catch` reddens exactly one test, confirming it is load-bearing rather than defensive decoration.

| Check | Result |
|---|---|
| `tests/panel-call-rejection.test.mts` + 3 adjacent suites | 49 passed, 0 failed |
| `tests/dom/late-mounted-panel-hydration.test.mts` (vitest) | 3 passed |
| `tsc --noEmit` | clean |
| `biome lint` (changed files) | clean |

Not verified in a browser: the fix is a rejection-handling path, and its observable effect is the absence of a global unhandled rejection, which the regression test asserts directly.

## Follow-up

`replayPendingCalls` awaits its result, so the queued cold-start path propagates rather than drops. Whether its own caller handles that rejection is a wider surface and is untouched here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_012grtSYTgxE2nhdVLe7VW99
