### PR TITLE
fix(redis): prefix temporal baseline lock

### DIFF
--- a/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
+++ b/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
@@ -5,7 +5,12 @@ import type {
   TemporalAnomaly as TemporalAnomalyProto,
 } from '../../../../src/generated/server/worldmonitor/infrastructure/v1/service_server';
 
-import { getCachedJson, readCachedJson, setCachedJson } from '../../../_shared/redis';
+import {
+  getCachedJson,
+  readCachedJson,
+  setCachedJson,
+  setCachedJsonIfAbsent,
+} from '../../../_shared/redis';
 import { resolveFireDetectionTotalCount } from '../../../../src/services/wildfires/payload';
 import {
   BASELINE_TTL,
@@ -54,29 +59,8 @@ function formatMessage(type: string, count: number, mean: number, multiplier: nu
   return `${TYPE_LABELS[type] || type} ${mult} normal for ${WEEKDAY_NAMES[weekday]} (${MONTH_NAMES[month]}) — ${count} vs baseline ${Math.round(mean)}`;
 }
 
-function redisCmd(cmd: string[]): { url: string; token: string; body: string } | null {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-  return { url, token, body: JSON.stringify(cmd) };
-}
-
 async function tryAcquireLock(): Promise<boolean> {
-  const r = redisCmd(['SET', BASELINE_LOCK_KEY, '1', 'NX', 'EX', String(BASELINE_LOCK_TTL)]);
-  if (!r) return false;
-  try {
-    const resp = await fetch(r.url, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${r.token}`, 'Content-Type': 'application/json' },
-      body: r.body,
-      signal: AbortSignal.timeout(3_000),
-    });
-    if (!resp.ok) return false;
-    const data = (await resp.json()) as { result?: string | null };
-    return data.result === 'OK';
-  } catch {
-    return false;
-  }
+  return setCachedJsonIfAbsent(BASELINE_LOCK_KEY, 1, BASELINE_LOCK_TTL);
 }
 
 /**

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -13,6 +13,7 @@ import {
   temporalAnomaliesContentMeta,
   temporalAnomaliesReadableContentMeta,
 } from '../server/worldmonitor/infrastructure/v1/_shared.ts';
+import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
 import { listTemporalAnomalies } from '../server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts';
 
 /**
@@ -29,15 +30,28 @@ async function runWithRedisStub(
     lockGranted = true,
     failedPostKeys = [],
     failedGetKeys = [],
-  }: { lockGranted?: boolean; failedPostKeys?: string[]; failedGetKeys?: string[] } = {},
+    vercelEnv,
+    vercelSha,
+  }: {
+    lockGranted?: boolean;
+    failedPostKeys?: string[];
+    failedGetKeys?: string[];
+    vercelEnv?: string;
+    vercelSha?: string;
+  } = {},
 ) {
   const originalFetch = globalThis.fetch;
   const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
   const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+  const originalVercelEnv = process.env.VERCEL_ENV;
+  const originalVercelSha = process.env.VERCEL_GIT_COMMIT_SHA;
   const calls: { method: string; key: string; recordCount?: number; value?: unknown }[] = [];
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  if (vercelEnv !== undefined) process.env.VERCEL_ENV = vercelEnv;
+  if (vercelSha !== undefined) process.env.VERCEL_GIT_COMMIT_SHA = vercelSha;
+  __resetKeyPrefixCacheForTests();
   globalThis.fetch = (async (input: unknown, init: { method?: string; body?: string } = {}) => {
     if (init.method === 'POST') {
       // Writes POST to `${url}/` with the command in the BODY (`['SET', key, ...]`),
@@ -83,6 +97,11 @@ async function runWithRedisStub(
     globalThis.fetch = originalFetch;
     process.env.UPSTASH_REDIS_REST_URL = originalUrl;
     process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    if (originalVercelEnv === undefined) delete process.env.VERCEL_ENV;
+    else process.env.VERCEL_ENV = originalVercelEnv;
+    if (originalVercelSha === undefined) delete process.env.VERCEL_GIT_COMMIT_SHA;
+    else process.env.VERCEL_GIT_COMMIT_SHA = originalVercelSha;
+    __resetKeyPrefixCacheForTests();
   }
 }
 
@@ -474,6 +493,25 @@ describe('temporal anomalies cache freshness', () => {
     assert.equal(
       calls.filter((c) => c.method === 'POST' && c.key !== 'baseline:lock').length, 0,
       'a lock loser must not publish a snapshot, a baseline, or a freshness stamp',
+    );
+  });
+
+  it('uses the preview namespace for the rebuild lock', async () => {
+    const prefix = 'preview:deadbeef:';
+    const stale = freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000);
+    const { response, calls } = await runWithRedisStub(
+      { [`${prefix}temporal:anomalies:v1`]: stale },
+      {
+        lockGranted: false,
+        vercelEnv: 'preview',
+        vercelSha: 'deadbeefcafebabe',
+      },
+    );
+
+    assert.deepEqual(response, stale);
+    assert.ok(
+      calls.some((c) => c.method === 'POST' && c.key === `${prefix}baseline:lock`),
+      'preview rebuilds must not contend on the production lock key',
     );
   });
 


### PR DESCRIPTION
## Why

Issue #7575 found that the temporal-anomalies rebuild lock bypassed the Redis deployment key prefix. Preview deployments could therefore contend on the production lock while their cache reads and writes used a preview namespace.

The fix uses the existing `setCachedJsonIfAbsent` contract. That helper applies the deployment prefix and preserves the existing NX and expiry behavior.

## Scope

- `tryAcquireLock` in `server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts` now uses `setCachedJsonIfAbsent`.
- The private raw Redis command builder is removed.
- `tests/temporal-anomalies-cache.test.mts` verifies the preview lock key.
- The original `mgetJson` helper is already removed from current `main` by #7573. This PR fixes the remaining live raw lock path.

## Blast Radius

This changes only the temporal-anomalies rebuild lock. Production keeps the unprefixed key. Preview and development deployments now use their own prefixed lock keys. The stale-cache fallback and lock contention behavior remain unchanged.

## Verification

- Red proof before the fix: 44 passed and 1 failed because the preview lock used `baseline:lock`.
- Focused regression after the fix: 45 passed and 0 failed.
- `npm run typecheck:api` passed.
- `npm run lint:boundaries` passed.
- `npm run lint` passed. The repository reported 53 existing warnings and 12 infos.
- `npm run test:data` passed with 29,746 passed, 0 failed, and 37 skipped.
