### PR TITLE
fix(markets): ungültige Yahoo-Kurswerte abfangen

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -2016,10 +2016,12 @@ export function parseYahooChart(data, symbol) {
   if (!meta) return null;
 
   const price = meta.regularMarketPrice;
-  const prevClose = meta.chartPreviousClose || meta.previousClose || price;
+  if (!Number.isFinite(price)) return null;
+  const prevClose = [meta.chartPreviousClose, meta.previousClose]
+    .find(value => Number.isFinite(value) && value !== 0) ?? price;
   const change = prevClose ? ((price - prevClose) / prevClose) * 100 : 0;
   const closes = result.indicators?.quote?.[0]?.close;
-  const sparkline = roundSparkline(Array.isArray(closes) ? closes.filter((v) => v != null) : []);
+  const sparkline = roundSparkline(Array.isArray(closes) ? closes.filter(Number.isFinite) : []);
 
   return { symbol, name: symbol, display: symbol, price, change: +change.toFixed(2), sparkline };
 }

--- a/tests/yahoo-chart-validation.test.mjs
+++ b/tests/yahoo-chart-validation.test.mjs
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseYahooChart } from '../scripts/_seed-utils.mjs';
+
+function chart(meta, close = []) {
+  return { chart: { result: [{ meta, indicators: { quote: [{ close }] } }] } };
+}
+
+test('rejects missing and nonnumeric market prices', () => {
+  for (const price of [undefined, null, NaN, Infinity, -Infinity, '100', false]) {
+    assert.equal(parseYahooChart(chart({ regularMarketPrice: price }), 'TEST'), null);
+  }
+});
+
+test('keeps only finite numeric observations in the sparkline', () => {
+  const result = parseYahooChart(chart({ regularMarketPrice: 100 },
+    [90, null, NaN, Infinity, '95', false, 0, -2, 100]), 'TEST');
+  assert.deepEqual(result.sparkline, [90, 0, -2, 100]);
+});
+
+test('falls back to a valid previous close when chartPreviousClose is unusable', () => {
+  for (const previous of [null, NaN, Infinity, 'bad', 0]) {
+    const result = parseYahooChart(chart({ regularMarketPrice: 110,
+      chartPreviousClose: previous, previousClose: 100 }), 'TEST');
+    assert.equal(result.change, 10);
+  }
+});
+
+test('uses the current price when neither previous close is usable', () => {
+  const result = parseYahooChart(chart({ regularMarketPrice: 100,
+    chartPreviousClose: Infinity, previousClose: 'bad' }), 'TEST');
+  assert.equal(result.change, 0);
+});
+
+test('preserves legitimate zero and negative market prices', () => {
+  assert.equal(parseYahooChart(chart({ regularMarketPrice: 0, previousClose: 100 }), 'TEST').change, -100);
+  assert.equal(parseYahooChart(chart({ regularMarketPrice: -10, previousClose: 100 }), 'TEST').price, -10);
+});


### PR DESCRIPTION
Der gemeinsame Yahoo-Chart-Parser für Markt- und Rohstoffkurse konnte fehlende/nicht endliche Preise, ungültige Vergleichskurse und nichtnumerische Sparkline-Werte weitergeben. Er verwirft jetzt ungültige aktuelle Preise, wählt einen endlichen Vergleichskurs und filtert ungültige Sparkline-Beobachtungen. Gültige Null- und Negativpreise bleiben erhalten.

Validierung: Vier Regressionstests scheiterten vor dem Fix. `node --test tests/yahoo-chart-validation.test.mjs tests/seed-utils.test.mjs`: 24/24 bestanden unter Windows. `git diff --check` bestanden. Kein Typecheck oder Gesamt-Build, da ausschließlich JavaScript-Datenvalidierung geändert wurde. Linux und Produktion nicht verifiziert.

Eigenständiger Branch direkt von Upstream-main, unabhängig von PRs #7627–#7630.
