### PR TITLE
fix(weather): ungültige Polygonpunkte aus Webhooks ausschließen

### DIFF
--- a/scripts/_weather-alert-select.mjs
+++ b/scripts/_weather-alert-select.mjs
@@ -145,7 +145,11 @@ function isClosedLinearRing(ring) {
   // Polygon. A real ring has at least 3 distinct vertices.
   const distinct = new Set();
   for (const position of ring) {
-    if (Array.isArray(position)) distinct.add(`${position[0]},${position[1]}`);
+    // A closed ring can still contain malformed interior vertices. In
+    // particular NaN/Infinity serialize as null in webhook GeoJSON.
+    if (!Array.isArray(position)
+      || !Number.isFinite(position[0]) || !Number.isFinite(position[1])) return false;
+    distinct.add(`${position[0]},${position[1]}`);
   }
   return distinct.size >= 3;
 }

--- a/tests/weather-alert-selection.test.mjs
+++ b/tests/weather-alert-selection.test.mjs
@@ -369,6 +369,26 @@ describe('weather_alert notification location payload', () => {
     );
   });
 
+  it('omits rings containing invalid interior positions even when their endpoints close', () => {
+    for (const position of [null, [], [-99], ['-99', 41], [-99, null],
+      [NaN, 41], [-99, Infinity], [false, 41]]) {
+      const ring = [[-100, 40], [-99, 40], position, [-100, 41], [-100, 40]];
+      assert.deepEqual(
+        weatherAlertNotifyLocation({ centroid: [-99.5, 40.5], coordinates: ring }),
+        { lat: 40.5, lon: -99.5 },
+      );
+    }
+  });
+
+  it('retains valid warned areas when another ring has invalid coordinates', () => {
+    const valid = POLYGON.coordinates[0];
+    const invalid = [[-100, 40], [-99, 40], [NaN, 41], [-100, 40]];
+    assert.deepEqual(
+      weatherAlertNotifyLocation({ centroid: [-99.5, 40.5], rings: [invalid, valid] }),
+      { lat: 40.5, lon: -99.5, geometry: { type: 'Polygon', coordinates: [valid] } },
+    );
+  });
+
   it('rejects a non-numeric centroid rather than coercing it to 0,0', () => {
     // Number(null) === 0 and Number.isFinite(0) is true, so a bare isFinite
     // check publishes 0,0 in the Gulf of Guinea — the exact value the


### PR DESCRIPTION
## Änderung

Geschlossene Wetterwarnungs-Polygone konnten ungültige innere Positionen enthalten und dennoch an Webhooks weitergegeben werden. NaN und Infinity wurden dabei als null serialisiert. Die Ringprüfung verlangt jetzt für jede Position zwei endliche numerische Koordinaten. Ungültige Ringe werden ausgelassen; der gültige Schwerpunkt und weitere gültige Teilflächen bleiben erhalten.

## Validierung

- Beide neuen Regressionstests scheiterten vor dem Fix.
- Wetter-Auswahl und Benachrichtigungs-Fan-out: 70/70 Tests bestanden unter Windows (Node.js 24).
- `git diff --check`: bestanden.
- Produktions-Build ausgeführt: Astro-Blog erfolgreich, danach Abbruch am unveränderten Upstream-Kopierschritt, weil `rm` unter Windows fehlt. Dieser unabhängige Fehler ist Gegenstand von PR #7627; dessen Commits sind hier nicht enthalten.
- Linux und produktive Webhook-Zustellung noch nicht verifiziert.

Branch direkt von Upstream-main; ausschließlich Wetter-Geometrievalidierung und Regressionstests.
