### PR TITLE
fix(cable-health): close cache publication race

### DIFF
--- a/docs/plans/2026-09-03-003-fix-cable-health-cache-race-plan.md
+++ b/docs/plans/2026-09-03-003-fix-cable-health-cache-race-plan.md
@@ -1,0 +1,107 @@
+---
+title: "Cable Health Cache Race - Plan"
+type: fix
+date: 2026-09-03
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: user-incident-report
+execution: code
+---
+
+# Cable Health Cache Race - Plan
+
+## Goal Capsule
+
+- Objective: Keep the public cable-health cache positive-only so a transient NGA null cannot expose `cable-health-v1` as empty while the handler publishes its last-good fallback.
+- Authority: The incident requirements and root `AGENTS.md` govern this work. Existing NGA negative caching, cable scoring, health thresholds, and production operation remain unchanged.
+- Stop conditions: Stop if the fix needs a seeder, grace period, threshold, or production-operation change. The response must complete fallback and seed metadata publication before it returns.
+- Tail ownership: Deliver the existing pull request ready for review. Do not merge, enable auto-merge, request reviewers, post comments, or run production seeders.
+
+## Product Contract
+
+### Summary
+
+The cable-health handler must serve its last usable snapshot through a transient NGA null without making the public Redis key negative or allowing health metadata to lag the served response.
+
+### Problem Frame
+
+The inner NGA cache correctly uses a negative sentinel and short backoff when the upstream fetch fails. The outer computed cache also receives `null` and writes its own negative sentinel. The handler then starts public-key and seed-meta fallback writes without awaiting them. A health read during that window sees the sentinel or stale metadata and can classify cable health as `EMPTY`, even while the request returns valid last-good cable data.
+
+### Requirements
+
+- R1. A transient NGA null with valid `fallbackCache` data must never expose the public cable-health key as `EMPTY`.
+- R2. Health metadata and the cable-health response must describe the same usable fallback snapshot after the handler completes.
+- R3. A legitimate computed result with zero cables remains valid positive data with `recordCount: 0`.
+- R4. Preserve the inner `cable-health-nga-warnings-v2` negative cache and backoff behavior.
+- R5. Do not change seeder schedules, health grace or thresholds, scoring, or production operations.
+
+### Acceptance Examples
+
+- AE1. Given a prior non-empty cable snapshot and a later NGA null, the handler returns the prior snapshot, leaves no public negative sentinel, and awaits public-key and seed-meta fallback writes before resolving.
+- AE2. A health read after the fallback response resolves sees the same cable count as the served fallback and does not classify the public key as empty.
+- AE3. Given a successful NGA computation with no active cable signals, the handler returns and positively caches `cables: {}` with metadata `recordCount: 0`.
+- AE4. The inner NGA cache still writes its negative sentinel on a null upstream result.
+
+### Scope Boundaries
+
+- In scope: the cable-health server handler and focused regression coverage for cache publication ordering and zero-cable validity.
+- Out of scope: the NGA fetcher, the inner NGA cache, relay warm-ping cadence, health classification rules, seeders, thresholds, grace periods, production Redis state, and production deployment.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Use `cachedFetchJsonWithMeta` with `cacheFailures: false` for the computed `cable-health-v1` call. This disables only the outer negative sentinel while retaining positive caching for both non-empty and legitimate zero-cable responses.
+- KTD2. Leave the nested NGA `cachedFetchJson` call unchanged. Its negative sentinel and unavailable backoff remain the upstream protection mechanism.
+- KTD3. Await the existing public-key and seed-meta `setCachedJson` calls together before returning the fallback. This makes the health view and served snapshot one completed publication unit without adding a new abstraction.
+- KTD4. Keep fallback selection and the honest `recordCount` calculation unchanged. An empty cable map is valid data, not a fake one-record response.
+
+### Data Shape
+
+The handler has one public response shape, `GetCableHealthResponse`, and one fallback publication pair. A successful or fallback response is usable data. Only the nested NGA warning fetch may use the negative sentinel path.
+
+### Sequencing
+
+1. Add proof-first coverage that observes the cache writes before the handler promise resolves and checks the former race window.
+2. Switch only the outer computed cache to positive-only behavior and await the existing fallback publications.
+3. Run focused handler and cache tests, then the required API, boundary, and diff checks.
+
+### Risks and Dependencies
+
+- Redis write failure remains best-effort because `setCachedJson` returns `false`; awaiting it only ensures the handler does not finish before the attempt completes. Production health can still be stale if Redis is unavailable, which remains an operational risk outside this change.
+- The test must distinguish the outer computed key from the inner NGA key so it proves the requested boundary without weakening upstream backoff.
+
+## Implementation Units
+
+### U1. Prove and repair positive-only cable-health publication
+
+- Goal: Prevent the public computed cache from storing a negative sentinel and close the fallback publication race.
+- Requirements: R1-R5; AE1-AE4.
+- Dependencies: None.
+- Files: `server/worldmonitor/infrastructure/v1/get-cable-health.ts`, `tests/handlers.test.mts`, `tests/cable-health-cache-race.test.mts`.
+- Approach: Add the smallest import-safe handler harness or focused source-level seam that controls Redis reads and writes. Start with a failing test that makes the inner NGA read return null, provides a valid last-good snapshot, delays the fallback writes, and reads the observed public and metadata state before and after handler resolution. Add coverage for a successful zero-cable result and the unchanged inner NGA negative-sentinel path. Then use the existing metadata-aware cache helper with outer failure caching disabled and await both fallback writes.
+- Execution note: Use proof-first regression coverage. The test must fail because the old outer sentinel and unawaited writes are observable before implementation changes.
+- Test scenarios:
+  - Covers AE1. A valid last-good snapshot plus transient NGA null returns that snapshot and produces no outer `cable-health-v1` negative sentinel.
+  - Covers AE2. A health-style read during the former write window cannot observe an empty public key after the handler promise resolves; the public payload and seed metadata carry the same cable count.
+  - Covers AE3. A successful empty computed map is positively cached with `recordCount: 0`.
+  - Covers AE4. The nested NGA cache still writes its negative sentinel and retains its short unavailable backoff behavior.
+  - A failed fallback write does not reject the response or change the served fallback shape.
+- Verification: The focused regression suite passes, including assertions that all required fallback writes settle before the handler resolves. Existing cable signal and health-map tests remain green.
+
+## Verification Contract
+
+- Red proof: The new cable-health race test fails on the current implementation for the expected outer-sentinel or unsettled-write reason.
+- Focused green proof: `node_modules/.bin/tsx --test tests/cable-health-cache-race.test.mts tests/handlers.test.mts tests/redis-caching.test.mjs`.
+- API gate: `npm run typecheck:api`.
+- Architecture gate: `npm run lint:boundaries`.
+- Diff hygiene: `git diff --check` and `git status --short`.
+- PR gate: Refresh the exact existing PR head before push and after CI reaches a terminal state. Keep readiness, formal approval, deployment, production observation, and merge authority separate.
+
+## Definition of Done
+
+- U1 passes every listed scenario and verification gate.
+- The outer public cable-health cache is positive-only, while the inner NGA negative cache is unchanged.
+- A completed response and its health metadata describe one usable snapshot, including a legitimate zero-cable snapshot.
+- No seeder, schedule, threshold, grace, or production-operation change is present.
+- The diff contains no abandoned experiment or speculative abstraction.

--- a/server/worldmonitor/infrastructure/v1/get-cable-health.ts
+++ b/server/worldmonitor/infrastructure/v1/get-cable-health.ts
@@ -7,7 +7,7 @@ import type {
   CableHealthStatus,
 } from '../../../../src/generated/server/worldmonitor/infrastructure/v1/service_server';
 
-import { cachedFetchJson, setCachedJson } from '../../../_shared/redis';
+import { cachedFetchJson, cachedFetchJsonWithMeta, setCachedJson } from '../../../_shared/redis';
 import { parseNgaBroadcastWarnings, type NgaBroadcastWarning } from '../../../_shared/nga-broadcast-warnings';
 import { UPSTREAM_TIMEOUT_MS } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
@@ -422,25 +422,25 @@ export async function getCableHealth(
   _req: GetCableHealthRequest,
 ): Promise<GetCableHealthResponse> {
   try {
-    const result = await cachedFetchJson<GetCableHealthResponse>(CACHE_KEY, CACHE_TTL, async () => {
+    const { data: result } = await cachedFetchJsonWithMeta<GetCableHealthResponse>(CACHE_KEY, CACHE_TTL, async () => {
       // NGA raw warnings cached 24h — expensive upstream call, data stable between pings.
       // Computed response cached 30 min — recomputes recencyWeight decay on each warm-ping cycle.
-      // null from fetchNgaWarnings = fetch failed; cachedFetchJson stores sentinel (2 min) and
-      // returns null here, which causes this outer fetcher to return null, leaving cable-health-v1
-      // untouched so the previous valid computed response is served from fallbackCache.
+      // null from fetchNgaWarnings = fetch failed; the inner cache stores its sentinel and
+      // returns null here. The outer computed cache is positive-only so the fallback path
+      // below controls the public key during an upstream outage.
       const ngaData = await cachedFetchJson<NgaWarning[]>(NGA_CACHE_KEY, NGA_CACHE_TTL, fetchNgaWarnings);
       if (ngaData === null) return null;
       const signals = processNgaSignals(ngaData);
       const cables = computeHealthMap(signals);
 
       return { generatedAt: Date.now(), cables };
-    });
+    }, 120, { cacheFailures: false });
 
     if (result) {
       // Write seed-meta on every successful response (cache hit or fresh) so the
       // 30-min warm-ping keeps seed-meta within the 90-min health.js stale window.
       // recordCount reflects the actual cable count — previous Math.max(count, 1)
-      // misrepresented empty responses as having 1 record; now writeback-path
+      // misrepresented empty responses as having 1 record; now fallback path
       // below keeps the canonical key populated (strlen > 10) so health.js
       // reads hasData=true without needing a fake recordCount floor.
       const count = result.cables ? Object.keys(result.cables).length : 0;
@@ -449,17 +449,15 @@ export async function getCableHealth(
       return result;
     }
 
-    // NGA upstream failed (cachedFetchJson stored NEG_SENTINEL in cable-health-v1
-    // for 2 min). Without writeback, api/health.js sees strlen=10 (NEG_SENTINEL
-    // length) → strlenIsData=false → records=0 → EMPTY alarm even though we're
-    // serving a valid fallbackCache response to the client. Refresh both the
-    // canonical key AND seed-meta with fallbackCache so health reflects the
-    // response the user is actually receiving. Short TTL (matches NEG_SENTINEL)
-    // so a recovered NGA fetch can immediately overwrite with fresh data.
+    // Refresh both the canonical key and seed-meta with fallbackCache so health
+    // reflects the response the user is actually receiving. Short TTL allows a
+    // recovered NGA fetch to overwrite the fallback immediately.
     const fallback = fallbackCache || { generatedAt: Date.now(), cables: {} };
     const fbCount = fallback.cables ? Object.keys(fallback.cables).length : 0;
-    setCachedJson(CACHE_KEY, fallback, 120).catch(() => {});
-    setCachedJson('seed-meta:cable-health', { fetchedAt: Date.now(), recordCount: fbCount }, 604800).catch(() => {});
+    await Promise.all([
+      setCachedJson(CACHE_KEY, fallback, 120),
+      setCachedJson('seed-meta:cable-health', { fetchedAt: Date.now(), recordCount: fbCount }, 604800),
+    ]);
     return fallback;
   } catch {
     if (fallbackCache) return fallbackCache;

--- a/server/worldmonitor/infrastructure/v1/get-cable-health.ts
+++ b/server/worldmonitor/infrastructure/v1/get-cable-health.ts
@@ -440,7 +440,7 @@ export async function getCableHealth(
       // Write seed-meta on every successful response (cache hit or fresh) so the
       // 30-min warm-ping keeps seed-meta within the 90-min health.js stale window.
       // recordCount reflects the actual cable count — previous Math.max(count, 1)
-      // misrepresented empty responses as having 1 record; now fallback path
+      // misrepresented empty responses as having 1 record; fallback path
       // below keeps the canonical key populated (strlen > 10) so health.js
       // reads hasData=true without needing a fake recordCount floor.
       const count = result.cables ? Object.keys(result.cables).length : 0;

--- a/tests/cable-health-cache-race.test.mts
+++ b/tests/cable-health-cache-race.test.mts
@@ -28,10 +28,6 @@ function currentNgaDate() {
   return `${day}${time}Z ${month} ${now.getUTCFullYear()}`;
 }
 
-function responseBody(response: GetCableHealthResponse) {
-  return JSON.stringify(response);
-}
-
 describe('getCableHealth cache publication', { concurrency: 1 }, () => {
   beforeEach(() => {
     for (const key of ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN', 'VERCEL_ENV', 'VERCEL_GIT_COMMIT_SHA']) {

--- a/tests/cable-health-cache-race.test.mts
+++ b/tests/cable-health-cache-race.test.mts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import type { GetCableHealthResponse } from '../src/generated/server/worldmonitor/infrastructure/v1/service_server';
+import { getCachedJson, __resetKeyPrefixCacheForTests } from '../server/_shared/redis';
+import { getCableHealth } from '../server/worldmonitor/infrastructure/v1/get-cable-health';
+
+const CACHE_KEY = 'cable-health-v1';
+const NGA_CACHE_KEY = 'cable-health-nga-warnings-v2';
+const META_KEY = 'seed-meta:cable-health';
+const NEG_SENTINEL = '__WM_NEG__';
+const originalFetch = globalThis.fetch;
+const originalEnv = new Map<string, string | undefined>();
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function currentNgaDate() {
+  const now = new Date();
+  const month = now.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' }).toUpperCase();
+  const day = String(now.getUTCDate()).padStart(2, '0');
+  const time = `${String(now.getUTCHours()).padStart(2, '0')}${String(now.getUTCMinutes()).padStart(2, '0')}`;
+  return `${day}${time}Z ${month} ${now.getUTCFullYear()}`;
+}
+
+function responseBody(response: GetCableHealthResponse) {
+  return JSON.stringify(response);
+}
+
+describe('getCableHealth cache publication', { concurrency: 1 }, () => {
+  beforeEach(() => {
+    for (const key of ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN', 'VERCEL_ENV', 'VERCEL_GIT_COMMIT_SHA']) {
+      originalEnv.set(key, process.env[key]);
+    }
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.cable-health.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    process.env.VERCEL_ENV = 'production';
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+    __resetKeyPrefixCacheForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const [key, value] of originalEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    originalEnv.clear();
+    __resetKeyPrefixCacheForTests();
+  });
+
+  it('awaits fallback publication before health can read the served snapshot', async () => {
+    const store = new Map<string, unknown>();
+    const delayedKeys = new Map<string, ReturnType<typeof deferred<void>>>();
+    const writesStarted = deferred<void>();
+    let delayedWriteCount = 0;
+    let upstreamAvailable = true;
+
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      if (url.startsWith('https://redis.cable-health.test/get/')) {
+        const key = decodeURIComponent(url.slice('https://redis.cable-health.test/get/'.length));
+        const value = store.get(key);
+        return Response.json({ result: value === undefined ? null : JSON.stringify(value) });
+      }
+      if (url === 'https://redis.cable-health.test/') {
+        const command = JSON.parse(String(init?.body)) as [string, string, string, string, string];
+        assert.equal(command[0], 'SET');
+        const key = command[1];
+        const value = JSON.parse(command[2]);
+        const gate = delayedKeys.get(key);
+        if (gate && value !== NEG_SENTINEL) {
+          delayedWriteCount += 1;
+          if (delayedWriteCount === delayedKeys.size) writesStarted.resolve();
+          await gate.promise;
+        }
+        store.set(key, value);
+        return Response.json({ result: 'OK' });
+      }
+      if (url.startsWith('https://msi.nga.mil/')) {
+        return upstreamAvailable
+          ? Response.json([{ text: 'FAULT REPORTED ON SUBMARINE CABLE MAREA', issueDate: currentNgaDate() }])
+          : new Response('upstream unavailable', { status: 503 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const first = await getCableHealth({} as never, {} as never);
+    assert.ok(Object.keys(first.cables).length > 0);
+
+    store.delete(CACHE_KEY);
+    store.delete(NGA_CACHE_KEY);
+    upstreamAvailable = false;
+    delayedKeys.set(CACHE_KEY, deferred<void>());
+    delayedKeys.set(META_KEY, deferred<void>());
+
+    let responseSettled = false;
+    const secondPromise = getCableHealth({} as never, {} as never).then((response) => {
+      responseSettled = true;
+      return response;
+    });
+
+    await writesStarted.promise;
+    assert.equal(store.get(NGA_CACHE_KEY), NEG_SENTINEL);
+    const healthDuringFormerWindow = await getCachedJson(CACHE_KEY);
+    assert.equal(healthDuringFormerWindow, null);
+    await Promise.resolve();
+    assert.equal(responseSettled, false);
+
+    for (const gate of delayedKeys.values()) gate.resolve();
+    const fallback = await secondPromise;
+    const published = await getCachedJson(CACHE_KEY) as GetCableHealthResponse;
+    const metadata = await getCachedJson(META_KEY) as { recordCount: number };
+
+    assert.deepEqual(fallback, first);
+    assert.deepEqual(published, fallback);
+    assert.equal(metadata.recordCount, Object.keys(fallback.cables).length);
+    assert.notEqual(published, NEG_SENTINEL);
+  });
+
+  it('keeps a legitimate empty computation as positive data', async () => {
+    const store = new Map<string, unknown>();
+    let upstreamCalls = 0;
+
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      if (url.startsWith('https://redis.cable-health.test/get/')) {
+        const key = decodeURIComponent(url.slice('https://redis.cable-health.test/get/'.length));
+        const value = store.get(key);
+        return Response.json({ result: value === undefined ? null : JSON.stringify(value) });
+      }
+      if (url === 'https://redis.cable-health.test/') {
+        const command = JSON.parse(String(init?.body)) as [string, string, string];
+        store.set(command[1], JSON.parse(command[2]));
+        return Response.json({ result: 'OK' });
+      }
+      if (url.startsWith('https://msi.nga.mil/')) {
+        upstreamCalls += 1;
+        return Response.json([]);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const response = await getCableHealth({} as never, {} as never);
+
+    assert.deepEqual(response.cables, {});
+    assert.deepEqual(store.get(CACHE_KEY), response);
+    assert.equal(upstreamCalls, 1);
+    assert.equal(store.get(META_KEY).recordCount, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- keep the public cable-health cache positive-only while preserving NGA negative caching
- await fallback and seed metadata publication before returning the fallback
- add a regression test for the former health EMPTY race and valid zero-cable data

## Verification
- node_modules/.bin/tsx --test tests/cable-health-cache-race.test.mts tests/handlers.test.mts tests/redis-caching.test.mjs
- npm run typecheck:api
- npm run lint:boundaries
- npm run lint
- git diff --check

## Scope
No seeder, grace, threshold, scoring, or production-operation changes. Production deployment and live acceptance remain outside this PR.