### PR TITLE
fix(schema): stabilize crawlable dataset identity

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -116,10 +116,10 @@ export const CHOKEPOINT_PAGE_LASTMOD_PATHS = Object.freeze([
 // families take the later of this version and their own committed source date,
 // so template changes are reflected without pretending every deploy is fresh.
 export const CORPUS_GENERATOR_CONTENT_VERSION = '2026-09-01';
-export const COUNTRY_PAGE_CONTENT_VERSION = '2026-09-02';
-export const CII_COUNTRY_PAGE_CONTENT_VERSION = '2026-09-02';
-const COUNTRIES_INDEX_CONTENT_VERSION = '2026-09-01';
-const CII_RANKING_PAGE_CONTENT_VERSION = '2026-09-01';
+export const COUNTRY_PAGE_CONTENT_VERSION = '2026-09-03';
+export const CII_COUNTRY_PAGE_CONTENT_VERSION = '2026-09-03';
+const COUNTRIES_INDEX_CONTENT_VERSION = '2026-09-03';
+const CII_RANKING_PAGE_CONTENT_VERSION = '2026-09-03';
 // Public ranking / confidence gates. Keep aligned with
 // server/worldmonitor/resilience/v1/_shared.ts and
 // docs/methodology/country-resilience-index.mdx.
@@ -132,7 +132,7 @@ export const RANKING_ELIGIBILITY_CLAUSE = `Ranking requires coverage of at least
 const RETIRED_DIMENSION_IDS = new Set(['fuelStockDays', 'reserveAdequacy']);
 const UNRANKED_INVENTORY_LIMIT = 12;
 const AVAILABLE_EVIDENCE_LIMIT = 6;
-export const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-09-02';
+export const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-09-03';
 const SOURCES_PAGE_CONTENT_VERSION = '2026-08-20';
 // Dataset schema versions stamp Dataset JSON-LD shape changes, per family. They
 // must NOT fold into every family's sitemap/page lastmod — that made ~90% of main
@@ -143,18 +143,23 @@ const SOURCES_PAGE_CONTENT_VERSION = '2026-08-20';
 // dateModified is pinned to the snapshot capturedAt as a truthful freshness
 // contract (#7391), so their recrawl signal is COUNTRY_PAGE_CONTENT_VERSION.
 export const DATASET_SCHEMA_CONTENT_VERSION = {
-  chokepoint: '2026-08-31',
-  crisis: '2026-09-01',
-  tools: '2026-09-01',
+  chokepoint: '2026-09-03',
+  crisis: '2026-09-03',
+  tools: '2026-09-03',
 };
-export const CRISIS_PAGE_CONTENT_VERSION = '2026-09-01';
-const TOOLS_PAGE_CONTENT_VERSION = '2026-09-01';
+export const CRISIS_PAGE_CONTENT_VERSION = '2026-09-03';
+const TOOLS_PAGE_CONTENT_VERSION = '2026-09-03';
+const RESEARCH_PAGE_CONTENT_VERSION = '2026-09-03';
 const DATASET_LICENSE = {
   '@type': 'CreativeWork',
   name: 'World Monitor Terms of Service (27 July 2026)',
   url: 'https://www.worldmonitor.app/docs/terms',
 };
+const CII_INDEX_DATASET_DOWNLOAD = 'cii-ranking.json';
+const COUNTRIES_INDEX_DATASET_DOWNLOAD = 'resilience-ranking.json';
 const COUNTRY_DATASET_DOWNLOAD = 'resilience.json';
+const COUNTRY_CII_DATASET_DOWNLOAD = 'cii.json';
+const CHOKEPOINTS_INDEX_DATASET_DOWNLOAD = 'status.json';
 const CHOKEPOINT_DATASET_DOWNLOAD = 'reference.json';
 const CRISIS_DATASET_DOWNLOAD = 'tracker.json';
 const CONVERGENCE_DATASET_DOWNLOAD = 'reference.json';
@@ -543,6 +548,16 @@ export function datasetTemporalCoverage(observationInterval) {
   return OBSERVATION_COVERAGE_RE.test(trimmed) ? trimmed : undefined;
 }
 
+export function datasetObservationCoverage(observedAtValues) {
+  const dates = [...new Set(
+    observedAtValues
+      .map((observedAt) => pulseDateOnly(observedAt, null))
+      .filter(Boolean),
+  )].sort();
+  if (dates.length === 0) return undefined;
+  return datasetTemporalCoverage(dates.length === 1 ? dates[0] : `${dates[0]}/${dates.at(-1)}`);
+}
+
 function datasetDownloadHref(pagePath, filename) {
   return `${pagePath}${filename}`;
 }
@@ -582,6 +597,40 @@ function countryDatasetDownload(country, {
   });
 }
 
+function countryCiiDatasetDownload(country, ciiEntry, { capturedAt, snapshotPath }) {
+  return stableJson({
+    dataset: 'country-instability-index',
+    countryCode: country.code,
+    countryName: country.name,
+    methodologyVersion: ciiEntry.methodologyVersion,
+    score: ciiEntry.score,
+    approximate24HourMovement: ciiEntry.change24h,
+    instabilityLevel: ciiEntry.band,
+    observedAt: ciiEntry.asOf,
+    capturedAt,
+    source: snapshotPath,
+    license: DATASET_LICENSE.url,
+  });
+}
+
+function countriesIndexDatasetDownload(countries, { capturedAt, snapshotPath }) {
+  return stableJson({
+    dataset: 'country-resilience-ranking',
+    capturedAt,
+    source: snapshotPath,
+    license: DATASET_LICENSE.url,
+    countries: countries.map((country) => ({
+      code: country.code,
+      name: country.name,
+      rank: country.headlineEligible === false ? null : country.rank,
+      overallScore: country.headlineEligible === false ? null : country.overallScore,
+      dimensionCoverage: country.dimensionCoverage,
+      confidence: country.lowConfidence ? 'low' : 'standard',
+      level: country.headlineEligible === false ? 'unpublished' : country.level,
+    })),
+  });
+}
+
 function chokepointDatasetDownload(chokepoint, {
   tradeRoutesById,
   capturedAt = null,
@@ -611,6 +660,44 @@ function chokepointDatasetDownload(chokepoint, {
     volumeObservedAt: volumeObservedAt || capturedAt || null,
     source: [CHOKEPOINT_REGISTRY_PATH, TRADE_ROUTES_PATH],
     license: DATASET_LICENSE.url,
+  });
+}
+
+function ciiIndexDatasetDownload(ciiRanking, { capturedAt, snapshotPath }) {
+  return stableJson({
+    dataset: 'country-instability-index',
+    methodologyVersion: ciiRanking.methodologyVersion,
+    capturedAt,
+    source: snapshotPath,
+    license: DATASET_LICENSE.url,
+    countries: ciiRanking.entries.map((entry) => ({
+      code: entry.code,
+      name: entry.country.name,
+      score: entry.score,
+      approximate24HourMovement: entry.change24h,
+      instabilityLevel: entry.band,
+      observedAt: entry.asOf,
+    })),
+  });
+}
+
+function chokepointsIndexDatasetDownload(chokepointHubRows, { capturedAt, snapshotPath }) {
+  return stableJson({
+    dataset: 'maritime-chokepoint-status',
+    capturedAt,
+    source: snapshotPath,
+    license: DATASET_LICENSE.url,
+    chokepoints: chokepointHubRows.map((row) => ({
+      id: row.chokepoint.id,
+      name: row.chokepoint.displayName,
+      slug: row.chokepoint.slug,
+      region: row.region,
+      disruptionScore: row.score,
+      status: row.status,
+      aisCongestion: row.congestion,
+      aisSnapshotAvailable: row.aisSnapshotAvailable,
+      observedAt: row.asOf,
+    })),
   });
 }
 
@@ -1541,6 +1628,7 @@ export async function loadCorpusData({ rootDir = DEFAULT_ROOT } = {}) {
   );
   const researchLastmod = laterDate(
     ...researchReports.map(({ report }) => report.dateModified),
+    RESEARCH_PAGE_CONTENT_VERSION,
   );
   const useCasesLastmod = laterDate(
     USE_CASES_CONTENT_VERSION,
@@ -1996,12 +2084,13 @@ ${ciiRanking.entries.map((entry) => `            <tr data-cii-country="${escapeH
         name: `World Monitor Country Instability Index (CII) ${ciiRanking.methodologyVersion}`,
         description: `Current 0-100 instability scores, available approximate 24-hour movement, and instability levels for ${ciiRanking.entries.length} monitored countries.`,
         url: absoluteUrl(baseUrl, path),
-        identifier: `world-monitor-cii-${ciiRanking.methodologyVersion}-${capturedAt}`,
+        identifier: `world-monitor-cii-${ciiRanking.methodologyVersion}`,
+        keywords: ['country instability', 'country risk', 'instability index', 'geopolitical risk'],
         creator: { ...WORLD_MONITOR_ORG },
         license: DATASET_LICENSE,
         datePublished: capturedAt,
         dateModified: ciiRanking.updatedAt,
-        temporalCoverage: datasetTemporalCoverage(capturedAt),
+        temporalCoverage: datasetObservationCoverage(ciiRanking.entries.map((entry) => entry.asOf)),
         spatialCoverage: 'Worldwide',
         isAccessibleForFree: true,
         includedInDataCatalog: includedInDataCatalog(baseUrl),
@@ -2011,7 +2100,7 @@ ${ciiRanking.entries.map((entry) => `            <tr data-cii-country="${escapeH
           { '@type': 'PropertyValue', name: 'Approximate 24-hour movement', unitText: 'index points' },
           { '@type': 'PropertyValue', name: 'Instability level' },
         ],
-        distribution: [dataDownload(absoluteUrl(baseUrl, path), 'text/html')],
+        distribution: [dataDownload(absoluteUrl(baseUrl, datasetDownloadHref(path, CII_INDEX_DATASET_DOWNLOAD)))],
         mainEntity: { '@id': rankingId },
       },
       {
@@ -2133,7 +2222,8 @@ ${countries.map((country) => {
         name: `World Monitor Country Resilience Index snapshot for ${capturedAt}`,
         description,
         url: absoluteUrl(baseUrl, path),
-        identifier: `country-resilience-ranking-${capturedAt}`,
+        identifier: 'country-resilience-ranking',
+        keywords: ['country resilience', 'country risk', 'resilience index', 'global indicators'],
         creator: { ...WORLD_MONITOR_ORG },
         license: DATASET_LICENSE,
         datePublished: capturedAt,
@@ -2149,7 +2239,7 @@ ${countries.map((country) => {
           maxValue: 100,
           unitText: 'index points',
         },
-        distribution: dataDownload(absoluteUrl(baseUrl, path), 'text/html'),
+        distribution: dataDownload(absoluteUrl(baseUrl, datasetDownloadHref(path, COUNTRIES_INDEX_DATASET_DOWNLOAD))),
       },
       dataCatalogLd(baseUrl),
     ],
@@ -2968,6 +3058,7 @@ ${analysis.readingGuide ? `      <h2>How to use this evidence</h2>
     description: datasetDescription,
     url: absoluteUrl(baseUrl, path),
     identifier: country.code,
+    keywords: ['country resilience', country.name, 'resilience index', 'country risk'],
     creator: { ...WORLD_MONITOR_ORG },
     license: DATASET_LICENSE,
     datePublished: capturedAt,
@@ -2987,6 +3078,7 @@ ${analysis.readingGuide ? `      <h2>How to use this evidence</h2>
     description: `The current World Monitor Country Instability Index score, available approximate 24-hour movement, instability level, and methodology version for ${country.name}.`,
     url: absoluteUrl(baseUrl, path),
     identifier: `${country.code}-cii-${ciiEntry.methodologyVersion}`,
+    keywords: ['country instability', country.name, 'instability index', 'country risk'],
     creator: { ...WORLD_MONITOR_ORG },
     license: DATASET_LICENSE,
     datePublished: pulseDateOnly(ciiEntry.asOf, capturedAt),
@@ -2995,7 +3087,7 @@ ${analysis.readingGuide ? `      <h2>How to use this evidence</h2>
     spatialCoverage,
     isAccessibleForFree: true,
     includedInDataCatalog: includedInDataCatalog(baseUrl),
-    distribution: [dataDownload(absoluteUrl(baseUrl, path), 'text/html')],
+    distribution: [dataDownload(absoluteUrl(baseUrl, datasetDownloadHref(path, COUNTRY_CII_DATASET_DOWNLOAD)))],
     measurementTechnique: `World Monitor CII ${ciiEntry.methodologyVersion}`,
     variableMeasured: [
       { '@type': 'PropertyValue', name: 'Instability score', value: ciiEntry.score, minValue: 0, maxValue: 100 },
@@ -3123,10 +3215,9 @@ export function buildChokepointHubRows(chokepoints, livePulse) {
   });
 }
 
-function renderChokepointsIndex({ chokepoints, livePulse, baseUrl, lastmod, snapshotPath }) {
+function renderChokepointsIndex({ chokepoints, chokepointHubRows, livePulse, baseUrl, lastmod, snapshotPath }) {
   const path = '/chokepoints/';
   const description = `Track current disruption scores, status, AIS congestion, and update times for the ${chokepoints.length} maritime chokepoints in the World Monitor public status snapshot.`;
-  const chokepointHubRows = buildChokepointHubRows(chokepoints, livePulse);
   const updatedAt = chokepointHubRows
     .map((row) => row.asOf)
     .sort((left, right) => Date.parse(left) - Date.parse(right))
@@ -3249,12 +3340,13 @@ ${chokepointHubRows.map((row) => {
         name: `World Monitor maritime chokepoint status snapshot for ${livePulse.capturedAt}`,
         description,
         url: absoluteUrl(baseUrl, path),
-        identifier: `world-monitor-chokepoint-status-${livePulse.capturedAt}`,
+        identifier: 'world-monitor-chokepoint-status',
+        keywords: ['maritime chokepoints', 'shipping disruption', 'AIS congestion', 'maritime risk'],
         creator: { ...WORLD_MONITOR_ORG },
         license: DATASET_LICENSE,
         datePublished: livePulse.capturedAt,
         dateModified: updatedAt,
-        temporalCoverage: datasetTemporalCoverage(livePulse.capturedAt),
+        temporalCoverage: datasetObservationCoverage(chokepointHubRows.map((row) => row.asOf)),
         spatialCoverage: 'Worldwide',
         isAccessibleForFree: true,
         includedInDataCatalog: includedInDataCatalog(baseUrl),
@@ -3264,7 +3356,7 @@ ${chokepointHubRows.map((row) => {
           { '@type': 'PropertyValue', name: 'Status' },
           { '@type': 'PropertyValue', name: 'AIS congestion' },
         ],
-        distribution: dataDownload(absoluteUrl(baseUrl, path), 'text/html'),
+        distribution: dataDownload(absoluteUrl(baseUrl, datasetDownloadHref(path, CHOKEPOINTS_INDEX_DATASET_DOWNLOAD))),
         mainEntity: { '@id': itemListId },
       },
       {
@@ -3559,6 +3651,7 @@ ${relatedItems.map((item) => `        <li>${item}</li>`).join('\n')}
     description: `A World Monitor maritime reference dataset for ${chokepoint.displayName}, with its position, connected waters, energy shock model support, and modelled trade-route corridors.`,
     url: absoluteUrl(baseUrl, path),
     identifier: chokepoint.id,
+    keywords: ['maritime chokepoint', chokepoint.displayName, 'shipping route', 'trade corridor'],
     creator: { ...WORLD_MONITOR_ORG },
     license: DATASET_LICENSE,
     datePublished: capturedAt || undefined,
@@ -3837,6 +3930,7 @@ ${snapshotSection}
           description: datasetDescription,
           url: absoluteUrl(baseUrl, path),
           identifier: `crisis-tracker-${crisis.slug}`,
+          keywords: ['crisis tracker', crisis.shortTitle || crisis.title, 'humanitarian conflict', ...crisis.coverage.map((country) => country.name)],
           creator: { ...WORLD_MONITOR_ORG },
           license: DATASET_LICENSE,
           datePublished: publishedDate,
@@ -3973,7 +4067,8 @@ ${examples}
           name: `World Monitor ${metricName} reference`,
           description,
           url: datasetUrl,
-          identifier: `signal-convergence-${signalConvergence.capturedAt || 'reference'}`,
+          identifier: 'signal-convergence-reference',
+          keywords: ['signal convergence', 'geographic convergence', 'event correlation', 'geopolitical signals'],
           creator: { ...WORLD_MONITOR_ORG },
           license: DATASET_LICENSE,
           // This reference is a formula plus documentation-derived examples. It
@@ -4365,6 +4460,14 @@ export async function buildCorpus({
       snapshotPath: data.sources.livePulseSnapshot,
     }),
   );
+  writeGeneratedFile(
+    outDir,
+    datasetDownloadFile('/country-instability-index/', CII_INDEX_DATASET_DOWNLOAD),
+    ciiIndexDatasetDownload(data.ciiRanking, {
+      capturedAt: data.livePulse.capturedAt,
+      snapshotPath: data.sources.livePulseSnapshot,
+    }),
+  );
 
   writeGeneratedFile(
     outDir,
@@ -4378,9 +4481,18 @@ export async function buildCorpus({
       snapshotPath: data.sources.resilienceSnapshot,
     }),
   );
+  writeGeneratedFile(
+    outDir,
+    datasetDownloadFile('/countries/', COUNTRIES_INDEX_DATASET_DOWNLOAD),
+    countriesIndexDatasetDownload(data.countries, {
+      capturedAt: data.resilience.capturedAt,
+      snapshotPath: data.sources.resilienceSnapshot,
+    }),
+  );
   const rankedCount = data.countries.filter((country) => country.rank != null).length;
   for (const country of data.countries) {
     const pagePath = `/countries/${country.slug}/`;
+    const ciiEntry = data.ciiRanking.byCode.get(country.code) || null;
     writeGeneratedFile(
       outDir,
       routeFile(pagePath),
@@ -4388,7 +4500,7 @@ export async function buildCorpus({
         country,
         baseUrl,
         capturedAt: data.resilience.capturedAt,
-        lastmod: data.ciiRanking.byCode.has(country.code)
+        lastmod: ciiEntry
           ? data.lastmod.ciiCountries
           : data.lastmod.countries,
         methodologyFormula: data.resilience.methodologyFormula || 'unknown',
@@ -4397,9 +4509,19 @@ export async function buildCorpus({
         snapshotPath: data.sources.resilienceSnapshot,
         bbox: data.countryBboxByCode.get(country.code) || null,
         livePulse: data.livePulse,
-        ciiEntry: data.ciiRanking.byCode.get(country.code) || null,
+        ciiEntry,
       }),
     );
+    if (ciiEntry) {
+      writeGeneratedFile(
+        outDir,
+        datasetDownloadFile(pagePath, COUNTRY_CII_DATASET_DOWNLOAD),
+        countryCiiDatasetDownload(country, ciiEntry, {
+          capturedAt: data.livePulse.capturedAt,
+          snapshotPath: data.sources.livePulseSnapshot,
+        }),
+      );
+    }
     writeGeneratedFile(
       outDir,
       datasetDownloadFile(pagePath, COUNTRY_DATASET_DOWNLOAD),
@@ -4412,16 +4534,29 @@ export async function buildCorpus({
     );
   }
 
+  const chokepointHubRows = buildChokepointHubRows(data.chokepoints, data.livePulse);
   writeGeneratedFile(
     outDir,
     'chokepoints/index.html',
     renderChokepointsIndex({
       chokepoints: data.chokepoints,
+      chokepointHubRows,
       livePulse: data.livePulse,
       baseUrl,
       lastmod: data.lastmod.chokepoints,
       snapshotPath: data.sources.livePulseSnapshot,
     }),
+  );
+  writeGeneratedFile(
+    outDir,
+    datasetDownloadFile('/chokepoints/', CHOKEPOINTS_INDEX_DATASET_DOWNLOAD),
+    chokepointsIndexDatasetDownload(
+      chokepointHubRows,
+      {
+        capturedAt: data.livePulse.capturedAt,
+        snapshotPath: data.sources.livePulseSnapshot,
+      },
+    ),
   );
   for (const chokepoint of data.chokepoints) {
     const pagePath = `/chokepoints/${chokepoint.slug}/`;

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -384,7 +384,7 @@ export function buildCiiRankingEntries(countries, livePulse) {
       throw new Error(`CII pulse score or band is invalid for ${code}`);
     }
     const asOf = String(pulse.asOf || '').trim();
-    if (!Number.isFinite(Date.parse(asOf))) {
+    if (!isCanonicalIsoInstant(asOf)) {
       throw new Error(`CII pulse timestamp is invalid for ${code}`);
     }
     const methodologyVersion = String(pulse.methodologyVersion || '').trim();

--- a/scripts/build-research-reports.mjs
+++ b/scripts/build-research-reports.mjs
@@ -897,6 +897,7 @@ ${justification}
       name: `Strait of Hormuz daily transit calls, ${focus.observationStart} to ${focus.observationEnd}`,
       description:
         'Daily AIS-observed vessel transit calls by class with deadweight-tonnage aggregates, from IMF PortWatch, frozen in a versioned snapshot.',
+      keywords: ['AIS vessel transits', 'Strait of Hormuz', 'maritime trade', 'IMF PortWatch'],
       creator: { ...WORLD_MONITOR_ORG },
       license: DATASET_LICENSE,
       datePublished: report.datePublished,

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -20,6 +20,7 @@ import {
   countryMetaDescription,
   COUNTRY_PAGE_CONTENT_VERSION,
   DATASET_SCHEMA_CONTENT_VERSION,
+  datasetObservationCoverage,
   datasetTemporalCoverage,
   describeHeadlineIneligibilityReason,
   describeInventoryScope,
@@ -489,6 +490,11 @@ function assertDatasetDownloadsAreGenerated(html, outDir, route, baseUrl = 'http
   assert.ok(downloads.length > 0, `${route} Dataset must expose at least one DataDownload`);
   const origin = new URL(baseUrl).origin;
   for (const item of downloads) {
+    assert.notEqual(
+      item.encodingFormat,
+      'text/html',
+      `${route} Dataset download must be machine-readable, not self-referential HTML`,
+    );
     assert.ok(isAbsoluteHttpUrl(item.contentUrl), `${route} DataDownload contentUrl must be absolute`);
     const url = new URL(item.contentUrl);
     assert.equal(url.origin, origin, `${route} DataDownload must stay on ${origin}`);
@@ -502,6 +508,12 @@ function assertDatasetDownloadsAreGenerated(html, outDir, route, baseUrl = 'http
       existsSync(join(outDir, relativePath)),
       `${route} DataDownload ${item.contentUrl} must map to generated file ${relativePath}`,
     );
+    if (item.encodingFormat === 'application/json') {
+      assert.doesNotThrow(
+        () => JSON.parse(read(outDir, relativePath)),
+        `${route} JSON DataDownload ${item.contentUrl} must contain valid JSON`,
+      );
+    }
   }
 }
 
@@ -512,6 +524,14 @@ function assertDatasetGoogleProperties(html, route, { requireDataset = false, re
   }
 
   for (const [index, dataset] of datasets.entries()) {
+    assert.ok(
+      Array.isArray(dataset.keywords)
+        && dataset.keywords.length > 0
+        && dataset.keywords.every((keyword) => (
+          typeof keyword === 'string' && keyword.trim().length > 0
+        )),
+      `${route} Dataset ${index + 1} must declare non-empty domain keywords`,
+    );
     const description = typeof dataset.description === 'string' ? dataset.description.trim() : '';
     assert.ok(
       description.length >= DATASET_DESCRIPTION_MIN_LENGTH,
@@ -632,6 +652,7 @@ describe('Dataset spatialCoverage Google contract', () => {
       '@type': 'Dataset',
       name: 'Contract test dataset',
       description: 'A focused contract fixture with enough detail for the Google Dataset description requirement.',
+      keywords: ['contract fixture'],
       creator: {
         '@id': 'https://www.worldmonitor.app/#organization',
         '@type': 'Organization',
@@ -1202,6 +1223,25 @@ describe('crawlable corpus generator', () => {
     assert.equal(datasetTemporalCoverage(''), undefined);
     assert.equal(datasetTemporalCoverage('2026-08-29T00:00:00Z'), undefined);
     assert.equal(datasetTemporalCoverage('schema-edit'), undefined);
+  });
+
+  it('derives Dataset temporalCoverage from all exported observation dates', () => {
+    assert.equal(
+      datasetObservationCoverage([
+        '2026-09-03T00:15:00.000Z',
+        '2026-09-01T23:45:00.000Z',
+        '2026-09-02T12:00:00.000Z',
+      ]),
+      '2026-09-01/2026-09-03',
+    );
+    assert.equal(
+      datasetObservationCoverage([
+        '2026-09-03T00:15:00.000Z',
+        '2026-09-03T23:45:00.000Z',
+      ]),
+      '2026-09-03',
+    );
+    assert.equal(datasetObservationCoverage([]), undefined);
   });
 
   it('uses one observed-value contract for every numeric page family', () => {
@@ -1972,12 +2012,106 @@ describe('crawlable corpus generator', () => {
       assertDataCatalogPresent(read(outDir, 'crises/index.html'), '/crises/');
       assertDataCatalogPresent(read(outDir, 'research/index.html'), '/research/');
 
+      const datasetTemplateContracts = [
+        {
+          name: 'CII hub',
+          route: '/country-instability-index/',
+          id: '#dataset',
+          identifier: `world-monitor-cii-${clock.ciiRanking.methodologyVersion}`,
+          artifact: 'country-instability-index/cii-ranking.json',
+          dataset: 'country-instability-index',
+          observationRows: 'countries',
+        },
+        {
+          name: 'countries hub',
+          route: '/countries/',
+          id: '#dataset',
+          identifier: 'country-resilience-ranking',
+          artifact: 'countries/resilience-ranking.json',
+          dataset: 'country-resilience-ranking',
+        },
+        {
+          name: 'country resilience',
+          route: '/countries/norway/',
+          id: '#resilience-dataset',
+        },
+        {
+          name: 'country CII',
+          route: '/countries/ukraine/',
+          id: '#cii-dataset',
+          artifact: 'countries/ukraine/cii.json',
+          dataset: 'country-instability-index',
+        },
+        {
+          name: 'chokepoints hub',
+          route: '/chokepoints/',
+          id: '#status-dataset',
+          identifier: 'world-monitor-chokepoint-status',
+          artifact: 'chokepoints/status.json',
+          dataset: 'maritime-chokepoint-status',
+          observationRows: 'chokepoints',
+        },
+        {
+          name: 'chokepoint detail',
+          route: '/chokepoints/strait-of-hormuz/',
+          id: '#chokepoint-dataset',
+        },
+        {
+          name: 'crisis tracker',
+          route: '/crises/red-sea-security/',
+          id: '#crisis-dataset',
+        },
+        {
+          name: 'signal convergence',
+          route: '/tools/signal-convergence/',
+          id: '#signal-convergence-dataset',
+          identifier: 'signal-convergence-reference',
+        },
+        {
+          name: 'research transit',
+          route: '/research/strait-of-hormuz-transit-report-2026-07/',
+          match: (dataset) => dataset.name?.startsWith('Strait of Hormuz daily transit calls'),
+        },
+      ];
+      assert.equal(datasetTemplateContracts.length, 9, 'the Dataset contract must cover all nine template families');
+      for (const contract of datasetTemplateContracts) {
+        const html = read(outDir, `${contract.route.slice(1)}index.html`);
+        const dataset = collectDatasets(jsonLdObjects(html)).find((entry) => (
+          contract.match?.(entry) || entry['@id']?.endsWith(contract.id)
+        ));
+        assert.ok(dataset, `${contract.name} Dataset template must be generated`);
+        assert.ok(Array.isArray(dataset.keywords) && dataset.keywords.length > 0,
+          `${contract.name} Dataset must expose keywords`);
+        if (contract.identifier) {
+          assert.equal(dataset.identifier, contract.identifier,
+            `${contract.name} Dataset identifier must be stable across captures`);
+        }
+        if (contract.artifact) {
+          const artifact = JSON.parse(read(outDir, contract.artifact));
+          assert.equal(artifact.dataset, contract.dataset,
+            `${contract.name} Dataset download must describe its published dataset`);
+          if (contract.observationRows) {
+            assert.equal(
+              dataset.temporalCoverage,
+              datasetObservationCoverage(
+                artifact[contract.observationRows].map((row) => row.observedAt),
+              ),
+              `${contract.name} Dataset temporalCoverage must span every exported observation`,
+            );
+          }
+        }
+      }
+
       for (const path of [
         'countries/index.html',
         'country-instability-index/index.html',
+        'country-instability-index/cii-ranking.json',
         'countries/norway/index.html',
         'countries/norway/resilience.json',
+        'countries/resilience-ranking.json',
+        'countries/ukraine/cii.json',
         'chokepoints/index.html',
+        'chokepoints/status.json',
         'chokepoints/strait-of-hormuz/index.html',
         'chokepoints/strait-of-hormuz/reference.json',
         'crises/index.html',
@@ -3077,7 +3211,11 @@ describe('crawlable corpus generator', () => {
         .sort()
         .at(-1);
       assert.equal(chokepointDataset.dateModified, latestChokepointUpdate);
-      assert.equal(chokepointDataset.temporalCoverage, corpusData.livePulse.capturedAt);
+      const chokepointArtifact = JSON.parse(read(outDir, 'chokepoints/status.json'));
+      assert.equal(
+        chokepointDataset.temporalCoverage,
+        datasetObservationCoverage(chokepointArtifact.chokepoints.map((row) => row.observedAt)),
+      );
       assert.ok(chokepointDataset.measurementTechnique);
       assert.ok(chokepointDataset.variableMeasured.length >= 3);
       assert.equal(chokepointDataset.distribution['@type'], 'DataDownload');
@@ -3908,7 +4046,7 @@ describe('crawlable corpus generator', () => {
       assert.equal(convergenceDataset['@id'], 'https://www.worldmonitor.app/tools/signal-convergence/#signal-convergence-dataset');
       assert.equal(convergenceDataset.url, 'https://www.worldmonitor.app/tools/signal-convergence/');
       const convergenceCapturedAt = corpus.livePulse.signalConvergence.capturedAt;
-      assert.equal(convergenceDataset.identifier, `signal-convergence-${convergenceCapturedAt}`);
+      assert.equal(convergenceDataset.identifier, 'signal-convergence-reference');
       assert.equal(convergenceDataset.datePublished, convergenceCapturedAt);
       assert.equal(convergenceDataset.spatialCoverage, 'Worldwide');
       assert.equal(convergenceDataset.variableMeasured[1].value, 3);
@@ -4045,7 +4183,7 @@ describe('crawlable corpus generator', () => {
       laterDate(data.lastmod.countries, CII_COUNTRY_PAGE_CONTENT_VERSION),
       'the CII country clock must derive from the generic country clock',
     );
-    assert.equal(data.lastmod.research, '2026-07-27');
+    assert.equal(data.lastmod.research, '2026-09-03');
     assert.equal(
       data.lastmod.chokepoints,
       laterDate(

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -1194,6 +1194,25 @@ describe('crawlable corpus generator', () => {
     );
   });
 
+  it('rejects a calendar-invalid CII observation timestamp', async () => {
+    const data = await loadCorpusData({ rootDir: repoRoot });
+    const livePulse = structuredClone(data.livePulse);
+    const countryCode = Object.keys(livePulse.countries).find((code) => {
+      const pulse = livePulse.countries[code];
+      return pulse.partial !== true && pulse.score != null && pulse.score !== '';
+    });
+    assert.ok(countryCode, 'expected a publishable CII country');
+    livePulse.countries[countryCode] = {
+      ...livePulse.countries[countryCode],
+      asOf: '2026-02-30T00:00:00.000Z',
+    };
+
+    assert.throws(
+      () => buildCiiRankingEntries(data.countries, livePulse),
+      new RegExp(`CII pulse timestamp is invalid for ${countryCode}`),
+    );
+  });
+
   it('rejects a chokepoint pulse key that is not in the registry', async () => {
     const data = await loadCorpusData({ rootDir: repoRoot });
     assert.doesNotThrow(

--- a/tests/research-report-corpus.test.mjs
+++ b/tests/research-report-corpus.test.mjs
@@ -95,7 +95,10 @@ describe('research report corpus (#5668)', () => {
       focus.observationEnd <= String(snapshot.capturedAt).slice(0, 10),
       'observation period must end on or before the retrieval date',
     );
-    assert.match(html, /<meta name="lastmod" content="2026-07-27">/);
+    assert.match(
+      html,
+      new RegExp(`<meta name="lastmod" content="${corpusData.lastmod.research}">`),
+    );
     assert.match(
       html,
       new RegExp(`published <time datetime="${report.datePublished}">`),


### PR DESCRIPTION
## Summary

World Monitor now publishes stable identities and real machine-readable downloads for its crawlable Dataset surfaces. Before this change, four identifiers changed with each capture, every Dataset template omitted keywords, and the highest-value distributions could point back to HTML instead of downloadable data.

## Scope

- Keep the CII ranking, resilience ranking, chokepoint status, and signal-convergence identifiers stable across captures.
- Add domain keywords to all nine Dataset template families.
- Generate JSON downloads for the CII ranking, resilience ranking, each published country CII record, and chokepoint status.
- Derive CII and chokepoint hub temporal coverage from the earliest and latest observations in each exported artifact.
- Advance the affected content clocks so crawlers can discover the corrected schema.

## Tradeoffs

The stable identifier names the evolving dataset series. Snapshot names, publication dates, modification dates, and temporal coverage still identify each edition. Dataset `sameAs` remains absent because there is no equivalent external dataset identity, and global spatial coverage remains plain text because synthetic geometry would not add source-backed precision.

## Blast radius

This changes only generated crawlable pages and their static artifacts. It does not change dashboard runtime APIs, bootstrap payloads, source ingestion, or persisted production data.

## Verification

- `node --import tsx --test tests/crawlable-corpus.test.mjs`: 65 passed
- `node --import tsx --test tests/research-report-corpus.test.mjs`: 12 passed
- `npm run test:data -- --test-reporter=dot`: 29,734 passed, 35 skipped, 0 failed
- `npm run typecheck`: passed
- `npm run lint`: passed with existing repository warnings
- Two clean corpus builds were byte-identical.
- A generated-output scan covered 242 pages and 249 Dataset nodes with zero missing keyword sets, date-stamped identifiers, HTML downloads, or missing download files.

## Post-Deploy Monitoring & Validation

On the first deployment, fetch `/country-instability-index/cii-ranking.json`, `/countries/resilience-ranking.json`, `/countries/ukraine/cii.json`, and `/chokepoints/status.json`. Each must return HTTP 200 with JSON content, and the adjacent page JSON-LD must keep stable identifiers, keywords, and observation-derived temporal coverage. A missing artifact, an HTML response, or a date-stamped identifier is a rollback trigger. Search Console URL inspection and index submission remain a manual maintainer acceptance step for the four issue URLs.

Fixes #7612

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
