### PR TITLE
fix(ci): isolate IndexNow deployment concurrency

### DIFF
--- a/.github/workflows/indexnow-submit.yml
+++ b/.github/workflows/indexnow-submit.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: indexnow-production
+  group: indexnow-${{ github.event_name == 'deployment_status' && github.event.deployment.environment || github.event_name }}
   cancel-in-progress: false
 
 jobs:

--- a/tests/indexnow-submit.test.mjs
+++ b/tests/indexnow-submit.test.mjs
@@ -469,4 +469,12 @@ describe('IndexNow submission', () => {
     assert.match(workflow, /node scripts\/seo-indexnow-submit\.mjs --host worldmonitor\.app/);
     assert.match(workflow, /node scripts\/seo-indexnow-submit\.mjs --host www\.worldmonitor\.app/);
   });
+
+  it('isolates concurrency by deployment environment before eligibility filtering', () => {
+    assert.equal(workflowDoc.concurrency?.['cancel-in-progress'], false);
+    assert.equal(
+      workflowDoc.concurrency?.group,
+      "indexnow-${{ github.event_name == 'deployment_status' && github.event.deployment.environment || github.event_name }}",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Ineligible deployment events no longer share the IndexNow production lock, so bursts from Preview, Railway, and Mintlify cannot cancel a pending eligible Production submission. Deployment-status runs now use the deployment environment as their concurrency key, while manual runs keep their own event key and cancellation remains disabled.

Fixes #7592.

## Tests

- `node --import tsx --test tests/indexnow-submit.test.mjs` passed 16/16 before and after rebasing onto current `main`.
- `npm run lint` passed with existing repository diagnostics only.
- `npm run lint:boundaries` passed.
- `npm run test:data` reached the suite but remains red on unrelated baseline failures involving missing generated inventory artifacts, missing blog dependencies, and relay startup timeouts.

## Post-Deploy Monitoring & Validation

- Watch the first IndexNow Submission run from a successful Vercel Production deployment and the next deployment-status burst.
- Healthy signals are one eligible Production run completing and ineligible environments remaining isolated from that run.
- Treat a cancelled eligible run, missing submission, or workflow expression error as a failed rollout and revert the change.
- The repository maintainer owns validation through the first Production event and the next burst.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![MODEL_GPT-5-Codex-000000]