### PR TITLE
fix(blog): keep sitemap lastmod importable without blog-site node_modules

### DIFF
--- a/blog-site/astro.config.mjs
+++ b/blog-site/astro.config.mjs
@@ -1,111 +1,12 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
-import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync, existsSync } from 'node:fs';
-import { basename } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const SITE_URL = 'https://www.worldmonitor.app';
-const BLOG_DIR = new URL('./src/content/blog/', import.meta.url);
-const GLOSSARY_DATA = new URL('./src/data/glossary.ts', import.meta.url);
-const AUTHORS_DIR = new URL('./src/pages/authors/', import.meta.url);
-const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
-
-function readFrontmatterDate(markdown, key) {
-  const frontmatter = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!frontmatter) return undefined;
-
-  const match = frontmatter[1].match(new RegExp(`^${key}:\\s*["']?([^"'\\n]+)["']?\\s*$`, 'm'));
-  return match?.[1];
-}
-
-function setPostDate(postDates, pathname, date) {
-  const normalized = pathname.endsWith('/') ? pathname : `${pathname}/`;
-  postDates.set(normalized, date);
-  postDates.set(normalized.slice(0, -1), date);
-  postDates.set(`${SITE_URL}${normalized}`, date);
-  postDates.set(`${SITE_URL}${normalized.slice(0, -1)}`, date);
-}
-
-/** Prefer git commit date (YYYY-MM-DD); fall back to null when unavailable. */
-function gitFileLastmod(absoluteFileUrl) {
-  try {
-    const absolutePath = fileURLToPath(absoluteFileUrl);
-    if (!existsSync(absolutePath)) return null;
-    const relative = absolutePath.startsWith(REPO_ROOT)
-      ? absolutePath.slice(REPO_ROOT.length).replace(/^\//, '')
-      : absolutePath;
-    const out = execFileSync(
-      'git',
-      ['log', '-1', '--format=%cs', '--', relative],
-      { cwd: REPO_ROOT, encoding: 'utf8' },
-    ).trim();
-    return /^\d{4}-\d{2}-\d{2}$/.test(out) ? out : null;
-  } catch {
-    return null;
-  }
-}
-
-function laterDate(...values) {
-  return values
-    .filter((value) => /^\d{4}-\d{2}-\d{2}$/.test(value ?? ''))
-    .sort()
-    .at(-1) ?? null;
-}
-
-function glossarySlugsFromSource(source) {
-  const slugs = [];
-  for (const match of source.matchAll(/slug:\s*'([^']+)'/g)) {
-    slugs.push(match[1]);
-  }
-  return slugs;
-}
-
-export function buildPostDateMap() {
-  const postDates = new Map();
-  let blogLastmod = '2026-06-10';
-
-  for (const file of readdirSync(BLOG_DIR)) {
-    if (!file.endsWith('.md')) continue;
-
-    const slug = basename(file, '.md');
-    const markdown = readFileSync(new URL(file, BLOG_DIR), 'utf8');
-    const date = readFrontmatterDate(markdown, 'modifiedDate')
-      || readFrontmatterDate(markdown, 'pubDate');
-
-    if (!date) continue;
-
-    setPostDate(postDates, `/blog/posts/${slug}/`, date);
-    if (date > blogLastmod) blogLastmod = date;
-  }
-
-  // Glossary + author hubs previously shipped without lastmod (#7382). Use
-  // git material dates so Astro's sitemap serialize can stamp every blog URL.
-  const glossaryLastmod = gitFileLastmod(GLOSSARY_DATA) || blogLastmod;
-  setPostDate(postDates, '/blog/glossary/', glossaryLastmod);
-  const glossarySource = readFileSync(GLOSSARY_DATA, 'utf8');
-  for (const slug of glossarySlugsFromSource(glossarySource)) {
-    setPostDate(postDates, `/blog/glossary/${slug}/`, glossaryLastmod);
-  }
-
-  if (existsSync(fileURLToPath(AUTHORS_DIR))) {
-    for (const file of readdirSync(AUTHORS_DIR)) {
-      if (!file.endsWith('.astro')) continue;
-      const slug = basename(file, '.astro');
-      const authorLastmod = laterDate(
-        gitFileLastmod(new URL(file, AUTHORS_DIR)),
-        blogLastmod,
-      );
-      setPostDate(postDates, `/blog/authors/${slug}/`, authorLastmod);
-    }
-  }
-
-  setPostDate(postDates, '/blog/', laterDate(blogLastmod, glossaryLastmod));
-  return postDates;
-}
-
-export const POST_DATES = buildPostDateMap();
+// Lastmod computation lives in post-dates.mjs so it stays importable without
+// this workspace's node_modules. Import it from there, not through this file:
+// anything reaching it via astro.config.mjs pulls astro/config in with it,
+// which is what broke the unit job after #7646.
+import { POST_DATES } from './post-dates.mjs';
 
 export default defineConfig({
   site: 'https://www.worldmonitor.app',

--- a/blog-site/post-dates.mjs
+++ b/blog-site/post-dates.mjs
@@ -1,0 +1,114 @@
+// @ts-check
+// Sitemap lastmod dates for every blog URL.
+//
+// Deliberately free of third-party imports so it can be read without
+// blog-site/node_modules present. astro.config.mjs consumes it, and
+// tests/blog-seo-contract.test.mjs imports it directly: CI jobs other than the
+// blog build no longer install this workspace, so a test reaching through
+// astro.config.mjs would pull in astro/config and fail to resolve.
+
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SITE_URL = 'https://www.worldmonitor.app';
+const BLOG_DIR = new URL('./src/content/blog/', import.meta.url);
+const GLOSSARY_DATA = new URL('./src/data/glossary.ts', import.meta.url);
+const AUTHORS_DIR = new URL('./src/pages/authors/', import.meta.url);
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+function readFrontmatterDate(markdown, key) {
+  const frontmatter = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontmatter) return undefined;
+
+  const match = frontmatter[1].match(new RegExp(`^${key}:\\s*["']?([^"'\\n]+)["']?\\s*$`, 'm'));
+  return match?.[1];
+}
+
+function setPostDate(postDates, pathname, date) {
+  const normalized = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  postDates.set(normalized, date);
+  postDates.set(normalized.slice(0, -1), date);
+  postDates.set(`${SITE_URL}${normalized}`, date);
+  postDates.set(`${SITE_URL}${normalized.slice(0, -1)}`, date);
+}
+
+/** Prefer git commit date (YYYY-MM-DD); fall back to null when unavailable. */
+function gitFileLastmod(absoluteFileUrl) {
+  try {
+    const absolutePath = fileURLToPath(absoluteFileUrl);
+    if (!existsSync(absolutePath)) return null;
+    const relative = absolutePath.startsWith(REPO_ROOT)
+      ? absolutePath.slice(REPO_ROOT.length).replace(/^\//, '')
+      : absolutePath;
+    const out = execFileSync(
+      'git',
+      ['log', '-1', '--format=%cs', '--', relative],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    ).trim();
+    return /^\d{4}-\d{2}-\d{2}$/.test(out) ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+function laterDate(...values) {
+  return values
+    .filter((value) => /^\d{4}-\d{2}-\d{2}$/.test(value ?? ''))
+    .sort()
+    .at(-1) ?? null;
+}
+
+function glossarySlugsFromSource(source) {
+  const slugs = [];
+  for (const match of source.matchAll(/slug:\s*'([^']+)'/g)) {
+    slugs.push(match[1]);
+  }
+  return slugs;
+}
+
+export function buildPostDateMap() {
+  const postDates = new Map();
+  let blogLastmod = '2026-06-10';
+
+  for (const file of readdirSync(BLOG_DIR)) {
+    if (!file.endsWith('.md')) continue;
+
+    const slug = basename(file, '.md');
+    const markdown = readFileSync(new URL(file, BLOG_DIR), 'utf8');
+    const date = readFrontmatterDate(markdown, 'modifiedDate')
+      || readFrontmatterDate(markdown, 'pubDate');
+
+    if (!date) continue;
+
+    setPostDate(postDates, `/blog/posts/${slug}/`, date);
+    if (date > blogLastmod) blogLastmod = date;
+  }
+
+  // Glossary + author hubs previously shipped without lastmod (#7382). Use
+  // git material dates so Astro's sitemap serialize can stamp every blog URL.
+  const glossaryLastmod = gitFileLastmod(GLOSSARY_DATA) || blogLastmod;
+  setPostDate(postDates, '/blog/glossary/', glossaryLastmod);
+  const glossarySource = readFileSync(GLOSSARY_DATA, 'utf8');
+  for (const slug of glossarySlugsFromSource(glossarySource)) {
+    setPostDate(postDates, `/blog/glossary/${slug}/`, glossaryLastmod);
+  }
+
+  if (existsSync(fileURLToPath(AUTHORS_DIR))) {
+    for (const file of readdirSync(AUTHORS_DIR)) {
+      if (!file.endsWith('.astro')) continue;
+      const slug = basename(file, '.astro');
+      const authorLastmod = laterDate(
+        gitFileLastmod(new URL(file, AUTHORS_DIR)),
+        blogLastmod,
+      );
+      setPostDate(postDates, `/blog/authors/${slug}/`, authorLastmod);
+    }
+  }
+
+  setPostDate(postDates, '/blog/', laterDate(blogLastmod, glossaryLastmod));
+  return postDates;
+}
+
+export const POST_DATES = buildPostDateMap();

--- a/tests/blog-seo-contract.test.mjs
+++ b/tests/blog-seo-contract.test.mjs
@@ -259,7 +259,9 @@ describe('blog SEO and GEO corpus contract', () => {
   });
 
   it('stamps glossary and author sitemap URLs with lastmod (#7382)', async () => {
-    const { buildPostDateMap } = await import('../blog-site/astro.config.mjs');
+    // post-dates.mjs, not astro.config.mjs: this workspace is installed only by
+    // the blog build now, so importing the config would need astro/config here.
+    const { buildPostDateMap } = await import('../blog-site/post-dates.mjs');
     const dates = buildPostDateMap();
     const iso = /^\d{4}-\d{2}-\d{2}$/;
     for (const key of [


### PR DESCRIPTION
**`main` is currently red.** This fixes it.

#7646 stopped `postinstall` installing `blog-site`. But `tests/blog-seo-contract.test.mjs:262` reaches the lastmod logic through `await import('../blog-site/astro.config.mjs')`, and that config's first line is `import { defineConfig } from 'astro/config'`. With the workspace no longer installed on the `unit` job, that resolves to:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'astro'
  imported from blog-site/astro.config.mjs
```

## This is my miss on #7646

I enumerated the blog-site consumers with a truncated `grep -rln ... | head -15` and concluded no test needed the workspace's `node_modules`. The real list is **19 files**, and this was one of the four outside that window. Verifying against a tree where an earlier build had repopulated `blog-site/node_modules` hid it locally.

## The fix

`buildPostDateMap` and its helpers use only `node:` builtins. Nothing about computing sitemap dates needs Astro; only the config's own framework imports do. So the pure block moves to `blog-site/post-dates.mjs`, `astro.config.mjs` consumes it, and the test imports the pure module.

`astro.config.mjs` deliberately **does not** re-export `buildPostDateMap`. It was exported only for that test, nothing else imports the config, and leaving the re-export would let the same bug back in through the same door.

The separation stands on its own terms too. Sitemap lastmod derivation is not framework configuration; it lived there only because that is where the sitemap integration reads it.

## Verification, under the real CI condition

Every check below ran with `blog-site/node_modules` **deleted**, which is what the `unit` job now sees.

| check | result |
|---|---|
| `blog-seo-contract` on **main's** files | **fails**, `Cannot find package 'astro'` |
| same test with this change | **passes** |
| all 19 blog-site-referencing suites | **434 pass, 0 fail** |
| `npm run build:blog:raw` | installs, builds **76 pages** + sitemap |

The before/after used the same command and the same conditions, so the failure is reproduced rather than inferred.

https://claude.ai/code/session_01XLRs5LLfcDemc5Z85eHE2R
