### PR TITLE
fix(summary-cache): derive cache identity from SHA-256, not FNV-1a

### DIFF
--- a/server/worldmonitor/news/v1/summarize-article.ts
+++ b/server/worldmonitor/news/v1/summarize-article.ts
@@ -192,7 +192,7 @@ export async function summarizeArticle(
   }
 
   try {
-    const cacheKey = getCacheKey(headlines, mode, sanitizedGeoContext, variant, lang, systemAppend || undefined, bodies);
+    const cacheKey = await getCacheKey(headlines, mode, sanitizedGeoContext, variant, lang, systemAppend || undefined, bodies);
 
     // Single atomic call — source tracking happens inside cachedFetchJsonWithMeta,
     // eliminating the TOCTOU race between a separate getCachedJson and cachedFetchJson.

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -295,7 +295,7 @@ export async function generateSummary(
   const optionsSuffix = options?.skipCloudProviders || options?.skipBrowserFallback
     ? `:opts${options.skipCloudProviders ? 'C' : ''}${options.skipBrowserFallback ? 'B' : ''}`
     : '';
-  const cacheKey = buildSummaryCacheKey(headlines, 'brief', geoContext, SITE_VARIANT, lang, undefined, bodies) + optionsSuffix;
+  const cacheKey = (await buildSummaryCacheKey(headlines, 'brief', geoContext, SITE_VARIANT, lang, undefined, bodies)) + optionsSuffix;
 
   return summaryResultBreaker.execute(
     async () => {
@@ -331,7 +331,7 @@ async function generateSummaryInternal(
   // authoritative cachedFetchJsonWithMeta lookup when bodies are present.
   if (!options?.skipCloudProviders && !bodies?.some((b) => typeof b === 'string' && b.length > 0)) {
     try {
-      const cacheKey = buildSummaryCacheKey(headlines, 'brief', geoContext, SITE_VARIANT, lang, undefined, bodies);
+      const cacheKey = await buildSummaryCacheKey(headlines, 'brief', geoContext, SITE_VARIANT, lang, undefined, bodies);
       const cached = await newsClient.getSummarizeArticleCache({ cacheKey });
       if (cached.summary) {
         return { summary: cached.summary, provider: 'cache', model: cached.model || '', cached: true };

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,3 +1,16 @@
+/**
+ * FNV-1a 52-bit hash — fast, non-cryptographic.
+ *
+ * WARNING: Do NOT use for cache keys derived from attacker-controlled input.
+ * The state is only 52 bits and every step is invertible (XOR is its own
+ * inverse, and multiplying by the odd FNV prime modulo 2^52 is a bijection),
+ * so a meet-in-the-middle second-preimage search costs seconds of CPU rather
+ * than the 2^52 a digest of this width suggests. An attacker who can pick the
+ * input can therefore force two different values onto one key. Use sha256Hex()
+ * for anything where a collision is a security event.
+ *
+ * Retained for non-security contexts: dedup, bucketing, change detection.
+ */
 export function hashString(input: string): string {
   let h = 0xcbf29ce484222325n;
   const FNV_PRIME = 0x100000001b3n;
@@ -7,4 +20,22 @@ export function hashString(input: string): string {
     h = (h * FNV_PRIME) & MASK_52;
   }
   return Number(h).toString(36);
+}
+
+/**
+ * SHA-256 hex digest over Web Crypto, which is present in browsers, on Vercel
+ * Edge and in Node 18+. One implementation therefore covers every runtime that
+ * mints a cache key, which matters because client and server must derive the
+ * same key byte-for-byte.
+ *
+ * Mirrors server/_shared/hash.ts::sha256Hex. Keep the two identical.
+ */
+export async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(input),
+  );
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
 }

--- a/src/utils/summary-cache-key.ts
+++ b/src/utils/summary-cache-key.ts
@@ -1,9 +1,19 @@
 // IMPORTANT: This module is the canonical cache-key builder shared by both
 // client (src/) and server (server/ via _shared.ts re-export). It imports
-// hashString from src/utils/hash.ts — do NOT swap to server/_shared/hash.ts
+// sha256Hex from src/utils/hash.ts — do NOT swap to server/_shared/hash.ts
 // or client/server cache keys will silently diverge.
-import { hashString } from './hash';
+import { sha256Hex } from './hash';
 
+// Bumped v9 → v10 on 2026-09-02 (GHSA-9gp4-366w-pcq3): the key was derived
+// with hashString, an FNV-1a digest masked to 52 bits. Every step of that
+// hash is invertible, so a meet-in-the-middle second preimage costs seconds
+// of CPU. Because summarize-article in translate mode is neither premium
+// gated nor quota gated and anonymous wms_ tokens are freely mintable, an
+// unauthenticated caller could mint a headline colliding with a real one and
+// seed the shared row that every other user then reads. Identity now comes
+// from SHA-256 over one length-delimited canonical string. The bump retires
+// every v9 row, which is required: any of them may already be poisoned.
+//
 // Bumped v8 → v9 on 2026-08-01 (#5969): prompt generation and cache
 // identity now select the same first five unique, non-empty headlines in
 // request order before the selected pairs are sorted for stable hashing.
@@ -24,7 +34,13 @@ import { hashString } from './hash';
 // DON'T pass `bodies` saw a forced cold-start so the pre-grounding
 // headline-only rows aged out cleanly on first tick after deploy. See
 // docs/plans/2026-04-24-001-fix-rss-description-end-to-end-plan.md U6.
-export const CACHE_VERSION = 'v9';
+export const CACHE_VERSION = 'v10';
+
+// 128 bits of SHA-256. Wide enough that a second preimage is infeasible,
+// short enough that the longest key stays inside the 120-character tail the
+// shared contract allows (shared/openapi-filter-param-contracts.json,
+// newsSummarizeArticleCacheKeyPattern).
+const DIGEST_HEX_CHARS = 32;
 
 const MAX_HEADLINE_LEN = 500;
 export const MAX_SUMMARY_HEADLINES = 5;
@@ -82,20 +98,38 @@ export function canonicalizeSummaryInputs(
 }
 
 /**
+ * Fold every identity-bearing field into one string, then hash it once.
+ *
+ * Each field carries its own length, so no field's content can be read as a
+ * delimiter and no two distinct field lists flatten to the same string.
+ *
+ * Hashing the whole identity once, rather than once per segment, is the point.
+ * With a digest per segment an attacker only has to collide whichever segment
+ * distinguishes the target, so the key is only as strong as its weakest
+ * segment. One digest over everything gives no such shortcut.
+ */
+async function digestIdentity(fields: readonly string[]): Promise<string> {
+  const canonical = fields.map(f => `${f.length}:${f}`).join('|');
+  return (await sha256Hex(canonical)).slice(0, DIGEST_HEX_CHARS);
+}
+
+/**
  * Canonical cache-key builder for SummarizeArticle results. Shared by both
  * client (src/services/summarization.ts) and server (server/worldmonitor/
  * news/v1/_shared.ts re-export as getCacheKey). Client and server MUST call
  * with identical inputs for the cache to align — sanitise any adversarial
  * text (bodies, geoContext) the same way on both sides before calling.
  *
+ * The returned key is `summary:<version>:<mode>:<scope>:<digest>`, where the
+ * digest is 128 bits of SHA-256 over the canonical identity. Callers read the
+ * plaintext prefix (see get-summarize-article-cache.ts, which gates on the
+ * current namespace); nothing parses the digest.
+ *
  * @param bodies Paired 1:1 with headlines (request order, post-sanitize).
- *   - When every body is empty → no `:bd<hash>` segment → key identical to
- *     the headline-only v5 shape (modulo the v5→v6 version bump).
- *   - When any body is non-empty → appends `:bd<hash>` where hash is over
- *     the pair-wise-sorted bodies string.
- *   - In translate mode, bodies are ignored (that path is headline[0]-only).
+ *   In translate mode bodies are ignored, since that path interpolates only
+ *   headlines[0] into the prompt.
  */
-export function buildSummaryCacheKey(
+export async function buildSummaryCacheKey(
   headlines: string[],
   mode: string,
   geoContext?: string,
@@ -103,7 +137,7 @@ export function buildSummaryCacheKey(
   lang?: string,
   systemAppend?: string,
   bodies?: string[],
-): string {
+): Promise<string> {
   const canon = canonicalizeSummaryInputs(headlines, geoContext, bodies);
   const pairs = canon.headlines.map((h, i) => ({ h, b: canon.bodies[i] ?? '' }));
   // Select in request order before sorting. Prompt generation uses the same
@@ -131,36 +165,37 @@ export function buildSummaryCacheKey(
   // ['A','B|C'] both flatten to 'A|B|C', so two genuinely different story
   // windows minted one key and either could be served the other's summary.
   const sortedHeadlines = topPairs.map(p => `${p.h.length}:${p.h}`).join('|');
+  // Bodies ride along pair-wise so a body change reaches identity, and an
+  // all-empty set folds to a fixed string rather than dropping out. Presence
+  // no longer changes the key's SHAPE, only the digest it feeds.
+  const sortedBodies = topPairs.map(p => `${p.b.length}:${p.b}`).join('|');
 
-  const anyBody = topPairs.some(p => p.b.length > 0);
-  // `:bd` (body-digest) rather than `:b` so a future string-match against the
-  // key doesn't collide with the literal `:brief:` mode segment.
-  const bodiesHash = anyBody
-    ? ':bd' + hashString(topPairs.map(p => `${p.b.length}:${p.b}`).join('|'))
-    : '';
-
-  const geoHash = canon.geoContext ? ':g' + hashString(canon.geoContext) : '';
-  const hash = hashString(`${mode}:${sortedHeadlines}`);
   const normalizedVariant = typeof variant === 'string' && variant ? variant.toLowerCase() : 'full';
   const normalizedLang = typeof lang === 'string' && lang ? lang.toLowerCase() : 'en';
-  const fwHash = systemAppend ? ':fw' + hashString(systemAppend).slice(0, 8) : '';
+  const append = typeof systemAppend === 'string' ? systemAppend : '';
 
   if (mode === 'translate') {
-    // translate mode only uses headlines[0]; bodies are never interpolated.
-    // Skip the bodies segment so translate cache identity is not shifted
-    // by unrelated upstream RSS-description changes.
+    // translate mode only uses headlines[0]; bodies are never interpolated,
+    // so they stay out of identity and an unrelated upstream RSS-description
+    // change cannot shift a translation's key.
     //
-    // Key on that single headline only, in REQUEST order. Hashing the whole
-    // sorted window made the key order-insensitive while the prompt is
+    // Key on that single headline in REQUEST order. Hashing the whole sorted
+    // window made the key order-insensitive while the prompt is
     // order-sensitive, so ['Alpha','Beta'] and ['Beta','Alpha'] shared one key
     // but asked for different translations — a hit could return the other
     // headline's text. Keying the exact input also stops unrelated trailing
     // headlines from fragmenting identity for the same translation.
     const firstHeadline = selected[0]?.h ?? '';
-    const translateHash = hashString(`${mode}:${firstHeadline.length}:${firstHeadline}`);
     const targetLang = normalizedVariant || normalizedLang;
-    return `summary:${CACHE_VERSION}:${mode}:${targetLang}:${translateHash}${geoHash}${fwHash}`;
+    const digest = await digestIdentity([
+      CACHE_VERSION, mode, targetLang, firstHeadline, canon.geoContext, append,
+    ]);
+    return `summary:${CACHE_VERSION}:${mode}:${targetLang}:${digest}`;
   }
 
-  return `summary:${CACHE_VERSION}:${mode}:${normalizedVariant}:${normalizedLang}:${hash}${geoHash}${bodiesHash}${fwHash}`;
+  const digest = await digestIdentity([
+    CACHE_VERSION, mode, normalizedVariant, normalizedLang,
+    sortedHeadlines, sortedBodies, canon.geoContext, append,
+  ]);
+  return `summary:${CACHE_VERSION}:${mode}:${normalizedVariant}:${normalizedLang}:${digest}`;
 }

--- a/tests/summarize-reasoning.test.mjs
+++ b/tests/summarize-reasoning.test.mjs
@@ -253,13 +253,29 @@ describe('Fix 3: hasReasoningPreamble', () => {
 describe('Fix 4: cache version bump', () => {
   const src = readSrc('src/utils/summary-cache-key.ts');
 
-  it('CACHE_VERSION is v9', () => {
-    // Bumped v8 → v9 on 2026-08-01 (#5969): prompt generation and cache
-    // identity now select the same first five unique, non-empty headlines in
-    // request order, so v8 rows keyed over the old sort-before-cap window
-    // must not be served. (v7 → v8 on 2026-07-06 for the DeepSeek cutover,
-    // #4944; v6 → v7 on 2026-07-05 for pair-dedup, #4914.)
-    assert.match(src, /CACHE_VERSION\s*=\s*'v9'/,
-      'CACHE_VERSION must be v9 to retire rows keyed over the pre-#5969 selection window');
+  it('CACHE_VERSION is v10', () => {
+    // Bumped v9 → v10 on 2026-09-02 (GHSA-9gp4-366w-pcq3): identity moved off
+    // the FNV-1a 52-bit hash, whose invertible steps made a second preimage
+    // cheap enough for an anonymous caller to poison a shared translate row.
+    // Every v9 row must be retired because any of them may already carry
+    // attacker-chosen text. (v8 → v9 on 2026-08-01 for prompt/cache selection
+    // parity, #5969; v7 → v8 on 2026-07-06 for the DeepSeek cutover, #4944;
+    // v6 → v7 on 2026-07-05 for pair-dedup, #4914.)
+    assert.match(src, /CACHE_VERSION\s*=\s*'v10'/,
+      'CACHE_VERSION must be v10 to retire rows keyed with the collidable FNV hash');
+  });
+
+  it('cache identity does not use the collidable FNV hash', () => {
+    // The root cause of GHSA-9gp4 was hashString reaching a cache key built
+    // from attacker-controlled headlines. Reintroducing that import here is
+    // the regression this guards.
+    // Match calls and imports, not prose: the version comment names
+    // hashString when explaining why it was removed.
+    assert.doesNotMatch(src, /\bhashString\s*\(/,
+      'summary-cache-key must derive identity from sha256Hex, never call hashString');
+    assert.doesNotMatch(src, /import\s*\{[^}]*\bhashString\b[^}]*\}/,
+      'summary-cache-key must not import hashString');
+    assert.match(src, /import\s*\{\s*sha256Hex\s*\}\s*from\s*'\.\/hash'/,
+      'summary-cache-key must import sha256Hex from the shared client/server hash module');
   });
 });

--- a/tests/summary-cache-key.test.mts
+++ b/tests/summary-cache-key.test.mts
@@ -1,107 +1,118 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { hashString } from '../src/utils/hash.ts';
 import {
+  CACHE_VERSION,
   buildSummaryCacheKey,
   selectUniqueHeadlinePairs,
 } from '../src/utils/summary-cache-key.ts';
 
 const HEADLINES = ['Inflation rises to 3.5%', 'Fed holds rates steady', 'Markets react'];
 
+// Identity is 128 bits of SHA-256, so the digest is 32 lowercase hex chars.
+// Built from CACHE_VERSION so a future bump does not need a test sweep.
+const DIGEST = '[0-9a-f]{32}';
+const BRIEF_SHAPE = new RegExp(`^summary:${CACHE_VERSION}:brief:full:en:${DIGEST}$`);
+
 describe('buildSummaryCacheKey', () => {
-  it('produces consistent keys for same inputs', () => {
-    const a = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
-    const b = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+  it('produces consistent keys for same inputs', async () => {
+    const a = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+    const b = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
     assert.equal(a, b);
   });
 
-  it('includes systemAppend suffix when provided', () => {
-    const withoutSA = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
-    const withSA = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', 'PMESII-PT analysis');
+  it('includes systemAppend suffix when provided', async () => {
+    const withoutSA = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+    const withSA = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', 'PMESII-PT analysis');
     assert.notEqual(withoutSA, withSA);
   });
 
-  it('different systemAppend values produce different keys', () => {
-    const keyA = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', 'Framework A');
-    const keyB = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', 'Framework B');
+  it('different systemAppend values produce different keys', async () => {
+    const keyA = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', 'Framework A');
+    const keyB = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', 'Framework B');
     assert.notEqual(keyA, keyB);
   });
 
-  it('empty systemAppend produces same key as omitting it', () => {
-    const withEmpty = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', '');
-    const withUndefined = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+  it('empty systemAppend produces same key as omitting it', async () => {
+    const withEmpty = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', '');
+    const withUndefined = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
     assert.equal(withEmpty, withUndefined);
   });
 
-  it('systemAppend suffix does not break existing namespace', () => {
-    const base = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+  it('key carries the current namespace and the documented shape', async () => {
+    const base = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+    // v9 → v10 on 2026-09-02 (GHSA-9gp4-366w-pcq3): FNV-1a 52-bit identity
+    // replaced by truncated SHA-256, retiring every poisonable v9 row.
     // v8 → v9 on 2026-08-01 (#5969 prompt/cache selection parity);
     // v7 → v8 on 2026-07-06 (#4944 DeepSeek cutover).
-    assert.match(base, /^summary:v9:/);
-    assert.doesNotMatch(base, /:fw/);
+    assert.match(base, BRIEF_SHAPE);
   });
 
-  it('systemAppend key contains :fw suffix', () => {
-    const key = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', 'some framework');
-    assert.match(key, /:fw[0-9a-z]+$/);
+  it('systemAppend reaches identity without changing the key shape', async () => {
+    const key = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', 'some framework');
+    const withoutSA = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+    assert.notEqual(key, withoutSA, 'systemAppend must reach cache identity');
+    assert.match(key, BRIEF_SHAPE);
   });
 
   // ── bodies (U6) ─────────────────────────────────────────────────────────
 
-  it('omitting bodies produces no :b segment (byte-identical to today for headline-only callers)', () => {
-    const k = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
-    assert.doesNotMatch(k, /:bd[0-9a-z]+/, 'no bodies → no :b segment');
+  it('every no-body spelling agrees: omitted, empty array, all-empty strings', async () => {
+    // Under the old key these asserted the absence of a `:bd` segment. With a
+    // single digest there is no segment to look for, and the absence check
+    // would pass against any key at all. The real invariant is that the three
+    // spellings a caller might use are one cache row, not three.
+    const omitted = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+    const emptyArray = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, []);
+    const emptyStrings = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, ['', '', '']);
+    assert.equal(emptyArray, omitted, 'empty bodies array must key like omitting bodies');
+    assert.equal(emptyStrings, omitted, 'all-empty bodies must key like omitting bodies');
   });
 
-  it('empty bodies array produces no :b segment', () => {
-    const k = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, []);
-    assert.doesNotMatch(k, /:bd[0-9a-z]+/, 'empty bodies → no :b segment');
-  });
-
-  it('all-empty-string bodies produce no :b segment', () => {
-    const k = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, ['', '', '']);
-    assert.doesNotMatch(k, /:bd[0-9a-z]+/, 'no non-empty body → no :b segment');
-  });
-
-  it('non-empty bodies append a :b segment', () => {
+  it('non-empty bodies reach identity', async () => {
     const bodies = ['Body of inflation story', 'Body about Fed holding rates', 'Body about market reaction'];
-    const k = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, bodies);
-    assert.match(k, /:bd[0-9a-z]+/);
+    const withBodies = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, bodies);
+    const withoutBodies = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+    assert.notEqual(withBodies, withoutBodies, 'bodies must change cache identity');
+    assert.match(withBodies, BRIEF_SHAPE);
   });
 
-  it('bodies change busts the cache', () => {
+  it('bodies change busts the cache', async () => {
     const baseBodies = ['Body A', 'Body B', 'Body C'];
     const shiftedBodies = ['Body A changed', 'Body B', 'Body C'];
-    const keyA = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, baseBodies);
-    const keyB = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, shiftedBodies);
+    const keyA = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, baseBodies);
+    const keyB = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, shiftedBodies);
     assert.notEqual(keyA, keyB, 'body drift must produce a distinct key');
   });
 
-  it('bodies are paired 1:1 with headlines — swapping bodies between stories produces a different key', () => {
+  it('bodies are paired 1:1 with headlines — swapping bodies between stories produces a different key', async () => {
     // The headlines themselves are unchanged; only the body pairing flips.
     // A naive "sort bodies independently" would collide these; pair-wise
     // sort keeps identity correct.
     const bodiesA = ['First story body', 'Second story body', 'Third story body'];
     const bodiesB = ['Second story body', 'First story body', 'Third story body'];
-    const keyA = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, bodiesA);
-    const keyB = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, bodiesB);
+    const keyA = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, bodiesA);
+    const keyB = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, bodiesB);
     assert.notEqual(keyA, keyB, 'pair-wise sort must distinguish shuffled bodies');
   });
 
-  it('bodies.length < headlines.length is padded (no crash)', () => {
-    const k = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, ['only first']);
-    assert.ok(k.startsWith('summary:v9:brief:'));
+  it('bodies.length < headlines.length is padded (no crash)', async () => {
+    const k = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, ['only first']);
+    assert.ok(k.startsWith(`summary:${CACHE_VERSION}:brief:`));
   });
 
-  it('translate mode ignores bodies (no :b segment)', () => {
-    const k = buildSummaryCacheKey(['Translate this'], 'translate', '', 'fr', 'en', undefined, ['body1']);
-    assert.doesNotMatch(k, /:bd[0-9a-z]+/, 'translate mode is headline[0]-only; bodies must not shift identity');
+  it('translate mode ignores bodies', async () => {
+    const withBody = await buildSummaryCacheKey(['Translate this'], 'translate', '', 'fr', 'en', undefined, ['body1']);
+    const withoutBody = await buildSummaryCacheKey(['Translate this'], 'translate', '', 'fr', 'en');
+    assert.equal(withBody, withoutBody, 'translate mode is headline[0]-only; bodies must not shift identity');
   });
 
-  it('bodies longer than 400 chars hash on their first 400 chars only', () => {
+  it('bodies longer than 400 chars hash on their first 400 chars only', async () => {
     const bodyA = 'A'.repeat(400);
     const bodyB = 'A'.repeat(400) + 'different tail';
-    const keyA = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, [bodyA, '', '']);
-    const keyB = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, [bodyB, '', '']);
+    const keyA = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, [bodyA, '', '']);
+    const keyB = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, [bodyB, '', '']);
     assert.equal(keyA, keyB, 'canonicalizeSummaryInputs clips to 400 before hashing — tails must not shift identity');
   });
 });
@@ -109,37 +120,37 @@ describe('buildSummaryCacheKey', () => {
 describe('duplicate-composition stability (#4914)', () => {
   // Prompt generation and key construction share first-arrival headline
   // deduplication, so duplicate composition cannot change only one side.
-  it('same unique headline set with different duplicate composition produces the same key', () => {
-    const base = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
-    const dupFirst = buildSummaryCacheKey([HEADLINES[0], ...HEADLINES], 'brief', 'US', 'full', 'en');
-    const dupSecond = buildSummaryCacheKey([HEADLINES[0], HEADLINES[1], HEADLINES[1], HEADLINES[2]], 'brief', 'US', 'full', 'en');
+  it('same unique headline set with different duplicate composition produces the same key', async () => {
+    const base = await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+    const dupFirst = await buildSummaryCacheKey([HEADLINES[0], ...HEADLINES], 'brief', 'US', 'full', 'en');
+    const dupSecond = await buildSummaryCacheKey([HEADLINES[0], HEADLINES[1], HEADLINES[1], HEADLINES[2]], 'brief', 'US', 'full', 'en');
     assert.equal(dupFirst, base, 'a duplicated first headline must not shift identity');
     assert.equal(dupSecond, base, 'a duplicated middle headline must not shift identity');
   });
 
-  it('duplicates must not displace unique headlines from the top-5 key window', () => {
+  it('duplicates must not displace unique headlines from the top-5 key window', async () => {
     const uniques = ['Alpha story', 'Beta story', 'Gamma story', 'Delta story', 'Epsilon story'];
     const padded = ['Alpha story', 'Alpha story', 'Alpha story', ...uniques];
     assert.equal(
-      buildSummaryCacheKey(padded, 'brief', 'US', 'full', 'en'),
-      buildSummaryCacheKey(uniques, 'brief', 'US', 'full', 'en'),
+      await buildSummaryCacheKey(padded, 'brief', 'US', 'full', 'en'),
+      await buildSummaryCacheKey(uniques, 'brief', 'US', 'full', 'en'),
       'headline dedup must run before the slice so dups cannot crowd out unique stories',
     );
   });
 
-  it('a later body for a repeated headline is ignored by both prompt and key', () => {
-    const withTwoBodies = buildSummaryCacheKey(['Same headline', 'Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body one', 'body two']);
-    const withOneBody = buildSummaryCacheKey(['Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body one']);
+  it('a later body for a repeated headline is ignored by both prompt and key', async () => {
+    const withTwoBodies = await buildSummaryCacheKey(['Same headline', 'Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body one', 'body two']);
+    const withOneBody = await buildSummaryCacheKey(['Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body one']);
     assert.equal(withTwoBodies, withOneBody, 'the prompt keeps only the first body, so the key must do the same');
   });
 
-  it('the first body for a repeated headline remains cache-relevant', () => {
-    const firstBodyOne = buildSummaryCacheKey(['Same headline', 'Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body one', 'body two']);
-    const firstBodyTwo = buildSummaryCacheKey(['Same headline', 'Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body two', 'body one']);
+  it('the first body for a repeated headline remains cache-relevant', async () => {
+    const firstBodyOne = await buildSummaryCacheKey(['Same headline', 'Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body one', 'body two']);
+    const firstBodyTwo = await buildSummaryCacheKey(['Same headline', 'Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body two', 'body one']);
     assert.notEqual(firstBodyOne, firstBodyTwo, 'changing the first body changes prompt content and must bust the key');
   });
 
-  it('different fifth prompt stories cannot collide after dedup-before-limit (#5969)', () => {
+  it('different fifth prompt stories cannot collide after dedup-before-limit (#5969)', async () => {
     const zuluPairs = [
       { h: 'Alpha', b: '' },
       { h: 'Alpha', b: '' },
@@ -162,49 +173,112 @@ describe('duplicate-composition stability (#4914)', () => {
       ['Alpha', 'Beta', 'Charlie', 'Delta', 'Yankee'],
     );
     assert.notEqual(
-      buildSummaryCacheKey(zuluPairs.map((pair) => pair.h), 'brief', 'US', 'full', 'en'),
-      buildSummaryCacheKey(yankeePairs.map((pair) => pair.h), 'brief', 'US', 'full', 'en'),
+      await buildSummaryCacheKey(zuluPairs.map((pair) => pair.h), 'brief', 'US', 'full', 'en'),
+      await buildSummaryCacheKey(yankeePairs.map((pair) => pair.h), 'brief', 'US', 'full', 'en'),
       'a different fifth selected story must change the cache key',
     );
   });
 });
 
 describe('cache-key collisions (#5969 review)', () => {
-  it('a headline containing the join delimiter cannot collide with a different window', () => {
+  it('a headline containing the join delimiter cannot collide with a different window', async () => {
     // No sanitizer strips '|', so a bare join made ['A|B','C'] and
     // ['A','B|C'] flatten to the same string — two different story sets, one
     // key, either servable to the other.
     assert.notEqual(
-      buildSummaryCacheKey(['Alpha|Bravo', 'Charlie'], 'brief', 'US', 'full', 'en'),
-      buildSummaryCacheKey(['Alpha', 'Bravo|Charlie'], 'brief', 'US', 'full', 'en'),
+      await buildSummaryCacheKey(['Alpha|Bravo', 'Charlie'], 'brief', 'US', 'full', 'en'),
+      await buildSummaryCacheKey(['Alpha', 'Bravo|Charlie'], 'brief', 'US', 'full', 'en'),
       'delimiter-ambiguous headline sets must not share a cache key',
     );
   });
 
-  it('translate keys the one headline it actually translates, not the whole window', () => {
+  it('translate keys the one headline it actually translates, not the whole window', async () => {
     // The translate prompt interpolates headlines[0] only. Hashing the sorted
     // window made the key order-insensitive while the prompt is order-
     // sensitive, so a hit could return the other headline's translation.
     assert.notEqual(
-      buildSummaryCacheKey(['Alpha', 'Beta'], 'translate', '', 'fr', 'en'),
-      buildSummaryCacheKey(['Beta', 'Alpha'], 'translate', '', 'fr', 'en'),
+      await buildSummaryCacheKey(['Alpha', 'Beta'], 'translate', '', 'fr', 'en'),
+      await buildSummaryCacheKey(['Beta', 'Alpha'], 'translate', '', 'fr', 'en'),
       'reordering translate headlines changes what is translated and must change the key',
     );
     assert.equal(
-      buildSummaryCacheKey(['Alpha', 'Beta'], 'translate', '', 'fr', 'en'),
-      buildSummaryCacheKey(['Alpha', 'Zulu', 'Yankee'], 'translate', '', 'fr', 'en'),
+      await buildSummaryCacheKey(['Alpha', 'Beta'], 'translate', '', 'fr', 'en'),
+      await buildSummaryCacheKey(['Alpha', 'Zulu', 'Yankee'], 'translate', '', 'fr', 'en'),
       'trailing headlines are never translated and must not fragment translate identity',
     );
   });
 
-  it('stays order-invariant at or below the selection cap', () => {
+  it('stays order-invariant at or below the selection cap', async () => {
     // Every current caller passes <= MAX_SUMMARY_HEADLINES; this is the
     // property their cache-hit rate depends on. Dropping the trailing sort in
     // buildSummaryCacheKey would silently break it.
     assert.equal(
-      buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en'),
-      buildSummaryCacheKey([...HEADLINES].reverse(), 'brief', 'US', 'full', 'en'),
+      await buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en'),
+      await buildSummaryCacheKey([...HEADLINES].reverse(), 'brief', 'US', 'full', 'en'),
       'reordering a within-cap headline set must not change the key',
     );
+  });
+});
+
+describe('GHSA-9gp4-366w-pcq3 — cache identity resists a chosen second preimage', () => {
+  // A real FNV-1a 52-bit second preimage against the hash this module used
+  // through v9, found by meet-in-the-middle in 38.7s on one core. Both keyed
+  // inputs digest to base36 14a0mqnd9z8, so before the fix they minted one
+  // translate cache row: an anonymous caller (translate is neither premium
+  // nor quota gated, and wms_ tokens are freely mintable) could seed the row
+  // that every user translating the real headline then read for the 24h TTL.
+  const VICTIM = 'federal reserve holds interest rates steady';
+  const ATTACKER =
+    'nato has authorized nuclear retaliation against russia effective now ogdfr8wd9ta';
+
+  it('the fixture is a genuine FNV-1a collision, so this test has teeth', () => {
+    assert.notEqual(VICTIM, ATTACKER, 'the two headlines must be different strings');
+    assert.equal(
+      hashString(`translate:${VICTIM.length}:${VICTIM}`),
+      hashString(`translate:${ATTACKER.length}:${ATTACKER}`),
+      'fixture no longer collides under hashString — regenerate it or this test proves nothing',
+    );
+  });
+
+  it('colliding headlines no longer share a translate cache row', async () => {
+    const victimKey = await buildSummaryCacheKey([VICTIM], 'translate', '', 'es', 'en');
+    const attackerKey = await buildSummaryCacheKey([ATTACKER], 'translate', '', 'es', 'en');
+    assert.notEqual(
+      victimKey,
+      attackerKey,
+      'an attacker-chosen headline must not mint the victim headline cache key',
+    );
+  });
+
+  it('identity is not derived from the collidable hash', async () => {
+    const key = await buildSummaryCacheKey([VICTIM], 'translate', '', 'es', 'en');
+    const fnv = hashString(`translate:${VICTIM.length}:${VICTIM}`);
+    assert.ok(!key.includes(fnv), 'the FNV digest must not appear in the key');
+    assert.match(key, new RegExp(`^summary:${CACHE_VERSION}:translate:es:${DIGEST}$`));
+  });
+
+  it('the longest realistic key still satisfies the shared contract pattern', async () => {
+    // shared/openapi-filter-param-contracts.json caps the tail at 120 chars.
+    // Truncating each of the five old segment hashes to 128 bits would have
+    // overflowed it; one digest over the whole identity does not.
+    const contracts = JSON.parse(
+      readFileSync(new URL('../shared/openapi-filter-param-contracts.json', import.meta.url), 'utf8'),
+    );
+    const pattern = new RegExp(contracts.newsSummarizeArticleCacheKeyPattern);
+    // No options suffix here on purpose. generateSummary appends one
+    // (`:optsCB`) for its circuit-breaker key only; the key that travels to
+    // getSummarizeArticleCache, and so the one the contract governs, is the
+    // bare builder output. The suffix carries uppercase and would not match
+    // this pattern, which is why the two keys must stay separate.
+    const worstCase = await buildSummaryCacheKey(
+      ['A'.repeat(500), 'B'.repeat(500), 'C'.repeat(500), 'D'.repeat(500), 'E'.repeat(500)],
+      'analysis',
+      'X'.repeat(2000),
+      'commodity',
+      'zh-tw',
+      'Y'.repeat(500),
+      ['b1', 'b2', 'b3', 'b4', 'b5'],
+    );
+    assert.match(worstCase, pattern, `contract rejected ${worstCase.length}-char key: ${worstCase}`);
   });
 });


### PR DESCRIPTION
## Why

`buildSummaryCacheKey` derived the shared Redis key with `hashString`, an FNV-1a digest masked to 52 bits. XOR is its own inverse and multiplying by the odd FNV prime modulo 2^52 is a bijection, so every step inverts and a meet-in-the-middle second preimage costs seconds rather than the 2^52 the width implies.

`server/_shared/hash.ts:4-6` already warned against exactly this use and offered `sha256Hex`. Its client twin `src/utils/hash.ts` carried neither the warning nor the helper, and `summary-cache-key.ts` imports from the client twin so client and server keys stay byte-identical. The warning existed; the file that needed it did not have it.

`summarizeArticle` in `mode:'translate'` is not premium gated (`summarize-article.ts:80`) and is excluded from the direct-LLM daily quota (`gateway.ts:791`), while `api/wm-session.js:259` mints anonymous `wms_` tokens to anyone. An unauthenticated caller could mint a headline colliding with a real one, seed the cold row, and have every user who translates the real headline read attacker-chosen text for the 24h TTL.

## Scope

- `src/utils/hash.ts` gains `sha256Hex`, mirroring `server/_shared/hash.ts:25`, and `hashString` gains the warning its server twin already carried. `hashString` stays exported for dedup and bucketing callers.
- `src/utils/summary-cache-key.ts` derives identity through a new `digestIdentity` helper: one SHA-256 over one length-delimited canonical string, truncated to 128 bits. This replaces five separate `hashString` calls that produced the `:g`, `:bd` and `:fw` segments.
- `CACHE_VERSION` moves `v9` to `v10`. Every existing `v9` row is retired because any of them may already carry poisoned content.
- `buildSummaryCacheKey` becomes `async`. All three production callers already sat in `async` functions: `summarization.ts:298`, `summarization.ts:334`, and `summarize-article.ts:195`.

Collapsing the five per-segment digests into one is not cosmetic. With a digest per segment an attacker only has to collide whichever segment distinguishes the target, so the key is only as strong as its weakest segment. It is also what keeps the key legal: truncating all five segments to 128 bits each yields a 126-character tail, and `newsSummarizeArticleCacheKeyPattern` in `shared/openapi-filter-param-contracts.json` allows 120. One digest yields 46.

## Tradeoffs

`buildSummaryCacheKey` is now async, which is a signature change on a module shared by client and server. The alternative was a synchronous pure-JS SHA-256 to avoid touching callers, which would mean owning a hand-written digest implementation. WebCrypto is already used in the browser bundle at `src/services/api-keys.ts:47`, so the async path uses a primitive this codebase already depends on rather than adding one.

The `v10` bump forces a cold cache for summaries and translations. That is the point rather than a side effect, since `v9` rows cannot be distinguished from poisoned ones.

## Blast Radius

Every summary and translation cache key changes, so the first request per headline and language after deploy regenerates. Reads are unaffected in shape: `get-summarize-article-cache.ts:47` already treats a well-formed key from a retired namespace as a clean miss, so a stale browser bundle minting `v9` keys degrades to a miss and falls through to the RPC path.

Nothing parses the removed `:g`, `:bd` or `:fw` segments. The only other repo key using a `:fw` segment is `deduct-situation.ts:130`, which is an unrelated namespace and already derives from `sha256Hex`.

## Verification

The failing repro first. A meet-in-the-middle search against the verbatim `hashString` found a real second preimage in 38.7s on one core, reproducing the reporter's published target digest `14a0mqnd9z8` independently:

```
victim   headline: "federal reserve holds interest rates steady"
attacker headline: "nato has authorized nuclear retaliation against russia effective now ogdfr8wd9ta"
distinct strings:  true
HASHES EQUAL:      true
```

Run against `origin/main`'s unpatched builder, those two headlines mint one key:

```
victim   cache key: summary:v9:translate:es:14a0mqnd9z8
attacker cache key: summary:v9:translate:es:14a0mqnd9z8
KEYS EQUAL: true
```

That pair is now a hard-coded fixture in `tests/summary-cache-key.test.mts`, with a guard test asserting it is still a genuine `hashString` collision so the regression cannot quietly go vacuous.

- `npx tsx --test tests/summary-cache-key.test.mts` — 25 pass, 0 fail.
- `npm run test:data` — 29461 pass, 0 fail, 35 skipped, across 4340 suites.
- `npm run typecheck` and `npm run typecheck:api` — both clean.
- `npm run lint` and `npm run lint:boundaries` — clean; no new diagnostics on the six changed files.

Three no-body spellings and the translate-ignores-bodies case previously asserted the absence of a `:bd` segment. With one digest there is no segment to look for, so those assertions would have passed against any key at all. They now assert the invariant they were written to protect: those spellings resolve to one cache row.

Refs GHSA-9gp4-366w-pcq3. The advisory stays unpublished until this merges and a patched version is recorded.

https://claude.ai/code/session_01Ef8cPUub4Ly2iAfk8WzhiJ
