### PR TITLE
test(mcp): prove a transient Pro-token verdict actually recovers on retry

### DIFF
--- a/tests/pro-mcp-token.test.mjs
+++ b/tests/pro-mcp-token.test.mjs
@@ -233,6 +233,70 @@ describe('pro-mcp-token', () => {
       assert.equal(redis.store.size, 0);
     });
 
+    // The three cases above each prove the NEGATIVE half of the fail-soft
+    // contract: a blip writes no sentinel. None of them proves the POSITIVE
+    // half — that the caller the blip degraded can actually come back. That
+    // gap matters, because api/mcp/auth.ts answers a transient verdict with a
+    // retryable 503 + `Retry-After: 5` and reports it at `warning` rather than
+    // `error` on exactly that premise (WORLDMONITOR-ZR). "No sentinel was
+    // written" is not the same claim as "the retry succeeds"; this pins the
+    // one the level downgrade actually rests on.
+    it('a transient blip recovers on the NEXT call — the retry the 503 + Retry-After invites', async () => {
+      const redis = makeRedisStub();
+      let attempt = 0;
+      const convex = (url) => {
+        if (!url.endsWith('/api/internal-validate-pro-mcp-token')) throw new Error(`unexpected: ${url}`);
+        attempt += 1;
+        // Round-trip 1 is the Convex blip WORLDMONITOR-ZR reports; round-trip
+        // 2 is the same token retried once the blip clears.
+        if (attempt === 1) return new Response('upstream blip', { status: 503 });
+        return new Response(JSON.stringify({ userId: 'user_123' }), { status: 200 });
+      };
+      const stub = makeFetchStub(redis, convex);
+      globalThis.fetch = stub;
+
+      const first = await mod.validateProMcpToken('tok_legit3');
+      assert.deepEqual(first, { ok: 'transient' }, 'the blip degrades the call');
+      assert.equal(redis.store.size, 0, 'and poisons nothing on the way out');
+
+      const retry = await mod.validateProMcpToken('tok_legit3');
+      assert.deepEqual(
+        retry,
+        { ok: 'valid', userId: 'user_123' },
+        'the retry recovers — a transient verdict is degraded, not defective',
+      );
+      assert.equal(
+        stub.counts.validate, 2,
+        'the retry re-reached Convex rather than replaying a cached verdict',
+      );
+    });
+
+    it('a REVOKED verdict does NOT recover on retry — the sentinel is the difference', async () => {
+      const redis = makeRedisStub();
+      let attempt = 0;
+      const convex = (url) => {
+        if (!url.endsWith('/api/internal-validate-pro-mcp-token')) throw new Error(`unexpected: ${url}`);
+        attempt += 1;
+        // Convex authoritatively says "no such grant", then (hypothetically)
+        // changes its mind. The sentinel must hold the verdict anyway.
+        if (attempt === 1) return new Response(JSON.stringify(null), { status: 200 });
+        return new Response(JSON.stringify({ userId: 'user_123' }), { status: 200 });
+      };
+      const stub = makeFetchStub(redis, convex);
+      globalThis.fetch = stub;
+
+      assert.deepEqual(await mod.validateProMcpToken('tok_revoked3'), { ok: 'revoked' });
+      assert.deepEqual(
+        await mod.validateProMcpToken('tok_revoked3'),
+        { ok: 'revoked' },
+        'a revoked grant stays revoked for the sentinel TTL — retrying must not launder it',
+      );
+      assert.equal(
+        stub.counts.validate, 1,
+        'the second call short-circuited on the sentinel and never re-reached Convex',
+      );
+    });
+
     it('returns ok:revoked on Convex response missing userId field (structurally not-found)', async () => {
       const redis = makeRedisStub();
       const convex = () => new Response(JSON.stringify({ unrelated: 'payload' }), { status: 200 });


### PR DESCRIPTION
Follow-up to #7601, which shipped while this validation was in flight.

#7601 downgraded the `transient` Pro-token capture from `error` to `warning` on the premise that such a call is **degraded, not defective** — the caller gets a retryable `503` + `Retry-After: 5`, and the retry works. That premise deserved a runnable proof rather than an assertion, and it turned out only half of it was covered.

## The gap

`tests/pro-mcp-token.test.mjs` already had three transient cases — Convex 5xx, network timeout, malformed body. Each asserts the **negative** half of the fail-soft contract: a blip writes no negative-cache sentinel. Each makes a **single** call.

None asserted the **positive** half: that the caller the blip degraded can actually come back. *"No sentinel was written"* is a weaker claim than *"the retry succeeds"* — the first is about what didn't happen, the second is the one the level downgrade actually rests on.

## What this adds

**`a transient blip recovers on the NEXT call`** — round-trip 1 returns 503 → `{ok:'transient'}` with an empty sentinel store; round-trip 2 returns the grant. `counts.validate === 2` proves the retry genuinely re-reached Convex rather than replaying a cached verdict.

**`a REVOKED verdict does NOT recover on retry`** — the preservation half. The sentinel holds the authoritative denial even when Convex would now answer differently, and `counts.validate === 1` proves the second call short-circuited. Retrying must not launder a revoked grant into a valid one.

Together these pin the actual distinction the fail-soft design depends on: the transient path recovers, the authoritative-denial path does not.

## Verified red before green

Adding `await writeNegCache(tokenId)` to the `!resp.ok` branch of `validateProMcpToken` — the exact poisoning bug these guard against — fails the recovery case on *"and poisons nothing on the way out"* (and the pre-existing 5xx case alongside it). Reverting returns 30/30.

```
tsx --test tests/pro-mcp-token.test.mjs   30/30 pass
biome lint                                clean
```

Tests only — no production code in this PR.

## Field evidence, for the record

The contract and mechanism are now proven above. The field half is corroborated but not positively confirmed: across Sentry's unbounded retention, all 6 WORLDMONITOR-ZR events came from 5 distinct IPs, and **each of those IPs appears in exactly one Sentry issue ever — ZR itself**. No cascade, no follow-on failure of any kind after the 503.

One caller (`13.214.137.205`) fired twice 4 seconds apart on 2026-08-17 — a retry into the same blip, slightly ahead of the advertised 5s `Retry-After`. The other four never produced a second event.

Positively confirming that a specific caller's retry returned 200 needs success telemetry (`wm_api_usage` in Axiom); Sentry records only failures. That is not reachable from this machine — no `.env.local`, and the Vercel project is not linked locally — so it stays unproven rather than asserted.

Refs WORLDMONITOR-ZR

https://claude.ai/code/session_01B6xEwAj24Q2eubZqW6uehR
