### PR TITLE
fix(conflict): Zukunftsdaten aus dem EMA-Zeitfenster ausschließen

### DIFF
--- a/scripts/_ema-threat-engine.mjs
+++ b/scripts/_ema-threat-engine.mjs
@@ -69,7 +69,7 @@ export function computeEmaWindows(priorWindows, acledEvents, ucdpEvents, nowMs =
     const country = normalizeCountry(ev?.country);
     if (!country) continue;
     const ts = Date.parse(ev.event_date);
-    if (Number.isFinite(ts) && ts >= cutoff) {
+    if (Number.isFinite(ts) && ts >= cutoff && ts <= nowMs) {
       counts24h.set(country, (counts24h.get(country) ?? 0) + 1);
     }
   }
@@ -78,7 +78,7 @@ export function computeEmaWindows(priorWindows, acledEvents, ucdpEvents, nowMs =
     const country = normalizeCountry(ev?.country ?? ev?.country_name);
     if (!country) continue;
     const ts = Date.parse(ev.date_start);
-    if (Number.isFinite(ts) && ts >= cutoff) {
+    if (Number.isFinite(ts) && ts >= cutoff && ts <= nowMs) {
       counts24h.set(country, (counts24h.get(country) ?? 0) + 1);
     }
   }

--- a/tests/ema-threat-engine.test.mjs
+++ b/tests/ema-threat-engine.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeEmaWindows, updateWindow } from '../scripts/_ema-threat-engine.mjs';
+
+const now = Date.parse('2026-09-04T12:00:00Z');
+const day = 24 * 60 * 60 * 1000;
+
+for (const source of ['acled', 'ucdp']) {
+  test(`${source}: counts only observations inside the inclusive 24-hour window`, () => {
+    const dates = [now - day - 1, now - day, now - 1, now, now + 1, now + day];
+    const events = dates.map(timestamp => ({
+      country: 'Sudan',
+      [source === 'acled' ? 'event_date' : 'date_start']: new Date(timestamp).toISOString(),
+    }));
+    events.push({ country: 'Sudan', event_date: 'invalid', date_start: 'invalid' });
+    const windows = computeEmaWindows(new Map(),
+      source === 'acled' ? events : [], source === 'ucdp' ? events : [], now);
+    assert.deepEqual(windows.get('sudan').window, [3]);
+  });
+
+  test(`${source}: future-only observations do not create a country window`, () => {
+    const events = [{ country: 'Sudan', event_date: '2026-09-05', date_start: '2026-09-05' }];
+    const windows = computeEmaWindows(new Map(),
+      source === 'acled' ? events : [], source === 'ucdp' ? events : [], now);
+    assert.equal(windows.size, 0);
+  });
+}
+
+test('existing countries receive zero when their only new observations are in the future', () => {
+  const prior = updateWindow('sudan', 2, null);
+  const windows = computeEmaWindows(new Map([['sudan', prior]]),
+    [{ country: 'Sudan', event_date: '2026-09-05' }],
+    [{ country_name: 'Sudan', date_start: '2026-09-05' }], now);
+  assert.deepEqual(windows.get('sudan').window, [2, 0]);
+  assert.deepEqual(prior.window, [2]);
+});
+
+test('both sources retain current-day date-only observations and country-name fallback', () => {
+  const windows = computeEmaWindows(new Map(),
+    [{ country: ' Sudan ', event_date: '2026-09-04' }],
+    [{ country_name: 'SUDAN', date_start: '2026-09-04' }], now);
+  assert.deepEqual(windows.get('sudan').window, [2]);
+});


### PR DESCRIPTION
## Änderung

Die Konflikt-EMA zählte jedes Ereignis nach der unteren 24-Stunden-Grenze, einschließlich zukünftiger Zeitstempel. Beide Quellenpfade (ACLED und UCDP) begrenzen Beobachtungen jetzt zusätzlich auf den Auswertungszeitpunkt. Damit erhöhen fehlerhafte Zukunftsdaten die aktuellen Ereigniszahlen nicht mehr.

Sechs Regressionstests prüfen beide Zeitgrenzen, ungültige und zukünftige Datumswerte, bestehende Länderfenster, Datumswerte ohne Uhrzeit sowie den UCDP-Ländernamen-Fallback.

## Validierung

- Fehler reproduziert: 5 der 6 neuen Tests scheiterten vor dem Fix.
- `node --test tests/ema-threat-engine.test.mjs tests/conflict-gdelt.test.mjs`: 38/38 bestanden unter Windows, Node.js 24.20.0.
- `npm run typecheck`: bestanden.
- `git diff --check`: bestanden.
- Kein vollständiger Build: Änderung betrifft ausschließlich die reine serverseitige Berechnungsfunktion.
- Linux-Ausführung und Produktionsverhalten noch nicht bestätigt.

Eigenständiger Branch direkt von Upstream-main; enthält keine Commits aus PR #7627.
