### PR TITLE
fix: Windows-Preflight und plattformneutraler Blog-Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "postinstall": "npm run inventory:facts && cross-env npm_config_allow_scripts= npm --prefix blog-site ci --prefer-offline",
     "prebuild:blog": "npm run product:facts",
     "build:blog": "npm run build:blog:raw",
-    "build:blog:raw": "cd blog-site && npm run build && rm -rf ../public/blog && mkdir -p ../public/blog && cp -r dist/* ../public/blog/",
+    "build:blog:raw": "cd blog-site && npm run build && cd .. && node scripts/copy-blog-build.mjs",
     "build:crawlable-corpus": "node --import tsx scripts/build-crawlable-corpus.mjs",
     "audit:microstate-corpus": "node scripts/audit-microstate-corpus-similarity.mjs --check",
     "build:llms-full": "node --import tsx scripts/build-llms-full.mjs",

--- a/scripts/agent-preflight.mjs
+++ b/scripts/agent-preflight.mjs
@@ -122,6 +122,17 @@ Options:
   -h, --help            Show this help text.`);
 }
 
+export function spawnPreflightCommand(file, args, options) {
+  // Windows cannot execute npm's .cmd shim without a shell. Invoke the CLI
+  // with Node instead, preserving argv, cwd, environment and timeout semantics.
+  if (process.platform === 'win32' && file === 'npm') {
+    const npmCli = process.env.npm_execpath
+      || join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+    return spawnSync(process.execPath, [npmCli, ...args], options);
+  }
+  return spawnSync(file, args, options);
+}
+
 function runCommand(runner, file, args, options = {}) {
   const env = {
     ...process.env,
@@ -192,7 +203,7 @@ function binEntries(packageJson) {
   return Object.entries(packageJson.bin);
 }
 
-export function probeDependencies(rootDir = process.cwd(), runner = spawnSync) {
+export function probeDependencies(rootDir = process.cwd(), runner = spawnPreflightCommand) {
   const dependencyRoots = [
     { label: 'root', path: resolve(rootDir) },
     ...(existsSync(resolve(rootDir, 'blog-site', 'package.json'))
@@ -649,7 +660,7 @@ export function prepareInventoryFacts(
   return { attempted: true, error: null, ok: true, timeoutMs };
 }
 
-export function runAgentPreflight(options = {}, runner = spawnSync) {
+export function runAgentPreflight(options = {}, runner = spawnPreflightCommand) {
   const rootDir = resolve(options.rootDir || process.cwd());
   const skipBootstrap = Boolean(options.skipBootstrap);
   const node = supportedNode(rootDir);

--- a/scripts/copy-blog-build.mjs
+++ b/scripts/copy-blog-build.mjs
@@ -1,0 +1,12 @@
+import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const source = resolve(root, 'blog-site', 'dist');
+const target = resolve(root, 'public', 'blog');
+
+rmSync(target, { recursive: true, force: true });
+mkdirSync(target, { recursive: true });
+cpSync(source, target, { recursive: true });
+
+console.log(`Copied blog build from ${source} to ${target}`);

--- a/tests/agent-preflight.test.mjs
+++ b/tests/agent-preflight.test.mjs
@@ -18,6 +18,7 @@ import {
   prAlignment,
   probeDependencies,
   runAgentPreflight,
+  spawnPreflightCommand,
   supportedNode,
 } from '../scripts/agent-preflight.mjs';
 import { createTempDir } from './helpers/temp-dir.mjs';
@@ -27,6 +28,22 @@ const currentMajor = process.versions.node.split('.')[0];
 const headOid = 'a'.repeat(40);
 
 describe('agent preflight', () => {
+  it('runs the real npm CLI on Windows without a shell', {
+    skip: process.platform !== 'win32',
+  }, () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'windows-npm-probe' }));
+    const result = spawnPreflightCommand('npm', ['ls', '--depth=0', '--json'], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, npm_config_offline: 'true' },
+      timeout: 30_000,
+    });
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).name, 'windows-npm-probe');
+  });
+
   it('requires explicit opt-ins for dirty, detached, and stale-main states', () => {
     const options = parseArgs([
       '--allow-dirty',


### PR DESCRIPTION
## Änderungen

Behebt zwei Windows-Probleme: Der Agent-Preflight startet die npm-CLI unter Windows korrekt. Der Blog-Build verwendet einen plattformneutralen Node.js-Kopiervorgang.

Enthaltene Commits:
- `dc57d2f73` – `fix(preflight): run npm CLI correctly on Windows`
- `3ed80ab91` – `fix(build): make blog copy cross-platform`

## Validierung

Bereits lokal unter Windows durchgeführt und vom Autor bestätigt:
- Gezielter Preflight-Test: 17/17 bestanden
- Typecheck: bestanden
- `build:blog:raw`: bestanden
- Vollständiger Produktions-Build (`npm build`): bestanden

Vor der PR-Erstellung erneut geprüft:
- Agent-Preflight: READY (Node.js 24)
- `git diff --check`: bestanden
- Arbeitsverzeichnis sauber; keine zusätzlichen Codeänderungen
