### PR TITLE
fix(imf): fehlende WEO-Wachstumswerte nicht konvertieren

### DIFF
--- a/scripts/seed-imf-growth.mjs
+++ b/scripts/seed-imf-growth.mjs
@@ -46,7 +46,8 @@ export function weoYears() {
 
 export function latestValue(byYear) {
   for (const year of weoYears()) {
-    const v = Number(byYear?.[year]);
+    // imfSdmxFetchIndicator already normalizes observations to numbers.
+    const v = byYear?.[year];
     if (Number.isFinite(v)) return { value: v, year: Number(year) };
   }
   return null;

--- a/tests/imf-growth-missing-values.test.mjs
+++ b/tests/imf-growth-missing-values.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { latestValue, weoYears, buildGrowthCountries } from '../scripts/seed-imf-growth.mjs';
+
+const [current, previous, oldest] = weoYears();
+
+// imfSdmxFetchIndicator normalizes SDMX observations to numbers before
+// returning the year map. Numeric strings are not part of this internal contract.
+for (const [label, value] of [
+  ['null', null], ['empty string', ''], ['whitespace', ' \t '],
+  ['false', false], ['true', true], ['numeric string', '2.5'],
+  ['nonnumeric string', 'missing'], ['undefined', undefined],
+  ['empty array', []], ['numeric array', [2.5]], ['object', {}],
+  ['NaN', NaN], ['Infinity', Infinity],
+]) {
+  test(`growth rejects ${label} and falls back to the next valid year`, () => {
+    assert.equal(latestValue({ [current]: value }), null);
+    assert.deepEqual(latestValue({ [current]: value, [previous]: 2.5 }),
+      { value: 2.5, year: Number(previous) });
+  });
+}
+
+test('growth retains a genuine numeric zero in preference to older observations', () => {
+  assert.deepEqual(latestValue({ [current]: 0, [previous]: 2.5 }),
+    { value: 0, year: Number(current) });
+});
+
+test('growth falls through multiple missing years without losing the observation year', () => {
+  assert.deepEqual(latestValue({ [current]: null, [previous]: '', [oldest]: -1.2 }),
+    { value: -1.2, year: Number(oldest) });
+});
+
+test('growth publication omits missing-only countries and preserves fallback freshness', () => {
+  const countries = buildGrowthCountries({ realGdpGrowth: {
+    USA: { [current]: null }, GBR: { [current]: '', [previous]: 1.5 },
+    FRA: { [current]: 0 },
+  } });
+  assert.equal(countries.US, undefined);
+  assert.equal(countries.GB.realGdpGrowthPct, 1.5);
+  assert.equal(countries.GB.year, Number(previous));
+  assert.equal(countries.GB.latestYear, Number(previous));
+  assert.equal(countries.FR.realGdpGrowthPct, 0);
+});


### PR DESCRIPTION
`latestValue()` konnte null, leere Strings, boolesche Werte und Arrays zu scheinbaren IMF-WEO-Beobachtungen konvertieren. Der Growth-Seeder akzeptiert jetzt ausschließlich endliche Zahlen und fällt sonst auf das nächstältere gültige Jahr zurück. Echte numerische Null bleibt gültig.

Datenvertrag: `imfSdmxFetchIndicator()` normalisiert SDMX-Beobachtungen bereits mit parseFloat zu Zahlen. Numerische Strings sind deshalb im internen Jahres-Mapping nicht erforderlich und werden in latestValue ebenso verworfen wie andere vertragswidrige Typen.

Validierung: 16 neue Tests, davon 10 vor dem Fix fehlgeschlagen. `node --test tests/imf-growth-missing-values.test.mjs tests/seed-imf-extended.test.mjs tests/imf-weo-content-age.test.mjs`: 49/49 bestanden unter Windows. Tests decken null, leere/Whitespace-Strings, beide Booleans, echte Null, numerische und nichtnumerische Strings, Arrays, NaN/Infinity, Mehrjahres-Fallback sowie Veröffentlichungs- und Freshness-Verhalten ab. `git diff --check` bestanden. Kein Gesamt-Build/Typecheck (nur JavaScript). Linux/Produktion nicht bestätigt.

Eigenständiger Branch direkt von Upstream-main. Keine bestehenden PRs verändert.
