### PR TITLE
fix(supply): keep vulnerability shards in one write wave

### DIFF
--- a/scripts/seed-supply-vulnerability.mjs
+++ b/scripts/seed-supply-vulnerability.mjs
@@ -700,7 +700,7 @@ export async function readRedisSnapshots(keys, {
   return result;
 }
 
-const MAX_SHARD_PIPELINE_BYTES = 4 * 1024 * 1024;
+const MAX_SHARD_PIPELINE_BYTES = 4.5 * 1024 * 1024;
 
 export function buildShardPipelineBatches(payload) {
   const commands = buildShardEntries(payload).map(({ key, value }) => {
@@ -723,7 +723,9 @@ export function buildShardPipelineBatches(payload) {
       batchBytes = 2;
     }
     if (batchBytes + entry.bytes > MAX_SHARD_PIPELINE_BYTES) {
-      throw new Error(`Shard pipeline command for ${entry.command[1]} exceeds the 4MB request budget`);
+      throw new Error(
+        `Shard pipeline command for ${entry.command[1]} exceeds the ${MAX_SHARD_PIPELINE_BYTES / 1024 / 1024}MB request budget`,
+      );
     }
     if (batch.length > 0) batchBytes += 1;
     batch.push(entry.command);

--- a/tests/supply-vulnerability-seeder.test.mjs
+++ b/tests/supply-vulnerability-seeder.test.mjs
@@ -547,7 +547,7 @@ describe('supply-vulnerability publication', () => {
     assert.ok(buildShardEntries(payload).every(({ value }) => Buffer.byteLength(JSON.stringify(value)) < 5 * 1024 * 1024));
 
     const batches = buildShardPipelineBatches(payload);
-    assert.equal(batches.length, 16, 'fixture must reproduce the production shard count');
+    assert.ok(batches.length <= 15, `all shard batches must fit one write wave, got ${batches.length}`);
     let active = 0;
     let peak = 0;
     const result = await publishShardCohort(payload, {

--- a/tests/supply-vulnerability-seeder.test.mjs
+++ b/tests/supply-vulnerability-seeder.test.mjs
@@ -476,7 +476,7 @@ describe('supply-vulnerability publication', () => {
     );
   });
 
-  it('keeps representative global projections below publication limits', () => {
+  it('publishes representative global projections within the runtime budget', async () => {
     const base = buildPayloadFromSources(fixtureSources(), {
       evaluatedAt,
       mappings,
@@ -510,7 +510,33 @@ describe('supply-vulnerability publication', () => {
         })),
       };
     }
-    const payload = { ...base, countries };
+    const records = Object.values(countries).flatMap((country) => country.vulnerabilities);
+    const dependencyCounts = [3441, 3441, 3248, 3717, 2505, 3115, 1984, 2518, 1535];
+    const chokepoints = Object.fromEntries(dependencyCounts.map((count, routeIndex) => {
+      const id = `route-${routeIndex}`;
+      return [id, {
+        id,
+        name: `Representative route ${routeIndex}`,
+        dependencies: records.slice(0, count).map((record) => {
+          const transit = record.components.transitExposure.chokepoints[routeIndex];
+          return {
+            countryIso2: record.countryIso2,
+            countryName: record.countryName,
+            commodityId: record.commodityId,
+            commodity: record.commodity,
+            transitShare: transit.transitShare,
+            weightedTransitShare: transit.weightedTransitShare,
+            score: record.score,
+            band: record.band,
+            state: record.state,
+            reasons: record.reasons,
+            methodologyVersion: record.methodologyVersion,
+            redistributionRestricted: record.redistributionRestricted,
+          };
+        }),
+      }];
+    }));
+    const payload = { ...base, countries, chokepoints };
     const legacyBytes = Buffer.byteLength(JSON.stringify({
       generatedAt: payload.generatedAt,
       methodologyVersion: payload.methodologyVersion,
@@ -519,6 +545,29 @@ describe('supply-vulnerability publication', () => {
     assert.ok(legacyBytes > 5 * 1024 * 1024, `expected legacy projection above 5MB, got ${legacyBytes}`);
     assert.ok(Buffer.byteLength(JSON.stringify(projectCountryIndex(payload))) < 5 * 1024 * 1024);
     assert.ok(buildShardEntries(payload).every(({ value }) => Buffer.byteLength(JSON.stringify(value)) < 5 * 1024 * 1024));
+
+    const batches = buildShardPipelineBatches(payload);
+    assert.equal(batches.length, 16, 'fixture must reproduce the production shard count');
+    let active = 0;
+    let peak = 0;
+    const result = await publishShardCohort(payload, {
+      credentials: { url: 'https://redis.example', token: 'test-token' },
+      retryDelayMs: 0,
+      fetchImpl: async (_url, request) => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setImmediate(resolve));
+        active -= 1;
+        const commands = JSON.parse(request.body);
+        return {
+          ok: true,
+          json: async () => commands.map(() => ({ result: 'OK' })),
+        };
+      },
+    });
+    assert.equal(result.batches, batches.length);
+    assert.equal(result.shards, buildShardEntries(payload).length);
+    assert.equal(peak, batches.length, 'all shard batches must fit in one write wave');
   });
 
   it('bounds source-read concurrency across Redis pipeline batches', async () => {


### PR DESCRIPTION
The Supply Vulnerability refresh failed before any Redis write because the current 197-country, 9-chokepoint cohort produced 206 shards and 16 pipeline requests, above the publisher's 15-request runtime budget.

The seeder now groups commands into 4.5 MiB requests, which packs the same production-shaped cohort into 14 requests. The 15-request cap, concurrency, retries, shard schema, and atomic cohort activation stay unchanged. This remains below Upstash's documented 10 MB request limit: https://upstash.com/docs/redis/troubleshooting/max_request_size_exceeded

Validation: the production-shaped regression failed with the exact 16-over-15 error before the fix; afterward, 57 focused Supply producer, publication, operations, mapping, and health tests passed. A read-only production-data probe confirmed 206 shards, 14 fake Redis calls, peak concurrency 14, and zero production writes. The next cohort also clears every health floor: country-specific imports 167/110, global production 12/1, rankable countries 197/110, rankable records 3,988/220, fresh rankable records 3,988/1, reviewed commodities 23/23, HS4 inputs 22/22, and HS2 inputs 9/9.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
