### PR TITLE
fix(seo): keep dashboard SEO summary in the accessibility tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@
   </head>
   <body>
     <h1 class="app-heading">World Monitor — Real-Time Global Intelligence Dashboard</h1>
-    <section class="app-seo-summary" aria-hidden="true">
+    <section class="app-seo-summary">
       <p>World Monitor is the full-spectrum real-time global intelligence dashboard: one browser workspace that combines geopolitical conflict tracking, military and civil aviation, maritime AIS, undersea cable and infrastructure maps, markets, climate hazards, cyber signals, and open-source news into a single live situation picture. Analysts, journalists, researchers, and operators use it to see how distant events connect before they harden into headlines.</p>
       <p>On the map you can follow conflict zones and protest activity alongside earthquake and wildfire alerts, power-outage clusters, and strategic infrastructure such as military bases, nuclear facilities, and subsea cables. Aviation layers surface military and commercial flights; maritime layers track ships through chokepoints and high-risk waters. Country deep-dives open resilience, risk, and source-backed context for more than 190 states without leaving the dashboard.</p>
       <p>Market and prediction panels sit beside the geospatial view so price moves, central-bank signals, commodities, and prediction-market odds can be read against the same map context that shows tankers, jets, and crisis corridors. Government-spending and macro indicators help separate noise from policy-relevant shifts. The goal is not another news feed — it is a continuously updating OSINT workbench with auditable upstream sources.</p>

--- a/src/config/variant-dashboard-html.ts
+++ b/src/config/variant-dashboard-html.ts
@@ -22,7 +22,7 @@ export function renderVariantSeoSummaryHtml(variant: VariantSeoKey): string {
     throw new Error(`[variant-dashboard-html] missing SEO paragraphs for "${variant}"`);
   }
   const body = paragraphs.map((p) => `<p>${escHtml(p)}</p>`).join('\n      ');
-  return `<section class="app-seo-summary" aria-hidden="true">\n      ${body}\n    </section>`;
+  return `<section class="app-seo-summary">\n      ${body}\n    </section>`;
 }
 
 export function renderVariantNoscriptMainHtml(variant: VariantSeoKey, meta: VariantMeta): string {
@@ -296,7 +296,7 @@ export function renderVariantDashboardHtml(fullDashboardHtml: string, variant: s
   const seoKey = variant as VariantSeoKey;
   html = replaceCounted(
     html,
-    /<section class="app-seo-summary" aria-hidden="true">[\s\S]*?<\/section>/,
+    /<section class="app-seo-summary">[\s\S]*?<\/section>/,
     () => renderVariantSeoSummaryHtml(seoKey),
     ONE,
     'app-seo-summary',

--- a/tests/seo-crawl-directive-hygiene.test.mts
+++ b/tests/seo-crawl-directive-hygiene.test.mts
@@ -50,7 +50,7 @@ describe('SEO crawl-directive hygiene (#7380)', () => {
 
   it('embeds the full-dashboard SEO summary outside #app so hydration cannot wipe it', () => {
     const html = read('index.html');
-    const summaryIdx = html.indexOf('<section class="app-seo-summary" aria-hidden="true">');
+    const summaryIdx = html.indexOf('<section class="app-seo-summary"');
     const appIdx = html.indexOf('<div id="app">');
     assert.ok(summaryIdx > 0, 'missing app-seo-summary');
     assert.ok(appIdx > summaryIdx, 'SEO summary must precede #app');
@@ -58,9 +58,23 @@ describe('SEO crawl-directive hygiene (#7380)', () => {
     assert.doesNotMatch(
       summaryOpenTag,
       /aria-label=/,
-      'crawler-only summary must stay out of the accessibility tree',
+      'summary must not carry a label that would replace its announced content',
+    );
+    assert.doesNotMatch(
+      summaryOpenTag,
+      /aria-hidden/,
+      'SEO summary must stay in the accessibility tree (#7607)',
     );
     assert.match(html, /full-spectrum real-time global intelligence dashboard/i);
+  });
+
+  it('keeps every speakable cssSelector target in the accessibility tree (#7607)', () => {
+    const html = read('index.html');
+    // The declared speakable selectors must not point at aria-hidden content:
+    // .app-seo-summary is announced to screen readers and truthfully citeable
+    // by voice assistants only while it stays in the accessibility tree.
+    assert.match(html, /"cssSelector": \["h1", ".app-seo-summary"\]/);
+    assert.doesNotMatch(html, /<section class="app-seo-summary"[^>]*aria-hidden/);
   });
 
   it('308-redirects bots away from ?ref= / utm_* duplicate dashboard URLs', () => {

--- a/tests/variant-dashboard-html.test.mts
+++ b/tests/variant-dashboard-html.test.mts
@@ -106,7 +106,7 @@ const fixture = `<!doctype html>
   </head>
   <body>
     <h1 class="app-heading">World Monitor — Real-Time Global Intelligence Dashboard</h1>
-    <section class="app-seo-summary" aria-hidden="true">
+    <section class="app-seo-summary">
       <p>Full dashboard SEO summary placeholder for transform tests.</p>
     </section>
     <noscript>
@@ -211,7 +211,12 @@ describe('renderVariantDashboardHtml (#4996)', () => {
 
   it('injects variant-specific SEO summary and noscript differentiation copy', () => {
     const html = renderVariantDashboardHtml(fixture, 'tech');
-    assert.match(html, /<section class="app-seo-summary" aria-hidden="true">/);
+    assert.match(html, /<section class="app-seo-summary">/);
+    assert.doesNotMatch(
+      html,
+      /<section class="app-seo-summary"[^>]*aria-hidden/,
+      'variant SEO summary must stay in the accessibility tree (#7607)',
+    );
     assert.match(html, /Tech Monitor is the World Monitor variant/);
     assert.match(html, /<main id="dashboard-noscript"/);
     assert.match(html, /Tech Monitor requires JavaScript for the live map/);


### PR DESCRIPTION
The six indexable dashboard shells shipped ~2,400 characters of SEO summary inside a section marked `aria-hidden="true"`: invisible to sighted users, silent for screen readers, and visible only to crawlers — exactly the "text positioned off-screen" pattern Google's spam policies target. The `speakable` JSON-LD then declared that same hidden block as the canonical passage for voice assistants to read aloud, turning an implicit signal into an explicit machine-readable assertion of intent. Screen-reader users also got no H1 at all, since the only H1 lives in the same clipped block.

Removing the attribute keeps the sr-only clip styling (so the page renders identically) while restoring the block to the accessibility tree: screen readers now announce it, the `speakable` selector becomes truthful, and the hidden-text exposure disappears. New guards in the crawl-directive hygiene and variant transform tests assert that no `.app-seo-summary` element ever carries `aria-hidden` again, so a future regression fails CI instead of shipping.

Fixes #7607

## Validation

- Proof-first: updated tests first and observed them fail on the old markup, then made the change; all 30 tests across the three affected suites pass.
- `npm run typecheck`, `npm run lint:boundaries`: clean.
- Full `npm run build` succeeded; verified all six built dashboard pages (`dashboard.html` + five variants) ship `<section class="app-seo-summary">` with no `aria-hidden`, and the speakable `cssSelector` is unchanged and now truthful.

## Post-Deploy Monitoring & Validation

- After deploy, fetch `/dashboard` and each variant dashboard (`tech`, `finance`, `commodity`, `happy`, `energy` subdomains) as a crawler and confirm the section open tag has no `aria-hidden` and rendered text length is unchanged.
- Recrawl acceptance: confirm GPTBot/Googlebot render shows the summary in the accessibility tree (e.g. via URL inspection or an a11y-tree render probe); expected healthy signal is identical visible render with the block present in the a11y tree.
- Failure signal: any built page regressing to `aria-hidden` now fails the new test guards before deploy; production-side signal would be re-measured hidden-text length equal to current values.
- Rollback: revert this commit and redeploy; no data or state is involved.
- Validation window: one recrawl cycle after merge (typically 1-2 weeks for GSC refresh).

Compound Engineered with GLM via Codex (ce-work)
