### PR TITLE
fix(demographics): retry transient WPP page failures

### DIFF
--- a/scripts/_demographics-capability-source.mjs
+++ b/scripts/_demographics-capability-source.mjs
@@ -304,7 +304,7 @@ async function fetchResponse(fetchImpl, url, {
         },
         signal: requestSignal,
       });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      if (!response.ok) throw new Error(`HTTP ${response.status} for ${url}`);
       return response;
     } catch (error) {
       lastError = error;
@@ -326,8 +326,8 @@ export async function fetchWppStage({
   for (let offset = 0; offset < locationIds.length; offset += 50) {
     const locations = locationIds.slice(offset, offset + 50).join(',');
     const [demographics, workingAge] = await Promise.all([
-      fetchResponse(fetchImpl, `${WPP_BASE}/indicators/67,84,86/locations/${locations}/years/${currentYear}/vars/4/ages/188,1005,1015/sexes/3/cats/0`, { accept: 'application/json', signal }).then((response) => response.json()),
-      fetchResponse(fetchImpl, `${WPP_BASE}/indicators/70/locations/${locations}/years/${currentYear},${currentYear + 10}/vars/4/ages/40/sexes/3/cats/0`, { accept: 'application/json', signal }).then((response) => response.json()),
+      fetchResponse(fetchImpl, `${WPP_BASE}/indicators/67,84,86/locations/${locations}/years/${currentYear}/vars/4/ages/188,1005,1015/sexes/3/cats/0`, { accept: 'application/json', signal, attempts: 4 }).then((response) => response.json()),
+      fetchResponse(fetchImpl, `${WPP_BASE}/indicators/70/locations/${locations}/years/${currentYear},${currentYear + 10}/vars/4/ages/40/sexes/3/cats/0`, { accept: 'application/json', signal, attempts: 4 }).then((response) => response.json()),
     ]);
     demographicsRows.push(...(Array.isArray(demographics) ? demographics : []));
     workingAgeRows.push(...(Array.isArray(workingAge) ? workingAge : []));

--- a/tests/demographics-capability-seed.test.mjs
+++ b/tests/demographics-capability-seed.test.mjs
@@ -98,7 +98,7 @@ describe('demographics capability source parsers (#6437)', () => {
     assert.equal(validateDemographicsStageCoverage(countries, 'ilostat').trainedIndustrialWorkforcePeople, 150);
   });
 
-  it('recovers when one WPP page returns HTTP 502 through the current retry window', async () => {
+  it('recovers after two consecutive HTTP 502 responses from one WPP page', async () => {
     const targetPage = '/indicators/67,84,86/locations/100,104,';
     let targetPageRequests = 0;
     const result = await fetchWppStage({
@@ -113,20 +113,24 @@ describe('demographics capability source parsers (#6437)', () => {
     });
 
     assert.equal(targetPageRequests, 3);
-    assert.equal(Object.keys(result.countries).length, 229);
-    assert.equal(validateDemographicsStageCoverage(result.countries, 'wpp').medianAgeYears, 229);
+    const recordCount = Object.keys(result.countries).length;
+    assert.ok(recordCount >= 229);
+    assert.equal(validateDemographicsStageCoverage(result.countries, 'wpp').medianAgeYears, recordCount);
   });
 
   it('identifies the exact WPP page when its HTTP failure is exhausted', async () => {
     const failedPage = '/indicators/70/locations/288,292,';
+    let failedPageRequests = 0;
     await assert.rejects(
       fetchWppStage({
         currentYear: 2026,
-        fetchImpl: async (url) => (
-          String(url).includes(failedPage)
-            ? new Response('Bad Gateway', { status: 502 })
-            : wppResponse(url)
-        ),
+        fetchImpl: async (url) => {
+          if (String(url).includes(failedPage)) {
+            failedPageRequests += 1;
+            return new Response('Bad Gateway', { status: 502 });
+          }
+          return wppResponse(url);
+        },
       }),
       (error) => {
         assert.match(error.message, /HTTP 502/);
@@ -134,6 +138,7 @@ describe('demographics capability source parsers (#6437)', () => {
         return true;
       },
     );
+    assert.equal(failedPageRequests, 4);
   });
 });
 

--- a/tests/demographics-capability-seed.test.mjs
+++ b/tests/demographics-capability-seed.test.mjs
@@ -9,6 +9,7 @@ import {
   buildDemographicsPayload,
   demographicsContentMeta,
   demographicsStageCoverageMeta,
+  fetchWppStage,
   parseIlostatWorkforceCsv,
   parseWorldBankEducation,
   parseWppCapability,
@@ -23,6 +24,26 @@ import { resolveSourceOrigin } from '../scripts/source-origin.mjs';
 
 const fixture = (name) => readFileSync(new URL(`./fixtures/demographics-capability/${name}`, import.meta.url), 'utf8');
 const repoFile = (name) => readFileSync(new URL(`../${name}`, import.meta.url), 'utf8');
+
+function wppResponse(url, currentYear = 2026) {
+  const requestUrl = String(url);
+  const locations = requestUrl.match(/\/locations\/([^/]+)\//)?.[1].split(',').map(Number) || [];
+  const shared = { variantId: 4, sexId: 3 };
+  const rows = requestUrl.includes('/indicators/70/')
+    ? locations.flatMap((locationId) => [
+      { ...shared, locationId, indicatorId: 70, ageId: 40, timeLabel: currentYear, value: 1_000_000 },
+      { ...shared, locationId, indicatorId: 70, ageId: 40, timeLabel: currentYear + 10, value: 900_000 },
+    ])
+    : locations.flatMap((locationId) => [
+      { ...shared, locationId, indicatorId: 67, ageId: 188, timeLabel: currentYear, value: 40 },
+      { ...shared, locationId, indicatorId: 84, ageId: 1005, timeLabel: currentYear, value: 20 },
+      { ...shared, locationId, indicatorId: 86, ageId: 1015, timeLabel: currentYear, value: 50 },
+    ]);
+  return new Response(JSON.stringify(rows), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
 
 describe('demographics capability source parsers (#6437)', () => {
   it('parses real WPP JSON without turning null into zero', () => {
@@ -75,6 +96,44 @@ describe('demographics capability source parsers (#6437)', () => {
       country.manufacturingEmploymentSharePercent = { value: 10 };
     }
     assert.equal(validateDemographicsStageCoverage(countries, 'ilostat').trainedIndustrialWorkforcePeople, 150);
+  });
+
+  it('recovers when one WPP page returns HTTP 502 through the current retry window', async () => {
+    const targetPage = '/indicators/67,84,86/locations/100,104,';
+    let targetPageRequests = 0;
+    const result = await fetchWppStage({
+      currentYear: 2026,
+      fetchImpl: async (url) => {
+        if (String(url).includes(targetPage)) {
+          targetPageRequests += 1;
+          if (targetPageRequests <= 2) return new Response('Bad Gateway', { status: 502 });
+        }
+        return wppResponse(url);
+      },
+    });
+
+    assert.equal(targetPageRequests, 3);
+    assert.equal(Object.keys(result.countries).length, 229);
+    assert.equal(validateDemographicsStageCoverage(result.countries, 'wpp').medianAgeYears, 229);
+  });
+
+  it('identifies the exact WPP page when its HTTP failure is exhausted', async () => {
+    const failedPage = '/indicators/70/locations/288,292,';
+    await assert.rejects(
+      fetchWppStage({
+        currentYear: 2026,
+        fetchImpl: async (url) => (
+          String(url).includes(failedPage)
+            ? new Response('Bad Gateway', { status: 502 })
+            : wppResponse(url)
+        ),
+      }),
+      (error) => {
+        assert.match(error.message, /HTTP 502/);
+        assert.match(error.message, new RegExp(failedPage));
+        return true;
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## Why

A transient UN WPP HTTP 502 exhausted the two-attempt page retry contract. The seeder safely retained the last WPP section, but `demographicsCapability` stayed at `COVERAGE_PARTIAL` with two of three stages fresh. Seven later read-only WPP stage probes returned HTTP 200 for all ten page requests and passed all five metric floors for 229 countries. This supports an upstream transient, not a schema or coverage change.

## Scope

- Give only WPP page requests four bounded attempts. World Bank and ILOSTAT requests keep their existing retry contract.
- Include the public upstream URL in an exhausted HTTP error, so a future failure identifies the exact page.
- Keep stage retention, the completion marker, coverage floors, and health classification unchanged.

## Tradeoffs

A persistent WPP failure can now use 1.5 seconds of retry delay instead of 250 milliseconds. This remains inside the existing 45-second stage deadline. The error log includes a public UN query URL and no credential.

## Blast Radius

The runtime change affects only the WPP stage of the demographics static-reference seed. The investigation made no Redis write and did not start a production seeder. Production remains partial until one deployed run completes all three source stages.

## Verification

- The regression test failed before the fix because the second 502 ended the WPP stage and the error omitted the page URL.
- `node --test tests/demographics-capability-seed.test.mjs` passed 20 tests.
- `npm run test:data` passed 29,483 tests with 35 skipped and no failures.
- `npm run lint:boundaries` passed.
- A final read-only live WPP stage probe returned 229 countries. Each of the five required metrics had 229 observations.

## Post-Deploy Monitoring & Validation

- Owner and window: the release operator checks the first `seed-bundle-static-ref` production run within 30 minutes after it ends.
- Confirm the service deployment contains this PR merge commit before a manual run. Otherwise, wait for the next scheduled daily tick. Do not loop retries manually.
- Search Railway logs for `Demographics-Capability` and `demographics:wpp`. Healthy evidence is `records=229 state=OK` with no WPP error.
- Confirm `seed-meta:demographics:capability-complete` has the same run timestamp.
- Query `/api/health?compact=1` with a cache-busting parameter. Accept only `coverage.status=complete`, `completedPages=3`, `failedPages=0`, `completionRatio=1`, and at least 229 records.
- If WPP still fails, use the newly logged page URL to inspect that request. Keep the retained snapshot, do not repeat the production job, and roll back only if the deployed adapter causes a new failure mode.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
