### PR TITLE
fix(viarail): classify positionless live responses

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1422,10 +1422,10 @@ const SEED_META = {
   intelHistoryIngestConflictAcled:       { key: 'seed-meta:intel-history:conflict:acled-intel',            maxStaleMin: 38 },  // mirrors acledIntel
   intelHistoryIngestMilitaryCrossStrait: { key: 'seed-meta:intel-history:military:cross-strait-activity',  maxStaleMin: 720 }, // mirrors crossStraitActivity
   intelHistoryIngestEnergyIntelligence:  { key: 'seed-meta:intel-history:energy:intelligence',             maxStaleMin: 720 }, // mirrors energyIntelligence
-  // Unofficial tsimobile.viarail.ca JSON. Optional: 404/shape-break writes
-  // sourceState unavailable (NOT_CONFIGURED) rather than SEED_ERROR. 15min
-  // cron; 45 = 3x cadence. EMPTY_DATA_OK so an unconfigured deploy is STALE_SEED
-  // (warn), not EMPTY (crit), until the first producer tick.
+  // Unofficial tsimobile.viarail.ca JSON. The source needs no credentials, so
+  // fetch/shape failures write sourceState stale and surface as SEED_ERROR when
+  // no last-good value exists. 15min cron; 45 = 3x cadence. EMPTY_DATA_OK makes
+  // a pre-first-publish absence STALE_SEED (warn), not EMPTY (crit).
   viarailLive: {
     key: 'seed-meta:transit:viarail-live',
     maxStaleMin: 45,

--- a/scripts/seed-viarail-live.mjs
+++ b/scripts/seed-viarail-live.mjs
@@ -2,8 +2,8 @@
 /**
  * Optional seeder for VIA Rail Tracker unofficial live JSON (#6615).
  *
- * Best-effort, undocumented, no customer-facing SLA. 404 / shape-break skip
- * publish and record sourceState 'unavailable'. Do not fail the box.
+ * Best-effort, undocumented, no customer-facing SLA. Source failures skip
+ * publish, preserve last-good, and remain visible to freshness health.
  *
  * Runs as the VIA-Rail-Live member of seed-bundle-canada (#6711), not as its own
  * Railway service, gated on intervalMs 15min — an optional unofficial feed does
@@ -40,9 +40,9 @@ async function fetchViaRailLiveSnapshot() {
 
     console.warn(
       `  VIA Rail live skip (${decision.reason || 'unavailable'}): `
-      + (decision.keepLastGood ? 'keeping last-good' : 'sourceState=unavailable'),
+      + (decision.keepLastGood ? 'keeping last-good' : `sourceState=${decision.sourceState}`),
     );
-    if (decision.sourceState === 'unavailable') {
+    if (decision.sourceState) {
       try {
         await writeFreshnessMetadata(
           'transit',
@@ -52,10 +52,10 @@ async function fetchViaRailLiveSnapshot() {
           VIA_RAIL_LIVE_TTL_SECONDS,
           undefined,
           undefined,
-          { sourceState: 'unavailable', skipReason: decision.reason || 'unavailable' },
+          { sourceState: decision.sourceState, skipReason: decision.reason || 'unavailable' },
         );
       } catch (err) {
-        console.warn(`  VIA Rail live unavailable-meta write failed: ${err?.message || err}`);
+        console.warn(`  VIA Rail live source-meta write failed: ${err?.message || err}`);
       }
     }
     return { sourceUnavailable: true, trains: [] };

--- a/scripts/viarail-live.mjs
+++ b/scripts/viarail-live.mjs
@@ -30,7 +30,7 @@ export class ViaRailLiveUnavailableError extends Error {
     this.name = 'ViaRailLiveUnavailableError';
     this.reason = reason;
     this.status = status;
-    this.sourceState = 'unavailable';
+    this.sourceState = 'stale';
     if (cause !== undefined) this.cause = cause;
   }
 }
@@ -148,19 +148,16 @@ function parseTrain(id, raw) {
   };
 }
 
-/**
- * A snapshot is publishable only when it carries at least one live lat/lng
- * pair AND at least one per-station numeric diffMin. A 200 with the wrong
- * shape must not overwrite last-good.
- */
-export function validateViaRailLiveSnapshot(snapshot) {
-  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) return false;
-  if (snapshot.schemaVersion !== VIA_RAIL_LIVE_SCHEMA_VERSION) return false;
-  if (!Array.isArray(snapshot.trains) || snapshot.trains.length === 0) return false;
+function classifyViaRailLiveSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) return 'shape_break';
+  if (snapshot.schemaVersion !== VIA_RAIL_LIVE_SCHEMA_VERSION) return 'shape_break';
+  if (!Array.isArray(snapshot.trains) || snapshot.trains.length === 0) return 'shape_break';
   let hasPosition = false;
   let hasDiffMin = false;
+  let hasRecognizedRoute = false;
   for (const train of snapshot.trains) {
-    if (!train || typeof train !== 'object') return false;
+    if (!train || typeof train !== 'object') return 'shape_break';
+    if (textOrNull(train.from) && textOrNull(train.to)) hasRecognizedRoute = true;
     if (finiteNumber(train.lat) != null && finiteNumber(train.lng) != null) hasPosition = true;
     if (Array.isArray(train.stations)) {
       for (const stop of train.stations) {
@@ -168,7 +165,18 @@ export function validateViaRailLiveSnapshot(snapshot) {
       }
     }
   }
-  return hasPosition && hasDiffMin;
+  if (hasPosition && hasDiffMin) return 'publishable';
+  if (!hasPosition && hasDiffMin && hasRecognizedRoute) return 'no_live_positions';
+  return 'shape_break';
+}
+
+/**
+ * A snapshot is publishable only when it carries at least one live lat/lng
+ * pair AND at least one per-station numeric diffMin. A 200 with no live
+ * positions or the wrong shape must not overwrite last-good.
+ */
+export function validateViaRailLiveSnapshot(snapshot) {
+  return classifyViaRailLiveSnapshot(snapshot) === 'publishable';
 }
 
 export function parseViaRailLive(raw, { fetchedAt = Date.now() } = {}) {
@@ -186,8 +194,9 @@ export function parseViaRailLive(raw, { fetchedAt = Date.now() } = {}) {
     fetchedAt,
     trains,
   };
-  if (!validateViaRailLiveSnapshot(snapshot)) {
-    throw new ViaRailLiveUnavailableError('shape_break');
+  const snapshotState = classifyViaRailLiveSnapshot(snapshot);
+  if (snapshotState !== 'publishable') {
+    throw new ViaRailLiveUnavailableError(snapshotState);
   }
   return snapshot;
 }
@@ -231,8 +240,8 @@ async function readBoundedBody(response, maxBytes) {
 }
 
 /**
- * Fetch + parse. Never throws SEED_ERROR — 404 and shape-break resolve to
- * `{ ok: false, sourceState: 'unavailable' }`.
+ * Fetch + parse. Failures resolve to a configured-source stale result so a
+ * caller can preserve last-good without disguising the failure as unconfigured.
  */
 export async function fetchViaRailLive({
   fetchImpl = DEFAULT_FETCH,
@@ -243,7 +252,7 @@ export async function fetchViaRailLive({
   now = Date.now(),
 } = {}) {
   if (!isAllowedViaRailLiveHost(url, allowedHosts)) {
-    return { ok: false, sourceState: 'unavailable', reason: 'host_not_allowlisted' };
+    return { ok: false, sourceState: 'stale', reason: 'host_not_allowlisted' };
   }
   let response;
   try {
@@ -258,28 +267,28 @@ export async function fetchViaRailLive({
   } catch (err) {
     const message = `${err?.message || err}`;
     if (/redirect/i.test(message) || err?.cause?.code === 'UNDICI_REDIRECT') {
-      return { ok: false, sourceState: 'unavailable', reason: 'redirect_rejected' };
+      return { ok: false, sourceState: 'stale', reason: 'redirect_rejected' };
     }
     return {
       ok: false,
-      sourceState: 'unavailable',
+      sourceState: 'stale',
       reason: 'fetch_failed',
       error: message,
     };
   }
   if (response.redirected) {
-    return { ok: false, sourceState: 'unavailable', reason: 'redirect_rejected' };
+    return { ok: false, sourceState: 'stale', reason: 'redirect_rejected' };
   }
   if (typeof response.url === 'string' && response.url && !isAllowedViaRailLiveHost(response.url, allowedHosts)) {
-    return { ok: false, sourceState: 'unavailable', reason: 'host_not_allowlisted' };
+    return { ok: false, sourceState: 'stale', reason: 'host_not_allowlisted' };
   }
   if (response.status === 404) {
-    return { ok: false, sourceState: 'unavailable', reason: 'http_404', status: 404 };
+    return { ok: false, sourceState: 'stale', reason: 'http_404', status: 404 };
   }
   if (!response.ok) {
     return {
       ok: false,
-      sourceState: 'unavailable',
+      sourceState: 'stale',
       reason: `http_${response.status}`,
       status: response.status,
     };
@@ -289,31 +298,30 @@ export async function fetchViaRailLive({
     text = await readBoundedBody(response, maxBytes);
   } catch (err) {
     if (err instanceof ViaRailLiveUnavailableError) {
-      return { ok: false, sourceState: 'unavailable', reason: err.reason };
+      return { ok: false, sourceState: 'stale', reason: err.reason };
     }
-    return { ok: false, sourceState: 'unavailable', reason: 'read_failed' };
+    return { ok: false, sourceState: 'stale', reason: 'read_failed' };
   }
   let raw;
   try {
     raw = JSON.parse(text);
   } catch {
-    return { ok: false, sourceState: 'unavailable', reason: 'shape_break' };
+    return { ok: false, sourceState: 'stale', reason: 'shape_break' };
   }
   try {
     const snapshot = parseViaRailLive(raw, { fetchedAt: now });
     return { ok: true, snapshot };
   } catch (err) {
     if (err instanceof ViaRailLiveUnavailableError) {
-      return { ok: false, sourceState: 'unavailable', reason: err.reason };
+      return { ok: false, sourceState: 'stale', reason: err.reason };
     }
-    return { ok: false, sourceState: 'unavailable', reason: 'shape_break' };
+    return { ok: false, sourceState: 'stale', reason: 'shape_break' };
   }
 }
 
 /**
- * Decide whether to publish. Failure ≠ miss: last-good is kept. A 404 or
- * shape-break with no last-good is `sourceState: 'unavailable'` so health
- * grades NOT_CONFIGURED rather than SEED_ERROR / EMPTY.
+ * Decide whether to publish. Failure ≠ miss: last-good is kept. A failed
+ * configured source with no last-good is stale so health exposes the failure.
  */
 export function resolveViaRailLivePublish(fetchResult, lastGood) {
   if (fetchResult?.ok && validateViaRailLiveSnapshot(fetchResult.snapshot)) {
@@ -330,7 +338,7 @@ export function resolveViaRailLivePublish(fetchResult, lastGood) {
   return {
     persist: false,
     keepLastGood: false,
-    sourceState: 'unavailable',
+    sourceState: 'stale',
     reason: fetchResult?.reason || 'shape_break',
   };
 }
@@ -339,7 +347,7 @@ export async function ingestViaRailLive({
   fetchImpl = DEFAULT_FETCH,
   readLastGood = async () => null,
   persist = async () => {},
-  writeUnavailableMeta = async () => {},
+  writeSourceMeta = async () => {},
   url = VIA_RAIL_LIVE_URL,
   allowedHosts = VIA_RAIL_LIVE_ALLOWED_HOSTS,
   now = Date.now(),
@@ -351,8 +359,8 @@ export async function ingestViaRailLive({
     await persist(decision.snapshot);
     return decision;
   }
-  if (decision.sourceState === 'unavailable') {
-    await writeUnavailableMeta({ reason: decision.reason });
+  if (decision.sourceState) {
+    await writeSourceMeta({ sourceState: decision.sourceState, reason: decision.reason });
   }
   return decision;
 }

--- a/tests/fixtures/viarail-live/no-live-positions.json
+++ b/tests/fixtures/viarail-live/no-live-positions.json
@@ -1,0 +1,43 @@
+{
+  "693": {
+    "departed": true,
+    "arrived": false,
+    "from": "WINNIPEG",
+    "to": "CHURCHILL",
+    "instance": "2026-09-01",
+    "times": [
+      {
+        "station": "Winnipeg",
+        "code": "WNPG",
+        "tz": "America/Winnipeg",
+        "estimated": "2026-09-01T12:54:32-05:00",
+        "scheduled": "2026-09-01T12:05:00-05:00",
+        "eta": "ARR",
+        "departure": {
+          "estimated": "2026-09-01T12:54:32-05:00",
+          "scheduled": "2026-09-01T12:05:00-05:00"
+        },
+        "diff": "bad",
+        "diffMin": 49
+      },
+      {
+        "station": "Portage La Prairie",
+        "code": "PLPX",
+        "tz": "America/Winnipeg",
+        "estimated": "2026-09-01T14:09:43-05:00",
+        "scheduled": "2026-09-01T13:15:00-05:00",
+        "eta": "ARR",
+        "arrival": {
+          "estimated": "2026-09-01T14:09:43-05:00",
+          "scheduled": "2026-09-01T13:15:00-05:00"
+        },
+        "departure": {
+          "estimated": "2026-09-01T14:09:43-05:00",
+          "scheduled": "2026-09-01T13:15:22-05:00"
+        },
+        "diff": "bad",
+        "diffMin": 54
+      }
+    ]
+  }
+}

--- a/tests/viarail-live.test.mjs
+++ b/tests/viarail-live.test.mjs
@@ -143,21 +143,21 @@ describe('VIA Rail live parser (#6615)', () => {
   });
 });
 
-describe('VIA Rail live ingest (404 / shape-break / last-good)', () => {
-  it('404 → sourceState unavailable, not SEED_ERROR, and does not persist', async () => {
+describe('VIA Rail live ingest (source failure / shape-break / last-good)', () => {
+  it('records a cold 404 as a configured-source failure and does not persist', async () => {
     const persisted = [];
-    const unavailable = [];
+    const sourceMeta = [];
     const decision = await ingestViaRailLive({
       fetchImpl: async () => stubResponse('not found', { status: 404 }),
       readLastGood: async () => null,
       persist: async (snapshot) => { persisted.push(snapshot); },
-      writeUnavailableMeta: async (meta) => { unavailable.push(meta); },
+      writeSourceMeta: async (meta) => { sourceMeta.push(meta); },
     });
     assert.equal(decision.persist, false);
-    assert.equal(decision.sourceState, 'unavailable');
+    assert.equal(decision.sourceState, 'stale');
     assert.equal(decision.reason, 'http_404');
     assert.equal(persisted.length, 0);
-    assert.deepEqual(unavailable, [{ reason: 'http_404' }]);
+    assert.deepEqual(sourceMeta, [{ sourceState: 'stale', reason: 'http_404' }]);
     const classified = healthTesting.classifyKey(
       'viarailLive',
       VIA_RAIL_LIVE_KEY,
@@ -168,50 +168,50 @@ describe('VIA Rail live ingest (404 / shape-break / last-good)', () => {
         keyMetaValues: new Map([[VIA_RAIL_LIVE_META_KEY, JSON.stringify({
           fetchedAt: Date.now(),
           recordCount: 0,
-          sourceState: 'unavailable',
+          sourceState: 'stale',
         })]]),
         keyMetaErrors: new Map(),
         now: Date.now(),
       },
     );
-    assert.equal(classified.status, 'NOT_CONFIGURED');
-    assert.equal(healthTesting.STATUS_COUNTS[classified.status], 'ok');
-    assert.notEqual(classified.status, 'SEED_ERROR');
-    assert.notEqual(healthTesting.STATUS_COUNTS[classified.status], 'crit');
+    assert.equal(classified.status, 'SEED_ERROR');
+    assert.equal(healthTesting.STATUS_COUNTS[classified.status], 'warn');
+    assert.notEqual(classified.status, 'NOT_CONFIGURED');
   });
 
-  it('shape-break 200 does not persist and keeps last-good', async () => {
+  it('a positionless 200 does not persist or refresh last-good metadata', async () => {
     const lastGood = parseViaRailLive(fixture);
     const persisted = [];
-    const unavailable = [];
+    const sourceMeta = [];
     const decision = await ingestViaRailLive({
-      fetchImpl: async () => stubResponse({ status: 'ok', trains: [] }),
+      fetchImpl: async () => stubResponse(noLivePositionsFixture),
       readLastGood: async () => lastGood,
       persist: async (snapshot) => { persisted.push(snapshot); },
-      writeUnavailableMeta: async (meta) => { unavailable.push(meta); },
+      writeSourceMeta: async (meta) => { sourceMeta.push(meta); },
     });
     assert.equal(decision.persist, false);
     assert.equal(decision.keepLastGood, true);
     assert.equal(decision.sourceState, null);
+    assert.equal(decision.reason, 'no_live_positions');
     assert.equal(persisted.length, 0, 'degraded 200 must not poison last-good');
-    assert.equal(unavailable.length, 0, 'last-good health stays in place');
+    assert.equal(sourceMeta.length, 0, 'last-good freshness metadata stays in place');
     assert.equal(validateViaRailLiveSnapshot(lastGood), true);
   });
 
   it('resolveViaRailLivePublish treats failure as skip, not miss', () => {
     const lastGood = parseViaRailLive(fixture);
     const broken = resolveViaRailLivePublish(
-      { ok: false, sourceState: 'unavailable', reason: 'shape_break' },
+      { ok: false, sourceState: 'stale', reason: 'no_live_positions' },
       lastGood,
     );
     assert.equal(broken.persist, false);
     assert.equal(broken.keepLastGood, true);
     const cold = resolveViaRailLivePublish(
-      { ok: false, sourceState: 'unavailable', reason: 'http_404' },
+      { ok: false, sourceState: 'stale', reason: 'http_404' },
       null,
     );
     assert.equal(cold.persist, false);
-    assert.equal(cold.sourceState, 'unavailable');
+    assert.equal(cold.sourceState, 'stale');
   });
 });
 
@@ -283,7 +283,8 @@ describe('VIA Rail live registration (no bootstrap / seeder import / ais-relay)'
     assert.match(parser, /\(\.\.\.args\) => globalThis\.fetch\(\.\.\.args\)/);
     assert.match(seeder, /loadEnvFile/);
     assert.match(seeder, /runSeed/);
-    assert.match(seeder, /sourceState: 'unavailable'/);
+    assert.match(seeder, /sourceState: decision\.sourceState/);
+    assert.doesNotMatch(seeder, /sourceState: 'unavailable'/);
     assert.doesNotMatch(seeder, /SEED_ERROR/);
     assert.doesNotMatch(seeder, /ais-relay/);
     assert.doesNotMatch(parser, /ais-relay/);

--- a/tests/viarail-live.test.mjs
+++ b/tests/viarail-live.test.mjs
@@ -25,6 +25,7 @@ import {
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const read = (path) => readFileSync(resolve(root, path), 'utf8');
 const fixture = JSON.parse(read('tests/fixtures/viarail-live/allData.json'));
+const noLivePositionsFixture = JSON.parse(read('tests/fixtures/viarail-live/no-live-positions.json'));
 
 function stubResponse(payload, {
   url = VIA_RAIL_LIVE_URL,
@@ -69,6 +70,17 @@ describe('VIA Rail live parser (#6615)', () => {
     assert.equal(delayed.diffMin, 16);
   });
 
+  it('classifies a recognized positionless response separately from a shape break', () => {
+    assert.throws(
+      () => parseViaRailLive(noLivePositionsFixture, { fetchedAt: 1_700_000_000_000 }),
+      { reason: 'no_live_positions' },
+    );
+    assert.throws(
+      () => parseViaRailLive({ unknown: { times: [{ diffMin: 4 }] } }),
+      { reason: 'shape_break' },
+    );
+  });
+
   it('keeps bilingual alerts when the unofficial payload includes them', () => {
     const snapshot = parseViaRailLive(fixture);
     const withAlerts = snapshot.trains.find((train) => train.alerts.length > 0);
@@ -92,7 +104,7 @@ describe('VIA Rail live parser (#6615)', () => {
         () => parseViaRailLive({
           '37': { from: 'MTRL', to: 'TRTO', lat: absent, lng: absent, times: [{ diffMin: 4 }] },
         }, { fetchedAt: 1_700_000_000_000 }),
-        { reason: 'shape_break' },
+        { reason: 'no_live_positions' },
         `lat/lng ${JSON.stringify(absent)} must not publish as 0,0`,
       );
     }


### PR DESCRIPTION
## Why

The current VIA Rail tracker response still contains recognized trains, routes, stations, and numeric delays, but it omits every live coordinate. The adapter reported that state as a generic `shape_break`. A cold failure also wrote `unavailable`, which health reserves for a deployment that never configured a source, although this adapter needs no credential.

This change keeps the publish gate closed while it reports the source condition accurately. It preserves last-good data and lets its original freshness clock reach `STALE_SEED` instead of hiding a configured-source failure as `NOT_CONFIGURED`.

## Scope

- Classify a recognized response with delays and no coordinates as `no_live_positions`.
- Keep valid positioned snapshots publishable and keep malformed payloads on `shape_break`.
- Report cold fetch and shape failures as `sourceState: stale`.
- Do not write freshness metadata when a valid last-good snapshot is retained.
- Add a reduced fixture from the observed production response and align the nearby health-contract comment.

## Tradeoffs

The fix does not publish schedule and delay data as live positions, and it does not manufacture coordinates. If VIA Rail continues to omit all coordinates, `viarailLive` remains stale by design until the upstream feed recovers.

## Blast Radius

The runtime change is limited to the VIA-Rail-Live member of `seed-bundle-canada` and its `viarailLive` health metadata. The endpoint, host allowlist, request bounds, cache key, TTL, 15-minute member interval, and 45-minute freshness budget are unchanged. No production data was changed or reseeded during diagnosis.

Related: #6615

## Verification

- `node --test tests/viarail-live.test.mjs` passed all 14 tests.
- A replay of the captured 2026-09-03 04:53 UTC response returned `no_live_positions` and refused publication.
- `npm run test:data` passed 29,494 tests with 35 skips and no failures.
- `npm run typecheck`, `npm run lint`, and `git diff --check` passed. Lint retained only existing warnings outside this diff.
- The final local review found no remaining correctness, test, API-contract, reliability, standards, or adversarial issue.

## Post-Deploy Monitoring & Validation

Owner: WorldMonitor production operator.

Window: the next natural VIA-Rail-Live 15-minute interval after `seed-bundle-canada` deploys the merged commit. Do not run the seeder manually.

Acceptance evidence:

- Confirm that the Railway deployment commit equals the merged PR head.
- Search the bounded bundle logs for `VIA-Rail-Live` and `VIA Rail live skip (no_live_positions)`.
- Read the production `viarailLive` health entry and its seed age.

If the upstream response remains positionless, acceptance requires a `no_live_positions` skip, retained last-good records, an unchanged freshness clock, and `STALE_SEED` after 45 minutes. The status must not be `NOT_CONFIGURED`.

If coordinates return, acceptance requires a nonzero publish on the next natural interval and `viarailLive: OK` with a seed age below 45 minutes.

Rollback if a positionless response publishes, replaces last-good data, refreshes the last-good clock, or suppresses the health failure. Revert the deployed commit and preserve the existing data. Do not force a manual seed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
