### PR TITLE
fix(imf): fehlende Labor- und External-Werte nicht konvertieren

### DIFF
--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -48,7 +48,8 @@ export function weoYears() {
 
 export function latestValue(byYear) {
   for (const year of weoYears()) {
-    const v = Number(byYear?.[year]);
+    // imfSdmxFetchIndicator already normalizes observations to numbers.
+    const v = byYear?.[year];
     if (Number.isFinite(v)) return { value: v, year: Number(year) };
   }
   return null;

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -39,7 +39,8 @@ export function weoYears() {
 
 export function latestValue(byYear) {
   for (const year of weoYears()) {
-    const v = Number(byYear?.[year]);
+    // imfSdmxFetchIndicator already normalizes observations to numbers.
+    const v = byYear?.[year];
     if (Number.isFinite(v)) return { value: v, year: Number(year) };
   }
   return null;

--- a/tests/imf-labor-external-missing-values.test.mjs
+++ b/tests/imf-labor-external-missing-values.test.mjs
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as labor from '../scripts/seed-imf-labor.mjs';
+import * as external from '../scripts/seed-imf-external.mjs';
+
+for (const [name, adapter] of [['labor', labor], ['external', external]]) {
+  const [current, previous, oldest] = adapter.weoYears();
+  test(`${name}: invalid values neither create observations nor hide older valid years`, () => {
+    for (const invalid of [null, undefined, '', ' \t ', false, true, '2.5', 'missing', [], [2.5], {}, NaN, Infinity]) {
+      assert.equal(adapter.latestValue({ [current]: invalid }), null);
+      assert.deepEqual(adapter.latestValue({ [current]: invalid, [previous]: -1.2 }),
+        { value: -1.2, year: Number(previous) });
+    }
+  });
+
+  test(`${name}: genuine zero takes precedence over an older value`, () => {
+    assert.deepEqual(adapter.latestValue({ [current]: 0, [previous]: 2.5 }),
+      { value: 0, year: Number(current) });
+  });
+
+  test(`${name}: skips consecutive missing years`, () => {
+    assert.deepEqual(adapter.latestValue({ [current]: null, [previous]: '', [oldest]: 2.5 }),
+      { value: 2.5, year: Number(oldest) });
+  });
+}
+
+test('labor does not publish a missing unemployment rate as current-year zero', () => {
+  const [current, previous] = labor.weoYears();
+  const countries = labor.buildLaborCountries({ unemployment: {
+    USA: { [current]: null }, GBR: { [current]: false, [previous]: 4.5 },
+  } });
+  assert.equal(countries.US, undefined);
+  assert.equal(countries.GB.unemploymentPct, 4.5);
+  assert.equal(countries.GB.latestYear, Number(previous));
+});
+
+test('external omits countries without any valid observations', () => {
+  const [current] = external.weoYears();
+  assert.deepEqual(external.buildExternalCountries({
+    currentAccount: { USA: { [current]: null } },
+    importVol: { USA: { [current]: false } },
+    exportVol: { USA: { [current]: '' } },
+  }), {});
+});


### PR DESCRIPTION
Die IMF-Labor- und External-Seeder konnten fehlende Jahreswerte über Number(...) in scheinbare Nullbeobachtungen umwandeln. Beide latestValue-Funktionen akzeptieren jetzt nur endliche Zahlen und verwenden bei ungültigen Werten das nächstältere gültige Jahr. Echte Nullwerte bleiben gültig.

Der interne Vertrag liefert Zahlen: imfSdmxFetchIndicator normalisiert SDMX-Beobachtungen bereits per parseFloat. Eine zweite, breitere Typkonvertierung ist daher unnötig. Numerische Strings im internen Mapping werden ebenfalls zurückgewiesen.

Validierung: Sechs neue Regressionstests scheiterten vor dem Fix. `node --test tests/imf-labor-external-missing-values.test.mjs tests/seed-imf-extended.test.mjs tests/imf-weo-content-age.test.mjs`: 41/41 bestanden unter Windows. Die Tests sichern Typvalidierung, echte Null, Jahres-Fallback und die veröffentlichten Länderwerte ab. `git diff --check` bestanden. Kein Typecheck/Gesamt-Build, ausschließlich JavaScript. Linux/Produktion nicht verifiziert.

Eigenständiger Branch direkt von Upstream-main. Der separate Growth-Fix #7634 ist nicht enthalten und bleibt unverändert.
