### PR TITLE
fix(toronto): ungültige Straßenkoordinaten abfangen

### DIFF
--- a/scripts/lib/toronto-road-restrictions.mjs
+++ b/scripts/lib/toronto-road-restrictions.mjs
@@ -123,9 +123,9 @@ export function parseGeoPolyline(value) {
     const out = [];
     for (const point of value) {
       if (Array.isArray(point) && point.length >= 2) {
-        const lon = Number(point[0]);
-        const lat = Number(point[1]);
-        if (Number.isFinite(lon) && Number.isFinite(lat)) out.push([lon, lat]);
+        const lon = finiteCoord(point[0]);
+        const lat = finiteCoord(point[1], 90);
+        if (lon != null && lat != null) out.push([lon, lat]);
       } else if (typeof point === 'string') {
         out.push(...parseGeoPolyline(point));
       }
@@ -139,13 +139,14 @@ export function parseGeoPolyline(value) {
     const re = /\[\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\]/g;
     let match;
     while ((match = re.exec(trimmed))) {
-      const lon = Number(match[1]);
-      const lat = Number(match[2]);
-      if (Number.isFinite(lon) && Number.isFinite(lat)) pairs.push([lon, lat]);
+      const lon = finiteCoord(match[1]);
+      const lat = finiteCoord(match[2], 90);
+      if (lon != null && lat != null) pairs.push([lon, lat]);
     }
     return pairs;
   }
-  return decodeEncodedPolyline(trimmed);
+  return decodeEncodedPolyline(trimmed)
+    .filter(([lon, lat]) => finiteCoord(lon) != null && finiteCoord(lat, 90) != null);
 }
 
 export function downsamplePath(path) {
@@ -171,10 +172,11 @@ export function centroidOfPath(path) {
   return [lon / path.length, lat / path.length];
 }
 
-function finiteCoord(value) {
-  if (value == null || value === '') return null;
+function finiteCoord(value, limit = 180) {
+  if (typeof value !== 'number'
+    && !(typeof value === 'string' && value.trim() !== '')) return null;
   const n = Number(value);
-  return Number.isFinite(n) ? n : null;
+  return Number.isFinite(n) && n >= -limit && n <= limit ? n : null;
 }
 
 function textOf(...values) {
@@ -205,7 +207,7 @@ function severityOf(item, { isFullClosure, type } = {}) {
 
 export function normalizeTorontoRoadRecord(item) {
   const type = restrictionType(item);
-  const lat = finiteCoord(item?.latitude ?? item?.Latitude ?? item?.lat);
+  const lat = finiteCoord(item?.latitude ?? item?.Latitude ?? item?.lat, 90);
   const lon = finiteCoord(item?.longitude ?? item?.Longitude ?? item?.lon ?? item?.lng);
   const decoded = parseGeoPolyline(
     item?.geoPolyline ?? item?.GeoPolyline ?? item?.EncodedPolyline ?? item?.encodedPolyline,

--- a/tests/toronto-coordinate-validation.test.mjs
+++ b/tests/toronto-coordinate-validation.test.mjs
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeTorontoRoadRecord, parseGeoPolyline } from '../scripts/lib/toronto-road-restrictions.mjs';
+
+test('Toronto array polylines reject missing or coerced positions', () => {
+  for (const invalid of [null, '', ' ', false, true, [], [1], {}, NaN, Infinity]) {
+    assert.deepEqual(parseGeoPolyline([[invalid, 43], [-79, invalid]]), []);
+  }
+});
+
+test('Toronto rejects out-of-range coordinates in array and string polylines', () => {
+  const invalid = [[181, 43], [-181, 43], [-79, 91], [-79, -91]];
+  assert.deepEqual(parseGeoPolyline(invalid), []);
+  assert.deepEqual(parseGeoPolyline(JSON.stringify(invalid)), []);
+});
+
+test('Toronto preserves genuine zeros, boundary values and numeric strings', () => {
+  assert.deepEqual(parseGeoPolyline([[0, 0], [180, 90], [-180, -90], ['-79.5', '43.5']]),
+    [[0, 0], [180, 90], [-180, -90], [-79.5, 43.5]]);
+});
+
+test('invalid direct Toronto coordinates cannot override a valid road path', () => {
+  for (const invalid of [false, true, ' ', [], 999]) {
+    const record = normalizeTorontoRoadRecord({ latitude: invalid, longitude: invalid,
+      geoPolyline: [[-80, 43], [-79, 44]] });
+    assert.deepEqual(record.centroid, [-79.5, 43.5]);
+    assert.equal(record.lat, null);
+    assert.equal(record.lon, null);
+  }
+});


### PR DESCRIPTION
Der Toronto-Straßenrestriktionsadapter wandelte ungültige Quellwerte in scheinbare Koordinaten um. Direkte false/Whitespace-Koordinaten konnten etwa den gültigen Linien-Fallback durch 0,0 verdrängen. Array-Polylines akzeptierten null als Nullkoordinate; Bereichsgrenzen fehlten.

Die Koordinatenprüfung akzeptiert Zahlen und nichtleere numerische Strings innerhalb gültiger Longitude-/Latitude-Grenzen. Sie wird für direkte Koordinaten sowie Array-, Text- und dekodierte Polylines verwendet. Echte Null- und Grenzkoordinaten bleiben gültig.

Validierung: Drei Regressionstests scheiterten vor dem Fix. `node --test tests/toronto-coordinate-validation.test.mjs tests/toronto-road-restrictions.test.mjs`: 24/24 bestanden unter Windows. `git diff --check` bestanden. Kein Build/Typecheck (nur JavaScript-Adapter). Linux und Produktion offen.

Eigenständiger Branch direkt von Upstream-main. Keine bestehenden PRs verändert.
