### PR TITLE
fix(gdelt): unmögliche Beobachtungszeitpunkte verwerfen

### DIFF
--- a/scripts/_conflict-gdelt.mjs
+++ b/scripts/_conflict-gdelt.mjs
@@ -25,7 +25,10 @@ export const GDELT_MAX_ARTICLES_PER_COUNTRY = 250;
 export function gdeltSeenDateToIso(seendate) {
   const s = String(seendate || '').replace(/[^0-9]/g, '');
   if (s.length < 8) return '';
-  return `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`;
+  const iso = `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`;
+  const ms = Date.parse(`${iso}T00:00:00Z`);
+  // Date.parse normalizes dates such as February 31 into the next month.
+  return Number.isFinite(ms) && new Date(ms).toISOString().slice(0, 10) === iso ? iso : '';
 }
 
 // Same stamp family, full precision: GDELT 14-digit timestamp → epoch ms, NaN
@@ -36,10 +39,11 @@ export function gdeltSeenDateToIso(seendate) {
 export function gdeltSeenDateToMs(value) {
   const digits = String(value || '').replace(/[^0-9]/g, '');
   if (digits.length < 14) return Number.NaN;
-  return Date.parse(
-    `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`
-      + `T${digits.slice(8, 10)}:${digits.slice(10, 12)}:${digits.slice(12, 14)}Z`,
-  );
+  const iso = `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`
+    + `T${digits.slice(8, 10)}:${digits.slice(10, 12)}:${digits.slice(12, 14)}`;
+  const ms = Date.parse(`${iso}Z`);
+  // Also reject clock rollover (24:00:00), rather than changing the observation day.
+  return Number.isFinite(ms) && new Date(ms).toISOString().slice(0, 19) === iso ? ms : Number.NaN;
 }
 
 export function buildGdeltConflictUrl(cc, name = GDELT_COUNTRY_NAMES[cc], maxRecords = GDELT_MAX_ARTICLES_PER_COUNTRY) {

--- a/tests/gdelt-calendar-validation.test.mjs
+++ b/tests/gdelt-calendar-validation.test.mjs
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { gdeltSeenDateToIso, gdeltSeenDateToMs, mapGdeltArticlesToEvents } from '../scripts/_conflict-gdelt.mjs';
+
+test('rejects impossible calendar days instead of rolling into another month', () => {
+  for (const stamp of ['20260229T120000Z', '20260431T120000Z', '20260231T120000Z',
+    '20261301T120000Z', '20260001T120000Z', '20260100T120000Z']) {
+    assert.equal(gdeltSeenDateToIso(stamp), '');
+    assert.ok(Number.isNaN(gdeltSeenDateToMs(stamp)));
+  }
+});
+
+test('preserves leap days, date-only inputs and both supported timestamp forms', () => {
+  assert.equal(gdeltSeenDateToIso('20240229'), '2024-02-29');
+  for (const stamp of ['20240229T123456Z', '20240229123456']) {
+    assert.equal(gdeltSeenDateToIso(stamp), '2024-02-29');
+    assert.equal(gdeltSeenDateToMs(stamp), Date.parse('2024-02-29T12:34:56Z'));
+  }
+});
+
+test('rejects overflowing clock components in full-precision timestamps', () => {
+  for (const stamp of ['20260430T240000Z', '20260430T126000Z', '20260430T125960Z']) {
+    assert.ok(Number.isNaN(gdeltSeenDateToMs(stamp)));
+  }
+});
+
+test('does not emit conflict events for articles with impossible dates', () => {
+  const events = mapGdeltArticlesToEvents([
+    { seendate: '20260231T120000Z', title: 'invalid', url: 'https://example.com/invalid' },
+    { seendate: '20260228T120000Z', title: 'valid', url: 'https://example.com/valid' },
+  ], 'SD');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event_date, '2026-02-28');
+});


### PR DESCRIPTION
GDELT-Datumswerte konnten unmögliche Kalendertage enthalten. Der Tagesparser übernahm sie unverändert, während Date.parse im Zeitstempelparser etwa den 31. Februar in den März verschob. Beide Parser prüfen jetzt nach dem Parsen, dass UTC-Datum beziehungsweise Datum und Uhrzeit exakt dem Eingang entsprechen. Ungültige Tage und überlaufende Uhrzeiten werden verworfen; gültige Schaltjahrestage und unterstützte Zeitformate bleiben erhalten.

Validierung: Drei Regressionstests scheiterten vor dem Fix. `node --test tests/gdelt-calendar-validation.test.mjs tests/conflict-gdelt.test.mjs tests/conflict-gdelt-bulk.test.mjs`: 50/50 bestanden unter Windows. `git diff --check` bestanden. Kein Gesamt-Build/Typecheck: ausschließlich JavaScript-Datumsparser geändert. Linux und Produktion nicht verifiziert.

Separater Branch direkt von Upstream-main; keine Änderungen an den bestehenden Entwicklungs-PRs.
