### PR TITLE
fix(provincial-511): validate direct geographic coordinates

### DIFF
--- a/scripts/lib/provincial-511.mjs
+++ b/scripts/lib/provincial-511.mjs
@@ -183,10 +183,10 @@ export function centroidOfPath(path) {
   return [lon / path.length, lat / path.length];
 }
 
-function finiteCoord(value) {
-  if (value == null || value === '') return null;
+function finiteCoord(value, limit = 180) {
+  if (typeof value !== 'number' && (typeof value !== 'string' || !value.trim())) return null;
   const n = Number(value);
-  return Number.isFinite(n) ? n : null;
+  return Number.isFinite(n) && Math.abs(n) <= limit ? n : null;
 }
 
 function textOf(...values) {
@@ -229,7 +229,7 @@ function severityOf(item, { isFullClosure, highImportance, kind } = {}) {
 export function normalize511Record(item, ctx) {
   const kind = ctx.kind;
   const jurisdiction = ctx.jurisdiction || 'ON';
-  const lat = finiteCoord(item?.Latitude ?? item?.latitude ?? item?.lat);
+  const lat = finiteCoord(item?.Latitude ?? item?.latitude ?? item?.lat, 90);
   const lon = finiteCoord(item?.Longitude ?? item?.longitude ?? item?.lon ?? item?.lng);
   const encoded = polylinesFrom(item?.EncodedPolyline ?? item?.encodedPolyline);
   const decoded = encoded.flatMap(decodeEncodedPolyline);

--- a/tests/provincial-coordinate-validation.test.mjs
+++ b/tests/provincial-coordinate-validation.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalize511Record } from '../scripts/lib/provincial-511.mjs';
+
+const normalize = (Latitude, Longitude, extra = {}) => normalize511Record(
+  { Id: 'coordinate-test', Latitude, Longitude, ...extra },
+  { kind: 'event', jurisdiction: 'ON' },
+);
+
+for (const value of [null, '', '  ', false, true, [], [43], {}, NaN, Infinity, 'invalid']) {
+  test(`rejects invalid direct coordinate ${JSON.stringify(value)} (${typeof value})`, () => {
+    assert.equal(normalize(value, -79).lat, null);
+    assert.equal(normalize(43, value).lon, null);
+    assert.equal(normalize(value, value).centroid, null);
+  });
+}
+
+test('rejects coordinates outside geographic bounds', () => {
+  for (const lat of [-90.1, 90.1, '91']) assert.equal(normalize(lat, 0).centroid, null);
+  for (const lon of [-180.1, 180.1, '181']) assert.equal(normalize(0, lon).centroid, null);
+});
+
+test('preserves zero, numeric strings, and geographic boundaries', () => {
+  for (const [lat, lon] of [[0, 0], ['43.5', '-79.5'], [' 0 ', '0'], [-90, -180], [90, 180]]) {
+    assert.deepEqual(normalize(lat, lon).centroid, [Number(lon), Number(lat)]);
+  }
+});
+
+test('invalid direct coordinates fall back to the encoded path', () => {
+  const record = normalize(false, [], { EncodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@' });
+  assert.equal(record.lat, null);
+  assert.equal(record.lon, null);
+  assert.ok(Math.abs(record.centroid[0] - (-122.53433333333334)) < 1e-8);
+  assert.ok(Math.abs(record.centroid[1] - 40.81733333333333) < 1e-8);
+});


### PR DESCRIPTION
Der Provincial-511-Adapter interpretierte Whitespace, Booleans und Arrays durch Number() als gültige Direktkoordinaten. Auch Werte außerhalb der geografischen Grenzen konnten den vorhandenen Polyline-Fallback verdrängen.

Der Fix akzeptiert nur endliche Zahlen oder nichtleere numerische Strings innerhalb der Breiten-/Längengrenzen. Echte Nullkoordinaten bleiben gültig. Ungültige Direktkoordinaten fallen auf die vorhandene Liniengeometrie zurück.

Validierung unter Windows: 7 Regressionstests vor dem Fix fehlgeschlagen; anschließend alle 51 Provincial-511-Tests bestanden. git diff --check bestanden. Ausschließlich JavaScript, daher kein Typecheck oder Gesamt-Build. Keine Aussage über Live-Daten oder Produktion.
