### PR TITLE
fix(health): separate China incidents from stale grace

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -3034,6 +3034,7 @@ function projectChinaCoverageStatus(raw, readError = false) {
   if (
     status === 'CHINA_DEGRADED'
     && candidate.degradedStreak === CHINA_DEGRADED_MIN_CONSECUTIVE - 1
+    && typeof candidate.degradedProblemKey === 'string'
   ) {
     status = 'OK';
   }
@@ -3051,6 +3052,9 @@ function projectChinaCoverageStatus(raw, readError = false) {
     // debounce becomes indistinguishable from health.
     ...(Number.isInteger(candidate.degradedStreak)
       ? { degradedStreak: candidate.degradedStreak }
+      : {}),
+    ...(typeof candidate.degradedProblemKey === 'string'
+      ? { degradedProblemKey: candidate.degradedProblemKey }
       : {}),
     ...(problems.length > 0 ? { problems } : {}),
   };
@@ -3260,14 +3264,15 @@ function computeOverallStatus(counts, totalChecks) {
 }
 
 // Failure-log / ?history=1 problem set. Distinct from the compact `problems` map
-// in exactly one way: EMPTY_ON_DEMAND is suppressed here. It is warn-level for
-// visibility only (realWarnCount subtracts it, it never flips `overall`), so an
-// unrequested on-demand key must not pollute the incident signature and cause a
-// spurious failure-log append. That single exception is the ONLY divergence —
-// everything else defers to isProblemStatus.
-function collectFailureLogProblems(checks) {
+// because EMPTY_ON_DEMAND and active stale-content grace are not active faults.
+// Both remain visible in diagnostics without polluting the incident signature.
+function collectFailureLogProblems(checks, now = Date.now()) {
   const entries = Object.entries(checks)
-    .filter(([, c]) => isProblemStatus(c.status) && c.status !== 'EMPTY_ON_DEMAND');
+    .filter(([, c]) => (
+      isProblemStatus(c.status)
+      && healthStatusBucket(c, now) !== 'ok'
+      && c.status !== 'EMPTY_ON_DEMAND'
+    ));
   return {
     problemKeys: entries.map(([k, c]) => `${k}:${c.status}${c.seedAgeMin != null ? `(${c.seedAgeMin}min)` : ''}`),
     // The dedupe signature uses only key:status (no age) so a long STALE_SEED
@@ -3732,7 +3737,7 @@ export async function handleHealth(req, ctx, options = {}) {
     // problemKeys includes seedAgeMin for the snapshot (useful for post-mortem),
     // but the dedupe signature uses only key:status (no age) so a long STALE_SEED
     // window doesn't produce a new log entry on every poll.
-    const { problemKeys, sigKeys } = collectFailureLogProblems(checks);
+    const { problemKeys, sigKeys } = collectFailureLogProblems(checks, evaluationNow);
     console.log('[health] %s problems=[%s]', overall, problemKeys.join(', '));
     const failureLogEntry = {
       at: new Date(evaluationNow).toISOString(),

--- a/scripts/china-coverage-health.mjs
+++ b/scripts/china-coverage-health.mjs
@@ -170,6 +170,26 @@ function reasonCodesFor(transport, content) {
   return reasons;
 }
 
+export function normalizeChinaProblemIdentity(entries) {
+  const problems = entries
+    .filter((entry) => entry?.launchStatus === 'launched' && entry?.status !== 'healthy')
+    .map((entry) => ({
+      id: typeof entry.id === 'string' ? entry.id : '',
+      status: typeof entry.status === 'string' ? entry.status : '',
+      reasonCodes: [...new Set(
+        Array.isArray(entry.reasonCodes)
+          ? entry.reasonCodes.filter((reason) => typeof reason === 'string')
+          : [],
+      )].sort(),
+    }))
+    .sort((left, right) => {
+      const leftKey = JSON.stringify(left);
+      const rightKey = JSON.stringify(right);
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+    });
+  return problems.length > 0 ? JSON.stringify(problems) : null;
+}
+
 export function evaluateChinaCoverage({
   entries = CHINA_COVERAGE_ENTRIES,
   data = {},
@@ -234,7 +254,10 @@ export function evaluateChinaCoverage({
   // at 17:03:23 and its snapshot published `status: healthy` at 17:05:26 — a
   // two-minute miss that cost ~50 minutes of CHINA_DEGRADED, with 13 of the
   // surrounding 16 monitor runs clean.
-  const previousStreak = Number.isInteger(previous?.degradedStreak) && previous.degradedStreak > 0
+  const degradedProblemKey = normalizeChinaProblemIdentity(evaluated);
+  const previousStreak = Number.isInteger(previous?.degradedStreak)
+    && previous.degradedStreak > 0
+    && previous.degradedProblemKey === degradedProblemKey
     ? previous.degradedStreak
     : 0;
   const degradedStreak = status === 'healthy' ? 0 : previousStreak + 1;
@@ -244,6 +267,7 @@ export function evaluateChinaCoverage({
     countryCode: 'CN',
     status,
     degradedStreak,
+    degradedProblemKey,
     evaluatedAt: new Date(now).toISOString(),
     counts,
     entries: evaluated,

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -14,6 +14,7 @@ import {
   chinaCoverageReadCommands,
   evaluateChinaCoverage,
   formatChinaCoverageHuman,
+  normalizeChinaProblemIdentity,
   readChinaCoverageInputs,
 } from '../scripts/china-coverage-health.mjs';
 import { chinaCoverageActivationCommand } from '../scripts/seed-china-coverage-health.mjs';
@@ -49,6 +50,25 @@ function singleEntry(overrides = {}) {
 
 function evaluate(entry, data = {}, meta = {}) {
   return evaluateChinaCoverage({ entries: [entry], data, meta, now: NOW });
+}
+
+function degradedEntry(id) {
+  return singleEntry({
+    id,
+    transport: { ...singleEntry().transport, key: `seed-meta:${id}` },
+    content: { ...singleEntry().content, key: `data:${id}` },
+  });
+}
+
+function evaluateDegraded(id, previous = null) {
+  const entry = degradedEntry(id);
+  return evaluateChinaCoverage({
+    entries: [entry],
+    data: { [`data:${id}`]: { rows: [{ countryCode: 'US', observedAt: '2026-07-13T11:30:00Z' }] } },
+    meta: { [`seed-meta:${id}`]: { fetchedAt: NOW - 10 * 60_000, status: 'ok' } },
+    now: NOW,
+    previous,
+  });
 }
 
 describe('China coverage manifest', () => {
@@ -554,8 +574,9 @@ describe('China coverage degraded streak', () => {
 
   it('increments while the degradation persists', () => {
     const [entry, data, meta] = degradedInputs();
+    const first = evaluateChinaCoverage({ entries: [entry], data, meta, now: NOW });
     const second = evaluateChinaCoverage({
-      entries: [entry], data, meta, now: NOW, previous: { degradedStreak: 1 },
+      entries: [entry], data, meta, now: NOW, previous: first,
     });
     assert.equal(second.degradedStreak, 2);
     const third = evaluateChinaCoverage({
@@ -585,6 +606,51 @@ describe('China coverage degraded streak', () => {
       const result = evaluateChinaCoverage({ entries: [entry], data, meta, now: NOW, previous });
       assert.equal(result.degradedStreak, 1, `previous=${JSON.stringify(previous)} must restart the streak`);
     }
+  });
+
+  it('does not combine different problem identities into one confirmation', () => {
+    const corporate = evaluateDegraded('corporate');
+    const news = evaluateDegraded('news', corporate);
+
+    assert.equal(corporate.degradedStreak, 1);
+    assert.equal(news.degradedStreak, 1);
+    assert.notEqual(news.degradedProblemKey, corporate.degradedProblemKey);
+  });
+
+  it('confirms the same normalized problem identity twice', () => {
+    const first = evaluateDegraded('corporate');
+    const second = evaluateDegraded('corporate', first);
+
+    assert.equal(second.degradedStreak, 2);
+    assert.equal(second.degradedProblemKey, first.degradedProblemKey);
+  });
+
+  it('normalizes problem ordering before storing the identity', () => {
+    const first = normalizeChinaProblemIdentity([
+      { id: 'news', launchStatus: 'launched', status: 'degraded', reasonCodes: ['B', 'A'] },
+      { id: 'corporate', launchStatus: 'launched', status: 'degraded', reasonCodes: ['C'] },
+    ]);
+    const second = normalizeChinaProblemIdentity([
+      { id: 'corporate', launchStatus: 'launched', status: 'degraded', reasonCodes: ['C'] },
+      { id: 'news', launchStatus: 'launched', status: 'degraded', reasonCodes: ['A', 'B', 'A'] },
+    ]);
+
+    assert.equal(second, first);
+  });
+
+  it('clears the problem identity on a healthy run', () => {
+    const first = evaluateDegraded('corporate');
+    const healthy = evaluateChinaCoverage({
+      entries: [degradedEntry('corporate')],
+      data: { 'data:corporate': { rows: [{ countryCode: 'CN', observedAt: new Date(NOW - 60_000).toISOString(), value: 42 }] } },
+      meta: { 'seed-meta:corporate': { fetchedAt: NOW - 10 * 60_000, status: 'ok' } },
+      now: NOW,
+      previous: first,
+    });
+
+    assert.equal(healthy.status, 'healthy');
+    assert.equal(healthy.degradedStreak, 0);
+    assert.equal(healthy.degradedProblemKey, null);
   });
 });
 

--- a/tests/global-tender-health.test.mjs
+++ b/tests/global-tender-health.test.mjs
@@ -142,6 +142,38 @@ test('NOT_CONFIGURED stays out of the failure log even when the fleet is degrade
   assert.equal(STATUS_COUNTS.EMPTY_ON_DEMAND, 'warn');
 });
 
+test('graced stale content stays in compact diagnostics but out of the failure log', () => {
+  const now = Date.parse('2026-09-03T12:00:00Z');
+  const checks = {
+    temporalAnomalies: {
+      status: 'STALE_CONTENT',
+      staleContentGraceUntil: new Date(now + 60_000).toISOString(),
+    },
+    defensePatents: { status: 'EMPTY', records: 0 },
+  };
+
+  const { problemKeys, sigKeys } = __testing__.collectFailureLogProblems(checks, now);
+  assert.deepEqual(problemKeys, ['defensePatents:EMPTY']);
+  assert.deepEqual(sigKeys, ['defensePatents:EMPTY']);
+
+  const body = __testing__.healthResponseBody({
+    status: 'DEGRADED',
+    checkedAt: new Date(now).toISOString(),
+    summary: { total: 2, ok: 1, warn: 0, crit: 1 },
+    checks,
+  }, true);
+  assert.equal(body.problems.temporalAnomalies.status, 'STALE_CONTENT');
+
+  const expired = { ...checks, temporalAnomalies: {
+    ...checks.temporalAnomalies,
+    staleContentGraceUntil: new Date(now).toISOString(),
+  } };
+  assert.deepEqual(
+    __testing__.collectFailureLogProblems(expired, now).sigKeys,
+    ['defensePatents:EMPTY', 'temporalAnomalies:STALE_CONTENT'],
+  );
+});
+
 // Guard the exemption's blast radius: only 'unavailable' (= never configured) is
 // exempt. A source that was configured and then broke must still warn.
 test('a source that actually failed still reports SEED_ERROR', () => {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -2196,6 +2196,11 @@ const chinaSummary = (over = {}) => ({
     status: 'degraded',
     reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
   }],
+  degradedProblemKey: JSON.stringify([{
+    id: 'market.china-stock-connect',
+    status: 'degraded',
+    reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
+  }]),
   ...over,
 });
 
@@ -2248,7 +2253,7 @@ test('china coverage: a summary with no streak field alarms as before', () => {
   // Rollout safety. Every summary written before the producer shipped the field
   // has no streak; absent evidence must not read as evidence of health, or the
   // rollout window would silence a genuine outage.
-  const projected = projectChinaCoverageStatus(chinaSummary());
+  const projected = projectChinaCoverageStatus(chinaSummary({ degradedStreak: undefined, degradedProblemKey: undefined }));
   assert.equal(projected.status, 'CHINA_DEGRADED');
 });
 


### PR DESCRIPTION
## Summary

- Key China confirmation streaks by a stable normalized problem identity.
- Exclude active stale-content grace from failure-log incident signatures while keeping it in compact diagnostics.
- Reset the China incident identity and streak after a healthy run.

## Verification

- Red proof before the fix: 149 passed, 3 failed in the focused health suites.
- Focused health suites after the fix: 152 passed, 0 failed.
- Wider stale-grace and verdict suites: 239 passed, 0 failed.
- `npm run typecheck:api`: passed.
- `npm run lint:boundaries`: passed.
- `npm run lint`: passed with existing warnings outside this change.
- `npm run test:data`: not a clean gate in this worktree. It hit unrelated generated-fact omissions and relay/AIS startup timeouts.

No production seeding or deployment action is included. Merge and review assignment are not requested.
