### PR TITLE
feat(mcp-proxy): emit wm_api_usage rows and stop swallowing handler faults

### DIFF
--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -15,6 +15,23 @@ import {
 import { MAX_JSON_RPC_BODY_BYTES, MAX_MCP_PROXY_RESPONSE_BYTES } from './mcp/body-limits';
 import { McpProxyJsonDepthError, parseMcpProxyJson } from './mcp/bounded-json';
 import { ENDPOINT_RATE_POLICIES, checkScopedRateLimit, getClientIp } from '../server/_shared/rate-limit';
+import { captureSilentError } from './_sentry-edge.js';
+import {
+  buildRequestEvent,
+  deriveAcceptLanguage,
+  deriveCountry,
+  deriveExecutionRegion,
+  deriveHost,
+  deriveIp,
+  deriveIpCity,
+  deriveIpRegion,
+  deriveReferer,
+  deriveReqBytes,
+  deriveRequestId,
+  deriveSentryTraceId,
+  deriveUserAgent,
+  emitUsageEvents,
+} from '../server/_shared/usage';
 
 export const config = { runtime: 'edge' };
 
@@ -62,6 +79,86 @@ function logProxyCall(entry: {
     ts: new Date().toISOString(),
     ...entry,
   });
+}
+
+// Map a terminal proxy status onto the closed RequestReason union. Mirrors
+// server/gateway.ts: `reason` names why WE short-circuited, and anything that
+// reached its natural outcome emits 'ok' with the real status alongside — so
+// an upstream 504/422 is `ok`/504, not a made-up rejection label.
+//
+// Exported as a test seam. This file is `@ts-nocheck`, so a typo here would
+// NOT be caught by tsc against the RequestReason union — it would ship a row
+// Axiom queries can never match. tests/mcp-proxy.test.mjs pins every branch.
+export function proxyReasonFor(status: number): string {
+  if (status === 403) return 'origin_403';
+  if (status === 401) return 'auth_401';
+  if (status === 429) return 'rate_limit_429';
+  if (status === 405) return 'method_not_allowed';
+  if (status === 400 || status === 413) return 'malformed_request';
+  return 'ok';
+}
+
+/**
+ * Emit one wm_api_usage RequestEvent per proxied call.
+ *
+ * Before this, `logProxyCall` was the ONLY record of a proxy request and it is
+ * `console.log` — Vercel runtime logs are a live tail with no historical query,
+ * so `/api/mcp-proxy` had ZERO rows in Axiom and its failure rate could not be
+ * asked about after the fact. That is the same hole #4866 closed for `/mcp`;
+ * this reuses the gateway's builders so rows are byte-compatible and joinable
+ * on customer_id. `logProxyCall` stays: it carries target_host/header_names,
+ * which the usage envelope has no field for, and existing log-ingest tooling
+ * parses its shape.
+ *
+ * OPTIONS preflights are deliberately NOT emitted — a static 204 that cannot
+ * fail would double row volume for no diagnostic value. /mcp skips them too
+ * (McpUsage.skip).
+ */
+function emitProxyUsage(req, status: number, durationMs: number, ctx): void {
+  if (!ctx) return;
+  try {
+    emitUsageEvents(ctx, [buildRequestEvent({
+      requestId: deriveRequestId(req),
+      domain: 'mcp',
+      route: '/api/mcp-proxy',
+      method: req.method,
+      status,
+      // Measured from handler entry, so this INCLUDES the auth/rate-limit
+      // gates — unlike logProxyCall's `started`, which begins after auth.
+      // The usage row is the end-to-end caller-visible latency.
+      durationMs,
+      reqBytes: deriveReqBytes(req),
+      // Not tracked: the proxy streams upstream bodies through bounded readers
+      // and jsonResponse sets no content-length, so there is no byte count to
+      // report without buffering a second time. Size questions belong to
+      // MAX_MCP_PROXY_RESPONSE_BYTES, not to this row.
+      resBytes: 0,
+      // The proxy gate is isCallerPremium, which does not hand back an
+      // identity — so there is no customer to attribute. Join on ip instead.
+      customerId: null,
+      principalId: null,
+      authKind: 'anon',
+      tier: 0,
+      planKey: null,
+      country: deriveCountry(req),
+      ipCity: deriveIpCity(req),
+      ipRegion: deriveIpRegion(req),
+      executionRegion: deriveExecutionRegion(req),
+      executionPlane: 'vercel-edge',
+      originKind: 'mcp',
+      cacheTier: 'no-store',
+      ip: deriveIp(req),
+      userAgent: deriveUserAgent(req),
+      uaHash: null,
+      referer: deriveReferer(req),
+      acceptLanguage: deriveAcceptLanguage(req),
+      host: deriveHost(req),
+      sentryTraceId: deriveSentryTraceId(req),
+      reason: proxyReasonFor(status),
+    })]);
+  } catch {
+    // Telemetry must never change the caller's outcome.
+  }
 }
 
 const TIMEOUT_MS = 15_000;
@@ -639,11 +736,15 @@ async function handleCallTool(req: Request, cors: Record<string, string>, meta: 
   return jsonResponse({ result }, 200, cors);
 }
 
-export default async function handler(req) {
-  if (isDisallowedOrigin(req))
+export default async function handler(req, ctx) {
+  const startedAt = Date.now();
+  if (isDisallowedOrigin(req)) {
+    emitProxyUsage(req, 403, Date.now() - startedAt, ctx);
     return new Response('Forbidden', { status: 403, headers: withProxyNoStore() });
+  }
 
   const cors = withProxyNoStore(getCorsHeaders(req, 'GET, POST, OPTIONS'));
+  // No emit: see emitProxyUsage — a static 204 preflight carries no signal.
   if (req.method === 'OPTIONS')
     return new Response(null, { status: 204, headers: cors });
 
@@ -670,8 +771,10 @@ export default async function handler(req) {
   // premiumFetch (not plain fetch) so the renderer attaches the Bearer
   // for Pro users; /api/mcp-proxy is now in PREMIUM_RPC_PATHS for that
   // path-gated injection.
-  if (!(await isCallerPremium(req)))
+  if (!(await isCallerPremium(req))) {
+    emitProxyUsage(req, 401, Date.now() - startedAt, ctx);
     return jsonResponse({ error: 'Pro authentication required' }, 401, cors);
+  }
 
   const started = Date.now();
   const ip = getClientIp(req);
@@ -694,6 +797,7 @@ export default async function handler(req) {
       status: 429,
       duration_ms: Date.now() - started,
     });
+    emitProxyUsage(req, 429, Date.now() - startedAt, ctx);
     // JSON-RPC -32029 mirrors api/mcp.ts; HTTP 429 + Retry-After follows the
     // shared rate-limit response shape.
     return new Response(
@@ -728,6 +832,23 @@ export default async function handler(req) {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     const isTimeout = msg.includes('TimeoutError') || msg.includes('timed out');
+    // Until now this catch swallowed EVERY handler fault into a 422/422-shaped
+    // JSON body with no Sentry event, so a genuine proxy defect was visible
+    // only to the caller who hit it. Capture it.
+    //
+    // An upstream timeout is the remote MCP server being slow, not our defect,
+    // so it reports at `warning` — the same call api/telegram-feed.js (#7438)
+    // and api/rss-proxy.js (#7588) already make for relay timeouts. Everything
+    // else stays at `error`.
+    //
+    // targetHost is caller-supplied, so it rides in `extra`, never a tag —
+    // an attacker-controlled tag value would shred Sentry's tag cardinality.
+    captureSilentError(err, {
+      tags: { route: 'api/mcp-proxy', step: 'proxy-dispatch' },
+      extra: { target_host: meta.targetHost, target_path: meta.targetPath, method: req.method },
+      ...(isTimeout ? { level: 'warning' as const } : {}),
+      ctx,
+    });
     // Return 422 (not 502) so Cloudflare proxy does not replace our JSON body with its own HTML error page
     response = jsonResponse({ error: isTimeout ? 'MCP server timed out' : msg }, isTimeout ? 504 : 422, cors);
   }
@@ -741,6 +862,7 @@ export default async function handler(req) {
     status: response.status,
     duration_ms: Date.now() - started,
   });
+  emitProxyUsage(req, response.status, Date.now() - startedAt, ctx);
 
   return response;
 }

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -1,11 +1,11 @@
-// @ts-nocheck — Migrated from .js to .ts only to unlock the
-// `isCallerPremium` import from server/ (PR #3768 review). Body remains
-// JS-shaped; not annotating types in this commit. Future PR can add
-// types incrementally; behaviour is unchanged.
+// @ts-nocheck — Migrated from .js to .ts to import server-side auth helpers
+// (PR #3768 review). Most of the body remains JS-shaped; types can be added
+// incrementally.
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
-import { isCallerPremium } from '../server/_shared/premium-check';
+import { resolvePremiumCallerIdentity } from '../server/_shared/premium-check';
 import { isBlockedResolvedAddress } from '../server/_shared/ip-address-classification';
+import { buildUsageIdentity } from '../server/_shared/usage-identity';
 import {
   readBoundedRequestBody,
   readBoundedResponseBody,
@@ -98,6 +98,45 @@ export function proxyReasonFor(status: number): string {
   return 'ok';
 }
 
+export function proxyUsageIdentityFor(req, identity) {
+  if (!identity?.isPremium) {
+    return buildUsageIdentity({
+      sessionUserId: null,
+      isUserApiKey: false,
+      enterpriseApiKey: null,
+      widgetKey: null,
+      clerkOrgId: null,
+      userApiKeyCustomerRef: null,
+      tier: null,
+      planKey: null,
+    });
+  }
+
+  if (identity.kind === 'internal-mcp') {
+    return {
+      auth_kind: 'mcp_oauth',
+      principal_id: identity.userId,
+      customer_id: identity.userId,
+      tier: 0,
+      plan_key: null,
+    };
+  }
+
+  const enterpriseApiKey = identity.kind === 'enterprise'
+    ? req.headers.get('X-WorldMonitor-Key') ?? req.headers.get('X-Api-Key')
+    : null;
+  return buildUsageIdentity({
+    sessionUserId: identity.userId,
+    isUserApiKey: identity.kind === 'user-api-key',
+    enterpriseApiKey,
+    widgetKey: null,
+    clerkOrgId: null,
+    userApiKeyCustomerRef: null,
+    tier: null,
+    planKey: null,
+  });
+}
+
 /**
  * Emit one wm_api_usage RequestEvent per proxied call.
  *
@@ -114,9 +153,10 @@ export function proxyReasonFor(status: number): string {
  * fail would double row volume for no diagnostic value. /mcp skips them too
  * (McpUsage.skip).
  */
-function emitProxyUsage(req, status: number, durationMs: number, ctx): void {
+function emitProxyUsage(req, status: number, durationMs: number, ctx, callerIdentity = null): void {
   if (!ctx) return;
   try {
+    const usageIdentity = proxyUsageIdentityFor(req, callerIdentity);
     emitUsageEvents(ctx, [buildRequestEvent({
       requestId: deriveRequestId(req),
       domain: 'mcp',
@@ -133,13 +173,11 @@ function emitProxyUsage(req, status: number, durationMs: number, ctx): void {
       // report without buffering a second time. Size questions belong to
       // MAX_MCP_PROXY_RESPONSE_BYTES, not to this row.
       resBytes: 0,
-      // The proxy gate is isCallerPremium, which does not hand back an
-      // identity — so there is no customer to attribute. Join on ip instead.
-      customerId: null,
-      principalId: null,
-      authKind: 'anon',
-      tier: 0,
-      planKey: null,
+      customerId: usageIdentity.customer_id,
+      principalId: usageIdentity.principal_id,
+      authKind: usageIdentity.auth_kind,
+      tier: usageIdentity.tier,
+      planKey: usageIdentity.plan_key,
       country: deriveCountry(req),
       ipCity: deriveIpCity(req),
       ipRegion: deriveIpRegion(req),
@@ -200,6 +238,38 @@ class McpProxySsrfError extends Error {
   constructor(message) {
     super(message);
     this.name = 'McpProxySsrfError';
+  }
+}
+
+export class McpProxyUpstreamError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'McpProxyUpstreamError';
+  }
+}
+
+export function proxyFailureFor(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  const isTimeout = (error instanceof Error && error.name === 'TimeoutError')
+    || message.includes('TimeoutError')
+    || message.includes('timed out');
+  const isExpectedExternal = error instanceof McpProxyUpstreamError
+    || error instanceof McpProxySsrfError
+    || error instanceof ResponseBodyTooLargeError
+    || error instanceof McpProxyJsonDepthError;
+  return {
+    isTimeout,
+    level: isTimeout || isExpectedExternal ? 'warning' : 'error',
+  };
+}
+
+async function fetchMcpUpstream(input, init) {
+  try {
+    return await fetch(input, init);
+  } catch (error) {
+    if (proxyFailureFor(error).isTimeout) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new McpProxyUpstreamError(message);
   }
 }
 
@@ -370,7 +440,7 @@ async function postJson(url, body, headers, sessionId) {
   const h = { ...headers };
   if (sessionId) h['Mcp-Session-Id'] = sessionId;
   await revalidateBeforeFetch(url);
-  const resp = await fetch(url.toString(), {
+  const resp = await fetchMcpUpstream(url.toString(), {
     method: 'POST',
     headers: h,
     body: JSON.stringify(body),
@@ -385,24 +455,30 @@ async function cancelResponseBody(response) {
 }
 
 async function parseJsonRpcResponse(resp) {
-  const body = await readBoundedResponseBody(resp, MAX_MCP_PROXY_RESPONSE_BYTES);
-  const text = new TextDecoder().decode(body);
-  const ct = resp.headers.get('content-type') || '';
-  if (ct.includes('text/event-stream')) {
-    const lines = text.split('\n');
-    for (const line of lines) {
-      if (line.startsWith('data: ')) {
-        try {
-          const parsed = parseMcpProxyJson(line.slice(6));
-          if (parsed.result !== undefined || parsed.error !== undefined) return parsed;
-        } catch (error) {
-          if (error instanceof McpProxyJsonDepthError) throw error;
+  try {
+    const body = await readBoundedResponseBody(resp, MAX_MCP_PROXY_RESPONSE_BYTES);
+    const text = new TextDecoder().decode(body);
+    const ct = resp.headers.get('content-type') || '';
+    if (ct.includes('text/event-stream')) {
+      const lines = text.split('\n');
+      for (const line of lines) {
+        if (line.startsWith('data: ')) {
+          try {
+            const parsed = parseMcpProxyJson(line.slice(6));
+            if (parsed.result !== undefined || parsed.error !== undefined) return parsed;
+          } catch (error) {
+            if (error instanceof McpProxyJsonDepthError) throw error;
+          }
         }
       }
+      throw new McpProxyUpstreamError('No result found in SSE response');
     }
-    throw new Error('No result found in SSE response');
+    return parseMcpProxyJson(text);
+  } catch (error) {
+    if (error instanceof McpProxyUpstreamError) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new McpProxyUpstreamError(message);
   }
-  return parseMcpProxyJson(text);
 }
 
 async function sendInitialized(serverUrl, headers, sessionId) {
@@ -422,35 +498,35 @@ async function sendInitialized(serverUrl, headers, sessionId) {
 async function mcpListTools(serverUrl, customHeaders) {
   const headers = buildHeaders(customHeaders);
   const initResp = await postJson(serverUrl, buildInitPayload(), headers, null);
-  if (!initResp.ok) throw new Error(`Initialize failed: HTTP ${initResp.status}`);
+  if (!initResp.ok) throw new McpProxyUpstreamError(`Initialize failed: HTTP ${initResp.status}`);
   const sessionId = initResp.headers.get('Mcp-Session-Id') || initResp.headers.get('mcp-session-id');
   const initData = await parseJsonRpcResponse(initResp);
-  if (initData.error) throw new Error(`Initialize error: ${initData.error.message}`);
+  if (initData.error) throw new McpProxyUpstreamError(`Initialize error: ${initData.error.message}`);
   await sendInitialized(serverUrl, headers, sessionId);
   const listResp = await postJson(serverUrl, {
     jsonrpc: '2.0', id: 2, method: 'tools/list', params: {},
   }, headers, sessionId);
-  if (!listResp.ok) throw new Error(`tools/list failed: HTTP ${listResp.status}`);
+  if (!listResp.ok) throw new McpProxyUpstreamError(`tools/list failed: HTTP ${listResp.status}`);
   const listData = await parseJsonRpcResponse(listResp);
-  if (listData.error) throw new Error(`tools/list error: ${listData.error.message}`);
+  if (listData.error) throw new McpProxyUpstreamError(`tools/list error: ${listData.error.message}`);
   return listData.result?.tools || [];
 }
 
 async function mcpCallTool(serverUrl, toolName, toolArgs, customHeaders) {
   const headers = buildHeaders(customHeaders);
   const initResp = await postJson(serverUrl, buildInitPayload(), headers, null);
-  if (!initResp.ok) throw new Error(`Initialize failed: HTTP ${initResp.status}`);
+  if (!initResp.ok) throw new McpProxyUpstreamError(`Initialize failed: HTTP ${initResp.status}`);
   const sessionId = initResp.headers.get('Mcp-Session-Id') || initResp.headers.get('mcp-session-id');
   const initData = await parseJsonRpcResponse(initResp);
-  if (initData.error) throw new Error(`Initialize error: ${initData.error.message}`);
+  if (initData.error) throw new McpProxyUpstreamError(`Initialize error: ${initData.error.message}`);
   await sendInitialized(serverUrl, headers, sessionId);
   const callResp = await postJson(serverUrl, {
     jsonrpc: '2.0', id: 3, method: 'tools/call',
     params: { name: toolName, arguments: toolArgs || {} },
   }, headers, sessionId);
-  if (!callResp.ok) throw new Error(`tools/call failed: HTTP ${callResp.status}`);
+  if (!callResp.ok) throw new McpProxyUpstreamError(`tools/call failed: HTTP ${callResp.status}`);
   const callData = await parseJsonRpcResponse(callResp);
-  if (callData.error) throw new Error(`tools/call error: ${callData.error.message}`);
+  if (callData.error) throw new McpProxyUpstreamError(`tools/call error: ${callData.error.message}`);
   return callData.result;
 }
 
@@ -487,12 +563,12 @@ class SseSession {
 
   async connect() {
     await revalidateBeforeFetch(new URL(this._sseUrl));
-    const resp = await fetch(this._sseUrl, {
+    const resp = await fetchMcpUpstream(this._sseUrl, {
       headers: { ...this._headers, Accept: 'text/event-stream', 'Cache-Control': 'no-cache' },
       redirect: 'manual',
       signal: AbortSignal.timeout(SSE_CONNECT_TIMEOUT_MS),
     });
-    if (!resp.ok) throw new Error(`SSE connect HTTP ${resp.status}`);
+    if (!resp.ok) throw new McpProxyUpstreamError(`SSE connect HTTP ${resp.status}`);
     this._reader = resp.body.getReader();
     this._startReadLoop();
     await this._endpointDeferred.promise;
@@ -518,7 +594,7 @@ class SseSession {
         while (true) {
           const { done, value } = await reader.read();
           if (done) {
-            const error = new Error(
+            const error = new McpProxyUpstreamError(
               this._endpointUrl ? 'SSE stream closed' : 'SSE stream closed before endpoint event',
             );
             this._terminalError = error;
@@ -546,15 +622,15 @@ class SseSession {
                 try {
                   resolved = new URL(data.startsWith('http') ? data : data, this._sseUrl);
                 } catch {
-                  this._endpointDeferred.reject(new Error('SSE endpoint event contains invalid URL'));
+                  this._endpointDeferred.reject(new McpProxyUpstreamError('SSE endpoint event contains invalid URL'));
                   return;
                 }
                 if (resolved.protocol !== 'https:' && resolved.protocol !== 'http:') {
-                  this._endpointDeferred.reject(new Error('SSE endpoint protocol not allowed'));
+                  this._endpointDeferred.reject(new McpProxyUpstreamError('SSE endpoint protocol not allowed'));
                   return;
                 }
                 if (BLOCKED_HOSTNAMES.has(resolved.hostname.toLowerCase()) || isBlockedResolvedAddress(resolved.hostname)) {
-                  this._endpointDeferred.reject(new Error('SSE endpoint host is blocked'));
+                  this._endpointDeferred.reject(new McpProxyUpstreamError('SSE endpoint host is blocked'));
                   return;
                 }
                 // Pin endpoint to the same host as the original SSE URL to
@@ -562,7 +638,7 @@ class SseSession {
                 // event to an internal host (DNS rebinding / SSRF).
                 if (resolved.host !== this._originHost || resolved.protocol !== this._originProtocol) {
                   this._endpointDeferred.reject(
-                    new Error('SSE endpoint host or protocol does not match origin server'),
+                    new McpProxyUpstreamError('SSE endpoint host or protocol does not match origin server'),
                   );
                   return;
                 }
@@ -596,12 +672,12 @@ class SseSession {
     const timer = setTimeout(() => {
       if (this._pending.has(id)) {
         this._pending.delete(id);
-        deferred.reject(new Error(`RPC ${method} timed out`));
+        deferred.reject(new McpProxyUpstreamError(`RPC ${method} timed out`));
       }
     }, SSE_RPC_TIMEOUT_MS);
     try {
       await revalidateBeforeFetch(new URL(this._endpointUrl));
-      const postResp = await fetch(this._endpointUrl, {
+      const postResp = await fetchMcpUpstream(this._endpointUrl, {
         method: 'POST',
         headers: { ...this._headers, 'Content-Type': 'application/json' },
         body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
@@ -611,7 +687,7 @@ class SseSession {
       await cancelResponseBody(postResp);
       if (!postResp.ok) {
         this._pending.delete(id);
-        throw new Error(`${method} POST HTTP ${postResp.status}`);
+        throw new McpProxyUpstreamError(`${method} POST HTTP ${postResp.status}`);
       }
       return await deferred.promise;
     } finally {
@@ -646,10 +722,10 @@ async function mcpListToolsSse(serverUrl, customHeaders) {
       capabilities: {},
       clientInfo: { name: 'worldmonitor', version: '1.0' },
     });
-    if (initResp.error) throw new Error(`Initialize error: ${initResp.error.message}`);
+    if (initResp.error) throw new McpProxyUpstreamError(`Initialize error: ${initResp.error.message}`);
     await session.notify('notifications/initialized', {});
     const listResp = await session.send(2, 'tools/list', {});
-    if (listResp.error) throw new Error(`tools/list error: ${listResp.error.message}`);
+    if (listResp.error) throw new McpProxyUpstreamError(`tools/list error: ${listResp.error.message}`);
     return listResp.result?.tools || [];
   } finally {
     session.close();
@@ -666,10 +742,10 @@ async function mcpCallToolSse(serverUrl, toolName, toolArgs, customHeaders) {
       capabilities: {},
       clientInfo: { name: 'worldmonitor', version: '1.0' },
     });
-    if (initResp.error) throw new Error(`Initialize error: ${initResp.error.message}`);
+    if (initResp.error) throw new McpProxyUpstreamError(`Initialize error: ${initResp.error.message}`);
     await session.notify('notifications/initialized', {});
     const callResp = await session.send(2, 'tools/call', { name: toolName, arguments: toolArgs || {} });
-    if (callResp.error) throw new Error(`tools/call error: ${callResp.error.message}`);
+    if (callResp.error) throw new McpProxyUpstreamError(`tools/call error: ${callResp.error.message}`);
     return callResp.result;
   } finally {
     session.close();
@@ -759,7 +835,7 @@ export default async function handler(req, ctx) {
   // validateApiKey forceKey:true, which broke the Pro "Connect MCP" UI
   // for normal web Pro users (no enterprise key path).
   //
-  // isCallerPremium is the project's canonical premium-caller check. It
+  // resolvePremiumCallerIdentity is the project's canonical premium-caller check. It
   // accepts: enterprise key (WORLDMONITOR_VALID_KEYS), wm_ user API key
   // (Convex-validated + entitlement check), and Clerk Pro Bearer JWT
   // (role==='pro' or entitlement tier>=1). It rejects wms_ session tokens
@@ -771,7 +847,8 @@ export default async function handler(req, ctx) {
   // premiumFetch (not plain fetch) so the renderer attaches the Bearer
   // for Pro users; /api/mcp-proxy is now in PREMIUM_RPC_PATHS for that
   // path-gated injection.
-  if (!(await isCallerPremium(req))) {
+  const callerIdentity = await resolvePremiumCallerIdentity(req);
+  if (!callerIdentity.isPremium) {
     emitProxyUsage(req, 401, Date.now() - startedAt, ctx);
     return jsonResponse({ error: 'Pro authentication required' }, 401, cors);
   }
@@ -797,7 +874,7 @@ export default async function handler(req, ctx) {
       status: 429,
       duration_ms: Date.now() - started,
     });
-    emitProxyUsage(req, 429, Date.now() - startedAt, ctx);
+    emitProxyUsage(req, 429, Date.now() - startedAt, ctx, callerIdentity);
     // JSON-RPC -32029 mirrors api/mcp.ts; HTTP 429 + Retry-After follows the
     // shared rate-limit response shape.
     return new Response(
@@ -831,26 +908,29 @@ export default async function handler(req, ctx) {
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    const isTimeout = msg.includes('TimeoutError') || msg.includes('timed out');
+    const failure = proxyFailureFor(err);
     // Until now this catch swallowed EVERY handler fault into a 422/422-shaped
     // JSON body with no Sentry event, so a genuine proxy defect was visible
     // only to the caller who hit it. Capture it.
     //
-    // An upstream timeout is the remote MCP server being slow, not our defect,
-    // so it reports at `warning` — the same call api/telegram-feed.js (#7438)
-    // and api/rss-proxy.js (#7588) already make for relay timeouts. Everything
-    // else stays at `error`.
+    // Expected upstream transport/protocol failures are the remote MCP server's
+    // outcome, not our defect, so they report at `warning`. Unknown failures
+    // stay at `error` so real proxy defects remain actionable.
     //
     // targetHost is caller-supplied, so it rides in `extra`, never a tag —
     // an attacker-controlled tag value would shred Sentry's tag cardinality.
     captureSilentError(err, {
       tags: { route: 'api/mcp-proxy', step: 'proxy-dispatch' },
       extra: { target_host: meta.targetHost, target_path: meta.targetPath, method: req.method },
-      ...(isTimeout ? { level: 'warning' as const } : {}),
+      level: failure.level,
       ctx,
     });
     // Return 422 (not 502) so Cloudflare proxy does not replace our JSON body with its own HTML error page
-    response = jsonResponse({ error: isTimeout ? 'MCP server timed out' : msg }, isTimeout ? 504 : 422, cors);
+    response = jsonResponse(
+      { error: failure.isTimeout ? 'MCP server timed out' : msg },
+      failure.isTimeout ? 504 : 422,
+      cors,
+    );
   }
 
   logProxyCall({
@@ -862,7 +942,7 @@ export default async function handler(req, ctx) {
     status: response.status,
     duration_ms: Date.now() - started,
   });
-  emitProxyUsage(req, response.status, Date.now() - startedAt, ctx);
+  emitProxyUsage(req, response.status, Date.now() - startedAt, ctx, callerIdentity);
 
   return response;
 }

--- a/scripts/generate-entitlement-crosswalk.mjs
+++ b/scripts/generate-entitlement-crosswalk.mjs
@@ -72,7 +72,7 @@ for (const f of ['src/config/panels.ts','convex/constants.ts','src/services/gate
 
 
 // ------------------------------------------------------- code-site gates
-const PAT = "features\\.tier\\s*[<>=]|tier\\s*[<>]=?\\s*1|!hasPremiumAccess\\(\\)|features\\.apiAccess|features\\.mcpAccess|features\\.dataExport|requiresPremium|isCallerPremium\\(|!isProUser\\(\\)";
+const PAT = "features\\.tier\\s*[<>=]|tier\\s*[<>]=?\\s*1|!hasPremiumAccess\\(\\)|features\\.apiAccess|features\\.mcpAccess|features\\.dataExport|requiresPremium|isCallerPremium\\(|resolvePremiumCallerIdentity\\(|!isProUser\\(\\)";
 const out = execSync(`grep -rnE "${PAT}" --include="*.ts" --include="*.js" src api convex server 2>/dev/null || true`, { encoding: 'utf8', maxBuffer: 1 << 26 });
 const sites = [];
 for (const ln of out.split('\n')) {
@@ -92,6 +92,7 @@ for (const ln of out.split('\n')) {
     : /features\.dataExport/.test(t) ? 'dataExport'
     : /requiresPremium/.test(t)      ? 'requiresPremium'
     : /isCallerPremium\(/.test(t)    ? 'isCallerPremium'
+    : /resolvePremiumCallerIdentity\(/.test(t) ? 'resolvePremiumCallerIdentity'
     : /hasPremiumAccess\(\)/.test(t)  ? 'hasPremiumAccess'
     : /isProUser\(\)/.test(t)         ? 'isProUser'
     : /features\.tier|tier\s*[<>]=?\s*1/.test(t) ? 'tier'
@@ -214,16 +215,16 @@ const SITE_MAP = [
   [/convex\/alertRules\.ts/,                  { cap: 'alerts.rules' , preds: ['tier'] }],
   [/api\/notification-channels\.ts/,          { cap: 'notifications.channels' , preds: ['tier'] }],
   [/api\/widget-agent\.ts/,                   { cap: 'widgets.custom' , preds: ['tier'] }],
-  [/summarize-article\.ts/,                   { cap: 'news.summarization' , preds: ['requiresPremium'] }],
+  [/summarize-article\.ts/,                   { cap: 'news.summarization' , preds: ['requiresPremium','resolvePremiumCallerIdentity'] }],
   [/gates\/playback/,                         { cap: 'playback.historical' }], // NOTE: matches no current gate
   [/convex\/apiKeys\.ts/,                     { cap: 'api.keys' , preds: ['apiAccess'] }],
-  [/pro-mcp-gate\.ts|api\/mcp-proxy\.ts|api\/mcp\//, { cap: 'mcp.access' , preds: ['isCallerPremium','mcpAccess','tier'] }],
+  [/pro-mcp-gate\.ts|api\/mcp-proxy\.ts|api\/mcp\//, { cap: 'mcp.access' , preds: ['isCallerPremium','resolvePremiumCallerIdentity','mcpAccess','tier'] }],
   [/gates\/export/,                           { cap: 'export.data' , preds: ['dataExport'] }],
   [/analysis-framework-store\.ts/,            { cap: 'analysis.frameworks' , preds: ['hasPremiumAccess'] }],
   [/correlation-engine\/engine\.ts/,          { cap: 'correlation.llm' , preds: ['hasPremiumAccess'] }],
   [/followedCountries/,    { cap: 'limits.followed_countries' , preds: ['tier'] }],
   [/search-manager\.ts/,                      { cap: 'aviation.data', note: 'callsign search' }], // NOTE: matches no current gate
-  [/ChatAnalystPanel|chat-analyst/,           { cap: 'analyst.chat' }], // NOTE: matches no current gate
+  [/ChatAnalystPanel|chat-analyst/,           { cap: 'analyst.chat', preds: ['resolvePremiumCallerIdentity'] }],
   [/supply-chain\/index\.ts/,   { cap: 'supplychain.routes' , preds: ['hasPremiumAccess'] }],
   [/services\/scenario\//,                    { cap: 'scenario.engine' }], // NOTE: matches no current gate
   [/sanctions-pressure/,                      { cap: 'sanctions.pressure' , preds: ['hasPremiumAccess','isCallerPremium'] }],
@@ -241,7 +242,7 @@ const SITE_MAP = [
   [/summarization\.ts|summarize-gate/,        { cap: 'news.summarization' }], // NOTE: matches no current gate
   [/panel-layout|settings-window|event-handlers/, { cap: 'limits.panels', note: 'cap + gate CTA plumbing' , preds: ['hasPremiumAccess','isProUser'] }],
   [/widget-store/,                            { cap: 'widgets.custom' }], // NOTE: matches no current gate
-  [/entitlements|entitlement-check|premium-check|pro-entitlement|billing|payments\//, { exclude: 'entitlement plumbing — resolves/propagates state, gates nothing itself' , preds: ['apiAccess','isCallerPremium','tier'] }],
+  [/entitlements|entitlement-check|premium-check|pro-entitlement|billing|payments\//, { exclude: 'entitlement plumbing — resolves/propagates state, gates nothing itself' , preds: ['apiAccess','isCallerPremium','resolvePremiumCallerIdentity','tier'] }],
   [/UnifiedSettings|data-loader|http\.ts|apiPlanLimitUsage|mcpProTokens|gateway\.ts|shipping/, { exclude: 'consumer of a gate mapped elsewhere — renders or forwards, does not define' , preds: ['apiAccess','hasPremiumAccess','isCallerPremium','isProUser','mcpAccess','tier'] }],
 ];
 
@@ -288,7 +289,8 @@ export function diffSiteCounts(actual, baseline = SITE_BASELINE) {
 // watching the sweep stay green. Pinning the expected count closes it: any
 // added or removed gate changes a count and must be re-baselined deliberately.
 const SITE_BASELINE = {
-  "api/mcp-proxy.ts::isCallerPremium": 1,
+  "api/chat-analyst.ts::resolvePremiumCallerIdentity": 1,
+  "api/mcp-proxy.ts::resolvePremiumCallerIdentity": 1,
   "api/mcp/skill-extension/generated.ts::tier": 1,
   "api/me/entitlement.ts::isCallerPremium": 1,
   "api/notification-channels.ts::tier": 1,
@@ -315,6 +317,7 @@ const SITE_BASELINE = {
   "server/_shared/entitlement-check.ts::tier": 1,
   "server/_shared/premium-check.ts::apiAccess": 1,
   "server/_shared/premium-check.ts::isCallerPremium": 1,
+  "server/_shared/premium-check.ts::resolvePremiumCallerIdentity": 3,
   "server/_shared/premium-check.ts::tier": 2,
   "server/_shared/pro-entitlement.ts::tier": 1,
   "server/_shared/pro-mcp-gate.ts::mcpAccess": 2,
@@ -326,6 +329,7 @@ const SITE_BASELINE = {
   "server/worldmonitor/intelligence/v1/get-country-intel-brief.ts::isCallerPremium": 1,
   "server/worldmonitor/military/v1/list-military-bases.ts::tier": 1,
   "server/worldmonitor/news/v1/summarize-article.ts::requiresPremium": 2,
+  "server/worldmonitor/news/v1/summarize-article.ts::resolvePremiumCallerIdentity": 1,
   "server/worldmonitor/sanctions/v1/list-sanctions-pressure.ts::isCallerPremium": 1,
   "server/worldmonitor/supply-chain/v1/get-bypass-options.ts::isCallerPremium": 1,
   "server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts::isCallerPremium": 1,

--- a/tests/entitlement-crosswalk-classifier.test.mjs
+++ b/tests/entitlement-crosswalk-classifier.test.mjs
@@ -48,6 +48,11 @@ describe('entitlement crosswalk classifier', () => {
     assert.equal(v, null, 'a different predicate in a mapped file must stay unmapped');
   });
 
+  it('maps the identity-preserving MCP proxy gate to MCP access', () => {
+    const v = classify(site('api/mcp-proxy.ts', 'resolvePremiumCallerIdentity'));
+    assert.equal(v?.cap, 'mcp.access');
+  });
+
   it('does NOT map a gate in a file nobody classified', () => {
     const v = classify(site('src/services/__not-a-real-file.ts', 'hasPremiumAccess'));
     assert.equal(v, null, 'an unmapped file must stay unmapped');
@@ -77,7 +82,8 @@ describe('entitlement crosswalk classifier', () => {
   it('a preds allow-list never contains an unknown predicate kind', () => {
     const KNOWN = new Set([
       'tier', 'hasPremiumAccess', 'isProUser', 'apiAccess',
-      'mcpAccess', 'dataExport', 'isCallerPremium', 'requiresPremium', 'other',
+      'mcpAccess', 'dataExport', 'isCallerPremium', 'resolvePremiumCallerIdentity',
+      'requiresPremium', 'other',
     ]);
     for (const [re, v] of SITE_MAP) {
       for (const p of v.preds ?? []) {

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -1513,3 +1513,157 @@ describe('api/mcp-proxy', () => {
     // RATE_LIMIT_WINDOW constant; the Upstash library handles expiry.
   });
 });
+
+// ---------------------------------------------------------------------------
+// Observability. Before this, `/api/mcp-proxy` was invisible to BOTH first-party
+// systems: `logProxyCall` is console.log (Vercel runtime logs are a live tail
+// with no historical query), so the route had zero rows in Axiom `wm_api_usage`
+// and its failure rate could not be asked about after the fact; and the
+// top-level catch turned every handler fault into a 422/504 with no Sentry
+// event. A 2026-09-03 triage could not measure a 3h production incident on this
+// endpoint for exactly that reason.
+//
+// Axiom emission is driven behaviourally — `isUsageEnabled()` and the ingest
+// token are both read at CALL time, so a per-test env flip is enough. The Sentry
+// capture is pinned from source text instead: `_sentry-common.js` parses its DSN
+// in a module-load IIFE, so enabling delivery would mean setting the DSN for the
+// whole file and every existing test's fetch stub would start seeing envelope
+// POSTs it does not expect. Same lever tests/rate-limit.test.mts uses.
+// ---------------------------------------------------------------------------
+describe('api/mcp-proxy — observability', () => {
+  let obsHandler;
+  const ORIGINAL_USAGE = process.env.USAGE_TELEMETRY;
+  const ORIGINAL_AXIOM = process.env.AXIOM_API_TOKEN;
+
+  beforeEach(async () => {
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-axiom-token-not-a-real-secret';
+    const mod = await import(`../api/mcp-proxy.ts?obs=${Date.now()}`);
+    obsHandler = mod.default;
+    setResolvedAddresses([PUBLIC_TEST_ADDRESS]);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_USAGE === undefined) delete process.env.USAGE_TELEMETRY;
+    else process.env.USAGE_TELEMETRY = ORIGINAL_USAGE;
+    if (ORIGINAL_AXIOM === undefined) delete process.env.AXIOM_API_TOKEN;
+    else process.env.AXIOM_API_TOKEN = ORIGINAL_AXIOM;
+    globalThis.fetch = originalFetch;
+  });
+
+  /** Collect ctx.waitUntil promises so the test can await delivery. */
+  function collectingCtx() {
+    const pending = [];
+    return { ctx: { waitUntil: (p) => pending.push(p) }, pending };
+  }
+
+  /** Intercept the Axiom ingest POST and return the rows it carried. */
+  function stubAxiom() {
+    const rows = [];
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('api.axiom.co')) {
+        rows.push(...JSON.parse(init.body));
+        return new Response('{}', { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+    return rows;
+  }
+
+  it('emits a wm_api_usage row for a rejected unauthenticated call', async () => {
+    const rows = stubAxiom();
+    const { ctx, pending } = collectingCtx();
+    const res = await obsHandler(
+      makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }, 'https://worldmonitor.app', { authed: false }),
+      ctx,
+    );
+    assert.equal(res.status, 401);
+    await Promise.all(pending);
+    assert.equal(rows.length, 1, 'exactly one usage row per proxied call');
+    assert.equal(rows[0].route, '/api/mcp-proxy', 'route must be queryable by name');
+    assert.equal(rows[0].status, 401);
+    assert.equal(rows[0].reason, 'auth_401');
+    assert.equal(rows[0].event_type, 'request');
+    assert.equal(rows[0].domain, 'mcp', 'joins with the /mcp surface');
+  });
+
+  it('labels a disallowed origin as origin_403, not a generic failure', async () => {
+    const rows = stubAxiom();
+    const { ctx, pending } = collectingCtx();
+    const res = await obsHandler(
+      makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }, 'https://evil.example.com', { authed: false }),
+      ctx,
+    );
+    assert.equal(res.status, 403);
+    await Promise.all(pending);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].status, 403);
+    assert.equal(rows[0].reason, 'origin_403');
+  });
+
+  it('does NOT emit for an OPTIONS preflight (a static 204 carries no signal)', async () => {
+    const rows = stubAxiom();
+    const { ctx, pending } = collectingCtx();
+    const res = await obsHandler(makeOptionsRequest(), ctx);
+    assert.equal(res.status, 204);
+    await Promise.all(pending);
+    assert.equal(rows.length, 0, 'preflights must not double the row volume');
+  });
+
+  it('emits nothing and still answers when the runtime passes no ctx', async () => {
+    const rows = stubAxiom();
+    const res = await obsHandler(
+      makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }, 'https://worldmonitor.app', { authed: false }),
+    );
+    assert.equal(res.status, 401, 'telemetry must never change the caller outcome');
+    assert.equal(rows.length, 0, 'no ctx means no waitUntil to hang delivery on');
+  });
+
+  // Every value below must be a member of the RequestReason union in
+  // server/_shared/usage.ts. api/mcp-proxy.ts is `@ts-nocheck`, so tsc will
+  // NOT catch a typo against that union — a misspelled reason would ship a row
+  // no Axiom query can ever match, which is the exact class of silent blindness
+  // this whole change exists to remove.
+  it('maps every terminal status onto a real RequestReason member', async () => {
+    const mod = await import(`../api/mcp-proxy.ts?reason=${Date.now()}`);
+    const { proxyReasonFor } = mod;
+    assert.equal(proxyReasonFor(403), 'origin_403');
+    assert.equal(proxyReasonFor(401), 'auth_401');
+    assert.equal(proxyReasonFor(429), 'rate_limit_429');
+    assert.equal(proxyReasonFor(405), 'method_not_allowed');
+    assert.equal(proxyReasonFor(400), 'malformed_request');
+    assert.equal(proxyReasonFor(413), 'malformed_request');
+    // Reaching its natural outcome is 'ok' even when the upstream failed —
+    // gateway convention (server/gateway.ts:2359,2395,2408). The status column
+    // carries the failure; inventing a reason label would break that join.
+    assert.equal(proxyReasonFor(200), 'ok');
+    assert.equal(proxyReasonFor(504), 'ok');
+    assert.equal(proxyReasonFor(422), 'ok');
+  });
+
+  it('the top-level catch reports to Sentry, and downgrades only upstream timeouts', async () => {
+    const fs = await import('node:fs');
+    const src = fs.readFileSync(new URL('../api/mcp-proxy.ts', import.meta.url), 'utf8');
+
+    const catchAt = src.indexOf('const isTimeout =');
+    assert.ok(catchAt > 0, 'the top-level catch still classifies timeouts');
+    const tail = src.slice(catchAt, src.indexOf('logProxyCall({', catchAt));
+
+    assert.match(tail, /captureSilentError\(err,/, 'a swallowed handler fault must not be silent');
+    assert.match(tail, /step:\s*'proxy-dispatch'/);
+    assert.match(
+      tail,
+      /isTimeout\s*\?\s*\{\s*level:\s*'warning'/,
+      'an upstream timeout is remote slowness, not our defect — it reports at warning',
+    );
+    // targetHost is caller-supplied. As a Sentry TAG it would let any caller
+    // mint unbounded tag values; it belongs in extra.
+    assert.match(tail, /extra:\s*\{[^}]*target_host/, 'target_host rides in extra');
+    assert.doesNotMatch(
+      tail.slice(tail.indexOf('tags:'), tail.indexOf('extra:')),
+      /target_host/,
+      'target_host must never become a Sentry tag',
+    );
+  });
+});

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -1,5 +1,5 @@
 // RUN WITH: `npm run test:data` OR `node --import=tsx --test tests/mcp-proxy.test.mjs`.
-// The handler under test (api/mcp-proxy.ts) imports isCallerPremium from
+// The handler under test (api/mcp-proxy.ts) imports premium auth helpers from
 // server/_shared/premium-check (extensionless TS). Plain `node --test`
 // cannot resolve that import and will fail with ERR_MODULE_NOT_FOUND —
 // this is expected; use tsx (the project's standard test runner).
@@ -148,7 +148,7 @@ function dnsJsonResponse(records) {
 describe('api/mcp-proxy', () => {
   beforeEach(async () => {
     // mcp-proxy migrated .js → .ts in PR #3768 to unlock the
-    // isCallerPremium import from server/. Test must follow the rename.
+    // premium-check import from server/. Test must follow the rename.
     const mod = await import(`../api/mcp-proxy.ts?t=${Date.now()}`);
     handler = mod.default;
     assert.equal(mod.__setMcpProxyResolveHostnameForTest, undefined);
@@ -197,7 +197,7 @@ describe('api/mcp-proxy', () => {
     // PR #3768 review finding; closes the residual #3723 surface.
     // wms_ session tokens are anonymous and freely mintable via
     // /api/wm-session. The auth gate must reject them — otherwise the
-    // bypass is "mint, then proxy". isCallerPremium does this by
+    // bypass is "mint, then proxy". resolvePremiumCallerIdentity does this by
     // requiring keyCheck.required === true (wms_ short-circuits at
     // required:false). PR #3768 review regression.
     it('rejects a wms_ session token even though it is technically valid', async () => {
@@ -213,7 +213,7 @@ describe('api/mcp-proxy', () => {
       assert.match(body.error, /Pro authentication required/i);
     });
 
-    // wm_ user keys: isCallerPremium calls validateUserApiKey which hits
+    // wm_ user keys: resolvePremiumCallerIdentity calls validateUserApiKey which hits
     // Convex. With CONVEX_SITE_URL unset in test env, it returns null →
     // 401. This proves the wm_ branch fails closed when the validator
     // can't run — and that the path is exercised (no MODULE_NOT_FOUND
@@ -902,11 +902,9 @@ describe('api/mcp-proxy', () => {
       assert.match(data.error, /Unknown tool/i);
     });
 
-    it('returns 504 on timeout during tool call', async () => {
+    it('returns 504 on a native fetch TimeoutError during tool call', async () => {
       globalThis.fetch = async () => {
-        const err = new Error('signal timed out');
-        err.name = 'TimeoutError';
-        throw err;
+        throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
       };
       const res = await handler(makePostRequest({
         serverUrl: 'https://mcp.example.com/mcp',
@@ -1558,7 +1556,7 @@ describe('api/mcp-proxy — observability', () => {
   }
 
   /** Intercept the Axiom ingest POST and return the rows it carried. */
-  function stubAxiom() {
+  function stubAxiom(upstreamFetch = async () => new Response('{}', { status: 200 })) {
     const rows = [];
     globalThis.fetch = async (input, init) => {
       const url = typeof input === 'string' ? input : input.url;
@@ -1566,7 +1564,7 @@ describe('api/mcp-proxy — observability', () => {
         rows.push(...JSON.parse(init.body));
         return new Response('{}', { status: 200 });
       }
-      return new Response('{}', { status: 200 });
+      return upstreamFetch(input, init);
     };
     return rows;
   }
@@ -1620,6 +1618,78 @@ describe('api/mcp-proxy — observability', () => {
     assert.equal(rows.length, 0, 'no ctx means no waitUntil to hang delivery on');
   });
 
+  it('attributes an authenticated enterprise request instead of reporting anonymous traffic', async () => {
+    const rows = stubAxiom(makeMcpFetch({ tools: [] }));
+    const { ctx, pending } = collectingCtx();
+    const res = await obsHandler(
+      makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }),
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    await Promise.all(pending);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].auth_kind, 'enterprise_api_key');
+    assert.equal(rows[0].customer_id, 'enterprise-unmapped');
+    assert.equal(rows[0].plan_key, 'enterprise');
+    assert.ok(rows[0].principal_id, 'enterprise key must have a hashed principal');
+    assert.notEqual(rows[0].principal_id, ENTERPRISE_KEY, 'raw enterprise key must never enter telemetry');
+  });
+
+  it('maps each premium caller identity onto the shared usage identity contract', async () => {
+    const { proxyUsageIdentityFor } = await import(`../api/mcp-proxy.ts?identity=${Date.now()}`);
+    const request = makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' });
+
+    assert.deepEqual(
+      proxyUsageIdentityFor(request, { isPremium: true, userId: 'user_bearer', kind: 'bearer' }),
+      {
+        auth_kind: 'clerk_jwt',
+        principal_id: 'user_bearer',
+        customer_id: 'user_bearer',
+        tier: 0,
+        plan_key: null,
+      },
+    );
+    assert.deepEqual(
+      proxyUsageIdentityFor(request, { isPremium: true, userId: 'user_key', kind: 'user-api-key' }),
+      {
+        auth_kind: 'user_api_key',
+        principal_id: 'user_key',
+        customer_id: 'user_key',
+        tier: 0,
+        plan_key: null,
+      },
+    );
+    assert.deepEqual(
+      proxyUsageIdentityFor(request, { isPremium: true, userId: 'user_mcp', kind: 'internal-mcp' }),
+      {
+        auth_kind: 'mcp_oauth',
+        principal_id: 'user_mcp',
+        customer_id: 'user_mcp',
+        tier: 0,
+        plan_key: null,
+      },
+    );
+  });
+
+  it('downgrades expected upstream failures but keeps proxy defects at error level', async () => {
+    const { McpProxyUpstreamError, proxyFailureFor } = await import(
+      `../api/mcp-proxy.ts?failure=${Date.now()}`
+    );
+
+    assert.deepEqual(
+      proxyFailureFor(new DOMException('The operation was aborted due to timeout', 'TimeoutError')),
+      { isTimeout: true, level: 'warning' },
+    );
+    assert.deepEqual(
+      proxyFailureFor(new McpProxyUpstreamError('Initialize failed: HTTP 401')),
+      { isTimeout: false, level: 'warning' },
+    );
+    assert.deepEqual(
+      proxyFailureFor(new Error('unexpected local invariant failure')),
+      { isTimeout: false, level: 'error' },
+    );
+  });
+
   // Every value below must be a member of the RequestReason union in
   // server/_shared/usage.ts. api/mcp-proxy.ts is `@ts-nocheck`, so tsc will
   // NOT catch a typo against that union — a misspelled reason would ship a row
@@ -1642,20 +1712,20 @@ describe('api/mcp-proxy — observability', () => {
     assert.equal(proxyReasonFor(422), 'ok');
   });
 
-  it('the top-level catch reports to Sentry, and downgrades only upstream timeouts', async () => {
+  it('the top-level catch reports to Sentry with the classified failure level', async () => {
     const fs = await import('node:fs');
     const src = fs.readFileSync(new URL('../api/mcp-proxy.ts', import.meta.url), 'utf8');
 
-    const catchAt = src.indexOf('const isTimeout =');
-    assert.ok(catchAt > 0, 'the top-level catch still classifies timeouts');
+    const catchAt = src.indexOf('const failure = proxyFailureFor(err);');
+    assert.ok(catchAt > 0, 'the top-level catch still classifies failures');
     const tail = src.slice(catchAt, src.indexOf('logProxyCall({', catchAt));
 
     assert.match(tail, /captureSilentError\(err,/, 'a swallowed handler fault must not be silent');
     assert.match(tail, /step:\s*'proxy-dispatch'/);
     assert.match(
       tail,
-      /isTimeout\s*\?\s*\{\s*level:\s*'warning'/,
-      'an upstream timeout is remote slowness, not our defect — it reports at warning',
+      /level:\s*failure\.level/,
+      'expected upstream failures are warnings while proxy defects remain errors',
     );
     // targetHost is caller-supplied. As a Sentry TAG it would let any caller
     // mint unbounded tag values; it belongs in extra.


### PR DESCRIPTION
Closes the observability hole found during the 2026-09-03 `/sentry-triage` pass, when a 3-hour production incident on `/api/mcp-proxy` turned out to be unmeasurable from either first-party system.

## What was broken

**Axiom: zero rows, ever.** `logProxyCall` (`mcp-proxy.ts:60`) was the only record of a proxied request, and it is `console.log`. Vercel runtime logs are a live tail with no historical query — `vercel logs` on an old deployment returns current traffic, not that deployment's past. Verified directly: no row matching `route contains 'proxy'` exists in `wm_api_usage` on any day queried. So "how many proxy calls failed between 13:24 and 16:30?" had no answer.

**Sentry: faults swallowed.** The top-level catch (`mcp-proxy.ts:728`) turned every handler exception into a 422/504 JSON body with no capture. A genuine proxy defect was visible only to the caller who hit it. The sole Sentry coverage was indirect — a comment at line 684 noting that `checkScopedRateLimit` captures its own degraded path.

This is the same hole #4866 closed for `/mcp`, whose header comment describes the identical situation: *"before this module the endpoint had ZERO rows in Axiom... had to be reconstructed from REST-side rows."*

## What this does

Reuses that exact seam rather than inventing one:

- One `RequestEvent` per call via `emitUsageEvents`, built with the gateway's own builders, so rows are byte-compatible with REST rows and joinable on `customer_id`. Emitted at every terminal return — 403, 401, 429, and the final response.
- `proxyReasonFor` maps status onto the closed `RequestReason` union following `server/gateway.ts`: `reason` names why *we* short-circuited, and anything reaching its natural outcome is `'ok'` with the real status alongside (`gateway.ts:2359,2395,2408`). An upstream 504 is `ok`/504, not an invented label — **no new union member needed**.
- The catch now reports. An upstream timeout is remote slowness, not our defect, so it captures at `warning` — the same call `api/telegram-feed.js` (#7438) and `api/rss-proxy.js` (#7588) already make for relay timeouts. Everything else stays `error`.

## Deliberate choices, each commented at the call site

- **`logProxyCall` stays.** It carries `target_host`/`header_names`, which the usage envelope has no field for, and existing log-ingest tooling parses its shape.
- **OPTIONS preflights do not emit.** A static 204 that cannot fail would double row volume for no signal; `/mcp` skips them the same way.
- **`target_host` rides in Sentry `extra`, never a tag.** It is caller-supplied — as a tag it would let any caller mint unbounded tag values and shred cardinality.
- **No customer attribution.** The gate is `isCallerPremium`, which returns no identity. Rows join on `ip`.
- **Telemetry cannot change the caller's outcome** — wrapped, and a no-op when the runtime passes no `ctx`.
- **`durationMs` is measured from handler entry**, so it includes the auth and rate-limit gates, unlike `logProxyCall`'s `started`. That is the end-to-end caller-visible latency; the two numbers differ on purpose.

## Why `proxyReasonFor` is exported

`api/mcp-proxy.ts` is `@ts-nocheck`. tsc will **not** check the returned string against `RequestReason`, so a typo would ship a row no Axiom query could ever match — precisely the silent blindness this PR removes. Exporting it makes every branch pinnable, matching how `rateLimitErrorLevel` is exported as a test seam.

## Tests — 78 pass

Axiom emission is driven **behaviourally**: `isUsageEnabled()` and the ingest token are both read at call time, so a per-test env flip plus a fetch stub on the ingest URL is enough. Covered: the 401 row, the 403 `origin_403` row, the no-emit preflight, and the no-ctx path. The reason mapping is pinned branch by branch.

The Sentry capture is pinned from **source text** rather than behaviourally, and that is a deliberate trade: `_sentry-common.js` parses its DSN in a module-load IIFE, so enabling delivery would require setting the DSN for the whole file — and all 72 pre-existing tests would start seeing envelope POSTs their fetch stubs do not expect. Same lever `tests/rate-limit.test.mts:529-541` uses on the rate-limit capture, for the same reason.

**Verified red before green.** Stubbing `emitProxyUsage` to a no-op fails both emission tests (and correctly leaves the two zero-row tests passing). Dropping the `warning` downgrade fails the capture test on its intended assertion.

```
tsx --test tests/mcp-proxy.test.mjs   78/78 pass (72 pre-existing, unchanged)
npm run typecheck:api                 pass
npm run lint:boundaries               pass
biome lint (both files)               clean
```

## What this does NOT fix

**`FUNCTION_INVOCATION_FAILED` remains invisible, and that was the actual outage.** The function never runs, so no in-handler instrumentation — this included — can observe it. Catching that class needs detection outside the function: Vercel-side alerting on the platform error, or a synthetic probe that actually executes.

Worth recording for whoever picks that up: both existing nets were already inert. #7591's per-deploy `deployment_status` smoke trigger fired 37 times and executed **zero** (its `if` gate never matched), and the 6h cron's windows at 12:23Z and 18:23Z straddled the 13:24–16:30 outage entirely.

https://claude.ai/code/session_01B6xEwAj24Q2eubZqW6uehR
