### PR TITLE
fix(mcp): report a transient Pro-token verdict at warning, not error

### DIFF
--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -554,8 +554,27 @@ export async function validateProMcpAuthorization(
     ) };
   }
   if (validation && 'ok' in validation && validation.ok === 'transient') {
+    // `transient` is the validator's own fail-soft verdict — a Convex 5xx,
+    // network error, timeout, or malformed body (see `ProMcpValidateUnion`).
+    // The caller already gets a retryable 503 + `Retry-After`, so the request
+    // is degraded, not defective, and the same union's other consumer
+    // (api/oauth/token.ts) treats it as routine enough to capture nothing at
+    // all. Capture at `warning` so a sustained Convex outage still escalates by
+    // volume without routine blips paging on-call at `error` (WORLDMONITOR-ZR:
+    // 6 events / 5 releases / 17 days, all isolated). Mirrors the
+    // SERVICE_UNAVAILABLE precedent in api/user-prefs.ts and the identical call
+    // in api/_rate-limit.js.
+    //
+    // A missing CONVEX_SITE_URL / CONVEX_SERVER_SHARED_SECRET also lands here
+    // (getConvexEnv() → null). That is deliberately NOT split out: the same
+    // misconfiguration breaks every other Convex-backed surface — checkout, the
+    // gateway, entitlements, briefs — which alarm far louder than this gate.
+    //
+    // The `catch` above stays at `error`: a THROWN validator is an unexpected
+    // defect, not this fail-soft path.
     captureSilentError(new Error('Pro MCP token validation temporarily unavailable'), {
       tags: { route: 'api/mcp', step: 'pro-token-validate' },
+      level: 'warning',
       ctx,
     });
     return { ok: false, response: new Response(

--- a/tests/mcp-auth-entitlement-and-limits.test.mjs
+++ b/tests/mcp-auth-entitlement-and-limits.test.mjs
@@ -864,3 +864,72 @@ describe('api/mcp/auth.ts — applyAnonDiscoveryLimit (#5379 Gap 10)', () => {
     assert.equal(calls[1].key, 'rl:mcp:anon:ip:8.8.8.8');
   });
 });
+
+// ---------------------------------------------------------------------------
+// WORLDMONITOR-ZR — a `transient` verdict is a fail-soft degrade, not a defect.
+// `validateProMcpToken` returns it for a Convex 5xx, network error, timeout, or
+// malformed body, and the caller is handed a retryable 503 + `Retry-After`.
+// Reporting that at Sentry's default `error` level paged on-call for routine
+// upstream blips (6 events across 5 releases in 17 days, every one isolated) —
+// the exact condition api/user-prefs.ts and api/_rate-limit.js already
+// downgrade. The asymmetry with the sibling `catch` is load-bearing, so it is
+// pinned here too: a THROWN validator is an unexpected defect and must keep
+// paging.
+//
+// `captureSilentError` self-disables without a DSN (`_envelopeUrl` / `_key` are
+// unset under test), so the level is not observable at runtime here. Pin it
+// from source text — the same lever tests/rate-limit.test.mts uses on the
+// rate-limit capture, for exactly this reason.
+// ---------------------------------------------------------------------------
+describe('api/mcp/auth.ts — a transient Convex verdict degrades, it does not page (WORLDMONITOR-ZR)', () => {
+  it('a transient validate verdict still fails closed on a retryable 503', async () => {
+    const { deps } = makeProDeps({ validateProMcpToken: async () => ({ ok: 'transient' }) });
+    const res = await authMod.runContextPreChecks(PRO_CONTEXT, deps, RESOURCE_META_URL, CORS);
+    assert.equal(res.ok, false, 'a transient verdict never grants the call');
+    assert.equal(res.response.status, 503);
+    assert.equal(res.response.headers.get('Retry-After'), '5', 'the client is told to back off');
+  });
+
+  it('the happy path is untouched by the downgrade', async () => {
+    const { deps } = makeProDeps();
+    const res = await authMod.runContextPreChecks(PRO_CONTEXT, deps, RESOURCE_META_URL, CORS);
+    assert.equal(res.ok, true, 'a valid grant still passes the gate');
+  });
+
+  it('the transient capture carries level: warning, and the thrown-validator catch does NOT', async () => {
+    const fs = await import('node:fs');
+    const src = fs.readFileSync(new URL('../api/mcp/auth.ts', import.meta.url), 'utf8');
+
+    const transientAt = src.indexOf("validation.ok === 'transient'");
+    assert.ok(transientAt > 0, 'the transient branch still exists');
+
+    const branch = src.slice(transientAt);
+    const transientCapture = branch.slice(
+      branch.indexOf('captureSilentError'),
+      branch.indexOf('return {'),
+    );
+    assert.match(
+      transientCapture,
+      /level:\s*'warning'/,
+      'the fail-soft transient verdict must not page on-call at error level',
+    );
+
+    // Preservation: the sibling `catch` reports an UNEXPECTED rejection of the
+    // validator. If a future widening drags it to `warning` too, a genuine
+    // defect on the gated Pro path goes quiet.
+    const validateAt = src.indexOf('deps.validateProMcpToken(context.mcpTokenId)');
+    const catchAt = src.indexOf('} catch (err) {', validateAt);
+    assert.ok(
+      validateAt > 0 && catchAt > validateAt && catchAt < transientAt,
+      'the guarded await and its catch still bracket the transient branch — if this '
+        + 'fails the slice below is meaningless, not merely failing',
+    );
+    const thrownCapture = src.slice(catchAt, transientAt);
+    assert.match(thrownCapture, /captureSilentError\(err,/, 'the catch still reports');
+    assert.doesNotMatch(
+      thrownCapture,
+      /level:\s*'warning'/,
+      'a THROWN validator is a defect, not the fail-soft path — it must keep paging',
+    );
+  });
+});


### PR DESCRIPTION
From the 2026-09-03 `/sentry-triage` board pass. One of two error-level signatures not covered by the existing taxonomy; the other (WORLDMONITOR-11G) turned out to be already fixed and draining, so this is the only code change.

## The bug

`validateProMcpAuthorization` captured its `transient` branch at `captureSilentError`'s default `error` level:

```ts
// api/mcp/auth.ts:556
if (validation && 'ok' in validation && validation.ok === 'transient') {
  captureSilentError(new Error('Pro MCP token validation temporarily unavailable'), {
    tags: { route: 'api/mcp', step: 'pro-token-validate' },
    ctx,   // ← no level → api/_sentry-common.js:66 defaults to 'error'
  });
```

But `transient` is the validator's **own fail-soft verdict**. `server/_shared/pro-mcp-token.ts:51-60` defines it as *"Convex 5xx, network error, timeout, or malformed JSON"*, and the branch hands the caller a retryable `503` + `Retry-After: 5`. The request is degraded, not defective.

## Why `warning` is the right level

- The **same union's other consumer**, `api/oauth/token.ts:712`, treats `transient` as routine and recoverable — it captures nothing at all.
- Every comparable transient in this repo was already deliberately downgraded, each with a comment saying so: `api/user-prefs.ts:296` (WORLDMONITOR-QA), `api/_rate-limit.js:69` (RX/VM), `api/telegram-feed.js:383` (#7438), `api/rss-proxy.js:213` (#7588).
- `api/_sentry-common.js:66` states the rule outright: level defaults to `error`; pass `warning` for expected-but-trackable conditions, else *"it drowns real bugs in dashboards/alerting."*
- The volume is a noise floor, not an outage — WORLDMONITOR-ZR is **6 events / 5 users over 17 days**, on 5 distinct releases from 5 distinct IPs, every one isolated in time. A sustained Convex outage still escalates by volume.

This is the WORLDMONITOR-VM shape that `api/_rate-limit.js:74-80` already describes in prose: one fail-closed condition reporting at two different levels.

## What deliberately did NOT change

The sibling `catch` at `auth.ts:550` stays at `error`. Per its own `#4860` comment the wired helper never rejects today, so a rejection there is an unexpected defect, not the fail-soft path. The test pins **both** halves, so a future widening cannot quietly silence the defect arm.

## Known, accepted tradeoff

`getConvexEnv()` returning null (missing `CONVEX_SITE_URL` / `CONVEX_SERVER_SHARED_SECRET`) also yields `transient`, so a deploy misconfig now reports at `warning` too. `api/_rate-limit.js:70-72` keeps `missing-config` at `error` — but there the config case is distinguishable at the capture site via a `stage` variable; here it is not, without adding a variant to `ProMcpValidateUnion` and touching `api/oauth/token.ts:712/731`, the GHSA-f6gj refresh-token restore path.

That was weighed and declined: the same misconfiguration breaks every other Convex-backed surface — checkout, the gateway, entitlements, briefs — which alarm far louder than this gate ever would. The reasoning is recorded inline so the next reader does not have to re-derive it.

## Tests

Three cases added to `tests/mcp-auth-entitlement-and-limits.test.mjs`, the existing unit-coverage file for `api/mcp/auth.ts`, driven through the `makeProDeps` DI seam:

1. a `transient` verdict still fails closed on a retryable 503 with `Retry-After`;
2. the happy path still passes the gate;
3. the transient capture carries `level: 'warning'` **and** the thrown-validator catch does not.

`captureSilentError` self-disables without a DSN, so the level is pinned from source text — the same lever `tests/rate-limit.test.mts:529-541` already uses on the rate-limit capture for exactly this reason.

Verified red before green: removing `level: 'warning'` fails case 3 on the intended assertion (*"the fail-soft transient verdict must not page on-call at error level"*), and nothing else.

```
tsx --test tests/mcp-auth-entitlement-and-limits.test.mjs   98/98 pass
npm run typecheck:api                                       pass
biome lint (both changed files)                             clean
```

## Note on Sentry status

Deliberately **not** using a `Fixes WORLDMONITOR-ZR` keyword. This change reclassifies the signature rather than eliminating it, so the group will keep firing at `warning`. Auto-resolving would make the next routine Convex blip reopen it as a "regression in X.Y.Z" — the same trap documented for the Dodo and Clerk monitors. The issue should be archived as a classified mute once post-deploy events are observed arriving at `warning`.

Refs WORLDMONITOR-ZR

https://claude.ai/code/session_01B6xEwAj24Q2eubZqW6uehR
