### PR TITLE
fix(ci): retry Mint docs export once

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -92,8 +92,12 @@ jobs:
         # The version is printed below and the checker carries a canary on a
         # punctuation-sensitive slug, which is the actual protection.
         run: |
-          npm i -g mint@4.2.860
-          mint export --output "$RUNNER_TEMP/docs-export.zip"
+          npm i -g mint@4.2.866
+          if ! mint export --output "$RUNNER_TEMP/docs-export.zip"; then
+            echo "::warning::Mint export failed once; retrying once."
+            rm -f "$RUNNER_TEMP/docs-export.zip"
+            mint export --output "$RUNNER_TEMP/docs-export.zip"
+          fi
           echo "renderer: $(cat ~/.mintlify/previews/shared/mint/mint-version.txt 2>/dev/null || echo unknown)"
       - name: Unpack export
         run: unzip -q "$RUNNER_TEMP/docs-export.zip" -d "$RUNNER_TEMP/docs-export"


### PR DESCRIPTION
## Why
The `doc-anchors` job failed after merge inside `mint export` with a `YAMLException`, while the same docs passed on nearby runs. The job should absorb one transient Mint export failure. A second export failure must still fail the job.

## Scope
This changes only `.github/workflows/lint-code.yml`. The `doc-anchors` job now installs `mint@4.2.866` and runs `mint export` a second time only when the first export fails. The export path stays `$RUNNER_TEMP/docs-export.zip`. The existing unzip and anchor-check steps are unchanged.

Out of scope: docs, app code, dependencies, seeders, Railway, health logic, deployment logic, review requests, auto-merge, and merge.

## Blast Radius
This affects only the GitHub Actions `doc-anchors` job. The retry is bounded to one extra export attempt and removes a partial first archive before retry.

## Verification
Ran `npm run --silent agent:preflight -- --allow-dirty`. The gate returned `status: ready` with Node 24, current `origin/main`, dependency bootstrap complete, and only the intended workflow file dirty.

Ran `npm view mint version`. The npm registry returned `4.2.866`.

Ran a focused Node verifier against `.github/workflows/lint-code.yml`. It parsed the YAML, checked the `mint@4.2.866` pin, checked that both export attempts use `$RUNNER_TEMP/docs-export.zip`, checked that the unpack and checker steps are unchanged, simulated a first-fail-then-success Mint export, and simulated a double failure. The first simulation exited 0 after two Mint attempts. The double-failure simulation exited non-zero after two Mint attempts.

Ran `npm run lint:public-docs`. The public documentation plan-reference check passed.

Ran `git diff --check`. It reported no whitespace errors.

## Post-Deploy Monitoring & Validation
No additional production monitoring is required. This PR only changes a GitHub Actions workflow. Validate by watching the next `lint-code.yml` `doc-anchors` job. Healthy signals are one successful `Export rendered docs` step, an unchanged unzip path, and a passing `Every doc anchor resolves` step. Failure signals are a second `mint export` failure or a missing `$RUNNER_TEMP/docs-export.zip` archive after the retry.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![MODEL_SLUG](https://img.shields.io/badge/MODEL_SLUG-Codex-000000)
