### PR TITLE
fix(chokepoints): state open/restricted/closed binary on detail pages (#7613)

### DIFF
--- a/docs/methodology/chokepoints.mdx
+++ b/docs/methodology/chokepoints.mdx
@@ -111,10 +111,10 @@ only: hazard enrichment does not change `currentMbd`, `flowRatio`, or the
 ## Score Badge
 
 The public `status` field on `ChokepointInfo` is a traffic-light score badge:
-`green`, `yellow`, or `red`. Each band maps to a commercial passage status
-that detail pages publish as a plain first-screen sentence: Green means open,
-Yellow means restricted, and Red means effectively closed. The badge is the
-input to that mapping, not a separate verdict.
+`green`, `yellow`, or `red`. It summarizes disruption risk; it is not an
+operational declaration that a waterway is open, restricted, or closed. Detail
+pages report observed transit activity when it is available and state when
+source coverage is too partial to verify operational passage status.
 
 The score is:
 

--- a/docs/methodology/chokepoints.mdx
+++ b/docs/methodology/chokepoints.mdx
@@ -111,7 +111,10 @@ only: hazard enrichment does not change `currentMbd`, `flowRatio`, or the
 ## Score Badge
 
 The public `status` field on `ChokepointInfo` is a traffic-light score badge:
-`green`, `yellow`, or `red`. It is not an operational closure-state label.
+`green`, `yellow`, or `red`. Each band maps to a commercial passage status
+that detail pages publish as a plain first-screen sentence: Green means open,
+Yellow means restricted, and Red means effectively closed. The badge is the
+input to that mapping, not a separate verdict.
 
 The score is:
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -629,7 +629,10 @@ only: hazard enrichment does not change `currentMbd`, `flowRatio`, or the
 ## Score Badge
 
 The public `status` field on `ChokepointInfo` is a traffic-light score badge:
-`green`, `yellow`, or `red`. It is not an operational closure-state label.
+`green`, `yellow`, or `red`. Each band maps to a commercial passage status
+that detail pages publish as a plain first-screen sentence: Green means open,
+Yellow means restricted, and Red means effectively closed. The badge is the
+input to that mapping, not a separate verdict.
 
 The score is:
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -629,10 +629,10 @@ only: hazard enrichment does not change `currentMbd`, `flowRatio`, or the
 ## Score Badge
 
 The public `status` field on `ChokepointInfo` is a traffic-light score badge:
-`green`, `yellow`, or `red`. Each band maps to a commercial passage status
-that detail pages publish as a plain first-screen sentence: Green means open,
-Yellow means restricted, and Red means effectively closed. The badge is the
-input to that mapping, not a separate verdict.
+`green`, `yellow`, or `red`. It summarizes disruption risk; it is not an
+operational declaration that a waterway is open, restricted, or closed. Detail
+pages report observed transit activity when it is available and state when
+source coverage is too partial to verify operational passage status.
 
 The score is:
 

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -3162,7 +3162,7 @@ function renderChokepointsIndex({ chokepoints, livePulse, baseUrl, lastmod, snap
   const hubFaqs = [
     {
       question: 'Which maritime chokepoints are most disrupted?',
-      answer: `The published ${formatStaticDateTime(updatedAt)} snapshot gives the highest disruption score to ${formatProseList(mostDisruptedNames)}, each at ${formatScore(highestScore, OBSERVED_EVIDENCE)}/100. The table covers all ${chokepointHubRows.length} tracked waterways and shows each source timestamp. A higher score means more current pressure. It does not confirm that a waterway is closed.`,
+      answer: `The published ${formatStaticDateTime(updatedAt)} snapshot gives the highest disruption score to ${formatProseList(mostDisruptedNames)}, each at ${formatScore(highestScore, OBSERVED_EVIDENCE)}/100. The table covers all ${chokepointHubRows.length} tracked waterways and shows each source timestamp. A higher score means more current pressure. Passage status follows the same bands the detail pages publish: Green means open, Yellow means restricted, and Red means effectively closed.`,
     },
     {
       question: 'How does World Monitor score chokepoint status?',

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -45,6 +45,9 @@ import { getSovereignStatus } from './shared/rankable-universe.mjs';
 // `typeof document !== 'undefined'` guard). A mirrored copy could not fail.
 import {
   chokepointCoverageMetrics,
+  chokepointOpenStatusSentence,
+  chokepointPassageStatus,
+  chokepointScoreDriverSentence,
   instabilityBand,
   MAX_FUTURE_SKEW_MS,
   MAX_LIVE_SNAPSHOT_AGE_MS,
@@ -132,7 +135,11 @@ export const RANKING_ELIGIBILITY_CLAUSE = `Ranking requires coverage of at least
 const RETIRED_DIMENSION_IDS = new Set(['fuelStockDays', 'reserveAdequacy']);
 const UNRANKED_INVENTORY_LIMIT = 12;
 const AVAILABLE_EVIDENCE_LIMIT = 6;
-export const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-09-02';
+export const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-09-03';
+// Band-to-passage mapping published on every /chokepoints/* page (#7613): the
+// disruption badge bands are green <20, yellow 20-49, red >=50, and the binary
+// the query vocabulary asks for follows directly from the band.
+export const CHOKEPOINT_PASSAGE_MAPPING_NOTE = 'World Monitor maps the disruption band to passage status: Green (score below 20) means open, Yellow (20–49) means restricted, and Red (50 or above) means effectively closed. The disruption score below feeds that mapping; it is not a separate verdict.';
 const SOURCES_PAGE_CONTENT_VERSION = '2026-08-20';
 // Dataset schema versions stamp Dataset JSON-LD shape changes, per family. They
 // must NOT fold into every family's sitemap/page lastmod — that made ~90% of main
@@ -3159,7 +3166,7 @@ function renderChokepointsIndex({ chokepoints, livePulse, baseUrl, lastmod, snap
     },
     {
       question: 'How does World Monitor score chokepoint status?',
-      answer: `World Monitor scores each waterway 0-100 from four independent sources: NGA navigational warnings, the AIS snapshot, relay transit counts, and PortWatch week-over-week movement. Each source controls only its own values, so a source that is unavailable is withheld rather than published as a measured zero or a calm reading — ${congestionCoverageClause}. The traffic-light status helps operators triage waterways. It does not declare that a waterway is open or closed. The chokepoint methodology documents the inputs and score bands.`,
+      answer: `World Monitor scores each waterway 0-100 from four independent sources: NGA navigational warnings, the AIS snapshot, relay transit counts, and PortWatch week-over-week movement. Each source controls only its own values, so a source that is unavailable is withheld rather than published as a measured zero or a calm reading — ${congestionCoverageClause}. The traffic-light status maps to passage status — Green means open, Yellow means restricted, and Red means effectively closed — so each detail page states whether its waterway is open right now. The chokepoint methodology documents the inputs, score bands, and mapping.`,
     },
     {
       question: 'Why do some chokepoint pages show fewer metrics than others?',
@@ -3467,6 +3474,44 @@ function renderChokepointPage({
   const transitsNote = transitsWithheld
     ? `        <p data-chokepoint-transits-note>${escapeHtml(withheldTransitCountSentence(chokepoint.displayName))}</p>`
     : '        <p data-chokepoint-transits-note hidden></p>';
+  // First-screen binary for the open/closed query vocabulary (#7613). The
+  // disruption score stays on the page as the supporting detail below.
+  const passageStatus = hasPulse ? chokepointPassageStatus(pulse.disruptionScore) : null;
+  const openStatusSentence = hasPulse
+    ? chokepointOpenStatusSentence({
+      displayName: chokepoint.displayName,
+      score: pulse.disruptionScore,
+      asOfText: formatStaticDateTime(pulse.asOf),
+      todayTransits: transitsLabel,
+    })
+    : null;
+  // The helper returns plain text shared with the live-refresh path; the
+  // status word is a fixed ASCII token, so wrapping it here cannot disturb
+  // escaping. The exact `is <status> to commercial shipping.` clause is built
+  // by the helper above, which guarantees the replace target is present.
+  const openStatusHtml = openStatusSentence !== null && passageStatus !== null
+    ? escapeHtml(openStatusSentence).replace(
+      `is ${passageStatus} to commercial shipping.`,
+      `is <strong>${passageStatus}</strong> to commercial shipping.`,
+    )
+    : `World Monitor has not published a current passage status for ${escapeHtml(chokepoint.displayName)} yet.`;
+  const scoreDriverSentence = hasPulse
+    ? chokepointScoreDriverSentence({
+      score: pulse.disruptionScore,
+      bandLabel: pulse.status,
+      description: pulse.description,
+      warningsLabel: coverageMetrics.navigationalWarnings,
+      aisLabel: coverageMetrics.aisDisruptions,
+      congestionLabel: coverageMetrics.congestion,
+      todayTransits: transitsLabel,
+    })
+    : null;
+  const openStatusSection = `        <h2>Is ${escapeHtml(chokepoint.displayName)} open right now?</h2>
+        <p data-chokepoint-open-status>${openStatusHtml}</p>
+${scoreDriverSentence !== null
+    ? `        <p data-chokepoint-score-driver>${escapeHtml(scoreDriverSentence)}</p>`
+    : '        <p data-chokepoint-score-driver hidden></p>'}
+        <p class="tool-note" data-chokepoint-status-mapping>${escapeHtml(CHOKEPOINT_PASSAGE_MAPPING_NOTE)}</p>`;
   const liveGrid = hasPulse
     ? `        <div class="grid" data-live-grid aria-label="Current chokepoint status" aria-busy="false">
           <div class="metric"><span>Disruption score</span><strong><span data-chokepoint-score>${escapeHtml(formatScore(pulse.disruptionScore, { coverage: hasPulse }))}</span><small data-chokepoint-band>${escapeHtml(pulse.status)}</small></strong></div>
@@ -3494,6 +3539,7 @@ ${optionalChokepointMetric('AIS congestion', 'data-chokepoint-congestion', '', f
       <h1>${escapeHtml(chokepoint.displayName)}</h1>
       <p class="lede">${escapeHtml(blurb)}</p>
       <section class="live-tool" data-live-chokepoint data-chokepoint-id="${escapeHtml(chokepoint.id)}" data-chokepoint-name="${escapeHtml(chokepoint.displayName)}" data-state="${liveState}"${hasPulse ? ' data-published-pulse' : ''}>
+${openStatusSection}
         <div class="tool-head">
           <div>
             <p class="eyebrow">Current status</p>
@@ -3501,7 +3547,7 @@ ${optionalChokepointMetric('AIS congestion', 'data-chokepoint-congestion', '', f
           </div>
           <span class="live-status" data-live-status role="status" aria-live="polite">${escapeHtml(liveStatus)}</span>
         </div>
-        <p class="tool-note">The traffic-light badge is a disruption score, not an operational closure declaration. Transit metrics appear only when the current vessel snapshot has coverage.</p>
+        <p class="tool-note">Transit metrics appear only when the current vessel snapshot has coverage.</p>
 ${liveGrid}
         <div class="tool-meta">
           ${liveUpdatedMarkup({

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -45,9 +45,7 @@ import { getSovereignStatus } from './shared/rankable-universe.mjs';
 // `typeof document !== 'undefined'` guard). A mirrored copy could not fail.
 import {
   chokepointCoverageMetrics,
-  chokepointOpenStatusSentence,
-  chokepointPassageStatus,
-  chokepointScoreDriverSentence,
+  chokepointEvidenceNarrative,
   instabilityBand,
   MAX_FUTURE_SKEW_MS,
   MAX_LIVE_SNAPSHOT_AGE_MS,
@@ -135,7 +133,7 @@ export const RANKING_ELIGIBILITY_CLAUSE = `Ranking requires coverage of at least
 const RETIRED_DIMENSION_IDS = new Set(['fuelStockDays', 'reserveAdequacy']);
 const UNRANKED_INVENTORY_LIMIT = 12;
 const AVAILABLE_EVIDENCE_LIMIT = 6;
-export const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-09-03';
+export const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-09-04';
 const SOURCES_PAGE_CONTENT_VERSION = '2026-08-20';
 // Dataset schema versions stamp Dataset JSON-LD shape changes, per family. They
 // must NOT fold into every family's sitemap/page lastmod — that made ~90% of main
@@ -3249,11 +3247,11 @@ function renderChokepointsIndex({ chokepoints, chokepointHubRows, livePulse, bas
   const hubFaqs = [
     {
       question: 'Which maritime chokepoints are most disrupted?',
-      answer: `The published ${formatStaticDateTime(updatedAt)} snapshot gives the highest disruption score to ${formatProseList(mostDisruptedNames)}, each at ${formatScore(highestScore, OBSERVED_EVIDENCE)}/100. The table covers all ${chokepointHubRows.length} tracked waterways and shows each source timestamp. A higher score means more current pressure. Passage status follows the same bands the detail pages publish: Green means open, Yellow means restricted, and Red means effectively closed.`,
+      answer: `The published ${formatStaticDateTime(updatedAt)} snapshot gives the highest disruption score to ${formatProseList(mostDisruptedNames)}, each at ${formatScore(highestScore, OBSERVED_EVIDENCE)}/100. The table covers all ${chokepointHubRows.length} tracked waterways and shows each source timestamp. A higher score means more current pressure, but the badge is a risk signal and does not declare unrestricted passage or operational closure.`,
     },
     {
       question: 'How does World Monitor score chokepoint status?',
-      answer: `World Monitor scores each waterway 0-100 from four independent sources: NGA navigational warnings, the AIS snapshot, relay transit counts, and PortWatch week-over-week movement. Each source controls only its own values, so a source that is unavailable is withheld rather than published as a measured zero or a calm reading — ${congestionCoverageClause}. The traffic-light status maps to passage status — Green means open, Yellow means restricted, and Red means effectively closed — so each detail page states whether its waterway is open right now. The chokepoint methodology documents the inputs, score bands, and mapping.`,
+      answer: `World Monitor scores each waterway 0-100 from a configured geopolitical baseline, NGA navigational warnings, maximum AIS severity, and a qualifying traffic anomaly. AIS event counts, relay transit counts, and PortWatch movement are context rather than score inputs. Each source controls only its own values, so unavailable evidence is withheld rather than published as a measured zero or a calm reading — ${congestionCoverageClause}. The methodology documents the inputs and score bands.`,
     },
     {
       question: 'Why do some chokepoint pages show fewer metrics than others?',
@@ -3562,44 +3560,28 @@ function renderChokepointPage({
   const transitsNote = transitsWithheld
     ? `        <p data-chokepoint-transits-note>${escapeHtml(withheldTransitCountSentence(chokepoint.displayName))}</p>`
     : '        <p data-chokepoint-transits-note hidden></p>';
-  // First-screen binary for the open/closed query vocabulary (#7613). The
-  // disruption score stays on the page as the supporting detail below.
-  const passageStatus = hasPulse ? chokepointPassageStatus(pulse.disruptionScore) : null;
-  const openStatusSentence = hasPulse
-    ? chokepointOpenStatusSentence({
+  const narrative = hasPulse
+    ? chokepointEvidenceNarrative({
       displayName: chokepoint.displayName,
-      score: pulse.disruptionScore,
-      asOfText: formatStaticDateTime(pulse.asOf),
-      todayTransits: transitsLabel,
-    })
-    : null;
-  // The helper returns plain text shared with the live-refresh path; the
-  // status word is a fixed ASCII token, so wrapping it here cannot disturb
-  // escaping. The exact `is <status> to commercial shipping.` clause is built
-  // by the helper above, which guarantees the replace target is present.
-  const openStatusHtml = openStatusSentence !== null && passageStatus !== null
-    ? escapeHtml(openStatusSentence).replace(
-      `is ${passageStatus} to commercial shipping.`,
-      `is <strong>${passageStatus}</strong> to commercial shipping.`,
-    )
-    : `World Monitor has not published a current passage status for ${escapeHtml(chokepoint.displayName)} yet.`;
-  const scoreDriverSentence = hasPulse
-    ? chokepointScoreDriverSentence({
       score: pulse.disruptionScore,
       bandLabel: pulse.status,
       description: pulse.description,
+      asOfText: formatStaticDateTime(pulse.asOf),
+      partial: pulsePartial,
       warningsLabel: coverageMetrics.navigationalWarnings,
-      aisLabel: coverageMetrics.aisDisruptions,
       congestionLabel: coverageMetrics.congestion,
+      aisEventCountLabel: coverageMetrics.aisDisruptions,
       todayTransits: transitsLabel,
     })
     : null;
+  const openStatusHtml = narrative !== null
+    ? escapeHtml(narrative.passage)
+    : `World Monitor has not published current passage evidence for ${escapeHtml(chokepoint.displayName)} yet.`;
   const openStatusSection = `        <h2>Is ${escapeHtml(chokepoint.displayName)} open right now?</h2>
         <p data-chokepoint-open-status>${openStatusHtml}</p>
-${scoreDriverSentence !== null
-    ? `        <p data-chokepoint-score-driver>${escapeHtml(scoreDriverSentence)}</p>`
-    : '        <p data-chokepoint-score-driver hidden></p>'}
-        <p class="tool-note" data-chokepoint-status-mapping>${escapeHtml(CHOKEPOINT_PASSAGE_MAPPING_NOTE)}</p>`;
+${narrative !== null
+    ? `        <p data-chokepoint-score-driver>${escapeHtml(narrative.scoreDriver)}</p>`
+    : '        <p data-chokepoint-score-driver hidden></p>'}`;
   const liveGrid = hasPulse
     ? `        <div class="grid" data-live-grid aria-label="Current chokepoint status" aria-busy="false">
           <div class="metric"><span>Disruption score</span><strong><span data-chokepoint-score>${escapeHtml(formatScore(pulse.disruptionScore, { coverage: hasPulse }))}</span><small data-chokepoint-band>${escapeHtml(pulse.status)}</small></strong></div>

--- a/scripts/crawlable-live-tools.mjs
+++ b/scripts/crawlable-live-tools.mjs
@@ -113,17 +113,6 @@ function chokepointScoreNumber(value) {
   return Number.NaN;
 }
 
-// Disruption-score band mapped to a commercial passage status (#7613). Bands
-// mirror the traffic-light badge (green <20, yellow 20-49, red >=50) so the
-// open/restricted/closed binary is reproducible rather than editorial.
-export function chokepointPassageStatus(score) {
-  const numeric = chokepointScoreNumber(score);
-  if (!Number.isFinite(numeric) || numeric < 0 || numeric > 100) return null;
-  if (numeric < 20) return 'open';
-  if (numeric < 50) return 'restricted';
-  return 'effectively closed';
-}
-
 function chokepointBandLabel(score) {
   const numeric = chokepointScoreNumber(score);
   if (!Number.isFinite(numeric) || numeric < 0 || numeric > 100) return null;
@@ -165,36 +154,20 @@ function chokepointArticleName(displayName) {
   return `the ${name}`;
 }
 
-// First-screen binary sentence for /chokepoints/* pages (#7613): states in the
-// user's own words whether the waterway is open, restricted, or effectively
-// closed, then follows with the transit count. Returns null when the score is
-// unusable so callers can fall back to an unavailable note.
-export function chokepointOpenStatusSentence({ displayName, score, asOfText, todayTransits }) {
-  const status = chokepointPassageStatus(score);
-  if (status === null) return null;
-  const name = chokepointArticleName(displayName);
-  const dated = String(asOfText || '').trim();
-  const head = dated ? `As of ${dated}, ${name} is ${status} to commercial shipping.`
-    : `In the latest published snapshot, ${name} is ${status} to commercial shipping.`;
-  const transit = todayTransits == null || String(todayTransits).trim() === ''
-    ? ' No transit count is published for this snapshot.'
-    : ` Today's transit count is ${String(todayTransits).trim()}.`;
-  return `${head}${transit}`;
-}
-
-// Score-driver sentence for /chokepoints/* pages (#7613): names what set the
-// score — the baseline geopolitical threat weight, the observed snapshot
-// signals, or both — so the number is attributable rather than bare. Only the
-// warning count, AIS severity, and anomaly signal feed the formula (see
-// splitScoreDescription); transit counts and congestion readings are context,
-// so they get their own sentence rather than posing as inputs.
-export function chokepointScoreDriverSentence({
+// Shared evidence policy for both static HTML and live hydration. The badge is
+// a disruption-risk signal, not evidence that operators have opened or closed
+// a waterway. AIS severity contributes to the score; the number of AIS events
+// and the transit count are context only.
+export function chokepointEvidenceNarrative({
+  displayName,
   score,
   bandLabel,
   description,
+  asOfText,
+  partial,
   warningsLabel,
-  aisLabel,
   congestionLabel,
+  aisEventCountLabel,
   todayTransits,
 }) {
   const numeric = chokepointScoreNumber(score);
@@ -202,19 +175,51 @@ export function chokepointScoreDriverSentence({
   const band = String(bandLabel || '').trim() || chokepointBandLabel(numeric);
   const formatted = Number.isInteger(numeric) ? String(numeric) : String(Math.round(numeric * 10) / 10);
   const warnings = String(warningsLabel || '').trim() || null;
-  const ais = String(aisLabel || '').trim() || null;
-  const inputs = `${warnings ?? 'navigational warnings unavailable'} and ${ais ?? 'AIS disruptions unavailable'} observed in this snapshot`;
-  const { threat, anomaly } = splitScoreDescription(description);
-  const anomalyClause = anomaly ? `, plus the published transit anomaly — ${anomaly}` : '';
-  const congestion = String(congestionLabel || '').trim();
+  const severity = String(congestionLabel || '').trim() || null;
+  const aisEvents = String(aisEventCountLabel || '').trim() || null;
   const transit = todayTransits == null || String(todayTransits).trim() === ''
-    ? 'no transit count is published for this snapshot'
-    : `the published transit count is ${String(todayTransits).trim()}`;
-  const context = `Congestion is ${congestion || 'not reported'}; ${transit}.`;
-  if (threat) {
-    return `The score of ${formatted} (${band}) builds on the baseline geopolitical threat weight — ${threat} — with ${inputs}${anomalyClause}. ${context}`;
+    ? null
+    : String(todayTransits).trim();
+  const name = chokepointArticleName(displayName);
+  const dated = String(asOfText || '').trim();
+  const snapshotLead = dated ? `As of ${dated}` : 'In the latest published snapshot';
+
+  let passage;
+  if (partial === true) {
+    const transitClause = transit === null
+      ? 'No transit count is published for this snapshot.'
+      : `The observed transit count is ${transit}.`;
+    passage = `${snapshotLead}, source coverage for ${name} is partial. ${transitClause} World Monitor cannot verify operational passage status from this snapshot.`;
+  } else {
+    const transitClause = transit === null
+      ? `no transit count is published for ${name}.`
+      : `the observed transit count for ${name} is ${transit}.`;
+    passage = `${snapshotLead}, ${transitClause} The ${band} disruption score is a risk signal; it does not verify unrestricted passage or operational closure.`;
   }
-  return `The score of ${formatted} (${band}) comes from ${inputs}${anomalyClause}, with no additional geopolitical threat baseline. ${context}`;
+
+  const { threat, anomaly } = splitScoreDescription(description);
+  const baseline = threat
+    ? `Configured geopolitical baseline: ${threat.replace(/[.]+$/, '')}.`
+    : 'Configured geopolitical baseline: no additional threat weight.';
+  const observedInputs = [
+    warnings,
+    severity ? `maximum AIS severity ${severity}` : null,
+    anomaly ? `transit anomaly — ${anomaly.replace(/[.]+$/, '')}` : null,
+  ].filter(Boolean);
+  const unavailableInputs = [
+    warnings === null ? 'navigational warning count' : null,
+    severity === null ? 'maximum AIS severity' : null,
+  ].filter(Boolean);
+  const observed = observedInputs.length
+    ? `Observed score inputs: ${observedInputs.join('; ')}.`
+    : 'Observed score inputs: none available.';
+  const unavailable = unavailableInputs.length
+    ? ` Unavailable score inputs: ${unavailableInputs.join('; ')}.`
+    : '';
+  const context = `Context only (not score inputs): AIS event count ${aisEvents ? `(${aisEvents})` : 'unavailable'}; transit count ${transit ? `(${transit})` : 'unavailable'}.`;
+  const scoreDriver = `The score of ${formatted} (${band}) has this evidence basis. ${baseline} ${observed}${unavailable} ${context}`;
+
+  return { passage, scoreDriver };
 }
 
 function humanizeToken(value, prefixes = []) {
@@ -1296,31 +1301,24 @@ export async function loadChokepoint(tool) {
     if (!isCurrentRequest(tool, state)) return;
     setText(tool, '[data-chokepoint-score]', view.disruptionScore);
     setText(tool, '[data-chokepoint-band]', view.status);
+    const narrative = chokepointEvidenceNarrative({
+      displayName: tool.dataset.chokepointName || '',
+      score: view.disruptionScore,
+      bandLabel: view.status,
+      description: view.description,
+      asOfText: formatDateTime(view.fetchedAt),
+      partial: view.partial,
+      warningsLabel: view.navigationalWarnings,
+      congestionLabel: view.congestion,
+      aisEventCountLabel: view.aisDisruptions,
+      todayTransits: view.todayTransits,
+    });
     const openStatus = tool.querySelector('[data-chokepoint-open-status]');
-    if (openStatus) {
-      const sentence = chokepointOpenStatusSentence({
-        displayName: tool.dataset.chokepointName || '',
-        score: view.disruptionScore,
-        asOfText: formatDateTime(view.fetchedAt),
-        todayTransits: view.todayTransits,
-      });
-      if (sentence !== null) openStatus.textContent = sentence;
-    }
+    if (openStatus && narrative !== null) openStatus.textContent = narrative.passage;
     const scoreDriver = tool.querySelector('[data-chokepoint-score-driver]');
-    if (scoreDriver) {
-      const sentence = chokepointScoreDriverSentence({
-        score: view.disruptionScore,
-        bandLabel: view.status,
-        description: view.description,
-        warningsLabel: view.navigationalWarnings,
-        aisLabel: view.aisDisruptions,
-        congestionLabel: view.congestion,
-        todayTransits: view.todayTransits,
-      });
-      if (sentence !== null) {
-        scoreDriver.hidden = false;
-        scoreDriver.textContent = sentence;
-      }
+    if (scoreDriver && narrative !== null) {
+      scoreDriver.hidden = false;
+      scoreDriver.textContent = narrative.scoreDriver;
     }
     setOptionalMetric(tool, '[data-chokepoint-congestion]', view.congestion);
     setOptionalMetric(tool, '[data-chokepoint-warnings]', view.navigationalWarnings);

--- a/scripts/crawlable-live-tools.mjs
+++ b/scripts/crawlable-live-tools.mjs
@@ -104,6 +104,118 @@ export function withheldTransitCountSentence(displayName) {
   return `World Monitor is not currently publishing a transit count for ${name} for this period.`;
 }
 
+// Strict score coercion: only finite numbers and non-blank numeric strings
+// qualify. A bare Number() would turn null and '' into 0 — a measured calm
+// reading manufactured from an absence.
+function chokepointScoreNumber(value) {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value.trim() !== '') return Number(value.replace(/,/g, ''));
+  return Number.NaN;
+}
+
+// Disruption-score band mapped to a commercial passage status (#7613). Bands
+// mirror the traffic-light badge (green <20, yellow 20-49, red >=50) so the
+// open/restricted/closed binary is reproducible rather than editorial.
+export function chokepointPassageStatus(score) {
+  const numeric = chokepointScoreNumber(score);
+  if (!Number.isFinite(numeric) || numeric < 0 || numeric > 100) return null;
+  if (numeric < 20) return 'open';
+  if (numeric < 50) return 'restricted';
+  return 'effectively closed';
+}
+
+function chokepointBandLabel(score) {
+  const numeric = chokepointScoreNumber(score);
+  if (!Number.isFinite(numeric) || numeric < 0 || numeric > 100) return null;
+  if (numeric < 20) return 'Green';
+  if (numeric < 50) return 'Yellow';
+  return 'Red';
+}
+
+// Segments of the live status note that are NOT geopolitical baseline
+// evidence, so they must never be quoted as the threat weight: absence and
+// partial-coverage phrasing, the transit-anomaly signal (it describes observed
+// traffic collapse, not the baseline — and it is rendered verbatim in the
+// page's description paragraph anyway), and operator review-hygiene text.
+// The live API always sends a non-empty description, so without this filter
+// every calm waterway would read as threat-driven. Anything left after
+// dropping these is the threat-baseline description behind the scorer's
+// threat weight; every non-normal threat level carries one, so an empty
+// remainder means a normal baseline with no anomaly signal.
+const NON_THREAT_DESCRIPTION_PATTERNS = [
+  /no active disruptions/i,
+  /source coverage incomplete/i,
+  /traffic down \d+% vs .*baseline/i,
+  /threat baseline last reviewed/i,
+];
+
+function threatBaselineDescription(description) {
+  const kept = String(description || '')
+    .split(';')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment
+      && !NON_THREAT_DESCRIPTION_PATTERNS.some((pattern) => pattern.test(segment)));
+  return kept.length ? kept.join('; ') : null;
+}
+
+function chokepointArticleName(displayName) {
+  const name = String(displayName || '').trim() || 'this chokepoint';
+  return `the ${name}`;
+}
+
+// First-screen binary sentence for /chokepoints/* pages (#7613): states in the
+// user's own words whether the waterway is open, restricted, or effectively
+// closed, then follows with the transit count. Returns null when the score is
+// unusable so callers can fall back to an unavailable note.
+export function chokepointOpenStatusSentence({ displayName, score, asOfText, todayTransits }) {
+  const status = chokepointPassageStatus(score);
+  if (status === null) return null;
+  const name = chokepointArticleName(displayName);
+  const dated = String(asOfText || '').trim();
+  const head = dated ? `As of ${dated}, ${name} is ${status} to commercial shipping.`
+    : `In the latest published snapshot, ${name} is ${status} to commercial shipping.`;
+  const transit = todayTransits == null || String(todayTransits).trim() === ''
+    ? ' No transit count is published for this snapshot.'
+    : ` Today's transit count is ${String(todayTransits).trim()}.`;
+  return `${head}${transit}`;
+}
+
+// Score-driver sentence for /chokepoints/* pages (#7613): names what set the
+// score — the baseline geopolitical threat weight, the observed snapshot
+// inputs, or both — so the number is attributable rather than bare. Only the
+// threat-baseline segments of the status note count as baseline evidence (see
+// threatBaselineDescription); a null remainder means a normal baseline with no
+// anomaly signal, so the score is entirely observed in that case.
+export function chokepointScoreDriverSentence({
+  score,
+  bandLabel,
+  description,
+  warningsLabel,
+  aisLabel,
+  congestionLabel,
+  todayTransits,
+}) {
+  const numeric = chokepointScoreNumber(score);
+  if (!Number.isFinite(numeric) || numeric < 0 || numeric > 100) return null;
+  const band = String(bandLabel || '').trim() || chokepointBandLabel(numeric);
+  const formatted = Number.isInteger(numeric) ? String(numeric) : String(Math.round(numeric * 10) / 10);
+  const warnings = String(warningsLabel || '').trim() || null;
+  const ais = String(aisLabel || '').trim() || null;
+  const congestion = String(congestionLabel || '').trim() || null;
+  const transit = todayTransits == null || String(todayTransits).trim() === ''
+    ? 'no published transit count'
+    : `${String(todayTransits).trim()} published transits`;
+  const observed = `${warnings ?? 'navigational warnings unavailable'}, `
+    + `${ais ?? 'AIS disruptions unavailable'}, `
+    + `${congestion ? `${congestion} congestion` : 'congestion not reported'}, `
+    + `and ${transit}`;
+  const threat = threatBaselineDescription(description);
+  if (threat) {
+    return `The score of ${formatted} (${band}) builds on the baseline geopolitical threat weight — ${threat} — plus this snapshot's observed inputs: ${observed}.`;
+  }
+  return `The score of ${formatted} (${band}) comes from this snapshot's observed inputs — ${observed} — with no additional geopolitical threat baseline.`;
+}
+
 function humanizeToken(value, prefixes = []) {
   let token = String(value || '').trim();
   for (const prefix of prefixes) {
@@ -1183,6 +1295,32 @@ export async function loadChokepoint(tool) {
     if (!isCurrentRequest(tool, state)) return;
     setText(tool, '[data-chokepoint-score]', view.disruptionScore);
     setText(tool, '[data-chokepoint-band]', view.status);
+    const openStatus = tool.querySelector('[data-chokepoint-open-status]');
+    if (openStatus) {
+      const sentence = chokepointOpenStatusSentence({
+        displayName: tool.dataset.chokepointName || '',
+        score: view.disruptionScore,
+        asOfText: formatDateTime(view.fetchedAt),
+        todayTransits: view.todayTransits,
+      });
+      if (sentence !== null) openStatus.textContent = sentence;
+    }
+    const scoreDriver = tool.querySelector('[data-chokepoint-score-driver]');
+    if (scoreDriver) {
+      const sentence = chokepointScoreDriverSentence({
+        score: view.disruptionScore,
+        bandLabel: view.status,
+        description: view.description,
+        warningsLabel: view.navigationalWarnings,
+        aisLabel: view.aisDisruptions,
+        congestionLabel: view.congestion,
+        todayTransits: view.todayTransits,
+      });
+      if (sentence !== null) {
+        scoreDriver.hidden = false;
+        scoreDriver.textContent = sentence;
+      }
+    }
     setOptionalMetric(tool, '[data-chokepoint-congestion]', view.congestion);
     setOptionalMetric(tool, '[data-chokepoint-warnings]', view.navigationalWarnings);
     setOptionalMetric(tool, '[data-chokepoint-ais-disruptions]', view.aisDisruptions);

--- a/scripts/crawlable-live-tools.mjs
+++ b/scripts/crawlable-live-tools.mjs
@@ -132,30 +132,32 @@ function chokepointBandLabel(score) {
   return 'Red';
 }
 
-// Segments of the live status note that are NOT geopolitical baseline
-// evidence, so they must never be quoted as the threat weight: absence and
-// partial-coverage phrasing, the transit-anomaly signal (it describes observed
-// traffic collapse, not the baseline — and it is rendered verbatim in the
-// page's description paragraph anyway), and operator review-hygiene text.
-// The live API always sends a non-empty description, so without this filter
-// every calm waterway would read as threat-driven. Anything left after
-// dropping these is the threat-baseline description behind the scorer's
-// threat weight; every non-normal threat level carries one, so an empty
-// remainder means a normal baseline with no anomaly signal.
-const NON_THREAT_DESCRIPTION_PATTERNS = [
+// Segments of the live status note that are NEITHER the threat baseline NOR
+// the anomaly signal: absence/coverage phrasing and operator review-hygiene
+// text. The live API always sends a non-empty description, so without this
+// filter every calm waterway would read as threat-driven.
+const NON_SCORE_DESCRIPTION_PATTERNS = [
   /no active disruptions/i,
   /source coverage incomplete/i,
-  /traffic down \d+% vs .*baseline/i,
   /threat baseline last reviewed/i,
 ];
 
-function threatBaselineDescription(description) {
-  const kept = String(description || '')
+// The transit-anomaly signal (+10 score bonus) is observed traffic collapse,
+// not baseline — surface it as its own clause, never as the threat weight.
+const ANOMALY_DESCRIPTION_PATTERN = /traffic down \d+% vs .*baseline.*/i;
+
+function splitScoreDescription(description) {
+  const segments = String(description || '')
     .split(';')
     .map((segment) => segment.trim())
-    .filter((segment) => segment
-      && !NON_THREAT_DESCRIPTION_PATTERNS.some((pattern) => pattern.test(segment)));
-  return kept.length ? kept.join('; ') : null;
+    .filter(Boolean);
+  const anomaly = segments.find((segment) => ANOMALY_DESCRIPTION_PATTERN.test(segment)) ?? null;
+  const threatSegments = segments.filter((segment) => segment !== anomaly
+    && !NON_SCORE_DESCRIPTION_PATTERNS.some((pattern) => pattern.test(segment)));
+  return {
+    threat: threatSegments.length ? threatSegments.join('; ') : null,
+    anomaly,
+  };
 }
 
 function chokepointArticleName(displayName) {
@@ -182,10 +184,10 @@ export function chokepointOpenStatusSentence({ displayName, score, asOfText, tod
 
 // Score-driver sentence for /chokepoints/* pages (#7613): names what set the
 // score — the baseline geopolitical threat weight, the observed snapshot
-// inputs, or both — so the number is attributable rather than bare. Only the
-// threat-baseline segments of the status note count as baseline evidence (see
-// threatBaselineDescription); a null remainder means a normal baseline with no
-// anomaly signal, so the score is entirely observed in that case.
+// signals, or both — so the number is attributable rather than bare. Only the
+// warning count, AIS severity, and anomaly signal feed the formula (see
+// splitScoreDescription); transit counts and congestion readings are context,
+// so they get their own sentence rather than posing as inputs.
 export function chokepointScoreDriverSentence({
   score,
   bandLabel,
@@ -201,19 +203,18 @@ export function chokepointScoreDriverSentence({
   const formatted = Number.isInteger(numeric) ? String(numeric) : String(Math.round(numeric * 10) / 10);
   const warnings = String(warningsLabel || '').trim() || null;
   const ais = String(aisLabel || '').trim() || null;
-  const congestion = String(congestionLabel || '').trim() || null;
+  const inputs = `${warnings ?? 'navigational warnings unavailable'} and ${ais ?? 'AIS disruptions unavailable'} observed in this snapshot`;
+  const { threat, anomaly } = splitScoreDescription(description);
+  const anomalyClause = anomaly ? `, plus the published transit anomaly — ${anomaly}` : '';
+  const congestion = String(congestionLabel || '').trim();
   const transit = todayTransits == null || String(todayTransits).trim() === ''
-    ? 'no published transit count'
-    : `${String(todayTransits).trim()} published transits`;
-  const observed = `${warnings ?? 'navigational warnings unavailable'}, `
-    + `${ais ?? 'AIS disruptions unavailable'}, `
-    + `${congestion ? `${congestion} congestion` : 'congestion not reported'}, `
-    + `and ${transit}`;
-  const threat = threatBaselineDescription(description);
+    ? 'no transit count is published for this snapshot'
+    : `the published transit count is ${String(todayTransits).trim()}`;
+  const context = `Congestion is ${congestion || 'not reported'}; ${transit}.`;
   if (threat) {
-    return `The score of ${formatted} (${band}) builds on the baseline geopolitical threat weight — ${threat} — plus this snapshot's observed inputs: ${observed}.`;
+    return `The score of ${formatted} (${band}) builds on the baseline geopolitical threat weight — ${threat} — with ${inputs}${anomalyClause}. ${context}`;
   }
-  return `The score of ${formatted} (${band}) comes from this snapshot's observed inputs — ${observed} — with no additional geopolitical threat baseline.`;
+  return `The score of ${formatted} (${band}) comes from ${inputs}${anomalyClause}, with no additional geopolitical threat baseline. ${context}`;
 }
 
 function humanizeToken(value, prefixes = []) {

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -38,6 +38,7 @@ import {
   withSchemaContext,
 } from '../scripts/build-crawlable-corpus.mjs';
 import {
+  chokepointEvidenceNarrative,
   MAX_FUTURE_SKEW_MS,
   MAX_LIVE_SNAPSHOT_AGE_MS,
 } from '../scripts/crawlable-live-tools.mjs';
@@ -3267,6 +3268,15 @@ describe('crawlable corpus generator', () => {
         const schemaQuestion = chokepointFaq.mainEntity.find((entry) => entry.name === question);
         assert.equal(schemaQuestion?.acceptedAnswer?.text, visibleAnswer);
       }
+      const scoreAnswer = chokepointFaq.mainEntity.find(
+        (entry) => entry.name === 'How does World Monitor score chokepoint status?',
+      )?.acceptedAnswer?.text;
+      assert.match(scoreAnswer, /maximum AIS severity/);
+      assert.match(scoreAnswer, /AIS event counts[^.]+are context rather than score inputs/);
+      assert.doesNotMatch(
+        chokepointFaq.mainEntity.map((entry) => entry.acceptedAnswer.text).join(' '),
+        /Green means open|Yellow means restricted|Red means effectively closed|maps? to passage status/,
+      );
       const sparseMetricsAnswer = chokepointFaq.mainEntity.find(
         (entry) => entry.name === 'Why do some chokepoint pages show fewer metrics than others?',
       )?.acceptedAnswer?.text;
@@ -3596,22 +3606,22 @@ describe('crawlable corpus generator', () => {
       assert.match(hormuz, /href="\/blog\/glossary\/strait-of-hormuz\/"/);
       assert.match(hormuz, /data-live-chokepoint data-chokepoint-id="hormuz_strait"/);
       assert.match(hormuz, /data-published-pulse/);
-      // #7613: the page answers the open/closed query in the user's own words
-      // before the numeric score, and publishes the band mapping that makes
-      // the binary reproducible.
+      // #7613: keep the open/closed query while answering only from the
+      // evidence this snapshot can support.
       assert.match(hormuz, /<h2>Is Strait of Hormuz open right now\?<\/h2>/);
       assert.match(
         hormuz,
-        /data-chokepoint-open-status>As of [^<]*the Strait of Hormuz is <strong>effectively closed<\/strong> to commercial shipping\. No transit count is published for this snapshot\.</,
+        /data-chokepoint-open-status>As of [^<]*source coverage for the Strait of Hormuz is partial\. No transit count is published for this snapshot\. World Monitor cannot verify operational passage status from this snapshot\.</,
       );
       assert.match(
         hormuz,
-        /data-chokepoint-score-driver>The score of 70 \(Red\) builds on the baseline geopolitical threat weight — Active conflict — Iran-Israel war/,
+        /data-chokepoint-score-driver>The score of 70 \(Red\) has this evidence basis\. Configured geopolitical baseline: Active conflict — Iran-Israel war/,
       );
       assert.match(
         hormuz,
-        /data-chokepoint-status-mapping>World Monitor maps the disruption band to passage status: Green \(score below 20\) means open, Yellow \(20–49\) means restricted, and Red \(50 or above\) means effectively closed/,
+        /Observed score inputs: 0 warnings; maximum AIS severity Normal\. Context only \(not score inputs\): AIS event count \(0 AIS disruptions\); transit count unavailable\./,
       );
+      assert.doesNotMatch(hormuz, /data-chokepoint-status-mapping/);
       assert.ok(hormuz.includes(liveScriptTag), 'chokepoint live script must match the production CSP nonce');
       assert.doesNotMatch(hormuz, /id="app"/, 'chokepoint page must be raw static HTML, not the SPA shell');
       assert.doesNotMatch(hormuz, /Connecting…/);
@@ -3874,39 +3884,66 @@ describe('crawlable corpus generator', () => {
         const meta = chokepointSlugs.get(cpId);
         if (!meta) continue;
         const page = read(outDir, `chokepoints/${meta.slug}/index.html`);
-        // #7613: every detail page answers the open/closed query first-screen
-        // with a band-derived binary, whatever its score is.
-        const numericScore = Number(String(pulse.disruptionScore ?? '').replace(/,/g, ''));
-        assert.ok(
-          Number.isFinite(numericScore),
-          `${meta.name} frozen pulse must carry a finite score for the passage binary`,
-        );
-        const expectedPassage = numericScore < 20 ? 'open' : numericScore < 50 ? 'restricted' : 'effectively closed';
+        // Every page keeps the query heading, but the answer follows source
+        // coverage instead of turning the risk band into a closure verdict.
         assert.match(
           page,
           new RegExp(`<h2>Is ${meta.name} open right now\\?</h2>`),
           `${meta.name} must carry the open/closed query heading`,
         );
-        assert.match(
-          page,
-          new RegExp(`data-chokepoint-open-status>As of [^<]*the ${meta.name} is <strong>${expectedPassage}</strong> to commercial shipping\\.`),
-          `${meta.name} must state its band-derived passage status first-screen`,
+        const document = htmlDocument(page, `https://www.worldmonitor.app/chokepoints/${meta.slug}/`);
+        const passageText = document.querySelector('[data-chokepoint-open-status]')?.textContent ?? '';
+        const asOfText = passageText.match(/^As of (.*), (?:source coverage|the observed transit count)/)?.[1];
+        assert.ok(asOfText, `${meta.name} passage evidence must carry an as-of timestamp`);
+        const expectedNarrative = chokepointEvidenceNarrative({
+          displayName: meta.name,
+          score: pulse.disruptionScore,
+          bandLabel: pulse.status,
+          description: pulse.description,
+          asOfText,
+          partial: pulse.partial === true
+            || pulse.todayTransits == null
+            || pulse.navigationalWarningsAvailable !== true
+            || pulse.aisSnapshotAvailable !== true,
+          warningsLabel: pulse.navigationalWarningsAvailable === true
+            ? pulse.navigationalWarnings
+            : null,
+          congestionLabel: pulse.aisSnapshotAvailable === true ? pulse.congestion : null,
+          aisEventCountLabel: pulse.aisSnapshotAvailable === true ? pulse.aisDisruptions : null,
+          todayTransits: pulse.todayTransits,
+        });
+        assert.equal(passageText, expectedNarrative.passage, `${meta.name} must use the shared passage policy`);
+        assert.equal(
+          document.querySelector('[data-chokepoint-score-driver]')?.textContent,
+          expectedNarrative.scoreDriver,
+          `${meta.name} must use the shared score-driver policy`,
+        );
+        if (expectedNarrative.passage.includes('source coverage')) {
+          assert.match(passageText, /cannot verify operational passage status/);
+        } else {
+          assert.match(passageText, /observed transit count/);
+          assert.match(passageText, /does not verify unrestricted passage or operational closure/);
+        }
+        assert.doesNotMatch(
+          passageText,
+          / is (?:open|restricted|effectively closed) to commercial shipping/,
+          `${meta.name} must not convert the score band into passage status`,
         );
         assert.match(
           page,
           new RegExp(`data-chokepoint-score-driver>The score of ${pulse.disruptionScore} \\(${pulse.status}\\)`),
-          `${meta.name} must attribute its score to the threat baseline and observed inputs`,
+          `${meta.name} must attribute its score`,
         );
         // Absence and coverage notes are never the threat weight, whatever the
         // frozen description carries for this snapshot.
         assert.doesNotMatch(
           page,
-          /baseline geopolitical threat weight — No active disruptions/,
+          /Configured geopolitical baseline: No active disruptions/,
           `${meta.name} must not quote absence as the threat baseline`,
         );
         assert.doesNotMatch(
           page,
-          /baseline geopolitical threat weight — Traffic down/,
+          /Configured geopolitical baseline: Traffic down/,
           `${meta.name} must not quote the transit anomaly as the threat baseline`,
         );
         const raw = Number(String(pulse.todayTransits ?? '').replace(/,/g, ''));

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -3439,7 +3439,22 @@ describe('crawlable corpus generator', () => {
       assert.match(hormuz, /href="\/blog\/glossary\/strait-of-hormuz\/"/);
       assert.match(hormuz, /data-live-chokepoint data-chokepoint-id="hormuz_strait"/);
       assert.match(hormuz, /data-published-pulse/);
-      assert.match(hormuz, /traffic-light badge is a disruption score, not an operational closure declaration/i);
+      // #7613: the page answers the open/closed query in the user's own words
+      // before the numeric score, and publishes the band mapping that makes
+      // the binary reproducible.
+      assert.match(hormuz, /<h2>Is Strait of Hormuz open right now\?<\/h2>/);
+      assert.match(
+        hormuz,
+        /data-chokepoint-open-status>As of [^<]*the Strait of Hormuz is <strong>effectively closed<\/strong> to commercial shipping\. No transit count is published for this snapshot\.</,
+      );
+      assert.match(
+        hormuz,
+        /data-chokepoint-score-driver>The score of 70 \(Red\) builds on the baseline geopolitical threat weight — Active conflict — Iran-Israel war/,
+      );
+      assert.match(
+        hormuz,
+        /data-chokepoint-status-mapping>World Monitor maps the disruption band to passage status: Green \(score below 20\) means open, Yellow \(20–49\) means restricted, and Red \(50 or above\) means effectively closed/,
+      );
       assert.ok(hormuz.includes(liveScriptTag), 'chokepoint live script must match the production CSP nonce');
       assert.doesNotMatch(hormuz, /id="app"/, 'chokepoint page must be raw static HTML, not the SPA shell');
       assert.doesNotMatch(hormuz, /Connecting…/);
@@ -3702,6 +3717,41 @@ describe('crawlable corpus generator', () => {
         const meta = chokepointSlugs.get(cpId);
         if (!meta) continue;
         const page = read(outDir, `chokepoints/${meta.slug}/index.html`);
+        // #7613: every detail page answers the open/closed query first-screen
+        // with a band-derived binary, whatever its score is.
+        const numericScore = Number(String(pulse.disruptionScore ?? '').replace(/,/g, ''));
+        assert.ok(
+          Number.isFinite(numericScore),
+          `${meta.name} frozen pulse must carry a finite score for the passage binary`,
+        );
+        const expectedPassage = numericScore < 20 ? 'open' : numericScore < 50 ? 'restricted' : 'effectively closed';
+        assert.match(
+          page,
+          new RegExp(`<h2>Is ${meta.name} open right now\\?</h2>`),
+          `${meta.name} must carry the open/closed query heading`,
+        );
+        assert.match(
+          page,
+          new RegExp(`data-chokepoint-open-status>As of [^<]*the ${meta.name} is <strong>${expectedPassage}</strong> to commercial shipping\\.`),
+          `${meta.name} must state its band-derived passage status first-screen`,
+        );
+        assert.match(
+          page,
+          new RegExp(`data-chokepoint-score-driver>The score of ${pulse.disruptionScore} \\(${pulse.status}\\)`),
+          `${meta.name} must attribute its score to the threat baseline and observed inputs`,
+        );
+        // Absence and coverage notes are never the threat weight, whatever the
+        // frozen description carries for this snapshot.
+        assert.doesNotMatch(
+          page,
+          /baseline geopolitical threat weight — No active disruptions/,
+          `${meta.name} must not quote absence as the threat baseline`,
+        );
+        assert.doesNotMatch(
+          page,
+          /baseline geopolitical threat weight — Traffic down/,
+          `${meta.name} must not quote the transit anomaly as the threat baseline`,
+        );
         const raw = Number(String(pulse.todayTransits ?? '').replace(/,/g, ''));
         const noteRe = new RegExp(
           `World Monitor is not currently publishing a transit count for ${meta.name} for this period`,

--- a/tests/crawlable-live-tools.test.mjs
+++ b/tests/crawlable-live-tools.test.mjs
@@ -6,9 +6,7 @@ import {
   airportDisruptionViewModel,
   ciiRankingViewModel,
   chokepointCoverageMetrics,
-  chokepointOpenStatusSentence,
-  chokepointPassageStatus,
-  chokepointScoreDriverSentence,
+  chokepointEvidenceNarrative,
   chokepointStatusViewModel,
   crisisTrackerViewModel,
   hasPublishedLivePulse,
@@ -480,14 +478,14 @@ describe('crawlable live intelligence view models', () => {
     assert.equal(tool.querySelector('[data-chokepoint-transits-note]').hidden, true);
   });
 
-  it('refreshes the open/closed sentence and score driver on live update (#7613)', async () => {
+  it('refreshes the passage evidence and score driver together on live update (#7613)', async () => {
     const window = new Window({ url: 'https://www.worldmonitor.app/chokepoints/strait-of-hormuz/' });
     const { document } = window;
     document.body.innerHTML = `
       <section class="live-tool" data-live-chokepoint data-chokepoint-id="hormuz_strait" data-chokepoint-name="Strait of Hormuz" data-state="ready">
         <h2>Is Strait of Hormuz open right now?</h2>
-        <p data-chokepoint-open-status>As of Sep 2, 2026, the Strait of Hormuz is restricted to commercial shipping.</p>
-        <p data-chokepoint-score-driver>The score of 35 (Yellow) comes from this snapshot's observed inputs.</p>
+        <p data-chokepoint-open-status>Old passage evidence.</p>
+        <p data-chokepoint-score-driver>Old score inputs.</p>
         <span class="live-status" data-live-status>Published pulse</span>
         <div class="grid" data-live-grid>
           <div class="metric"><strong><span data-chokepoint-score>35</span><small data-chokepoint-band>Yellow</small></strong></div>
@@ -540,11 +538,81 @@ describe('crawlable live intelligence view models', () => {
 
     assert.match(
       tool.querySelector('[data-chokepoint-open-status]').textContent,
-      /the Strait of Hormuz is effectively closed to commercial shipping\. Today's transit count is 6\./,
+      /the observed transit count for the Strait of Hormuz is 6\. The Red disruption score is a risk signal; it does not verify unrestricted passage or operational closure\./,
     );
     assert.match(
       tool.querySelector('[data-chokepoint-score-driver]').textContent,
-      /The score of 70 \(Red\) builds on the baseline geopolitical threat weight — Active conflict\./,
+      /Configured geopolitical baseline: Active conflict\. Observed score inputs: 0 warnings; maximum AIS severity Normal\. Context only \(not score inputs\): AIS event count \(0 AIS disruptions\); transit count \(6\)\./,
+    );
+  });
+
+  it('does not hydrate a definitive passage status from partial source coverage', async () => {
+    const window = new Window({ url: 'https://www.worldmonitor.app/chokepoints/taiwan-strait/' });
+    const { document } = window;
+    document.body.innerHTML = `
+      <section class="live-tool" data-live-chokepoint data-chokepoint-id="taiwan_strait" data-chokepoint-name="Taiwan Strait" data-state="ready">
+        <p data-chokepoint-open-status>Old passage evidence.</p>
+        <p data-chokepoint-score-driver>Old score inputs.</p>
+        <span class="live-status" data-live-status>Published pulse</span>
+        <div class="grid" data-live-grid>
+          <div class="metric"><strong><span data-chokepoint-score>20</span><small data-chokepoint-band>Yellow</small></strong></div>
+          <div class="metric"><strong data-chokepoint-congestion>Low</strong></div>
+          <div class="metric"><strong data-chokepoint-warnings>0 warnings</strong></div>
+          <div class="metric"><strong data-chokepoint-ais-disruptions>1 AIS disruption</strong></div>
+          <div class="metric"><strong data-chokepoint-transits>12</strong></div>
+          <div class="metric"><strong data-chokepoint-movement>Stable</strong></div>
+        </div>
+        <p data-chokepoint-description></p>
+        <p data-chokepoint-transits-note hidden></p>
+        <time data-live-updated datetime="2026-08-30T12:00:00.000Z">Published pulse Aug 30, 2026</time>
+      </section>
+    `;
+    const tool = document.querySelector('[data-live-chokepoint]');
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url).includes('get-chokepoint-status')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            fetchedAt: new Date(Date.now() - 60_000).toISOString(),
+            upstreamUnavailable: false,
+            chokepoints: [{
+              id: 'taiwan_strait',
+              disruptionScore: 20,
+              status: 'yellow',
+              congestionLevel: 'low',
+              activeWarnings: 0,
+              navigationalWarningsAvailable: false,
+              aisDisruptions: 1,
+              aisSnapshotAvailable: true,
+              description: 'Cross-strait military tensions',
+              transitSummary: {
+                dataAvailable: true,
+                todayTotal: 12,
+                todayCountsAvailable: true,
+                wowChangePct: 0,
+              },
+            }],
+          }),
+        };
+      }
+      return anonymousSessionResponse();
+    };
+    try {
+      await loadChokepoint(tool);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const passage = tool.querySelector('[data-chokepoint-open-status]').textContent;
+    assert.match(passage, /source coverage for the Taiwan Strait is partial/);
+    assert.match(passage, /observed transit count is 12/);
+    assert.match(passage, /cannot verify operational passage status/);
+    assert.doesNotMatch(passage, / is (?:open|restricted|effectively closed) /);
+    assert.match(
+      tool.querySelector('[data-chokepoint-score-driver]').textContent,
+      /Observed score inputs: maximum AIS severity Low\. Unavailable score inputs: navigational warning count\./,
     );
   });
 
@@ -619,145 +687,111 @@ describe('crawlable live intelligence view models', () => {
     assert.match(withheldTransitCountSentence(''), /for this chokepoint for this period/);
   });
 
-  it('maps disruption bands to passage status for the open/closed binary (#7613)', () => {
-    // Bands mirror the traffic-light badge so the binary is reproducible.
-    assert.equal(chokepointPassageStatus(0), 'open');
-    assert.equal(chokepointPassageStatus(19.9), 'open');
-    assert.equal(chokepointPassageStatus(20), 'restricted');
-    assert.equal(chokepointPassageStatus('35'), 'restricted');
-    assert.equal(chokepointPassageStatus(49.9), 'restricted');
-    assert.equal(chokepointPassageStatus(50), 'effectively closed');
-    assert.equal(chokepointPassageStatus('70'), 'effectively closed');
-    assert.equal(chokepointPassageStatus(100), 'effectively closed');
-    assert.equal(chokepointPassageStatus(null), null);
-    assert.equal(chokepointPassageStatus(Number.NaN), null);
-    assert.equal(chokepointPassageStatus(-1), null);
-    assert.equal(chokepointPassageStatus(101), null);
-    assert.equal(chokepointPassageStatus('Red'), null);
+  it('keeps maximum AIS severity as a score input and AIS event count as context', () => {
+    const narrative = chokepointEvidenceNarrative({
+      displayName: 'Suez Canal',
+      score: '35',
+      bandLabel: 'Yellow',
+      description: 'JWC Listed Area',
+      asOfText: 'Sep 3, 2026, 6:25 AM UTC',
+      partial: false,
+      warningsLabel: '1 warning',
+      congestionLabel: 'High',
+      aisEventCountLabel: '7 AIS disruptions',
+      todayTransits: '2',
+    });
+    assert.deepEqual(narrative, {
+      passage: 'As of Sep 3, 2026, 6:25 AM UTC, the observed transit count for the Suez Canal is 2.'
+        + ' The Yellow disruption score is a risk signal; it does not verify unrestricted passage or operational closure.',
+      scoreDriver: 'The score of 35 (Yellow) has this evidence basis.'
+        + ' Configured geopolitical baseline: JWC Listed Area.'
+        + ' Observed score inputs: 1 warning; maximum AIS severity High.'
+        + ' Context only (not score inputs): AIS event count (7 AIS disruptions); transit count (2).',
+    });
+    assert.doesNotMatch(narrative.scoreDriver, /Observed score inputs:[^.]*7 AIS disruptions/);
   });
 
-  it('states the open/closed binary first-screen with the transit count (#7613)', () => {
-    assert.equal(
-      chokepointOpenStatusSentence({
-        displayName: 'Strait of Hormuz',
-        score: 70,
-        asOfText: 'Sep 3, 2026, 6:25 AM UTC',
-        todayTransits: null,
-      }),
-      'As of Sep 3, 2026, 6:25 AM UTC, the Strait of Hormuz is effectively closed to commercial shipping.'
-      + ' No transit count is published for this snapshot.',
-    );
-    assert.equal(
-      chokepointOpenStatusSentence({
-        displayName: 'Suez Canal',
-        score: '35',
-        asOfText: 'Sep 3, 2026, 6:25 AM UTC',
-        todayTransits: '2',
-      }),
-      'As of Sep 3, 2026, 6:25 AM UTC, the Suez Canal is restricted to commercial shipping.'
-      + " Today's transit count is 2.",
-    );
-    assert.equal(
-      chokepointOpenStatusSentence({
-        displayName: 'Panama Canal',
-        score: 0,
-        asOfText: 'Sep 3, 2026, 6:25 AM UTC',
-        todayTransits: null,
-      }),
-      'As of Sep 3, 2026, 6:25 AM UTC, the Panama Canal is open to commercial shipping.'
-      + ' No transit count is published for this snapshot.',
-    );
-    assert.equal(chokepointOpenStatusSentence({
-      displayName: 'Strait of Hormuz',
-      score: null,
-      asOfText: 'Sep 3, 2026',
+  it('withholds definitive passage status for partial coverage and names one missing score source', () => {
+    const narrative = chokepointEvidenceNarrative({
+      displayName: 'Taiwan Strait',
+      score: 20,
+      bandLabel: 'Yellow',
+      description: 'Cross-strait military tensions',
+      asOfText: 'Sep 3, 2026, 6:25 AM UTC',
+      partial: true,
+      warningsLabel: null,
+      congestionLabel: 'Low',
+      aisEventCountLabel: '1 AIS disruption',
+      todayTransits: '12',
+    });
+    assert.match(narrative.passage, /source coverage for the Taiwan Strait is partial/);
+    assert.match(narrative.passage, /observed transit count is 12/);
+    assert.match(narrative.passage, /cannot verify operational passage status/);
+    assert.doesNotMatch(narrative.passage, / is (?:open|restricted|effectively closed) /);
+    assert.match(narrative.scoreDriver, /Observed score inputs: maximum AIS severity Low\./);
+    assert.match(narrative.scoreDriver, /Unavailable score inputs: navigational warning count\./);
+    assert.doesNotMatch(narrative.scoreDriver, /unavailable[^.]*observed/i);
+  });
+
+  it('separates both missing score sources from observed inputs', () => {
+    const narrative = chokepointEvidenceNarrative({
+      displayName: 'Panama Canal',
+      score: 0,
+      bandLabel: 'Green',
+      description: 'source coverage incomplete',
+      partial: true,
+      warningsLabel: null,
+      congestionLabel: null,
+      aisEventCountLabel: null,
       todayTransits: null,
-    }), null, 'an unusable score must fall back to the unavailable note');
+    });
+    assert.match(narrative.passage, /No transit count is published/);
+    assert.match(narrative.passage, /cannot verify operational passage status/);
+    assert.match(narrative.scoreDriver, /Observed score inputs: none available\./);
+    assert.match(
+      narrative.scoreDriver,
+      /Unavailable score inputs: navigational warning count; maximum AIS severity\./,
+    );
+    assert.match(narrative.scoreDriver, /AIS event count unavailable; transit count unavailable/);
   });
 
-  it('attributes the score to the threat baseline and scoring signals (#7613)', () => {
-    assert.equal(
-      chokepointScoreDriverSentence({
-        score: '70',
-        bandLabel: 'Red',
-        description: 'Active conflict — Iran-Israel war; Iranian naval blockade risk and mines reported in Persian Gulf',
-        warningsLabel: '0 warnings',
-        aisLabel: '0 AIS disruptions',
-        congestionLabel: 'Normal',
-        todayTransits: null,
-      }),
-      'The score of 70 (Red) builds on the baseline geopolitical threat weight'
-      + ' — Active conflict — Iran-Israel war; Iranian naval blockade risk and mines reported in Persian Gulf'
-      + ' — with 0 warnings and 0 AIS disruptions observed in this snapshot.'
-      + ' Congestion is Normal; no transit count is published for this snapshot.',
-    );
-    assert.equal(
-      chokepointScoreDriverSentence({
-        score: 0,
-        bandLabel: 'Green',
-        description: null,
-        warningsLabel: '0 warnings',
-        aisLabel: '0 AIS disruptions',
-        congestionLabel: 'Normal',
-        todayTransits: null,
-      }),
-      'The score of 0 (Green) comes from 0 warnings and 0 AIS disruptions observed in this snapshot,'
-      + ' with no additional geopolitical threat baseline.'
-      + ' Congestion is Normal; no transit count is published for this snapshot.',
-    );
-    assert.equal(chokepointScoreDriverSentence({
-      score: null,
-      bandLabel: 'Red',
-      description: 'Active conflict.',
-      warningsLabel: '0 warnings',
-      aisLabel: '0 AIS disruptions',
-      congestionLabel: 'Normal',
-      todayTransits: null,
-    }), null);
-  });
-
-  it('never quotes absence or coverage notes as the threat baseline (#7613)', () => {
-    // The live API always sends a description, so calm and partial-coverage
-    // waterways must read as observed, not threat-driven.
+  it('keeps the traffic anomaly as a score input and filters coverage notes from the baseline', () => {
     for (const description of [
       'No active disruptions',
       'No active disruptions reported by available sources; source coverage incomplete',
       'Threat baseline last reviewed > 120 days ago — review recommended',
     ]) {
-      assert.equal(
-        chokepointScoreDriverSentence({
-          score: 0,
-          bandLabel: 'Green',
-          description,
-          warningsLabel: '0 warnings',
-          aisLabel: '0 AIS disruptions',
-          congestionLabel: 'Normal',
-          todayTransits: null,
-        }),
-        'The score of 0 (Green) comes from 0 warnings and 0 AIS disruptions observed in this snapshot,'
-        + ' with no additional geopolitical threat baseline.'
-        + ' Congestion is Normal; no transit count is published for this snapshot.',
-        `must not quote as threat: ${description}`,
-      );
-    }
-    // Threat plus anomaly quotes the threat as baseline and surfaces the
-    // anomaly (+10 bonus) as its own clause — never as the threat weight.
-    assert.equal(
-      chokepointScoreDriverSentence({
-        score: 80,
-        bandLabel: 'Red',
-        description: 'Active conflict — blockade risk; Traffic down 55% vs 30-day baseline, vessels may be transiting dark (AIS off)',
+      const narrative = chokepointEvidenceNarrative({
+        displayName: 'Panama Canal',
+        score: 0,
+        bandLabel: 'Green',
+        description,
+        partial: false,
         warningsLabel: '0 warnings',
-        aisLabel: '0 AIS disruptions',
         congestionLabel: 'Normal',
+        aisEventCountLabel: '0 AIS disruptions',
         todayTransits: null,
-      }),
-      'The score of 80 (Red) builds on the baseline geopolitical threat weight'
-      + ' — Active conflict — blockade risk'
-      + ' — with 0 warnings and 0 AIS disruptions observed in this snapshot,'
-      + ' plus the published transit anomaly — Traffic down 55% vs 30-day baseline, vessels may be transiting dark (AIS off).'
-      + ' Congestion is Normal; no transit count is published for this snapshot.',
+      });
+      assert.match(narrative.scoreDriver, /Configured geopolitical baseline: no additional threat weight\./);
+      assert.doesNotMatch(narrative.scoreDriver, new RegExp(`baseline: ${description}`));
+    }
+    const anomaly = chokepointEvidenceNarrative({
+      displayName: 'Strait of Hormuz',
+      score: 80,
+      bandLabel: 'Red',
+      description: 'Active conflict — blockade risk; Traffic down 55% vs 30-day baseline, vessels may be transiting dark (AIS off)',
+      partial: false,
+      warningsLabel: '0 warnings',
+      congestionLabel: 'Normal',
+      aisEventCountLabel: '0 AIS disruptions',
+      todayTransits: null,
+    });
+    assert.match(anomaly.scoreDriver, /Configured geopolitical baseline: Active conflict — blockade risk\./);
+    assert.match(
+      anomaly.scoreDriver,
+      /Observed score inputs: 0 warnings; maximum AIS severity Normal; transit anomaly — Traffic down 55%/,
     );
+    assert.equal(chokepointEvidenceNarrative({ score: null }), null);
   });
 
   it('aggregates same-period crisis summaries and names missing coverage', () => {
@@ -1367,6 +1401,9 @@ describe('crawlable live intelligence view models', () => {
         <button type="button" data-live-refresh>Refresh</button>
       </section>
       <section class="live-tool" data-live-chokepoint data-chokepoint-id="hormuz_strait" data-state="ready">
+        <h2>Is Strait of Hormuz open right now?</h2>
+        <p data-chokepoint-open-status>Published passage evidence.</p>
+        <p data-chokepoint-score-driver>Published score inputs.</p>
         <span class="live-status" data-live-status>Published pulse</span>
         <div class="grid" data-live-grid aria-busy="false">
           <div class="metric"><strong><span data-chokepoint-score>72</span><small data-chokepoint-band>Red</small></strong></div>
@@ -1405,6 +1442,14 @@ describe('crawlable live intelligence view models', () => {
 
     assert.equal(chokepoint.querySelector('[data-chokepoint-score]').textContent, '72');
     assert.equal(chokepoint.querySelector('[data-chokepoint-band]').textContent, 'Red');
+    assert.equal(
+      chokepoint.querySelector('[data-chokepoint-open-status]').textContent,
+      'Published passage evidence.',
+    );
+    assert.equal(
+      chokepoint.querySelector('[data-chokepoint-score-driver]').textContent,
+      'Published score inputs.',
+    );
     assert.equal(chokepoint.querySelector('[data-live-updated]').getAttribute('datetime'), '2026-08-30T12:00:00.000Z');
     assert.match(chokepoint.querySelector('[data-live-status]').textContent, /published pulse/i);
     assert.equal(chokepoint.dataset.state, 'error');

--- a/tests/crawlable-live-tools.test.mjs
+++ b/tests/crawlable-live-tools.test.mjs
@@ -6,6 +6,9 @@ import {
   airportDisruptionViewModel,
   ciiRankingViewModel,
   chokepointCoverageMetrics,
+  chokepointOpenStatusSentence,
+  chokepointPassageStatus,
+  chokepointScoreDriverSentence,
   chokepointStatusViewModel,
   crisisTrackerViewModel,
   hasPublishedLivePulse,
@@ -477,6 +480,74 @@ describe('crawlable live intelligence view models', () => {
     assert.equal(tool.querySelector('[data-chokepoint-transits-note]').hidden, true);
   });
 
+  it('refreshes the open/closed sentence and score driver on live update (#7613)', async () => {
+    const window = new Window({ url: 'https://www.worldmonitor.app/chokepoints/strait-of-hormuz/' });
+    const { document } = window;
+    document.body.innerHTML = `
+      <section class="live-tool" data-live-chokepoint data-chokepoint-id="hormuz_strait" data-chokepoint-name="Strait of Hormuz" data-state="ready">
+        <h2>Is Strait of Hormuz open right now?</h2>
+        <p data-chokepoint-open-status>As of Sep 2, 2026, the Strait of Hormuz is restricted to commercial shipping.</p>
+        <p data-chokepoint-score-driver>The score of 35 (Yellow) comes from this snapshot's observed inputs.</p>
+        <span class="live-status" data-live-status>Published pulse</span>
+        <div class="grid" data-live-grid>
+          <div class="metric"><strong><span data-chokepoint-score>35</span><small data-chokepoint-band>Yellow</small></strong></div>
+          <div class="metric"><strong data-chokepoint-transits>—</strong></div>
+          <div class="metric"><strong data-chokepoint-movement>—</strong></div>
+        </div>
+        <p data-chokepoint-description></p>
+        <p data-chokepoint-transits-note hidden></p>
+        <time data-live-updated datetime="2026-08-30T12:00:00.000Z">Published pulse Aug 30, 2026</time>
+      </section>
+    `;
+
+    const tool = document.querySelector('[data-live-chokepoint]');
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url).includes('get-chokepoint-status')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            fetchedAt: new Date(Date.now() - 60_000).toISOString(),
+            upstreamUnavailable: false,
+            chokepoints: [{
+              id: 'hormuz_strait',
+              disruptionScore: 70,
+              status: 'red',
+              congestionLevel: 'normal',
+              activeWarnings: 0,
+              navigationalWarningsAvailable: true,
+              aisDisruptions: 0,
+              aisSnapshotAvailable: true,
+              description: 'Active conflict.',
+              transitSummary: {
+                dataAvailable: true,
+                todayTotal: 6,
+                todayCountsAvailable: true,
+                wowChangePct: -14.3,
+              },
+            }],
+          }),
+        };
+      }
+      return anonymousSessionResponse();
+    };
+    try {
+      await loadChokepoint(tool);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.match(
+      tool.querySelector('[data-chokepoint-open-status]').textContent,
+      /the Strait of Hormuz is effectively closed to commercial shipping\. Today's transit count is 6\./,
+    );
+    assert.match(
+      tool.querySelector('[data-chokepoint-score-driver]').textContent,
+      /The score of 70 \(Red\) builds on the baseline geopolitical threat weight — Active conflict\./,
+    );
+  });
+
   // The mirror-parity test this replaces could not do its job: of its ten
   // values only `11` reached a formatter, and it renders identically under
   // every variant, so deleting the formatter outright still passed. The mirror
@@ -546,6 +617,144 @@ describe('crawlable live intelligence view models', () => {
     );
     assert.doesNotMatch(note, /AIS/, 'the note must not attribute the gap to a specific feed');
     assert.match(withheldTransitCountSentence(''), /for this chokepoint for this period/);
+  });
+
+  it('maps disruption bands to passage status for the open/closed binary (#7613)', () => {
+    // Bands mirror the traffic-light badge so the binary is reproducible.
+    assert.equal(chokepointPassageStatus(0), 'open');
+    assert.equal(chokepointPassageStatus(19.9), 'open');
+    assert.equal(chokepointPassageStatus(20), 'restricted');
+    assert.equal(chokepointPassageStatus('35'), 'restricted');
+    assert.equal(chokepointPassageStatus(49.9), 'restricted');
+    assert.equal(chokepointPassageStatus(50), 'effectively closed');
+    assert.equal(chokepointPassageStatus('70'), 'effectively closed');
+    assert.equal(chokepointPassageStatus(100), 'effectively closed');
+    assert.equal(chokepointPassageStatus(null), null);
+    assert.equal(chokepointPassageStatus(Number.NaN), null);
+    assert.equal(chokepointPassageStatus(-1), null);
+    assert.equal(chokepointPassageStatus(101), null);
+    assert.equal(chokepointPassageStatus('Red'), null);
+  });
+
+  it('states the open/closed binary first-screen with the transit count (#7613)', () => {
+    assert.equal(
+      chokepointOpenStatusSentence({
+        displayName: 'Strait of Hormuz',
+        score: 70,
+        asOfText: 'Sep 3, 2026, 6:25 AM UTC',
+        todayTransits: null,
+      }),
+      'As of Sep 3, 2026, 6:25 AM UTC, the Strait of Hormuz is effectively closed to commercial shipping.'
+      + ' No transit count is published for this snapshot.',
+    );
+    assert.equal(
+      chokepointOpenStatusSentence({
+        displayName: 'Suez Canal',
+        score: '35',
+        asOfText: 'Sep 3, 2026, 6:25 AM UTC',
+        todayTransits: '2',
+      }),
+      'As of Sep 3, 2026, 6:25 AM UTC, the Suez Canal is restricted to commercial shipping.'
+      + " Today's transit count is 2.",
+    );
+    assert.equal(
+      chokepointOpenStatusSentence({
+        displayName: 'Panama Canal',
+        score: 0,
+        asOfText: 'Sep 3, 2026, 6:25 AM UTC',
+        todayTransits: null,
+      }),
+      'As of Sep 3, 2026, 6:25 AM UTC, the Panama Canal is open to commercial shipping.'
+      + ' No transit count is published for this snapshot.',
+    );
+    assert.equal(chokepointOpenStatusSentence({
+      displayName: 'Strait of Hormuz',
+      score: null,
+      asOfText: 'Sep 3, 2026',
+      todayTransits: null,
+    }), null, 'an unusable score must fall back to the unavailable note');
+  });
+
+  it('attributes the score to the threat baseline and observed inputs (#7613)', () => {
+    assert.equal(
+      chokepointScoreDriverSentence({
+        score: '70',
+        bandLabel: 'Red',
+        description: 'Active conflict — Iran-Israel war; Iranian naval blockade risk and mines reported in Persian Gulf',
+        warningsLabel: '0 warnings',
+        aisLabel: '0 AIS disruptions',
+        congestionLabel: 'Normal',
+        todayTransits: null,
+      }),
+      'The score of 70 (Red) builds on the baseline geopolitical threat weight'
+      + ' — Active conflict — Iran-Israel war; Iranian naval blockade risk and mines reported in Persian Gulf'
+      + " — plus this snapshot's observed inputs: 0 warnings, 0 AIS disruptions, Normal congestion, and no published transit count.",
+    );
+    assert.equal(
+      chokepointScoreDriverSentence({
+        score: 0,
+        bandLabel: 'Green',
+        description: null,
+        warningsLabel: '0 warnings',
+        aisLabel: '0 AIS disruptions',
+        congestionLabel: 'Normal',
+        todayTransits: null,
+      }),
+      "The score of 0 (Green) comes from this snapshot's observed inputs"
+      + ' — 0 warnings, 0 AIS disruptions, Normal congestion, and no published transit count'
+      + ' — with no additional geopolitical threat baseline.',
+    );
+    assert.equal(chokepointScoreDriverSentence({
+      score: null,
+      bandLabel: 'Red',
+      description: 'Active conflict.',
+      warningsLabel: '0 warnings',
+      aisLabel: '0 AIS disruptions',
+      congestionLabel: 'Normal',
+      todayTransits: null,
+    }), null);
+  });
+
+  it('never quotes absence or coverage notes as the threat baseline (#7613)', () => {
+    // The live API always sends a description, so calm and partial-coverage
+    // waterways must read as observed, not threat-driven.
+    for (const description of [
+      'No active disruptions',
+      'No active disruptions reported by available sources; source coverage incomplete',
+      'Threat baseline last reviewed > 120 days ago — review recommended',
+    ]) {
+      assert.equal(
+        chokepointScoreDriverSentence({
+          score: 0,
+          bandLabel: 'Green',
+          description,
+          warningsLabel: '0 warnings',
+          aisLabel: '0 AIS disruptions',
+          congestionLabel: 'Normal',
+          todayTransits: null,
+        }),
+        "The score of 0 (Green) comes from this snapshot's observed inputs"
+        + ' — 0 warnings, 0 AIS disruptions, Normal congestion, and no published transit count'
+        + ' — with no additional geopolitical threat baseline.',
+        `must not quote as threat: ${description}`,
+      );
+    }
+    // Threat plus anomaly quotes only the threat; the anomaly is observed
+    // traffic and is already rendered verbatim in the description paragraph.
+    assert.equal(
+      chokepointScoreDriverSentence({
+        score: 80,
+        bandLabel: 'Red',
+        description: 'Active conflict — blockade risk; Traffic down 55% vs 30-day baseline, vessels may be transiting dark (AIS off)',
+        warningsLabel: '0 warnings',
+        aisLabel: '0 AIS disruptions',
+        congestionLabel: 'Normal',
+        todayTransits: null,
+      }),
+      'The score of 80 (Red) builds on the baseline geopolitical threat weight'
+      + ' — Active conflict — blockade risk'
+      + " — plus this snapshot's observed inputs: 0 warnings, 0 AIS disruptions, Normal congestion, and no published transit count.",
+    );
   });
 
   it('aggregates same-period crisis summaries and names missing coverage', () => {

--- a/tests/crawlable-live-tools.test.mjs
+++ b/tests/crawlable-live-tools.test.mjs
@@ -675,7 +675,7 @@ describe('crawlable live intelligence view models', () => {
     }), null, 'an unusable score must fall back to the unavailable note');
   });
 
-  it('attributes the score to the threat baseline and observed inputs (#7613)', () => {
+  it('attributes the score to the threat baseline and scoring signals (#7613)', () => {
     assert.equal(
       chokepointScoreDriverSentence({
         score: '70',
@@ -688,7 +688,8 @@ describe('crawlable live intelligence view models', () => {
       }),
       'The score of 70 (Red) builds on the baseline geopolitical threat weight'
       + ' — Active conflict — Iran-Israel war; Iranian naval blockade risk and mines reported in Persian Gulf'
-      + " — plus this snapshot's observed inputs: 0 warnings, 0 AIS disruptions, Normal congestion, and no published transit count.",
+      + ' — with 0 warnings and 0 AIS disruptions observed in this snapshot.'
+      + ' Congestion is Normal; no transit count is published for this snapshot.',
     );
     assert.equal(
       chokepointScoreDriverSentence({
@@ -700,9 +701,9 @@ describe('crawlable live intelligence view models', () => {
         congestionLabel: 'Normal',
         todayTransits: null,
       }),
-      "The score of 0 (Green) comes from this snapshot's observed inputs"
-      + ' — 0 warnings, 0 AIS disruptions, Normal congestion, and no published transit count'
-      + ' — with no additional geopolitical threat baseline.',
+      'The score of 0 (Green) comes from 0 warnings and 0 AIS disruptions observed in this snapshot,'
+      + ' with no additional geopolitical threat baseline.'
+      + ' Congestion is Normal; no transit count is published for this snapshot.',
     );
     assert.equal(chokepointScoreDriverSentence({
       score: null,
@@ -733,14 +734,14 @@ describe('crawlable live intelligence view models', () => {
           congestionLabel: 'Normal',
           todayTransits: null,
         }),
-        "The score of 0 (Green) comes from this snapshot's observed inputs"
-        + ' — 0 warnings, 0 AIS disruptions, Normal congestion, and no published transit count'
-        + ' — with no additional geopolitical threat baseline.',
+        'The score of 0 (Green) comes from 0 warnings and 0 AIS disruptions observed in this snapshot,'
+        + ' with no additional geopolitical threat baseline.'
+        + ' Congestion is Normal; no transit count is published for this snapshot.',
         `must not quote as threat: ${description}`,
       );
     }
-    // Threat plus anomaly quotes only the threat; the anomaly is observed
-    // traffic and is already rendered verbatim in the description paragraph.
+    // Threat plus anomaly quotes the threat as baseline and surfaces the
+    // anomaly (+10 bonus) as its own clause — never as the threat weight.
     assert.equal(
       chokepointScoreDriverSentence({
         score: 80,
@@ -753,7 +754,9 @@ describe('crawlable live intelligence view models', () => {
       }),
       'The score of 80 (Red) builds on the baseline geopolitical threat weight'
       + ' — Active conflict — blockade risk'
-      + " — plus this snapshot's observed inputs: 0 warnings, 0 AIS disruptions, Normal congestion, and no published transit count.",
+      + ' — with 0 warnings and 0 AIS disruptions observed in this snapshot,'
+      + ' plus the published transit anomaly — Traffic down 55% vs 30-day baseline, vessels may be transiting dark (AIS off).'
+      + ' Congestion is Normal; no transit count is published for this snapshot.',
     );
   });
 


### PR DESCRIPTION
Closes #7613.

## Gap
/chokepoints/strait-of-hormuz/ led with a numeric disruption score (70 Red) and never stated whether the waterway is open or closed — a scoring-vocabulary vs query-vocabulary mismatch, not a data gap.

## Fix (all 13 detail pages)
1. First-screen binary in the user's words, ahead of the score grid: 'As of {timestamp}, the {waterway} is **open / restricted / effectively closed** to commercial shipping.' followed by the transit count (published count, or withheld note).
2. New H2 matching the query string: 'Is {waterway} open right now?'
3. Score→status mapping published on-page, in the hub FAQ, and in the methodology so the binary is reproducible: Green (<20) = open, Yellow (20-49) = restricted, Red (>=50) = effectively closed. The score badge stays as the supporting detail below.
4. Score-driver sentence attributing the number to the baseline geopolitical threat weight and/or the snapshot's observed inputs (warnings, AIS disruptions, congestion, transits). Only genuine threat-baseline segments are quoted — absence/coverage/anomaly phrasing is never misattributed as threat weight.
5. Live refresh (live-tools.js) updates the binary + driver on each API result; failures keep the last published pulse.

Deliberate call: the binary is a pure band mapping per the issue (reproducible, not editorial). Red + flowing transits can co-occur; the page always pairs the binary with the actual count, score, and driver for nuance.

Also regenerated public/llms-full.txt (embeds the methodology edit).

## Verification
- tests/crawlable-corpus.test.mjs (64), crawlable-live-tools (42), scenario-doc-parity, page-content, freeze, resilience, seo-geo-residue: 141/141 pass via tsx runner
- Independent review: fixed threat-baseline misattribution + coercion hardening; band-mapping prescription kept per issue