### PR TITLE
fix(railway): make control deploy fence closure-aware

### DIFF
--- a/.github/workflows/deploy-railway-reconcile-control.yml
+++ b/.github/workflows/deploy-railway-reconcile-control.yml
@@ -59,11 +59,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           filter: blob:none
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '24'
-      - name: Install
-        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Fence stale main deployment
         run: |
           set -euo pipefail
@@ -94,6 +89,11 @@ jobs:
           if [ "$current_main_sha" != "$GITHUB_SHA" ]; then
             echo "::notice::Current main advanced only outside the reconcile-control deployment closure."
           fi
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '24'
+      - name: Install
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Set control-plane secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-railway-reconcile-control.yml
+++ b/.github/workflows/deploy-railway-reconcile-control.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - 'workers/railway-reconcile-control/**'
+      - 'scripts/railway-reconcile-control-client.mjs'
       - '.github/workflows/deploy-railway-reconcile-control.yml'
       - 'tests/deploy-railway-reconcile-control-workflow.test.mjs'
   workflow_dispatch:
@@ -56,6 +57,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+          fetch-depth: 0
+          filter: blob:none
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '24'
@@ -64,10 +67,32 @@ jobs:
       - name: Fence stale main deployment
         run: |
           set -euo pipefail
-          git fetch --no-tags origin main
-          if [ "$(git rev-parse origin/main)" != "$GITHUB_SHA" ]; then
-            echo "::error::Refusing to deploy a superseded control-plane SHA."
+          repo_root="$(git rev-parse --show-toplevel)"
+          deploy_paths=(
+            'workers/railway-reconcile-control/**'
+            'scripts/railway-reconcile-control-client.mjs'
+            '.github/workflows/deploy-railway-reconcile-control.yml'
+            'tests/deploy-railway-reconcile-control-workflow.test.mjs'
+          )
+          git -C "$repo_root" fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          current_main_sha="$(git -C "$repo_root" rev-parse --verify 'refs/remotes/origin/main^{commit}')"
+          if ! git -C "$repo_root" merge-base --is-ancestor "$GITHUB_SHA" "$current_main_sha"; then
+            echo "::error::Refusing to deploy because the event SHA is not an ancestor of current main."
             exit 1
+          fi
+          diff_status=0
+          git -C "$repo_root" diff --quiet --no-renames \
+            "$GITHUB_SHA" "$current_main_sha" -- "${deploy_paths[@]}" || diff_status=$?
+          if [ "$diff_status" -gt 1 ]; then
+            echo "::error::Unable to prove that the reconcile-control deployment closure is unchanged."
+            exit 1
+          fi
+          if [ "$diff_status" -eq 1 ]; then
+            echo "::error::Refusing to deploy a superseded reconcile-control revision."
+            exit 1
+          fi
+          if [ "$current_main_sha" != "$GITHUB_SHA" ]; then
+            echo "::notice::Current main advanced only outside the reconcile-control deployment closure."
           fi
       - name: Set control-plane secrets
         env:

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -100,8 +100,6 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // The YAML key is `deploy` but the job carries `name: Wrangler deploy`,
     // which is what the jobs API returns.
     deployJobName: 'Wrangler deploy',
-    // Keep this list equal to the workflow's path filter and deployment fence.
-    // A push touching ONLY these paths must deploy; a skipped deploy alarms.
     skipProofPaths: null,
     triggerPaths: Object.freeze([
       'workers/railway-reconcile-control/**',

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -100,12 +100,12 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // The YAML key is `deploy` but the job carries `name: Wrangler deploy`,
     // which is what the jobs API returns.
     deployJobName: 'Wrangler deploy',
-    // The workflow's own path filter covers workers/railway-reconcile-control/**
-    // plus its own file and test. A push touching ONLY those paths must
-    // deploy; a deploy job skipped there is an unexpected skip, which alarms.
+    // Keep this list equal to the workflow's path filter and deployment fence.
+    // A push touching ONLY these paths must deploy; a skipped deploy alarms.
     skipProofPaths: null,
     triggerPaths: Object.freeze([
       'workers/railway-reconcile-control/**',
+      'scripts/railway-reconcile-control-client.mjs',
       '.github/workflows/deploy-railway-reconcile-control.yml',
       'tests/deploy-railway-reconcile-control-workflow.test.mjs',
     ]),

--- a/tests/deploy-railway-reconcile-control-workflow.test.mjs
+++ b/tests/deploy-railway-reconcile-control-workflow.test.mjs
@@ -1,12 +1,13 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import YAML from 'yaml';
+
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowPath = resolve(repoRoot, '.github/workflows/deploy-railway-reconcile-control.yml');
@@ -49,14 +50,13 @@ function commitFixture(root, message) {
   return runGit(root, ['rev-parse', 'HEAD']);
 }
 
-function createFenceFixture() {
-  const root = mkdtempSync(join(tmpdir(), 'wm-reconcile-deploy-fence-'));
+function createFenceFixture(t) {
+  const root = createTempDir('wm-reconcile-deploy-fence-', t);
   runGit(root, ['init', '--quiet', '--initial-branch=main', '.']);
   runGit(root, ['config', 'user.name', 'Reconcile Deploy Fence Fixture']);
   runGit(root, ['config', 'user.email', 'reconcile-fence@wm-fixture.localhost']);
   for (const path of expectedDeployPaths) {
-    const concretePath = path.endsWith('/**') ? `${path.slice(0, -3)}/index.js` : path;
-    writeFixtureFile(root, concretePath, 'base\n');
+    writeFixtureFile(root, concreteDeployPath(path), 'base\n');
   }
   writeFixtureFile(root, 'README.md', 'base\n');
   const eventSha = commitFixture(root, 'event revision');
@@ -73,13 +73,8 @@ function runFence(root, eventSha) {
   });
 }
 
-function withFenceFixture(run) {
-  const fixture = createFenceFixture();
-  try {
-    return run(fixture);
-  } finally {
-    rmSync(fixture.root, { recursive: true, force: true });
-  }
+function withFenceFixture(t, run) {
+  return run(createFenceFixture(t));
 }
 
 function concreteDeployPath(path) {
@@ -200,8 +195,8 @@ describe('Railway reconcile control deployment workflow', () => {
     }
   });
 
-  it('admits the exact event revision and an unrelated descendant of it', () => {
-    withFenceFixture(({ eventSha, root }) => {
+  it('admits the exact event revision and an unrelated descendant of it', (t) => {
+    withFenceFixture(t, ({ eventSha, root }) => {
       const exact = runFence(root, eventSha);
       assert.equal(exact.status, 0, exact.stderr || exact.stdout);
 
@@ -212,9 +207,9 @@ describe('Railway reconcile control deployment workflow', () => {
     });
   });
 
-  it('rejects a descendant change under every deployment trigger path', () => {
+  it('rejects a descendant change under every deployment trigger path', (t) => {
     for (const path of expectedDeployPaths) {
-      withFenceFixture(({ eventSha, root }) => {
+      withFenceFixture(t, ({ eventSha, root }) => {
         writeFixtureFile(root, concreteDeployPath(path), `changed ${path}\n`);
         commitFixture(root, `change ${path}`);
         const result = runFence(root, eventSha);
@@ -223,8 +218,8 @@ describe('Railway reconcile control deployment workflow', () => {
     }
   });
 
-  it('admits a descendant whose deployment paths return to the event tree', () => {
-    withFenceFixture(({ eventSha, root }) => {
+  it('admits a descendant whose deployment paths return to the event tree', (t) => {
+    withFenceFixture(t, ({ eventSha, root }) => {
       const path = concreteDeployPath(expectedDeployPaths[0]);
       writeFixtureFile(root, path, 'temporary change\n');
       commitFixture(root, 'temporary deployment change');
@@ -235,8 +230,8 @@ describe('Railway reconcile control deployment workflow', () => {
     });
   });
 
-  it('rejects divergent history and missing comparison evidence', () => {
-    withFenceFixture(({ eventSha, root }) => {
+  it('rejects divergent history and missing comparison evidence', (t) => {
+    withFenceFixture(t, ({ eventSha, root }) => {
       const tree = runGit(root, ['rev-parse', 'HEAD^{tree}']);
       const divergentSha = runGit(root, ['commit-tree', tree, '-m', 'divergent main']);
       runGit(root, ['update-ref', 'refs/heads/main', divergentSha]);
@@ -244,12 +239,12 @@ describe('Railway reconcile control deployment workflow', () => {
       assert.notEqual(divergent.status, 0, divergent.stdout);
     });
 
-    withFenceFixture(({ root }) => {
+    withFenceFixture(t, ({ root }) => {
       const missing = runFence(root, 'f'.repeat(40));
       assert.notEqual(missing.status, 0, missing.stdout);
     });
 
-    withFenceFixture(({ eventSha, root }) => {
+    withFenceFixture(t, ({ eventSha, root }) => {
       runGit(root, ['remote', 'remove', 'origin']);
       const unreadable = runFence(root, eventSha);
       assert.notEqual(unreadable.status, 0, unreadable.stdout);

--- a/tests/deploy-railway-reconcile-control-workflow.test.mjs
+++ b/tests/deploy-railway-reconcile-control-workflow.test.mjs
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
@@ -11,20 +12,90 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowPath = resolve(repoRoot, '.github/workflows/deploy-railway-reconcile-control.yml');
 const source = readFileSync(workflowPath, 'utf8');
 const workflow = YAML.parse(source);
+const expectedDeployPaths = [
+  'workers/railway-reconcile-control/**',
+  'scripts/railway-reconcile-control-client.mjs',
+  '.github/workflows/deploy-railway-reconcile-control.yml',
+  'tests/deploy-railway-reconcile-control-workflow.test.mjs',
+];
+const fence = workflow.jobs.deploy.steps.find((step) => step.name === 'Fence stale main deployment');
+
+const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' };
+const localGitVariables = spawnSync('git', ['rev-parse', '--local-env-vars'], {
+  encoding: 'utf8',
+}).stdout.trim().split('\n').filter(Boolean);
+for (const name of localGitVariables) delete gitEnv[name];
 
 function assertBashSyntax(script) {
   const result = spawnSync('bash', ['-n'], { input: script, encoding: 'utf8' });
   assert.equal(result.status, 0, result.stderr);
 }
 
+function runGit(cwd, args) {
+  const result = spawnSync('git', args, { cwd, env: gitEnv, encoding: 'utf8' });
+  assert.equal(result.status, 0, `${args.join(' ')}\n${result.stderr || result.stdout}`);
+  return result.stdout.trim();
+}
+
+function writeFixtureFile(root, path, contents) {
+  const absolutePath = join(root, path);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, contents);
+}
+
+function commitFixture(root, message) {
+  runGit(root, ['add', '-A']);
+  runGit(root, ['commit', '--quiet', '-m', message]);
+  return runGit(root, ['rev-parse', 'HEAD']);
+}
+
+function createFenceFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'wm-reconcile-deploy-fence-'));
+  runGit(root, ['init', '--quiet', '--initial-branch=main', '.']);
+  runGit(root, ['config', 'user.name', 'Reconcile Deploy Fence Fixture']);
+  runGit(root, ['config', 'user.email', 'reconcile-fence@wm-fixture.localhost']);
+  for (const path of expectedDeployPaths) {
+    const concretePath = path.endsWith('/**') ? `${path.slice(0, -3)}/index.js` : path;
+    writeFixtureFile(root, concretePath, 'base\n');
+  }
+  writeFixtureFile(root, 'README.md', 'base\n');
+  const eventSha = commitFixture(root, 'event revision');
+  runGit(root, ['remote', 'add', 'origin', root]);
+  return { eventSha, root };
+}
+
+function runFence(root, eventSha) {
+  assert.ok(fence?.run, 'workflow must define the deployment fence');
+  return spawnSync('bash', ['-c', fence.run], {
+    cwd: join(root, 'workers/railway-reconcile-control'),
+    env: { ...gitEnv, GITHUB_SHA: eventSha },
+    encoding: 'utf8',
+  });
+}
+
+function withFenceFixture(run) {
+  const fixture = createFenceFixture();
+  try {
+    return run(fixture);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+function concreteDeployPath(path) {
+  return path.endsWith('/**') ? `${path.slice(0, -3)}/index.js` : path;
+}
+
+function fenceDeployPaths(script) {
+  const match = script.match(/deploy_paths=\(\n([\s\S]*?)\n\s*\)/);
+  assert.ok(match, 'deployment fence must declare its compared path closure');
+  return [...match[1].matchAll(/^\s*'([^']+)'\s*$/gm)].map((entry) => entry[1]);
+}
+
 describe('Railway reconcile control deployment workflow', () => {
   it('deploys only from main changes to the isolated Worker or its deployment contract', () => {
     assert.deepEqual(workflow.on.push.branches, ['main']);
-    assert.deepEqual(new Set(workflow.on.push.paths), new Set([
-      'workers/railway-reconcile-control/**',
-      '.github/workflows/deploy-railway-reconcile-control.yml',
-      'tests/deploy-railway-reconcile-control-workflow.test.mjs',
-    ]));
+    assert.deepEqual(workflow.on.push.paths, expectedDeployPaths);
     assert.ok(Object.hasOwn(workflow.on, 'workflow_dispatch'));
   });
 
@@ -44,6 +115,9 @@ describe('Railway reconcile control deployment workflow', () => {
       const install = workflow.jobs[jobName].steps.find((step) => step.name === 'Install');
       assert.match(install.run, /npm ci --ignore-scripts/);
     }
+    const deployCheckout = workflow.jobs.deploy.steps.find((step) => step.uses?.startsWith('actions/checkout@'));
+    assert.equal(deployCheckout.with['fetch-depth'], 0);
+    assert.equal(deployCheckout.with.filter, 'blob:none');
   });
 
   it('requires all four route credentials plus one server-owned scope', () => {
@@ -83,9 +157,12 @@ describe('Railway reconcile control deployment workflow', () => {
     assert.ok(workflow.jobs.deploy.steps.some((step) => step.name === 'Deploy' && /wrangler deploy/.test(step.run)));
     const deploy = workflow.jobs.deploy.steps.find((step) => step.name === 'Deploy');
     assert.match(deploy.run, /DEPLOYMENT_SHA:\$GITHUB_SHA/);
-    const fence = workflow.jobs.deploy.steps.find((step) => step.name === 'Fence stale main deployment');
-    assert.match(fence.run, /git fetch --no-tags origin main/);
-    assert.match(fence.run, /git rev-parse origin\/main/);
+    assert.match(fence.run, /git .*fetch --no-tags origin/);
+    assert.match(fence.run, /refs\/remotes\/origin\/main/);
+    assert.match(fence.run, /merge-base --is-ancestor/);
+    assert.match(fence.run, /diff --quiet --no-renames/);
+    assert.deepEqual(fenceDeployPaths(fence.run), workflow.on.push.paths);
+    assertBashSyntax(fence.run);
     const objectSmoke = workflow.jobs.deploy.steps.find((step) => step.name === 'Smoke canonical Durable Object');
     assert.equal(
       objectSmoke.env.RAILWAY_RECONCILE_WATCHDOG_HMAC,
@@ -121,5 +198,61 @@ describe('Railway reconcile control deployment workflow', () => {
         assert.match(step.uses, /^[^@]+@[0-9a-f]{40}$/i, step.uses);
       }
     }
+  });
+
+  it('admits the exact event revision and an unrelated descendant of it', () => {
+    withFenceFixture(({ eventSha, root }) => {
+      const exact = runFence(root, eventSha);
+      assert.equal(exact.status, 0, exact.stderr || exact.stdout);
+
+      writeFixtureFile(root, 'README.md', 'unrelated change\n');
+      commitFixture(root, 'unrelated main advance');
+      const advanced = runFence(root, eventSha);
+      assert.equal(advanced.status, 0, advanced.stderr || advanced.stdout);
+    });
+  });
+
+  it('rejects a descendant change under every deployment trigger path', () => {
+    for (const path of expectedDeployPaths) {
+      withFenceFixture(({ eventSha, root }) => {
+        writeFixtureFile(root, concreteDeployPath(path), `changed ${path}\n`);
+        commitFixture(root, `change ${path}`);
+        const result = runFence(root, eventSha);
+        assert.notEqual(result.status, 0, `${path} must reject\n${result.stdout}`);
+      });
+    }
+  });
+
+  it('admits a descendant whose deployment paths return to the event tree', () => {
+    withFenceFixture(({ eventSha, root }) => {
+      const path = concreteDeployPath(expectedDeployPaths[0]);
+      writeFixtureFile(root, path, 'temporary change\n');
+      commitFixture(root, 'temporary deployment change');
+      writeFixtureFile(root, path, 'base\n');
+      commitFixture(root, 'restore deployment tree');
+      const result = runFence(root, eventSha);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+    });
+  });
+
+  it('rejects divergent history and missing comparison evidence', () => {
+    withFenceFixture(({ eventSha, root }) => {
+      const tree = runGit(root, ['rev-parse', 'HEAD^{tree}']);
+      const divergentSha = runGit(root, ['commit-tree', tree, '-m', 'divergent main']);
+      runGit(root, ['update-ref', 'refs/heads/main', divergentSha]);
+      const divergent = runFence(root, eventSha);
+      assert.notEqual(divergent.status, 0, divergent.stdout);
+    });
+
+    withFenceFixture(({ root }) => {
+      const missing = runFence(root, 'f'.repeat(40));
+      assert.notEqual(missing.status, 0, missing.stdout);
+    });
+
+    withFenceFixture(({ eventSha, root }) => {
+      runGit(root, ['remote', 'remove', 'origin']);
+      const unreadable = runFence(root, eventSha);
+      assert.notEqual(unreadable.status, 0, unreadable.stdout);
+    });
   });
 });


### PR DESCRIPTION
## Why

A valid reconcile-control deployment could fail when an unrelated commit reached `main` while the run was waiting. Because the workflow is path-filtered, that unrelated commit created no replacement deploy run. The failed deployment then remained the newest evidence, and the strict Post-merge Deploy Monitor stayed red.

The fence now admits the event revision only when current `main` is its proven descendant and the complete reconcile-control deployment tree is unchanged. Relevant changes, divergent history, and unavailable Git evidence still fail closed. The monitor policy remains strict.

This addresses the failure seen in [Deploy Railway Reconcile Control run 33667194579](https://github.com/koala73/worldmonitor/actions/runs/33667194579).

## Design

- Preserve `GITHUB_SHA` as the deployed identity and retain the exact-SHA live smoke.
- Treat the authenticated smoke client as a deployment input.
- Use full commit history with a blobless checkout and compare root-relative trigger paths.
- Reject stale work before Node setup and dependency installation.

## Verification

- A regression test first reproduced the unrelated-main race: 5 of 9 cases failed before the implementation.
- Focused deployment and monitor contracts: 84 passed.
- Full data and integration suite: 29,497 passed, 35 skipped, 0 failed.
- Browser and API typechecks passed.
- Repository lint passed; existing unrelated warnings remain.
- Exact-head code review found no actionable correctness, security, reliability, maintainability, or project-standard defects.

## Post-Deploy Monitoring & Validation

- Watch `Deploy Railway Reconcile Control` for terminal success, including Wrangler deploy, canonical Durable Object smoke, and the exact `/version` live smoke.
- Search workflow logs for `Current main advanced only outside the reconcile-control deployment closure`, `Refusing to deploy`, and `Unable to prove`.
- Expected healthy signal: a successful deployment run followed by a green `Post-merge Deploy Monitor` run.
- Failure trigger: any fence rejection without a later replacement deployment, a failed live smoke, or a continued monitor alarm. Stop rollout and inspect the changed trigger-path tree. Revert this PR if safe unrelated descendants are still rejected.
- Validation window and owner: the first matching merge and the next scheduled monitor run; repository maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
