### PR TITLE
fix(open511): ungültige Verkehrskoordinaten verwerfen

### DIFF
--- a/scripts/lib/open511.mjs
+++ b/scripts/lib/open511.mjs
@@ -54,7 +54,8 @@ function hostnameOf(baseUrl) {
 }
 
 function finiteCoord(value) {
-  if (value == null || value === '') return null;
+  if (typeof value !== 'number'
+    && !(typeof value === 'string' && value.trim() !== '')) return null;
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
 }
@@ -96,6 +97,7 @@ function pairFrom(value) {
   const lon = finiteCoord(value[0]);
   const lat = finiteCoord(value[1]);
   if (lon == null || lat == null) return null;
+  if (lon < -180 || lon > 180 || lat < -90 || lat > 90) return null;
   return [lon, lat];
 }
 

--- a/tests/open511-coordinate-validation.test.mjs
+++ b/tests/open511-coordinate-validation.test.mjs
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { geometryFromOpen511, normalizeOpen511Event } from '../scripts/lib/open511.mjs';
+
+const empty = { lat: null, lon: null, centroid: null, path: null };
+
+test('Open511 rejects coerced coordinate values in either axis', () => {
+  for (const invalid of [null, '', '  ', false, true, {}, NaN, Infinity]) {
+    for (const coordinates of [[invalid, 49], [-123, invalid]]) {
+      assert.deepEqual(geometryFromOpen511({ type: 'Point', coordinates }), empty);
+    }
+  }
+  assert.deepEqual(geometryFromOpen511({ type: 'Point', coordinates: [-123, []] }), empty);
+});
+
+test('Open511 rejects coordinates outside longitude and latitude ranges', () => {
+  for (const coordinates of [[181, 49], [-181, 49], [-123, 91], [-123, -91]]) {
+    assert.deepEqual(geometryFromOpen511({ type: 'Point', coordinates }), empty);
+  }
+});
+
+test('Open511 preserves zero, boundary coordinates and supported numeric strings', () => {
+  for (const coordinates of [[0, 0], [180, 90], [-180, -90], ['-123.5', '49.5']]) {
+    const point = geometryFromOpen511({ type: 'Point', coordinates });
+    assert.deepEqual(point.centroid, coordinates.map(Number));
+  }
+});
+
+test('malformed line vertices cannot distort the normalized event location', () => {
+  const record = normalizeOpen511Event({ id: 'example', geography: {
+    type: 'LineString', coordinates: [[-124, 48], [false, ' '], [-122, 50], [1000, 49]],
+  } });
+  assert.deepEqual(record.centroid, [-123, 49]);
+  assert.equal(record.lon, -123);
+  assert.equal(record.lat, 49);
+});


### PR DESCRIPTION
Open511-Koordinaten konnten Whitespace, Booleans und Arrays zu scheinbaren Zahlen konvertieren; Bereichsgrenzen fehlten ebenfalls. Dadurch verzerrten fehlerhafte Quellpunkte den Schwerpunkt normalisierter Verkehrsereignisse.

Der Adapter akzeptiert nur Zahlen oder nichtleere numerische Strings sowie Longitude [-180,180] und Latitude [-90,90]. Ungültige Punkte verwenden das bestehende Verhalten für fehlende Geometrie; ungültige Linienpositionen werden vor der Schwerpunktberechnung ausgelassen. Echte Null- und Grenzkoordinaten bleiben gültig.

Validierung: Drei Regressionstests scheiterten vor dem Fix. `node --test tests/open511-coordinate-validation.test.mjs tests/open511.test.mjs`: 32/32 bestanden unter Windows. `git diff --check` bestanden. Kein Build/Typecheck (JavaScript-Adapter). Linux/Produktion offen.

Eigenständiger Branch direkt von Upstream-main; bestehende PRs unverändert.
