### PR TITLE
fix(weather): fehlende WMO-Koordinaten nicht als Null interpretieren

### DIFF
--- a/scripts/_weather-alert-select.mjs
+++ b/scripts/_weather-alert-select.mjs
@@ -613,19 +613,27 @@ export function requireSwicItems(data) {
   return data.items;
 }
 
+function swicCoordinate(value) {
+  // SWIC can supply numeric strings, but empty strings, null and booleans
+  // are missing data rather than coordinates on the equator/prime meridian.
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value.trim() !== '') return Number(value);
+  return NaN;
+}
+
 function swicCentroid(item, member) {
   const coords = extractCoordinates(item?.geometry);
   if (coords.length) {
     return { coordinates: coords, centroid: calculateCentroid(coords), geometryPrecision: 'polygon' };
   }
-  const itemLat = Number(item?.lat ?? item?.latitude);
-  const itemLon = Number(item?.lon ?? item?.lng ?? item?.longitude);
+  const itemLat = swicCoordinate(item?.lat ?? item?.latitude);
+  const itemLon = swicCoordinate(item?.lon ?? item?.lng ?? item?.longitude);
   if (Number.isFinite(itemLat) && Number.isFinite(itemLon)
     && itemLat >= -90 && itemLat <= 90 && itemLon >= -180 && itemLon <= 180) {
     return { coordinates: [], centroid: [itemLon, itemLat], geometryPrecision: 'point' };
   }
-  const memberLat = Number(member?.lat);
-  const memberLon = Number(member?.lng ?? member?.lon);
+  const memberLat = swicCoordinate(member?.lat);
+  const memberLon = swicCoordinate(member?.lng ?? member?.lon);
   if (Number.isFinite(memberLat) && Number.isFinite(memberLon)
     && memberLat >= -90 && memberLat <= 90 && memberLon >= -180 && memberLon <= 180) {
     return { coordinates: [], centroid: [memberLon, memberLat], geometryPrecision: 'country' };

--- a/tests/weather-alert-selection.test.mjs
+++ b/tests/weather-alert-selection.test.mjs
@@ -632,6 +632,34 @@ describe('WMO SWIC adapter on weather:alerts:v1', () => {
     assert.equal(location.geometry, undefined);
   });
 
+  it('falls back to the country when SWIC point coordinates are not numeric values', () => {
+    const members = indexSwicMembers([{ ra: 2, members: [swicMember()] }]);
+    for (const bad of ['', '  ', false, true, [], [12], {}, null]) {
+      const [alert] = selectSwicAlerts([swicItem({ extras: { lat: bad, lon: bad } })], members);
+      assert.equal(alert.geometryPrecision, 'country');
+      assert.deepEqual(alert.centroid, [78.96, 20.59]);
+    }
+  });
+
+  it('drops unplaceable SWIC alerts instead of coercing missing member coordinates to zero', () => {
+    for (const bad of ['', '  ', false, true, [], [12], {}, null]) {
+      const members = indexSwicMembers([{ ra: 2, members: [swicMember({ lat: bad, lng: bad })] }]);
+      assert.deepEqual(selectSwicAlerts([swicItem()], members), []);
+    }
+  });
+
+  it('retains genuine zero coordinates and numeric strings in SWIC point and country locations', () => {
+    for (const coordinate of [0, '0', ' 12.5 ']) {
+      const [point] = selectSwicAlerts([swicItem({ extras: { lat: coordinate, lon: coordinate } })]);
+      assert.equal(point.geometryPrecision, 'point');
+      assert.deepEqual(point.centroid, [Number(coordinate), Number(coordinate)]);
+      const members = indexSwicMembers([{ ra: 2, members: [swicMember({ lat: coordinate, lng: coordinate })] }]);
+      const [country] = selectSwicAlerts([swicItem()], members);
+      assert.equal(country.geometryPrecision, 'country');
+      assert.deepEqual(country.centroid, point.centroid);
+    }
+  });
+
   it('normalizes offset-free SWIC timestamps to explicit UTC instants', () => {
     const originalTimezone = process.env.TZ;
     process.env.TZ = 'America/New_York';


### PR DESCRIPTION
## Änderung

Der WMO-SWIC-Adapter interpretierte leere Zeichenketten, boolesche Werte und Arrays über Number(...) als Koordinaten. Dadurch konnten Warnungen fälschlich bei 0,0 oder anderen erfundenen Positionen erscheinen.

Die Konvertierung akzeptiert nur Zahlen und nichtleere numerische Zeichenketten. Ungültige Punktkoordinaten verwenden den vorhandenen Länder-Fallback. Sind auch dessen Koordinaten ungültig, bleibt die Warnung unplatzierbar. Echte Nullkoordinaten werden weiterhin unterstützt.

## Validierung

- Zwei neue Regressionstests reproduzierten den Fehler vor der Korrektur; ein positiver Kontrolltest schützt gültige Nullkoordinaten und numerische Strings.
- `node --test tests/weather-alert-selection.test.mjs tests/weather-alert-notify-fanout.test.mjs`: 71/71 bestanden unter Windows.
- `git diff --check`: bestanden.
- Kein erneuter Gesamt-Build: Der unmittelbar zuvor auf derselben Upstream-Basis ausgeführte Build scheiterte am unveränderten Windows-Blog-Kopierschritt (`rm` fehlt, separater PR #7627). Builddateien sind hier unverändert.
- Linux und produktiver Quellenbetrieb noch nicht verifiziert.

Eigenständiger Branch direkt von Upstream-main, ohne Commits aus PR #7627 oder #7629.
