### PR TITLE
fix(desktop): clear ten Rust advisories and floor openssl against regression

### DIFF
--- a/scripts/check-rust-security-floors.mjs
+++ b/scripts/check-rust-security-floors.mjs
@@ -44,6 +44,16 @@ export const RUST_SECURITY_FLOORS = [
     // cannot silently diverge (asserted in tests/check-rust-security-floors.test.mjs).
     manifestFile: 'src-tauri/Cargo.toml',
   },
+  {
+    crate: 'openssl',
+    minVersion: '0.10.80',
+    advisory:
+      'GHSA-ghm9-cr32-g9qj, GHSA-hppc-g8h3-xhp3, GHSA-8c75-8mhr-p7r9, GHSA-pqf5-4pqq-29f5, GHSA-xp3w-r5p5-63rr (HIGH); GHSA-xv59-967r-8726, GHSA-phqj-4mhp-q6mq (MEDIUM); GHSA-xmgf-hq76-4vx2 (LOW)',
+    reason:
+      'Eight advisories against 0.10.75, five of them HIGH and all memory-safety: digest_final() and PkeyCtxRef::derive write past caller buffers, PSK/cookie trampolines leak adjacent memory to the peer, AES key wrap asserts the wrong bound, and X509Ref::ocsp_responders is UB on non-UTF-8 OCSP URLs. This is not a dormant transitive: reqwest is a direct dependency built with default-features = false + native-tls, and on Linux native-tls IS this crate, so it is the live TLS implementation in the x86_64 and aarch64 desktop binaries build-desktop.yml ships. 0.10.80 is the first release patching the newest of the eight (GHSA-phqj-4mhp-q6mq); no manifestFile because openssl is transitive through reqwest -> native-tls and has no direct constraint to pin.',
+    // No issue was filed; the provenance is the Dependabot alert set itself.
+    issue: 'Dependabot alerts #75, #76, #77, #78, #79, #97, #101, #133',
+  },
 ];
 
 /**

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -314,6 +314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,9 +670,9 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -671,11 +680,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -685,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -1664,7 +1672,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2528,15 +2536,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2560,9 +2567,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -2909,9 +2916,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -3399,11 +3406,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3418,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3727,7 +3735,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -4064,6 +4072,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4689,7 +4712,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -4713,7 +4736,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4769,7 +4792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -4781,7 +4804,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4793,21 +4816,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4816,7 +4826,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -4861,7 +4871,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -4875,30 +4885,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5325,7 +5317,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/tests/check-rust-security-floors.test.mjs
+++ b/tests/check-rust-security-floors.test.mjs
@@ -22,6 +22,27 @@ const realLock = readFileSync(resolve(root, 'src-tauri/Cargo.lock'), 'utf8');
 const lockFixture = (crate, version) =>
   `[[package]]\nname = "${crate}"\nversion = "${version}"\nsource = "registry+https://github.com/rust-lang/crates.io-index"\n`;
 
+/**
+ * A lockfile fixture that satisfies EVERY recorded floor, with optional
+ * per-crate version overrides.
+ *
+ * The absent-crate guard means a fixture naming only the crate under test
+ * fails on every OTHER floor, so hand-rolled single-crate lockfiles turned
+ * unrelated tests red the moment a second floor was recorded. Building from
+ * the real floor list keeps each test isolated to the behaviour it probes and
+ * keeps it correct as floors are added or removed.
+ */
+const satisfyingLock = (overrides = {}) =>
+  RUST_SECURITY_FLOORS.map((floor) =>
+    lockFixture(floor.crate, overrides[floor.crate] ?? floor.minVersion),
+  ).join('');
+
+/** The same fixture with one floored crate omitted, to probe the absent-crate guard. */
+const satisfyingLockWithout = (crate) =>
+  RUST_SECURITY_FLOORS.filter((floor) => floor.crate !== crate)
+    .map((floor) => lockFixture(floor.crate, floor.minVersion))
+    .join('');
+
 describe('check-rust-security-floors', () => {
   it('orders versions numerically, not lexically', () => {
     assert.equal(compareVersions('2.9.3', '2.11.1'), -1, '2.9.3 must sort below 2.11.1');
@@ -48,25 +69,35 @@ describe('check-rust-security-floors', () => {
   it('fails when ANY locked copy is below the floor, even beside a patched one', () => {
     // Multi-version crates are normal in Cargo.lock (this repo has dozens), so
     // a patched copy must not mask a vulnerable duplicate of the same crate.
-    const errors = checkRustSecurityFloors(lockFixture('tauri', '2.11.5') + lockFixture('tauri', '2.10.3'));
+    const errors = checkRustSecurityFloors(
+      satisfyingLock({ tauri: '2.11.5' }) + lockFixture('tauri', '2.10.3'),
+    );
     assert.equal(errors.length, 1);
     assert.match(errors[0], /tauri 2\.10\.3 is below the security floor/);
     assert.match(errors[0], /2 versions locked/);
   });
 
   it('passes when every floored crate meets its floor', () => {
-    assert.deepEqual(checkRustSecurityFloors(lockFixture('tauri', '2.11.1')), []);
+    assert.deepEqual(checkRustSecurityFloors(satisfyingLock()), []);
   });
 
   it('fails when a crate sits below its floor (mutation: the CVE-2026-42184 regression)', () => {
-    const errors = checkRustSecurityFloors(lockFixture('tauri', '2.10.3'));
+    const errors = checkRustSecurityFloors(satisfyingLock({ tauri: '2.10.3' }));
     assert.equal(errors.length, 1);
     assert.match(errors[0], /tauri 2\.10\.3 is below the security floor 2\.11\.1/);
     assert.match(errors[0], /cargo update -p tauri --precise/);
   });
 
+  it('fails when a crate sits below its floor (mutation: the openssl memory-safety regression)', () => {
+    // reqwest -> native-tls -> openssl is the live TLS stack in the Linux
+    // desktop binaries, so a `cargo update` that walks this back must not pass.
+    const errors = checkRustSecurityFloors(satisfyingLock({ openssl: '0.10.75' }));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /openssl 0\.10\.75 is below the security floor 0\.10\.80/);
+  });
+
   it('fails when a floored crate is absent entirely (vacuous-pass guard)', () => {
-    const errors = checkRustSecurityFloors(lockFixture('wry', '0.55.1'));
+    const errors = checkRustSecurityFloors(satisfyingLockWithout('tauri') + lockFixture('wry', '0.55.1'));
     assert.equal(errors.length, 1);
     assert.match(errors[0], /absent from Cargo\.lock/);
   });
@@ -124,7 +155,7 @@ describe('check-rust-security-floors', () => {
         join(tauriRoot, 'Cargo.toml'),
         'tauri = { version = ">=2.11.1, <3", features = [] }\n',
       );
-      writeFileSync(join(tauriRoot, 'Cargo.lock'), lockFixture('tauri', '2.11.5'));
+      writeFileSync(join(tauriRoot, 'Cargo.lock'), satisfyingLock({ tauri: '2.11.5' }));
 
       const defaultRun = spawnSync(process.execPath, [checker], {
         cwd: fixtureRoot,
@@ -148,7 +179,7 @@ describe('check-rust-security-floors', () => {
         join(tauriRoot, 'Cargo.toml'),
         'tauri = { version = ">=2.11.1, <3", features = [] }\n',
       );
-      writeFileSync(join(tauriRoot, 'Cargo.lock'), lockFixture('tauri', '2.10.3'));
+      writeFileSync(join(tauriRoot, 'Cargo.lock'), satisfyingLock({ tauri: '2.10.3' }));
       const rootRun = spawnSync(process.execPath, [checker, `--root=${fixtureRoot}`], {
         cwd: root,
         encoding: 'utf8',


### PR DESCRIPTION
## What

`src-tauri/Cargo.lock` carried **all ten** of the repo's open Rust advisories.

```
openssl       0.10.75 -> 0.10.81    5 HIGH, 2 MEDIUM, 1 LOW
openssl-sys   0.9.111 -> 0.9.117
rand          0.8.5   -> 0.8.8      LOW,    via keyring -> secret-service/zbus
serde_with    3.17.0  -> 3.21.0     MEDIUM, via tauri-utils
```

## Why openssl is not a dormant transitive

Every one of the five HIGH advisories is a memory-safety bug: `digest_final()` and `PkeyCtxRef::derive` writing past caller buffers, PSK/cookie trampolines leaking adjacent memory **to the peer**, a wrong bounds assertion in AES key wrap, and UB in `X509Ref::ocsp_responders` on non-UTF-8 OCSP URLs.

`reqwest` is a direct dependency built with `default-features = false` + `native-tls`. On Linux, native-tls **is** the openssl crate — so this is the live TLS implementation inside the x86_64 and aarch64 desktop binaries `build-desktop.yml` signs and ships.

## Why `serde_with` is pinned

`--precise 3.21.0` rather than the latest 3.22.0: 3.22 additionally pulls `jiff`, `defmt` and a `portable-atomic` stack, and 3.21 is the first release carrying the fix.

Net crate churn is **+3 / -3**: `bs58`, `tinyvec`, `tinyvec_macros` arrive from serde_with's own graph; a duplicate `windows-core`/`-result`/`-strings` 0.62.x drops out, deduped to the 0.61.2 already locked.

## The bump alone would not stay fixed

Nothing in CI scans this lockfile for advisories — there is no `cargo audit` or `cargo-deny` step anywhere under `.github/`. The next `cargo update` could silently walk openssl back and no gate would notice. That is exactly the desktop-drift class `check-rust-security-floors.mjs` was written to close, so **openssl is now a recorded floor** beside `tauri`.

No `manifestFile` on the entry: openssl is transitive through `reqwest -> native-tls` and has no direct constraint to pin.

## A test-suite fix that came with it

Recording a second floor exposed a latent brittleness. The absent-crate guard means any fixture naming only **one** floored crate fails on every *other* floor — so five tests built on hand-rolled single-crate lockfiles went red on a change that had nothing to do with them.

Fixtures now derive from `RUST_SECURITY_FLOORS` itself via `satisfyingLock()`, which keeps each test isolated to the behaviour it probes and correct as floors are added or removed. Without this, every future floor would have cost a round of unrelated test edits.

## Verification

```
$ cargo check --manifest-path src-tauri/Cargo.toml
exit 0

$ node scripts/check-rust-security-floors.mjs
rust security floors OK: tauri >= 2.11.1, openssl >= 0.10.80

$ node --test tests/check-rust-security-floors.test.mjs
ℹ tests 17   ℹ pass 17   ℹ fail 0
   — including a new mutation test proving the gate REJECTS openssl 0.10.75

$ node --test tests/ci-workflow-coverage.test.mts
ℹ tests 30   ℹ pass 30   ℹ fail 0
```

The mutation test is the point: it fails if someone reverts the lockfile, so the fix is locked rather than merely applied.

https://claude.ai/code/session_01Y5vyBXXWCfN5oLyDaQHd4Y
