### PR TITLE
chore(deps): bump DOMPurify to 3.4.14 on the LLM-output XSS boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13555,9 +13555,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
## What

```
dompurify 3.4.12 -> 3.4.14    GHSA-55q2-fjhq-7xh7 (MEDIUM)
```

Lockfile only — `^3.4.11` already admits 3.4.14.

## The advisory does not apply to us

Saying so up front, because the alert reads scarier than the situation. GHSA-55q2-fjhq-7xh7 needs **`IN_PLACE` sanitization combined with hook removal**, which leaves a detached subtree still executable. Neither precondition exists here:

```
$ grep -rn "IN_PLACE\|removeHook\|removeAllHooks" src/
(no matches)
```

Neither `PURIFY_CONFIG` (`src/utils/widget-sanitizer.ts`) nor `ANALYST_PURIFY_CONFIG` (`src/components/ChatAnalystPanel.ts`) sets `IN_PLACE`, and the one hook we register is added and never removed.

## Why bump it anyway

`dompurify` is a **direct production dependency** and the single XSS boundary between model output and the DOM:

- `ChatAnalystPanel` sanitizes `marked.parse()` of streamed analyst markdown
- `DeductionPanel` sanitizes parsed model output
- `widget-sanitizer` gates agent-authored widget HTML

On the one component whose entire job is to not fail open, sitting two patch releases behind its own advisory isn't a position worth defending — and the fix is three lines of lockfile.

## Verification

```
$ npm audit
dompurify no longer reported at any severity

$ tsx --test  tests/sanitize.test.mts tests/sanitize-safe-html.test.mts
              tests/chat-analyst-sanitize-yield.test.mts
              tests/deduction-sanitize-yield.test.mts tests/llm-sanitize.test.mjs
ℹ tests 65    ℹ pass 65    ℹ fail 0

$ tsx --test  tests/widget-builder.test.mjs tests/widget-store.test.mts
              tests/dashboard-eager-chunks.test.mjs
ℹ tests 229   ℹ pass 229   ℹ fail 0
```

294 tests across the sanitizer contracts and every consumer of them, green on 3.4.14.

https://claude.ai/code/session_01Y5vyBXXWCfN5oLyDaQHd4Y
