### PR TITLE
chore(deps): let Dependabot actually fix npm and cargo advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,44 +55,36 @@ updates:
       - "/workers/railway-reconcile-control"
     schedule:
       interval: "weekly"
-    # Eight directories on one shared budget. Security fixes arrive as a single
-    # grouped PR per directory, so the limit is spent on those rather than on a
-    # queue of routine bumps.
-    open-pull-requests-limit: 5
+    # Security updates only, on purpose. open-pull-requests-limit caps VERSION
+    # updates exclusively — security-update PRs are drawn from a separate
+    # internal budget and never consume this one — so 0 switches off routine
+    # weekly bumps across eight directories while leaving advisory fixes, and
+    # the grouping below (which does apply to them), fully intact. Raising this
+    # above 0 is how you would later opt into routine version bumps; do that
+    # deliberately, with an `ignore` rule for semver-major, rather than by
+    # accident. See PR #7554.
+    open-pull-requests-limit: 0
     groups:
+      # One PR per directory per advisory batch instead of one per package.
       npm-security:
         applies-to: security-updates
         patterns: ["*"]
-      npm-minor-and-patch:
-        applies-to: version-updates
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
-    ignore:
-      # Majors stay a deliberate, reviewed step — the same policy the Node base
-      # image above already follows. Astro 6 -> 7 and wrangler 3 -> 4 are the two
-      # live examples: both are real upgrades with their own blast radius, not
-      # something to take from an unattended weekly PR.
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
 
-  # The desktop app. Nothing else audits src-tauri/Cargo.lock — there is no
-  # `cargo audit` or `cargo-deny` step anywhere under .github/ — while
-  # build-desktop.yml ships signed binaries for five platforms, two of them Linux,
-  # where reqwest -> native-tls -> openssl is the live TLS implementation.
+  # The desktop app. src-tauri/Cargo.lock has no general advisory scan — there
+  # is no `cargo audit` or `cargo-deny` step anywhere under .github/. The one
+  # Rust gate, scripts/check-rust-security-floors.mjs, is a hand-maintained
+  # allow-list of recorded floors and currently covers exactly one crate
+  # (tauri >= 2.11.1), so an advisory against any other crate passes unnoticed.
+  # That matters because build-desktop.yml ships signed binaries for five
+  # platforms, two of them Linux, where reqwest -> native-tls -> openssl is the
+  # live TLS implementation.
   - package-ecosystem: "cargo"
     directory: "/src-tauri"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    # Same reasoning as the npm entry above: security updates only.
+    open-pull-requests-limit: 0
     groups:
       cargo-security:
         applies-to: security-updates
         patterns: ["*"]
-      cargo-minor-and-patch:
-        applies-to: version-updates
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
-    ignore:
-      # Tauri majors in particular are migrations, not bumps.
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,66 @@ updates:
       # Hold the Node base image at the current LTS major (24). See PR #4709.
       - dependency-name: "node"
         update-types: ["version-update:semver-major"]
+
+  # Every npm manifest in the repo. Without this block Dependabot raises alerts
+  # but can never open a fix PR for them, which is how 69 open advisories
+  # accumulated while `security-audit.yml` stayed green — the gate only blocks on
+  # high-severity PRODUCTION findings, so everything below that floor piles up
+  # unattended. Omitted on purpose:
+  #   /docker            — its manifest is `runtime-package.json`, a non-standard
+  #                        name Dependabot cannot discover. Covered by the audit
+  #                        matrix instead.
+  #   /cli               — declares no dependencies at all.
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/blog-site"
+      - "/consumer-prices-core"
+      - "/docker/umami/runtime"
+      - "/pro-test"
+      - "/scripts"
+      - "/workers/api-cors-preflight"
+      - "/workers/railway-reconcile-control"
+    schedule:
+      interval: "weekly"
+    # Eight directories on one shared budget. Security fixes arrive as a single
+    # grouped PR per directory, so the limit is spent on those rather than on a
+    # queue of routine bumps.
+    open-pull-requests-limit: 5
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # Majors stay a deliberate, reviewed step — the same policy the Node base
+      # image above already follows. Astro 6 -> 7 and wrangler 3 -> 4 are the two
+      # live examples: both are real upgrades with their own blast radius, not
+      # something to take from an unattended weekly PR.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # The desktop app. Nothing else audits src-tauri/Cargo.lock — there is no
+  # `cargo audit` or `cargo-deny` step anywhere under .github/ — while
+  # build-desktop.yml ships signed binaries for five platforms, two of them Linux,
+  # where reqwest -> native-tls -> openssl is the live TLS implementation.
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      cargo-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      cargo-minor-and-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # Tauri majors in particular are migrations, not bumps.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## The gap

`.github/dependabot.yml` covered `github-actions` and `docker` only. There was no `npm` entry and no `cargo` entry, so **not one** of the repo's npm or Rust advisories could ever arrive as a fix PR — Dependabot raised the alert and then had no configured way to act on it.

That is the mechanism behind the backlog. `security-audit.yml` only blocks on **high-severity production** findings, so everything below that floor accumulates quietly while CI stays green, and nothing ever pushes the pile back down.

## What this adds

**npm** — all eight discoverable manifests:

```
/                                    /pro-test
/blog-site                           /scripts
/consumer-prices-core                /workers/api-cors-preflight
/docker/umami/runtime                /workers/railway-reconcile-control
```

Two omissions, documented inline:

- `/docker` — its manifest is `runtime-package.json`, a non-standard name Dependabot cannot discover. The audit matrix already covers it.
- `/cli` — declares no dependencies at all.

**cargo** — `/src-tauri`, which has no general advisory scan. There is no `cargo audit` or `cargo-deny` step anywhere under `.github/`. The one Rust gate, `scripts/check-rust-security-floors.mjs` (run in both `build-desktop.yml` and `test.yml`), is a hand-maintained allow-list of recorded floors covering exactly **one** crate — `tauri >= 2.11.1` — so an advisory against any other crate passes unnoticed. That is why the five open `openssl` advisories sit unflagged, while `build-desktop.yml` ships signed binaries for five platforms, two of them Linux, where `reqwest → native-tls → openssl` is the live TLS implementation.

## Security updates only

Both entries set `open-pull-requests-limit: 0`.

That reads like "disabled", but it is the opposite of what it does here. The limit caps **version** updates exclusively — security-update PRs are drawn from a separate internal budget and never consume it. So `0` switches off routine weekly bumps across nine directories while leaving advisory fixes, and the `groups` blocks that batch them one-PR-per-directory, fully intact.

Raising the limit above `0` is the deliberate way to opt into routine version bumps later; the config says so inline, and notes that doing it should come with a `semver-major` ignore rule.

> Credit where due: the first push had nonzero limits plus version-update groups, on the mistaken belief that the limit reserved capacity for advisories. Codex caught it in review ([thread](https://github.com/koala73/worldmonitor/pull/7554#discussion_r3917216269)).

## Verification

```
parsed with js-yaml -> 6 update entries; both new entries resolve to
  limit=0 with a single security-updates group
all 9 configured directories confirmed to contain a discoverable manifest
```

## One thing this PR cannot do

Repo-level Dependabot security updates are still **off**:

```
$ gh api repos/koala73/worldmonitor/automated-security-fixes
{"enabled":false,"paused":false}
```

Grouped security PRs will not start arriving until that switch is flipped in repo settings. Landing this config first is the right order — it means the flip produces a handful of grouped PRs instead of one PR per advisory.

https://claude.ai/code/session_01Y5vyBXXWCfN5oLyDaQHd4Y
