### PR TITLE
fix(sentry): filter Chrome's overlapping-WebAuthn rejection on both surfaces

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -285,6 +285,37 @@ export const MARKETING_IGNORE_ERRORS: RegExp[] = [
   // `!hasFirstParty` gate for exactly that reason), so only the WebAuthn
   // wording — which no first-party call site can reach — is suppressed here.
   /^(?:Error: )?NotSupportedError: The user agent does not support public key credentials\.$/,
+  // The same WebAuthn surface as the entry above, reached from the other
+  // direction: a SECOND credential request issued while one is still
+  // outstanding. WORLDMONITOR-11T is the shape: `Error: OperationError: A
+  // request is already pending.` on Chrome 151 / Windows at `/pro`, arriving
+  // via `onunhandledrejection` with zero frames, breadcrumbs running Clerk's
+  // `GET /v1/environment` -> `GET /v1/client` -> a button click ->
+  // `POST /v1/client/sign_ins`.
+  //
+  // Chrome serialises `navigator.credentials` requests per page and rejects the
+  // overlapping one with this exact sentence. The documented triggers are a
+  // user double-clicking the sign-in button and a submit issued while a
+  // conditional-mediation passkey autofill request is still open
+  // (keycloak/keycloak#41037; w3c/webauthn#1790 records that the spec leaves
+  // the overlap undefined and that Chrome errors). Clerk's sign-in UI opens
+  // exactly that conditional request, so both triggers sit behind the marketing
+  // sign-in button and neither is reachable from this bundle to fix.
+  //
+  // Same licence as the `NotSupportedError` entry above, and it holds twice
+  // over. Only a WebAuthn CALLER can raise the sentence, and this surface has
+  // none - `navigator.credentials` and `PublicKeyCredential` appear in no
+  // `pro-test/src` file, no `shared/` leaf and neither inline script, which the
+  // WebAuthn-free scan that licenses that entry already pins. Independently,
+  // `OperationError` is a browser-minted DOMException name and the only
+  // DOMException this bundle ever constructs is `timeout-signal.ts`'s
+  // `TimeoutError`, so the type alone is unreachable from first-party code.
+  //
+  // Anchored to the whole sentence for the reason the `Error invoking` entry
+  // spells out: `ignoreErrors` is frame-blind, so an unanchored `A request is
+  // already pending` would also drop a first-party message that merely CONTAINS
+  // the phrase while riding a `/pro/assets/*.js` frame.
+  /^(?:Error: )?OperationError: A request is already pending\.$/,
 ];
 
 /** Sentry's own hashed SDK chunk — infrastructure, never evidence of our code. */

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -986,6 +986,30 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
           // future first-party WebAuthn call site would keep a source-mapped
           // .ts frame and still surface (WORLDMONITOR-11B).
           || /An unknown error occurred while talking to the credential manager/.test(msg)
+          // The overlapping-request half of the same WebAuthn surface. Chrome
+          // serialises `navigator.credentials` requests per page and rejects
+          // the second one with `OperationError: A request is already
+          // pending.`; the documented triggers are a double-clicked sign-in
+          // button and a submit issued while a conditional-mediation passkey
+          // autofill request is still open (keycloak/keycloak#41037;
+          // w3c/webauthn#1790 records that the spec leaves the overlap
+          // undefined and that Chrome errors). Clerk's sign-in UI opens exactly
+          // that conditional request, which is the same third-party origin as
+          // the CredMan entry above, and it arrives the same way — an unhandled
+          // rejection out of the Clerk bundle with zero captured frames.
+          //
+          // Kept HERE rather than in `ignoreErrors`, unlike the marketing
+          // copy in `pro-test/src/sentry-filter-policy.ts`, because the two
+          // surfaces have different licences: the marketing bundle calls no
+          // WebAuthn API at all, but this one does — `createPasskey()` in
+          // src/services/passkeys.ts drives `user.createPasskey()`. That path
+          // cannot leak today (it wraps the call in try/catch and returns a
+          // classified outcome), but a future first-party double-invoke is
+          // precisely the bug worth seeing, and it would keep a source-mapped
+          // .ts frame. `!hasFirstParty` is what preserves it (WORLDMONITOR-11T,
+          // observed on `/pro`; the same class reaches this surface through the
+          // dashboard's own Clerk sign-in).
+          || /^(?:Error: )?OperationError: A request is already pending\.$/.test(msg)
         )
       ) return null;
       if (hasAnyStack && !hasFirstParty && (

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -985,6 +985,45 @@ describe('marketing ignoreErrors — injected-script classes (2026-09-02 triage)
     assert.deepEqual(offenders, [],
       'the marketing surface now calls WebAuthn — re-derive the WORLDMONITOR-11Q rule');
   });
+
+  it('drops the overlapping WebAuthn request rejection (WORLDMONITOR-11T)', () => {
+    // Verbatim production value: Chrome 151 / Windows on `/pro`, zero frames,
+    // breadcrumbs running Clerk's `GET /v1/environment` -> `GET /v1/client` ->
+    // a button click -> `POST /v1/client/sign_ins`. Chrome rejects a second
+    // `navigator.credentials` request while one is outstanding, which is what a
+    // double-clicked sign-in button (or a submit over Clerk's conditional
+    // passkey autofill) produces.
+    assert.equal(isIgnored('Error', 'OperationError: A request is already pending.'), true);
+    // Some engines fold the type into the value.
+    assert.equal(isIgnored('Error', 'Error: OperationError: A request is already pending.'), true);
+  });
+
+  it('keeps other OperationError messages so a real one still reports', () => {
+    assert.equal(isIgnored('Error', 'OperationError: The operation failed.'), false);
+  });
+
+  it('keeps a message that merely contains the pending-request phrase', () => {
+    // The entry is anchored at both ends for the reason the `Error invoking`
+    // entry spells out: `ignoreErrors` is frame-blind, so an unanchored pattern
+    // would drop this even riding a `/pro/assets/*.js` frame.
+    assert.equal(
+      isIgnored('Error', 'Checkout aborted: a request is already pending. Retry in 5s'),
+      false,
+    );
+  });
+
+  it('pins the marketing surface as OperationError-free, the rule\'s second licence', () => {
+    // Independent of the WebAuthn-free scan above: `OperationError` is a
+    // browser-minted DOMException name, and `timeout-signal.ts`'s `TimeoutError`
+    // is the only DOMException this bundle constructs. If first-party code ever
+    // mints an `OperationError`, the frame-blind entry has to be re-derived.
+    const offenders = marketingFirstPartySources()
+      .filter((f) => !f.rel.includes('sentry-filter-policy'))
+      .filter((f) => /OperationError|A request is already pending/.test(f.code))
+      .map((f) => f.rel);
+    assert.deepEqual(offenders, [],
+      'the marketing surface now mints OperationError — re-derive the WORLDMONITOR-11T rule');
+  });
 });
 
 describe('marketingBeforeSend — leaked fetch abort (WORLDMONITOR-11M)', () => {

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -459,6 +459,16 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
     // first-party frame here would mean a NEW call site, which the "lets
     // through" arm of this loop keeps visible.
     ['NotReadableError: An unknown error occurred while talking to the credential manager.', 'Error'],
+    // The overlapping-request half of the same WebAuthn surface
+    // (WORLDMONITOR-11T: Chrome 151 / Windows, /pro, zero frames, breadcrumbs
+    // ending at Clerk's `POST /v1/client/sign_ins`). Chrome serialises
+    // `navigator.credentials` per page and rejects the second request with this
+    // sentence when the sign-in button is double-clicked or submitted while
+    // Clerk's conditional passkey autofill is still open. Both value shapes:
+    // production carried the bare sentence with `type: 'Error'`, and some
+    // engines fold the type into the value.
+    ['OperationError: A request is already pending.', 'Error'],
+    ['Error: OperationError: A request is already pending.', 'Error'],
   ];
 
   for (const [msg, type] of zeroFrameErrors) {
@@ -488,6 +498,14 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
       [{ filename: '<anonymous>', lineno: 1 }, { filename: '<anonymous>', lineno: 1 }],
     );
     assert.equal(beforeSend(event), null);
+  });
+
+  it('keeps a pending-request message that is not the whole browser sentence', () => {
+    // The entry is anchored at both ends precisely so a first-party message
+    // that merely CONTAINS the phrase still reports, even with no frames at all
+    // — the blind spot an unanchored substring would open.
+    const event = makeEvent('Checkout aborted: a request is already pending. Retry in 5s', 'Error', []);
+    assert.ok(beforeSend(event) !== null);
   });
 
   it('lets through an appendChild parse failure attributed to a first-party script loader', () => {


### PR DESCRIPTION
## Summary

Chrome rejects a second `navigator.credentials` request while one is outstanding, and Clerk's sign-in UI holds a conditional-mediation passkey request open the whole time its form is on screen — so a double-clicked sign-in button, or a submit over that open autofill, throws `OperationError: A request is already pending.` straight into `onunhandledrejection`. It reached Sentry as WORLDMONITOR-11T (Chrome 151 / Windows on `/pro`, zero frames, breadcrumbs ending at Clerk's `POST /v1/client/sign_ins`) — a direct sibling of the `NotSupportedError` (-11Q) and `NotReadableError` (-11B) entries both surfaces already carry. Nothing in our code can prevent it, so it is dropped on both surfaces — but by different mechanisms, because the two surfaces have different licences for suppressing it.

| Surface | Mechanism | What licenses it |
|---|---|---|
| `/` and `/pro` (`pro-test`) | `MARKETING_IGNORE_ERRORS` — frame-blind | Calls no WebAuthn API at all, and mints no `OperationError` |
| `/dashboard` (`src`) | `beforeSend`, behind `!hasFirstParty` | **Does** call WebAuthn — `createPasskey()` drives `user.createPasskey()` |

The marketing licence holds twice over: `navigator.credentials` and `PublicKeyCredential` appear in no `pro-test/src` file, no `shared/` leaf and neither inline script; and independently, `timeout-signal.ts`'s `TimeoutError` is the only DOMException that bundle constructs, so `OperationError` is unreachable from its first-party code. A scan pins each, so the entry cannot rot into a blind spot.

On the dashboard a frame-blind entry would hide a first-party double-invoke instead, so that copy sits behind `!hasFirstParty` — a real `createPasskey()` bug rides a source-mapped `.ts` frame and still pages. Both patterns are anchored end to end, so a first-party message that merely *contains* "a request is already pending" keeps reporting.

## Validation

391/391 pass across both suites; `tsc --noEmit` and biome clean. Mutation-checked rather than trusted on absence: removing the marketing entry reds exactly 1 new assertion, removing the dashboard entry reds exactly 2. Chrome's behaviour confirmed against [keycloak/keycloak#41037](https://github.com/keycloak/keycloak/issues/41037) and [w3c/webauthn#1790](https://lists.w3.org/Archives/Public/public-webauthn/2022Aug/0072.html).

Related: #7542

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_01W1i2eKU5xHhTyHT6K1t2mb
