### PR TITLE
fix(statcan): fehlende Beobachtungen nicht als Nullwerte veröffentlichen

### DIFF
--- a/scripts/lib/statcan-wds.mjs
+++ b/scripts/lib/statcan-wds.mjs
@@ -102,6 +102,10 @@ export function parseVectorSeries(doc, vectorId) {
     const points = [];
     for (const pt of Array.isArray(object.vectorDataPoint) ? object.vectorDataPoint : []) {
       const refPer = typeof pt?.refPer === 'string' ? pt.refPer : null;
+      // Missing/suppressed observations are not measured zeros. Retain numeric
+      // strings, but do not let Number(null), Number('') or Number(false) invent data.
+      if (typeof pt?.value !== 'number'
+        && !(typeof pt?.value === 'string' && pt.value.trim() !== '')) continue;
       const value = typeof pt?.value === 'number' ? pt.value : Number(pt?.value);
       if (!refPer || !/^\d{4}-\d{2}-\d{2}$/.test(refPer) || !Number.isFinite(value)) continue;
       points.push({

--- a/tests/statcan-missing-observations.test.mjs
+++ b/tests/statcan-missing-observations.test.mjs
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseVectorSeries, latestUnemployment } from '../scripts/lib/statcan-wds.mjs';
+
+function parse(values) {
+  return parseVectorSeries([{ status: 'SUCCESS', object: {
+    vectorId: 123, productId: 456,
+    vectorDataPoint: values.map((value, i) => ({ refPer: `2026-0${i + 1}-01`, value })),
+  } }], 123);
+}
+
+test('missing or malformed observations do not become zero-valued StatCan data', () => {
+  for (const value of [null, undefined, '', '  ', false, true, [], [12], {}, NaN, Infinity]) {
+    assert.deepEqual(parse([value]).points, []);
+  }
+});
+
+test('genuine zero and numeric strings remain valid observations', () => {
+  assert.deepEqual(parse([0, '0', ' 6.5 ', -2]).points.map(point => point.value), [0, 0, 6.5, -2]);
+});
+
+test('a missing latest observation cannot replace the preceding unemployment rate with zero', () => {
+  const series = parse([6.5, null]);
+  const latest = latestUnemployment(series.points);
+  assert.equal(latest.unemploymentPct, 6.5);
+  assert.equal(latest.refPer, '2026-01-01');
+});


### PR DESCRIPTION
Der StatCan-Vektorparser wandelte null, leere Strings und boolesche Werte über Number(...) in scheinbare Beobachtungen um. Eine fehlende jüngste Arbeitslosenquote konnte so den letzten gültigen Wert durch 0 Prozent ersetzen.

Der Parser lässt nur numerische Werte und nichtleere numerische Zeichenketten zu. Fehlende Beobachtungen werden ausgelassen; der letzte gültige Wert behält sein tatsächliches Referenzdatum. Echte Nullwerte bleiben gültig.

Validierung: Zwei neue Regressionstests scheiterten vor dem Fix. `node --test tests/statcan-missing-observations.test.mjs tests/statcan-wds.test.mjs`: 17/17 bestanden unter Windows, einschließlich vorhandener Freshness- und Zeitzonentests. `git diff --check` bestanden. Keine Build-/TypeScript-Änderungen, daher kein Gesamt-Build/Typecheck. Linux und Produktion nicht verifiziert.

Eigenständiger Branch direkt von Upstream-main; keine bestehenden PR-Commits enthalten.
