### PR TITLE
fix(conflict): cover HRP countries with a global subnational HAPI sweep

### DIFF
--- a/scripts/_conflict-hapi.mjs
+++ b/scripts/_conflict-hapi.mjs
@@ -5,7 +5,15 @@ import {
 } from './_seed-utils.mjs';
 
 export const HAPI_PAGE_LIMIT = 10_000;
-export const HAPI_MAX_PAGES = 3;
+// 3 pages sized the admin-0-only sweep, which is ~650 rows — two orders of
+// magnitude of slack. The global admin-2 sweep that covers the HRP countries is
+// ~13.8k rows for ONE monthly reference period (measured 2026-09-04), and the
+// seeder's previousMonthStart window can hold TWO of them, i.e. ~27.6k — 92% of
+// a 30k ceiling, with an overflow throwing instead of truncating. 5 pages keeps
+// ~1.8x headroom on that measured worst case while capping a stalled sweep at
+// 5 x HAPI_REQUEST_TIMEOUT_MS(15s) = 75s, which the seeder's fetch-deadline
+// arithmetic above GDELT_SWEEP_BUDGET_MS accounts for.
+export const HAPI_MAX_PAGES = 5;
 export const HAPI_HDX_PACKAGE_URL = 'https://data.humdata.org/api/3/action/package_show?id=hdx-hapi-conflict-event';
 const HAPI_HDX_METADATA_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 export const HAPI_HDX_MAX_RESPONSE_BYTES = 64 * 1024 * 1024;

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1200,10 +1200,12 @@
       "scripts/package.json",
       "scripts/seed-conflict-intel.mjs",
       "scripts/shared/country-names.json",
+      "scripts/shared/crawlable-crises.json",
       "scripts/shared/hapi-app-identifier.json",
       "scripts/shared/iso2-to-iso3.json",
       "scripts/shared/iso3-to-iso2.json",
       "shared/country-names.json",
+      "shared/crawlable-crises.json",
       "shared/hapi-app-identifier.json",
       "shared/iso2-to-iso3.json",
       "shared/iso3-to-iso2.json"

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -106,6 +106,19 @@ export const HAPI_FAILURE_BACKOFF_MS = 2 * 60 * 60 * 1000;
 const HAPI_FAILURE_BACKOFF_KEY = 'conflict:humanitarian:hapi-backoff:v1';
 const HAPI_REQUEST_TIMEOUT_MS = 15_000;
 const HAPI_REQUEST_DELAY_MS = 1_100;
+// #7656: wall-clock budget for the last-resort per-country fan-out, in the same
+// "a request may not LAUNCH after the cutoff" shape as GDELT_SWEEP_BUDGET_MS.
+// Without it the two global sweeps (each ≤ HAPI_MAX_PAGES × HAPI_REQUEST_TIMEOUT_MS
+// = 75s) could be followed by 23 sequential per-country requests — 23 × 15s plus
+// 22 × 1.1s pacing ≈ 369s — for a 519s direct route, well past the 315s envelope
+// the whole fetch-deadline model is anchored on. Elapsed is measured from
+// fetchAllHumanitarianSummaries ENTRY, matching fetchAll's own documented anchor,
+// so slow sweeps SHRINK this window instead of stacking on top of it: the direct
+// route is bounded by max(150s sweeps, 140s budget) + one 15s in-flight request
+// = 165s. seed-fetch-deadline-budget-invariants models the looser 150 + 140 + 15
+// = 305s ≤ 315s on purpose — an invariant that cannot understate reality is the
+// one worth asserting, and it still fails if this constant grows past 150s.
+export const HAPI_FALLBACK_BUDGET_MS = 140_000;
 const PIZZINT_TTL = 600;
 
 export const CONFLICT_COUNTRIES = [
@@ -175,17 +188,21 @@ const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_
 // auxiliary stage, not after the sweep, and re-derive as follows. Direct route:
 // each sweep costs at most HAPI_MAX_PAGES(5) × HAPI_REQUEST_TIMEOUT_MS(15s) = 75s,
 // so ≤150s, and the per-country fallback below now iterates ZERO countries because
-// the two sweeps are upstream-disjoint and jointly cover every published country.
+// the two sweeps are upstream-disjoint and jointly cover every published country —
+// and is wall-clock capped by HAPI_FALLBACK_BUDGET_MS when it does iterate.
 // Bot-block route: a 15s API rejection plus 60s HDX metadata and, only at the
 // January boundary, at most two 120s annual snapshot downloads — the same ≤315s
 // bound as before, because that ONE memoized snapshot serves both sweeps and the
 // fallback rather than being paid per request. Degenerate route (both sweeps miss
-// a required country): the retained fallback adds at most 23 × (15s timeout +
-// 1.1s pacing) ≈ 370s on top of the 150s sweeps ≈ 520s. All three remain under
-// ACLED_INTEL_LOCK_TTL_MS's 540s fetch deadline (lockTtlMs+120s)
-// below. What this replaced was a fan-out paid on EVERY run — 6 missing countries
-// ≈ 97s, and ≈290s once the 13 HRP countries that publish only admin-2 rows were
-// added to the required set (re-verified #5554 review; HAPI_COUNTRIES is 38).
+// a required country): the retained fallback is capped by HAPI_FALLBACK_BUDGET_MS
+// measured from this function's entry, so the sweeps and the fan-out SHARE that
+// window rather than stacking — max(150s, 140s) + one 15s in-flight request =
+// 165s (#7656; unbounded it was 150s + 369s = 519s, which broke the anchor).
+// All three remain under ACLED_INTEL_LOCK_TTL_MS's 540s fetch deadline
+// (lockTtlMs+120s) below. What this replaced was a fan-out paid on EVERY run —
+// 6 missing countries ≈ 97s, and ≈290s once the 13 HRP countries that publish
+// only admin-2 rows were added to the required set (re-verified #5554 review;
+// HAPI_COUNTRIES is 38).
 export const GDELT_SWEEP_BUDGET_MS = 120_000;
 // Cold-start floor for the bulk-primary path (#5849 review): only consulted
 // on a TRUE cold start (no previous snapshot of any kind — #5855 review). Kept
@@ -777,6 +794,11 @@ async function fetchHapiRows({
 export async function fetchAllHumanitarianSummaries({
   fetchFn = (...args) => globalThis.fetch(...args),
   now = Date.now,
+  // `now` is the DATA clock — tests pin it to a fixed date so request URLs and
+  // reference periods stay stable — so elapsed time needs its own reader. It
+  // defaults to the MONOTONIC clock rather than Date.now: a mid-run NTP step
+  // must not hand the fan-out below a budget it has not actually spent.
+  readElapsedMs = () => performance.now(),
   pace = sleep,
   countryCodes = HAPI_COUNTRIES,
   requiredCountryCodes = countryCodes === HAPI_COUNTRIES ? HAPI_REQUIRED_COUNTRIES : countryCodes,
@@ -796,6 +818,7 @@ export async function fetchAllHumanitarianSummaries({
   preserveLastGood = defaultPreserveHapiLastGood,
 } = {}) {
   const nowMs = now();
+  const startedAtMs = readElapsedMs();
   const failureBackoff = await loadFailureBackoff().catch((error) => {
     console.warn(`  HAPI backoff read failed: ${error.message}`);
     return null;
@@ -924,6 +947,18 @@ export async function fetchAllHumanitarianSummaries({
     let fallbackRows = 0;
     for (let i = 0; i < missingCountries.length; i += 1) {
       const countryCode = missingCountries[i];
+      // Snapshot-backed iterations issue no network request — they filter rows
+      // already in memory — so they are not what this budget bounds, and gating
+      // them would disable the net exactly when the bot-block route needs it.
+      if (!useSnapshot && readElapsedMs() - startedAtMs >= HAPI_FALLBACK_BUDGET_MS) {
+        const skipped = missingCountries.slice(i);
+        fallbackFailure = Object.assign(
+          new Error(`fallback budget exhausted with ${skipped.length} required countries unattempted`),
+          { reasonCode: 'HAPI_FALLBACK_BUDGET_EXHAUSTED' },
+        );
+        console.warn(`  HAPI fallback budget exhausted after ${i}/${missingCountries.length} countries — skipped ${skipped.join(', ')}`);
+        break;
+      }
       try {
         const rows = await fetchRows({
           nowMs,

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -113,30 +113,48 @@ export const CONFLICT_COUNTRIES = [
   'IQ', 'PS', 'LY', 'ML', 'BF', 'NE', 'NG', 'CM', 'MZ', 'HT',
 ];
 export const GDELT_MIN_SUCCESSFUL_COUNTRIES = Math.ceil(CONFLICT_COUNTRIES.length * 0.8);
-// Crisis-tracker registry (shared/crawlable-crises.json) countries HAPI must cover that
-// CONFLICT_COUNTRIES doesn't already include. Kept as a SEPARATE list, not merged into
-// CONFLICT_COUNTRIES — that array also sizes GDELT_MIN_SUCCESSFUL_COUNTRIES and the GDELT
-// sweep threshold below; growing it here would silently shift GDELT's coverage floor and
-// break its fixed-count tests (#5554 — a prior fix attempt did exactly this).
-const HAPI_ONLY_COUNTRIES = ['IR', 'IL', 'RU', 'SA', 'DJ', 'ER'];
+// DERIVED from the crisis-tracker registry, never hand-listed. This used to be a
+// hardcoded duplicate of shared/crawlable-crises.json's coverage codes with nothing
+// pinning the two together, so adding a tracker shipped a public /crises/<slug> page
+// whose country the seeder never requested — a page that fails closed forever with no
+// test, no alarm and no drift signal. Reading the registry makes it the single source.
+export const HAPI_CRISIS_COUNTRIES = [
+  ...new Set(
+    (loadSharedConfig('crawlable-crises.json') || [])
+      .flatMap((crisis) => (Array.isArray(crisis?.coverage) ? crisis.coverage : []))
+      .map((entry) => String(entry?.code || '').toUpperCase())
+      .filter(Boolean),
+  ),
+].sort();
+// Registry countries HAPI must cover that CONFLICT_COUNTRIES doesn't already include.
+// Kept as a SEPARATE list, not merged into CONFLICT_COUNTRIES — that array also sizes
+// GDELT_MIN_SUCCESSFUL_COUNTRIES and the GDELT sweep threshold below; growing it here
+// would silently shift GDELT's coverage floor and break its fixed-count tests
+// (#5554 — a prior fix attempt did exactly this).
+const HAPI_ONLY_COUNTRIES = HAPI_CRISIS_COUNTRIES.filter(
+  (countryCode) => !CONFLICT_COUNTRIES.includes(countryCode),
+);
 // The dashboard's country-tension widget (src/services/conflict/index.ts
 // HAPI_COUNTRY_CODES) requests this 20-country watchlist. Before this fix, a cache
 // miss fell back to a live HAPI fetch, so incomplete seed coverage was invisible;
 // the RPC handlers are now cache-only (#5554 review), so every widget country is
 // part of the guaranteed coverage contract. Keep the complete list in sync with
 // that file rather than listing only the countries unique to the dashboard.
-const HAPI_DASHBOARD_COUNTRIES = [
+export const HAPI_DASHBOARD_COUNTRIES = [
   'US', 'RU', 'CN', 'UA', 'IR', 'IL', 'TW', 'KP', 'SA', 'TR',
   'PL', 'DE', 'FR', 'GB', 'IN', 'PK', 'SY', 'YE', 'MM', 'VE',
 ];
-const HAPI_CRISIS_COUNTRIES = ['IR', 'IL', 'UA', 'RU', 'SD', 'YE', 'SA', 'DJ', 'ER'];
 // Public crisis trackers and the dashboard batch are the guaranteed coverage
-// contract. The broader conflict set is still collected when national rows are
-// present, but it does not trigger a per-country fallback fan-out.
+// contract. The broader conflict set is still collected opportunistically from the
+// same two bulk sweeps. api/health.js's humanitarianSummary minRecordCount tracks
+// this length — tests/seed-conflict-intel-hapi-circuit-breaker pins the pair.
 export const HAPI_REQUIRED_COUNTRIES = [
   ...new Set([...HAPI_CRISIS_COUNTRIES, ...HAPI_DASHBOARD_COUNTRIES]),
 ];
-const HAPI_COUNTRIES = [...new Set([...HAPI_ONLY_COUNTRIES, ...HAPI_DASHBOARD_COUNTRIES, ...CONFLICT_COUNTRIES])];
+// countryCodes filters the aggregation, so a registry code absent here would be
+// fetched by the sweeps below and then silently discarded. HAPI_ONLY_COUNTRIES is what
+// carries every crisis-registry code into this list; that link is asserted by test.
+export const HAPI_COUNTRIES = [...new Set([...HAPI_ONLY_COUNTRIES, ...HAPI_DASHBOARD_COUNTRIES, ...CONFLICT_COUNTRIES])];
 // The bounded transport emits stable route-specific failure codes. Treat the
 // failures known to implicate the selected route as a run-scoped circuit
 // signal; repeating them for another country cannot improve source reachability.
@@ -144,8 +162,8 @@ const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_
 // #5140: the GDELT fallback sweep may not LAUNCH a batch after this much of the
 // fetch phase has elapsed (fetchAll anchors the clock at its own entry and passes
 // an absolute deadline down, so slow aux feeds automatically shrink the sweep
-// window instead of stacking on top of it). HAPI now uses one bounded API request
-// plus, only on bot detection, an official snapshot instead of a 38-country
+// window instead of stacking on top of it). HAPI now uses two bounded global API
+// sweeps plus, only on bot detection, an official snapshot instead of a 38-country
 // sequential sweep. One
 // in-flight batch may still drain past the cutoff: ≤~100s at the knobs below
 // (either 15s concurrent direct legs when no proxy is configured, or 4 × 20s
@@ -153,11 +171,21 @@ const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_
 // proxy attempts block the event loop one at a time). Worst single fetchAll attempt before the bulk
 // fallback is now dominated by the GDELT path. Without this cap a
 // GDELT brownout ran 5 batches ≈ 375s+ → deadline breach → exit 75 every tick.
-// HAPI's 15s API plus 60s metadata and, only at the January boundary, at most
-// two 120s annual snapshot downloads run inside the parallel auxiliary stage,
-// not after the sweep. The resulting ≤315s HAPI bound remains comfortably under
+// HAPI's two global sweeps (admin-0 then admin-2) run inside the parallel
+// auxiliary stage, not after the sweep, and re-derive as follows. Direct route:
+// each sweep costs at most HAPI_MAX_PAGES(5) × HAPI_REQUEST_TIMEOUT_MS(15s) = 75s,
+// so ≤150s, and the per-country fallback below now iterates ZERO countries because
+// the two sweeps are upstream-disjoint and jointly cover every published country.
+// Bot-block route: a 15s API rejection plus 60s HDX metadata and, only at the
+// January boundary, at most two 120s annual snapshot downloads — the same ≤315s
+// bound as before, because that ONE memoized snapshot serves both sweeps and the
+// fallback rather than being paid per request. Degenerate route (both sweeps miss
+// a required country): the retained fallback adds at most 23 × (15s timeout +
+// 1.1s pacing) ≈ 370s on top of the 150s sweeps ≈ 520s. All three remain under
 // ACLED_INTEL_LOCK_TTL_MS's 540s fetch deadline (lockTtlMs+120s)
-// below (re-verified #5554 review after growing HAPI_COUNTRIES to 38).
+// below. What this replaced was a fan-out paid on EVERY run — 6 missing countries
+// ≈ 97s, and ≈290s once the 13 HRP countries that publish only admin-2 rows were
+// added to the required set (re-verified #5554 review; HAPI_COUNTRIES is 38).
 export const GDELT_SWEEP_BUDGET_MS = 120_000;
 // Cold-start floor for the bulk-primary path (#5849 review): only consulted
 // on a TRUE cold start (no previous snapshot of any kind — #5855 review). Kept
@@ -854,13 +882,45 @@ export async function fetchAllHumanitarianSummaries({
       nowMs,
       adminLevel: '0',
     });
-    const results = aggregateHapiConflictEvents(nationalRows, { nowMs, countryCodes });
 
-    // HRP/GHO countries may only publish subnational rows. Fetch only the
-    // national-missing target countries and aggregate their deepest available
-    // administrative level, pacing the bounded fallback sequentially.
+    // HRP/GHO countries publish ONLY admin-2 rows and never a national row, so
+    // admin-0 alone left every one of them (AFG, SOM, COD, SSD, ETH, MLI, BFA,
+    // NER, NGA, CMR, MOZ, HTI, PSE …) reachable only through the per-country
+    // fan-out below — i.e. invisible unless someone remembered to hand-add the
+    // code to a required list. One more global request at the deepest published
+    // level covers all of them in ~2 pages. Upstream publishes each country at
+    // exactly ONE admin level, so the two sweeps are disjoint today; aggregating
+    // the concatenation in a SINGLE pass (rather than merging two aggregates)
+    // still routes any future overlap through aggregateHapiConflictEvents'
+    // "latest reference period, then deepest admin level" tiebreak, with the
+    // national rows placed first so the deeper level wins the reset.
+    // A failure here is deliberately NOT fatal — the admin-0 countries are
+    // already in hand and the bounded fallback below can still cover the rest —
+    // but it is recorded as a fallback failure so the run still backs off.
+    let subnationalRows = [];
+    let sweepFailure = null;
+    try {
+      subnationalRows = await fetchRows({
+        nowMs,
+        adminLevel: '2',
+      });
+    } catch (error) {
+      if (error.reasonCode === 'HAPI_HDX_SNAPSHOT_FALLBACK_FAILED') throw error;
+      sweepFailure = error;
+      console.warn(`  HAPI subnational sweep failed: ${error.message}`);
+    }
+
+    const results = aggregateHapiConflictEvents(
+      [...nationalRows, ...subnationalRows],
+      { nowMs, countryCodes },
+    );
+
+    // Last-resort guard, not the normal path: with both global sweeps in hand
+    // this iterates ZERO countries. It stays as the fail-closed net for a
+    // required country upstream moves to an admin level neither sweep requests,
+    // pacing the bounded per-country requests sequentially.
     const missingCountries = requiredCountryCodes.filter((countryCode) => !results[countryCode]);
-    let fallbackFailure = null;
+    let fallbackFailure = sweepFailure;
     let fallbackRows = 0;
     for (let i = 0; i < missingCountries.length; i += 1) {
       const countryCode = missingCountries[i];
@@ -920,7 +980,7 @@ export async function fetchAllHumanitarianSummaries({
     }
 
     const requiredCovered = requiredCountryCodes.filter((countryCode) => results[countryCode]).length;
-    console.log(`  Humanitarian: ${Object.keys(results).length}/${countryCodes.length} countries (${requiredCovered}/${requiredCountryCodes.length} required) from ${nationalRows.length + fallbackRows} bulk rows`);
+    console.log(`  Humanitarian: ${Object.keys(results).length}/${countryCodes.length} countries (${requiredCovered}/${requiredCountryCodes.length} required) from ${nationalRows.length + subnationalRows.length + fallbackRows} bulk rows`);
     return results;
   } catch (error) {
     failure = error;

--- a/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
+++ b/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
@@ -3,7 +3,8 @@
 // The first repair paced 38 per-country requests at ~1 request/second, but the
 // production identifier was blocked again after that still produced thousands
 // of requests per day. The durable contract is:
-//   - one national-level bulk request for the target countries,
+//   - two global bulk requests (admin-0, then admin-2 for the HRP countries that
+//     publish no national row at all) for the target countries,
 //   - no new request while the last successful snapshot is fresh,
 //   - direct bot-block failures switch to HAPI's official HDX snapshot,
 //   - quota/identifier throttles persist a failure backoff without snapshotting,
@@ -17,6 +18,8 @@ import {
   HAPI_FAILURE_BACKOFF_MS,
   HAPI_HDX_MAX_RESPONSE_BYTES,
   HAPI_HDX_PACKAGE_URL,
+  HAPI_COUNTRIES,
+  HAPI_DASHBOARD_COUNTRIES,
   HAPI_REFRESH_INTERVAL_MS,
   HAPI_REQUIRED_COUNTRIES,
   aggregateHapiConflictEvents,
@@ -28,11 +31,33 @@ import {
 import {
   HAPI_HDX_METADATA_TIMEOUT_MS,
   HAPI_HDX_SNAPSHOT_TIMEOUT_MS,
+  HAPI_MAX_PAGES,
+  HAPI_PAGE_LIMIT,
   hapiHdxFailureReason,
   readBoundedHapiHdxText,
 } from '../scripts/_conflict-hapi.mjs';
 
 const NOW = Date.parse('2026-07-26T13:30:00Z');
+// The seeder DERIVES its crisis coverage from this registry instead of duplicating
+// the codes, so these tests read the same file rather than restating them: a
+// hand-written expectation here would reintroduce the exact drift being fixed.
+const CRISIS_REGISTRY_PATH = new URL('../shared/crawlable-crises.json', import.meta.url);
+const CRISIS_REGISTRY_COUNTRIES = [...new Set(
+  JSON.parse(readFileSync(CRISIS_REGISTRY_PATH, 'utf8'))
+    .flatMap((crisis) => crisis.coverage.map((entry) => entry.code.toUpperCase())),
+)];
+
+function hapiRow(locationCode, overrides = {}) {
+  return {
+    location_code: locationCode,
+    reference_period_start: '2026-07-01',
+    admin_level: 0,
+    event_type: 'political_violence',
+    events: 1,
+    fatalities: 0,
+    ...overrides,
+  };
+}
 const HAPI_CSV_HEADER = '\ufefflocation_code,has_hrp,in_gho,provider_admin1_name,provider_admin2_name,admin1_code,admin1_name,admin2_code,admin2_name,admin_level,event_type,events,fatalities,reference_period_start,reference_period_end,dataset_hdx_id,resource_hdx_id,warning,error';
 
 function hapiCsv(...rows) {
@@ -58,9 +83,9 @@ function hapiHdxMetadata(resources = [hapiHdxResource(2026)]) {
 test('humanitarian health reports partial target-country coverage', () => {
   const healthSource = readFileSync(new URL('../api/health.js', import.meta.url), 'utf8');
   const seedSource = readFileSync(new URL('../scripts/seed-conflict-intel.mjs', import.meta.url), 'utf8');
-  assert.match(
-    healthSource,
-    /humanitarianSummary:\s*\{[^}]*maxStaleMin:\s*300,\s*minRecordCount:\s*23\s*\}/,
+  const minRecordCount = Number(
+    /humanitarianSummary:\s*\{[^}]*maxStaleMin:\s*300,\s*minRecordCount:\s*(\d+)\s*\}/
+      .exec(healthSource)?.[1],
   );
   assert.match(
     seedSource,
@@ -70,16 +95,45 @@ test('humanitarian health reports partial target-country coverage', () => {
     seedSource,
     /HAPI_SEED_META_TTL_SECONDS,\s*requiredCountriesCovered,\s*HAPI_SEED_META_KEY/,
   );
-  assert.equal(HAPI_REQUIRED_COUNTRIES.length, 23);
+  assert.equal(
+    minRecordCount,
+    HAPI_REQUIRED_COUNTRIES.length,
+    'health.js minRecordCount must track the guaranteed-coverage contract, not a frozen count',
+  );
   assert.equal(new URL(HAPI_HDX_PACKAGE_URL).hostname, 'data.humdata.org');
   assert.doesNotMatch(seedSource, /HAPI_PROXY_URL/);
   assert.deepEqual(
     new Set(HAPI_REQUIRED_COUNTRIES),
-    new Set([
-      'US', 'RU', 'CN', 'UA', 'IR', 'IL', 'TW', 'KP', 'SA', 'TR',
-      'PL', 'DE', 'FR', 'GB', 'IN', 'PK', 'SY', 'YE', 'MM', 'VE',
-      'SD', 'DJ', 'ER',
-    ]),
+    new Set([...CRISIS_REGISTRY_COUNTRIES, ...HAPI_DASHBOARD_COUNTRIES]),
+    'required coverage is the crisis registry plus the dashboard watchlist — never a third hand-maintained list',
+  );
+});
+
+test('every crisis-tracker registry country reaches the HAPI aggregation filter', () => {
+  // THE regression guard for the bug this file's dual sweep exists to fix: the
+  // registry shipped public /crises/<slug> pages for countries the seeder never
+  // requested, and countryCodes silently DISCARDS rows for any country outside
+  // HAPI_COUNTRIES — so a miss here is invisible in logs and in health.
+  assert.ok(CRISIS_REGISTRY_COUNTRIES.length > 0, 'the crisis registry must not be empty');
+  for (const countryCode of CRISIS_REGISTRY_COUNTRIES) {
+    assert.ok(
+      HAPI_COUNTRIES.includes(countryCode),
+      `${countryCode} is published by a crisis tracker but sits outside the HAPI aggregation filter`,
+    );
+    assert.ok(
+      HAPI_REQUIRED_COUNTRIES.includes(countryCode),
+      `${countryCode} is published by a crisis tracker but is not in the guaranteed coverage contract`,
+    );
+  }
+});
+
+test('the Railway deploy copy of the crisis registry stays byte-identical', () => {
+  // loadSharedConfig resolves ../shared/ first and scripts/shared/ second, so the
+  // seeder reads a DIFFERENT file inside the Railway image than it does locally.
+  // Divergence would make coverage depend on where the seeder happens to run.
+  assert.equal(
+    readFileSync(new URL('../scripts/shared/crawlable-crises.json', import.meta.url), 'utf8'),
+    readFileSync(CRISIS_REGISTRY_PATH, 'utf8'),
   );
 });
 
@@ -94,6 +148,29 @@ test('HAPI bulk URL requests national totals for the current and previous month'
   assert.equal(url.searchParams.get('offset'), '0');
   assert.equal(url.searchParams.has('location_code'), false);
   assert.equal(url.searchParams.has('app_identifier'), false, 'identifier belongs in the supported request header');
+});
+
+test('the bulk page budget clears two monthly periods of subnational rows', () => {
+  // Measured against the live API on 2026-09-04: ONE monthly reference period is
+  // 13,785 admin-2 rows (vs 654 at admin-0, which is what the old 3-page budget
+  // was sized for), and previousMonthStart can put TWO periods in the window.
+  // fetchHapiRows THROWS past the budget instead of truncating, so a breach takes
+  // the HRP countries dark again behind nothing but a warn line.
+  const measuredRowsPerReferencePeriod = 13_785;
+  const worstCaseRows = 2 * measuredRowsPerReferencePeriod;
+
+  assert.ok(
+    HAPI_MAX_PAGES * HAPI_PAGE_LIMIT >= Math.ceil(worstCaseRows * 1.5),
+    `page budget ${HAPI_MAX_PAGES * HAPI_PAGE_LIMIT} leaves under 1.5x headroom on the measured ${worstCaseRows}-row worst case`,
+  );
+});
+
+test('HAPI subnational sweep URL requests the deepest published level globally', () => {
+  const url = new URL(buildHapiConflictEventsUrl({ nowMs: NOW, adminLevel: '2' }));
+
+  assert.equal(url.searchParams.get('admin_level'), '2');
+  assert.equal(url.searchParams.get('start_date'), '2026-06-01');
+  assert.equal(url.searchParams.has('location_code'), false, 'the subnational sweep is global, not per country');
 });
 
 test('HAPI HDX snapshot selection spans the year boundary needed by the two-month query', () => {
@@ -295,49 +372,101 @@ test('HAPI aggregation uses the deepest available administrative level without d
   assert.equal(result.SD.summary.conflictFatalities, 3);
 });
 
-test('HAPI ingestion makes one bulk request and maps all returned target countries', async () => {
+test('one aggregation pass over both sweeps keeps each country at its own admin level', () => {
+  // The live shape: HAPI publishes a country at exactly ONE admin level, so the
+  // two global sweeps are disjoint. Aggregating the CONCATENATION in a single
+  // pass (rather than merging two aggregates) is what keeps the deepest-level
+  // tiebreak available if that ever stops being true.
+  const nationalRows = [
+    hapiRow('SDN', { location_name: 'Sudan', events: 12, fatalities: 3 }),
+    hapiRow('SDN', { location_name: 'Sudan', event_type: 'demonstration', events: 7 }),
+    hapiRow('UKR', { location_name: 'Ukraine', event_type: 'demonstration', events: 8 }),
+  ];
+  const subnationalRows = [
+    hapiRow('AFG', { location_name: 'Afghanistan', admin_level: 2, events: 5, fatalities: 2 }),
+    hapiRow('AFG', { location_name: 'Afghanistan', admin_level: 2, events: 6, fatalities: 1 }),
+    hapiRow('HTI', { location_name: 'Haiti', admin_level: 2, event_type: 'civilian_targeting', events: 4, fatalities: 9 }),
+  ];
+  const countryCodes = ['SD', 'UA', 'AF', 'HT'];
+
+  const combined = aggregateHapiConflictEvents(
+    [...nationalRows, ...subnationalRows],
+    { nowMs: NOW, countryCodes },
+  );
+
+  assert.deepEqual(Object.keys(combined).sort(), ['AF', 'HT', 'SD', 'UA']);
+  assert.equal(combined.SD.summary.conflictEventsTotal, 19);
+  assert.equal(combined.AF.summary.conflictEventsTotal, 11);
+  assert.equal(combined.AF.summary.conflictFatalities, 3);
+  assert.equal(combined.HT.summary.conflictEventsTotal, 4);
+  assert.equal(combined.HT.summary.conflictFatalities, 9);
+
+  // Behaviour preservation: every country live today comes from the admin-0
+  // sweep, and appending the disjoint subnational rows must not perturb them.
+  const nationalOnly = aggregateHapiConflictEvents(nationalRows, { nowMs: NOW, countryCodes });
+  assert.deepEqual(combined.SD, nationalOnly.SD);
+  assert.deepEqual(combined.UA, nationalOnly.UA);
+  assert.equal(nationalOnly.AF, undefined, 'admin-0 alone is exactly what left the HRP countries dark');
+  assert.equal(nationalOnly.HT, undefined);
+});
+
+test('a country returned by both sweeps resolves to the deeper level without double counting', () => {
+  const result = aggregateHapiConflictEvents([
+    hapiRow('UKR', { location_name: 'Ukraine', events: 100, fatalities: 10 }),
+    hapiRow('UKR', { location_name: 'Ukraine', admin_level: 2, events: 40, fatalities: 4 }),
+    hapiRow('UKR', { location_name: 'Ukraine', admin_level: 2, events: 20, fatalities: 1 }),
+  ], { nowMs: NOW, countryCodes: ['UA'] });
+
+  assert.equal(result.UA.summary.conflictEventsTotal, 60);
+  assert.equal(result.UA.summary.conflictFatalities, 5);
+});
+
+test('HAPI ingestion makes two global bulk requests and maps all returned target countries', async () => {
   const calls = [];
   const result = await fetchAllHumanitarianSummaries({
     now: () => NOW,
-    countryCodes: ['SD', 'UA'],
-    pace: async () => {},
+    countryCodes: ['SD', 'UA', 'AF'],
+    pace: async () => assert.fail('two covering sweeps must leave the fallback fan-out with nothing to pace'),
     loadPreviousMarker: async () => null,
     loadFailureBackoff: async () => null,
     writeFailureBackoff: async () => assert.fail('success must not write a failure backoff'),
     preserveLastGood: async () => assert.fail('success must not extend stale rows'),
     fetchFn: async (url, options) => {
-      calls.push({ url: String(url), options });
-      return new Response(JSON.stringify({
-        data: [
-          {
-            location_code: 'SDN',
-            location_name: 'Sudan',
-            reference_period_start: '2026-07-01',
-            admin_level: 0,
-            event_type: 'political_violence',
-            events: 12,
-            fatalities: 3,
-          },
-          {
-            location_code: 'UKR',
-            location_name: 'Ukraine',
-            reference_period_start: '2026-07-01',
-            admin_level: 0,
-            event_type: 'demonstration',
-            events: 8,
-            fatalities: 0,
-          },
-        ],
-      }), { status: 200 });
+      const parsed = new URL(String(url));
+      calls.push({ url: parsed, options });
+      assert.equal(parsed.searchParams.has('location_code'), false, 'both sweeps are global');
+      const data = parsed.searchParams.get('admin_level') === '0'
+        ? [
+            hapiRow('SDN', { location_name: 'Sudan', events: 12, fatalities: 3 }),
+            hapiRow('UKR', { location_name: 'Ukraine', event_type: 'demonstration', events: 8 }),
+          ]
+        : [
+            hapiRow('AFG', { location_name: 'Afghanistan', admin_level: 2, events: 5, fatalities: 2 }),
+            hapiRow('AFG', { location_name: 'Afghanistan', admin_level: 2, events: 6, fatalities: 1 }),
+          ];
+      return new Response(JSON.stringify({ data }), { status: 200 });
     },
   });
 
-  assert.equal(calls.length, 1, 'one bulk request replaces the 38-request per-country sweep');
+  assert.deepEqual(
+    calls.map((call) => call.url.searchParams.get('admin_level')),
+    ['0', '2'],
+    'two global bulk requests replace the 38-request per-country sweep',
+  );
   assert.ok(calls[0].options.headers['X-HDX-HAPI-APP-IDENTIFIER']);
-  assert.deepEqual(Object.keys(result).sort(), ['SD', 'UA']);
+  assert.ok(calls[1].options.headers['X-HDX-HAPI-APP-IDENTIFIER']);
+  assert.deepEqual(Object.keys(result).sort(), ['AF', 'SD', 'UA']);
+  assert.equal(
+    result.AF.summary.conflictEventsTotal,
+    11,
+    'an HRP country with no national row must publish from the subnational sweep',
+  );
 });
 
-test('HAPI ingestion falls back only for targets missing national rows', async () => {
+test('HAPI ingestion keeps the per-country fallback for targets neither sweep covers', async () => {
+  // Sudan here is published only at admin-1, which neither global sweep requests.
+  // The fan-out is dead weight against today's upstream shape and MUST stay: it
+  // is the fail-closed net for a required country moving between admin levels.
   const urls = [];
   const result = await fetchAllHumanitarianSummaries({
     now: () => NOW,
@@ -350,35 +479,101 @@ test('HAPI ingestion falls back only for targets missing national rows', async (
     fetchFn: async (url) => {
       const parsed = new URL(url);
       urls.push(parsed);
-      const data = parsed.searchParams.get('location_code') === 'SDN'
-        ? [{
-            location_code: 'SDN',
-            location_name: 'Sudan',
-            reference_period_start: '2026-07-01',
-            admin_level: 2,
-            event_type: 'political_violence',
-            events: 12,
-            fatalities: 3,
-          }]
-        : [{
-            location_code: 'UKR',
-            location_name: 'Ukraine',
-            reference_period_start: '2026-07-01',
-            admin_level: 0,
-            event_type: 'demonstration',
-            events: 8,
-            fatalities: 0,
-          }];
+      if (parsed.searchParams.get('location_code') === 'SDN') {
+        return new Response(JSON.stringify({
+          data: [hapiRow('SDN', { location_name: 'Sudan', admin_level: 1, events: 12, fatalities: 3 })],
+        }), { status: 200 });
+      }
+      const data = parsed.searchParams.get('admin_level') === '0'
+        ? [hapiRow('UKR', { location_name: 'Ukraine', event_type: 'demonstration', events: 8 })]
+        : [];
       return new Response(JSON.stringify({ data }), { status: 200 });
     },
   });
 
-  assert.equal(urls.length, 2);
-  assert.equal(urls[0].searchParams.get('admin_level'), '0');
-  assert.equal(urls[0].searchParams.has('location_code'), false);
-  assert.equal(urls[1].searchParams.has('admin_level'), false);
-  assert.equal(urls[1].searchParams.get('location_code'), 'SDN');
+  assert.deepEqual(
+    urls.map((parsed) => [
+      parsed.searchParams.get('admin_level'),
+      parsed.searchParams.get('location_code'),
+    ]),
+    [['0', null], ['2', null], [null, 'SDN']],
+  );
   assert.deepEqual(Object.keys(result).sort(), ['SD', 'UA']);
+  assert.equal(result.SD.summary.conflictEventsTotal, 12);
+});
+
+test('the HDX snapshot fallback serves the subnational sweep instead of returning nothing', async () => {
+  // fetchRowsFromSnapshot filters on row.admin_level, so a bot-blocked run must
+  // still hand the admin-2 sweep its rows out of the ONE memoized download.
+  let directCalls = 0;
+  let snapshotCalls = 0;
+  const csv = hapiCsv(
+    'SDN,,,,,,,,,0,political_violence,12,3,2026-07-01,2026-07-31,dataset,resource,,',
+    'AFG,,,,,,,,,2,political_violence,5,2,2026-07-01,2026-07-31,dataset,resource,,',
+    'AFG,,,,,,,,,2,political_violence,6,1,2026-07-01,2026-07-31,dataset,resource,,',
+  );
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD', 'AF'],
+    pace: async () => assert.fail('a snapshot covering every target must not pace a fallback'),
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async () => assert.fail('successful snapshot recovery must not back off'),
+    writeFailureMeta: async () => assert.fail('successful snapshot recovery must not publish SEED_ERROR'),
+    preserveLastGood: async () => assert.fail('successful snapshot recovery must not preserve stale rows'),
+    snapshotFetchFn: async (input) => {
+      snapshotCalls += 1;
+      return String(input).includes('/api/3/action/package_show')
+        ? Response.json(hapiHdxMetadata())
+        : new Response(csv, { headers: { 'Content-Type': 'text/csv' } });
+    },
+    fetchFn: async () => {
+      directCalls += 1;
+      return new Response('Blocked due to bot activity.', { status: 406 });
+    },
+  });
+
+  assert.equal(directCalls, 1, 'the subnational sweep must reuse the snapshot, not re-hit the blocked API');
+  assert.equal(snapshotCalls, 2, 'one metadata plus one CSV download serves both sweeps');
+  assert.deepEqual(Object.keys(result).sort(), ['AF', 'SD']);
+  assert.equal(result.SD.summary.conflictEventsTotal, 12);
+  assert.equal(
+    result.AF.summary.conflictEventsTotal,
+    11,
+    'admin-2 rows must survive the snapshot admin_level filter',
+  );
+});
+
+test('a failed subnational sweep still publishes the national sweep and backs off', async () => {
+  let backoff;
+  let preserved = 0;
+  const adminLevels = [];
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async (value) => { backoff = value; },
+    writeFailureMeta: async () => assert.fail('a partial success must not publish SEED_ERROR'),
+    preserveLastGood: async () => { preserved += 1; },
+    fetchFn: async (url) => {
+      const parsed = new URL(url);
+      adminLevels.push(parsed.searchParams.get('admin_level'));
+      if (parsed.searchParams.get('admin_level') === '2') {
+        return new Response(JSON.stringify({ error: 'Too Many Requests' }), { status: 429 });
+      }
+      return new Response(JSON.stringify({
+        data: [hapiRow('SDN', { location_name: 'Sudan', events: 12, fatalities: 3 })],
+      }), { status: 200 });
+    },
+  });
+
+  assert.deepEqual(adminLevels, ['0', '2'], 'a rejected subnational sweep must not abort the run');
+  assert.deepEqual(Object.keys(result), ['SD']);
+  assert.equal(preserved, 1);
+  assert.equal(backoff.status, 429);
+  assert.equal(backoff.reasonCode, 'HAPI_RATE_LIMIT');
 });
 
 test('HAPI bot-detection rejection loads the official HDX snapshot', async () => {
@@ -652,15 +847,9 @@ test('HAPI snapshot failure aborts the cycle without publishing a partial direct
       const url = new URL(String(input));
       if (!url.searchParams.has('location_code')) {
         return Response.json({
-          data: [{
-            location_code: 'SDN',
-            location_name: 'Sudan',
-            reference_period_start: '2026-07-01',
-            admin_level: 0,
-            event_type: 'political_violence',
-            events: 12,
-            fatalities: 3,
-          }],
+          data: url.searchParams.get('admin_level') === '0'
+            ? [hapiRow('SDN', { location_name: 'Sudan', events: 12, fatalities: 3 })]
+            : [],
         });
       }
       assert.equal(url.searchParams.get('location_code'), 'UKR');
@@ -669,7 +858,7 @@ test('HAPI snapshot failure aborts the cycle without publishing a partial direct
   });
 
   assert.equal(result, null, 'a terminal snapshot failure must discard the partial Sudan result');
-  assert.equal(directCalls, 2, 'the initial sweep and first missing-country request should run');
+  assert.equal(directCalls, 3, 'both global sweeps and the first missing-country request should run');
   assert.equal(snapshotUrls.length, 2, 'metadata plus one failed CSV request should run');
   assert.equal(preserved, 1);
   assert.equal(backoff.status, 503);

--- a/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
+++ b/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
@@ -502,6 +502,50 @@ test('HAPI ingestion keeps the per-country fallback for targets neither sweep co
   assert.equal(result.SD.summary.conflictEventsTotal, 12);
 });
 
+test('the per-country fallback stops LAUNCHING once its wall-clock budget is spent', async () => {
+  // #7656: unbounded, this loop could add 23 × 15s behind two 75s sweeps and blow
+  // the 315s envelope the fetch-deadline model is anchored on. Each per-country
+  // request here burns 70s of the 140s budget, so exactly two may launch.
+  const requested = [];
+  let elapsedMs = 0;
+  let backoff;
+  let preserved = 0;
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    readElapsedMs: () => elapsedMs,
+    countryCodes: ['SD', 'UA', 'IR', 'IL', 'YE'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async (value) => { backoff = value; },
+    writeFailureMeta: async () => assert.fail('partial coverage must not publish SEED_ERROR'),
+    preserveLastGood: async () => { preserved += 1; },
+    fetchFn: async (url) => {
+      const parsed = new URL(url);
+      const locationCode = parsed.searchParams.get('location_code');
+      if (!locationCode) {
+        // Only Sudan comes back from the sweeps; the rest fall to the fan-out.
+        const data = parsed.searchParams.get('admin_level') === '0'
+          ? [hapiRow('SDN', { location_name: 'Sudan', events: 12, fatalities: 3 })]
+          : [];
+        return new Response(JSON.stringify({ data }), { status: 200 });
+      }
+      requested.push(locationCode);
+      elapsedMs += 70_000;
+      return new Response(JSON.stringify({
+        data: [hapiRow(locationCode, { admin_level: 1, events: 5, fatalities: 1 })],
+      }), { status: 200 });
+    },
+  });
+
+  assert.deepEqual(requested, ['UKR', 'IRN'], 'the third launch is over budget and must never be issued');
+  assert.deepEqual(Object.keys(result).sort(), ['IR', 'SD', 'UA'], 'countries already covered must still publish');
+  assert.equal(backoff.reasonCode, 'HAPI_FALLBACK_BUDGET_EXHAUSTED');
+  assert.equal(backoff.status, 0, 'a budget cut has no provider status to record');
+  assert.equal(backoff.retryAt, NOW + HAPI_FAILURE_BACKOFF_MS);
+  assert.equal(preserved, 1, 'partial coverage must preserve last-good rather than pass as complete');
+});
+
 test('the HDX snapshot fallback serves the subnational sweep instead of returning nothing', async () => {
   // fetchRowsFromSnapshot filters on row.admin_level, so a bot-blocked run must
   // still hand the admin-2 sweep its rows out of the ONE memoized download.

--- a/tests/seed-fetch-deadline-budget-invariants.test.mjs
+++ b/tests/seed-fetch-deadline-budget-invariants.test.mjs
@@ -86,6 +86,7 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
     const {
       HAPI_HDX_METADATA_TIMEOUT_MS,
       HAPI_HDX_SNAPSHOT_TIMEOUT_MS,
+      HAPI_MAX_PAGES,
     } = await import('../scripts/_conflict-hapi.mjs');
     const { GDELT_BULK_WORST_NETWORK_MS } = await import('../scripts/_conflict-gdelt-bulk.mjs');
 
@@ -111,6 +112,15 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
     const HAPI_WORST_MS = HAPI_DIRECT_REQUEST_MS
       + HAPI_HDX_METADATA_TIMEOUT_MS
       + 2 * HAPI_HDX_SNAPSHOT_TIMEOUT_MS;
+    // Pure-direct route (no bot block): the admin-0 and admin-2 global sweeps each
+    // page up to HAPI_MAX_PAGES. That budget was raised for the ~13.8k-row
+    // subnational sweep, and it must not push the direct route past the snapshot
+    // route the max() above is anchored on — otherwise this model understates.
+    const HAPI_GLOBAL_SWEEPS = 2;
+    const HAPI_DIRECT_WORST_MS = HAPI_GLOBAL_SWEEPS * HAPI_MAX_PAGES * HAPI_DIRECT_REQUEST_MS;
+    assert.ok(HAPI_DIRECT_WORST_MS <= HAPI_WORST_MS,
+      `direct sweeps ${HAPI_DIRECT_WORST_MS}ms must stay inside the ${HAPI_WORST_MS}ms bot-block bound this model is anchored on`);
+
     const EXTRA_KEY_WRITE_SLACK_MS = 30_000;
     const worstFetchAttempt = Math.max(HAPI_WORST_MS, GDELT_SWEEP_BUDGET_MS + worstBatch)
       + GDELT_BULK_WORST_NETWORK_MS

--- a/tests/seed-fetch-deadline-budget-invariants.test.mjs
+++ b/tests/seed-fetch-deadline-budget-invariants.test.mjs
@@ -82,6 +82,7 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
       GDELT_SWEEP_BUDGET_MS,
       GDELT_COUNTRY_FETCH_OPTS,
       ACLED_INTEL_LOCK_TTL_MS,
+      HAPI_FALLBACK_BUDGET_MS,
     } = await import('../scripts/seed-conflict-intel.mjs');
     const {
       HAPI_HDX_METADATA_TIMEOUT_MS,
@@ -113,13 +114,21 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
       + HAPI_HDX_METADATA_TIMEOUT_MS
       + 2 * HAPI_HDX_SNAPSHOT_TIMEOUT_MS;
     // Pure-direct route (no bot block): the admin-0 and admin-2 global sweeps each
-    // page up to HAPI_MAX_PAGES. That budget was raised for the ~13.8k-row
-    // subnational sweep, and it must not push the direct route past the snapshot
-    // route the max() above is anchored on — otherwise this model understates.
+    // page up to HAPI_MAX_PAGES, and the per-country fallback runs BEHIND them.
+    // #7656 shipped the sweeps while modelling only the sweeps, so an unbounded
+    // fan-out (23 × 15s + 22 × 1.1s ≈ 369s) sat outside this envelope and pushed
+    // the real direct route to 519s. Model all three terms: the sweeps, the
+    // fallback's launch budget, and the one request that may already be in flight
+    // when that budget expires. The seeder measures the budget from its own entry,
+    // so the sweeps and the fan-out actually SHARE the window and the true bound is
+    // tighter than this; summing them is deliberate — an invariant that cannot
+    // understate reality is the one worth asserting.
     const HAPI_GLOBAL_SWEEPS = 2;
-    const HAPI_DIRECT_WORST_MS = HAPI_GLOBAL_SWEEPS * HAPI_MAX_PAGES * HAPI_DIRECT_REQUEST_MS;
+    const HAPI_DIRECT_WORST_MS = HAPI_GLOBAL_SWEEPS * HAPI_MAX_PAGES * HAPI_DIRECT_REQUEST_MS
+      + HAPI_FALLBACK_BUDGET_MS
+      + HAPI_DIRECT_REQUEST_MS;
     assert.ok(HAPI_DIRECT_WORST_MS <= HAPI_WORST_MS,
-      `direct sweeps ${HAPI_DIRECT_WORST_MS}ms must stay inside the ${HAPI_WORST_MS}ms bot-block bound this model is anchored on`);
+      `direct route ${HAPI_DIRECT_WORST_MS}ms (sweeps + fallback budget + one in-flight request) must stay inside the ${HAPI_WORST_MS}ms bot-block bound this model is anchored on`);
 
     const EXTRA_KEY_WRITE_SLACK_MS = 30_000;
     const worstFetchAttempt = Math.max(HAPI_WORST_MS, GDELT_SWEEP_BUDGET_MS + worstBatch)


### PR DESCRIPTION
## The problem

Thirteen of the twenty `CONFLICT_COUNTRIES` have **no humanitarian summary in production at all**: Afghanistan, Somalia, DR Congo, South Sudan, Ethiopia, Mali, Burkina Faso, Niger, Nigeria, Cameroon, Mozambique, Haiti and Palestine. Probed live on 2026-09-04, `/api/conflict/v1/get-humanitarian-summary` returns `{}` for every one of them.

Two causes, both verified:

**1. HRP countries publish only admin-2 rows.** A global `admin_level=0` sweep was the only bulk request, so every Humanitarian Response Plan country was reachable only through the per-country fallback loop, which runs exclusively for `HAPI_REQUIRED_COUNTRIES`.

**2. `HAPI_CRISIS_COUNTRIES` was a hand-maintained duplicate** of the coverage codes in `shared/crawlable-crises.json`, with nothing pinning the two together. Adding a crisis tracker published a `/crises/<slug>` page whose countries the seeder never requested. That page fails closed forever, with no test, no alarm and no drift signal.

Measured upstream, `start_date=2026-08-01`:

| sweep | countries | rows | pages | time |
|---|---|---|---|---|
| `admin_level=0` | 218 | 654 | 1 | ~1s |
| `admin_level=2` | 24 | 13,785 | 2 | 4.0s |

The two country sets are **perfectly disjoint**. HAPI publishes each country at exactly one admin level.

## The change

- **`HAPI_CRISIS_COUNTRIES` is derived from the registry**, never hand-listed. `shared/crawlable-crises.json` becomes the single source of truth. Derived values are identical to the old hardcoded ones (`HAPI_REQUIRED_COUNTRIES` still 23, `HAPI_COUNTRIES` still 38), so this PR changes no country list today; it removes the drift.
- **A second global sweep at `admin_level=2`** covers all 24 HRP countries. Both row sets are aggregated in a **single pass** so `aggregateHapiConflictEvents`' "latest reference period, then deepest admin level" tiebreak still governs any future overlap.
- **The per-country fallback is kept** as the fail-closed net for a level neither sweep requests. It iterates zero countries in the normal path, replacing a fan-out that cost ~97s every run and would have reached ~290s once the HRP countries were added. The binding ceiling is `ACLED_INTEL_LOCK_TTL_MS` (420s), which `tests/seed-fetch-deadline-budget-invariants.test.mjs:129` asserts `worstFetchAttempt` against.
- **An admin-2 sweep failure is non-fatal.** The admin-0 countries still publish and the run still backs off, so one bad subnational response cannot take out every country that works today.
- **`HAPI_MAX_PAGES` 3 → 5.** `start_date` is the first of the previous month with no end bound, so once the current month publishes the window holds two reference periods, ~27.6k rows against the old 30k ceiling. `fetchHapiRows` throws rather than truncates on overflow. To be precise about what this is: **3 pages does not break today** (27,570 < 30,000). This is a margin argument, not a live break. It breaks the first month a single period exceeds 15,000 rows, i.e. 9% growth on today's 13,785, on a dataset that grows as ACLED coverage expands. Because the sweep is non-fatal, that breach would be quiet: admin-0 still publishes, one `console.warn`, and the 13 countries go dark again.

## Verification

End to end against **live HAPI** with stubbed Redis: `38/38 countries (23/23 required)`.

All 13 previously-dark countries return real August 2026 figures (AF 217 events, SO 596, CD 315, SS 140, ET 219, ML 156, BF 122, NE 73, NG 1180, CM 465, MZ 40, HT 108, PS 1489). Every already-live country is unchanged, cross-checked against production: UA 9147/4398, SD 349/1064, YE 816/578, MM 859/907.

That run served from the HDX snapshot route, which independently confirms the bot-block fallback carries admin-2 rows rather than silently returning nothing.

New tests, each proven red against the pre-fix code:

- every crisis-registry country reaches the HAPI aggregation filter (the regression guard for cause 2)
- the Railway deploy copy of the registry stays byte-identical
- the page budget clears two monthly periods of subnational rows
- one aggregation pass keeps each country at its own admin level, and a country in both sweeps resolves to the deeper one without double counting
- the HDX snapshot fallback serves the subnational sweep
- a failed subnational sweep still publishes the national sweep and backs off

Suites green: `seed-conflict-intel-hapi-circuit-breaker` (30), `railway-watch-path-audit` (96), `crawlable-corpus` (86), plus the deadline-budget invariants.

## Verified non-regression on both HAPI routes

The fan-out was not dead weight. UKR, SDN, YEM, SYR, MMR and VEN have no admin-0 row at all and were reaching production purely through it, which is why an admin-2 sweep failure is non-fatal here.

Both routes were checked to produce identical numbers to the path they replace:

| country | per-country fallback (today) | global admin-2 sweep (this PR) |
|---|---|---|
| UA | 7227 events / 3349 fatalities | 7227 / 3349 |
| SD | 265 / 682 | 265 / 682 |

Ukraine is the sharp case: it is the one country publishing both admin-1 (6 rows) and admin-2 (411 rows), and the aggregator's deepest-level tiebreak resolves both paths to the same 411 rows.

## Out of scope, pre-existing

HAPI's JSON API and its HDX CSV snapshot disagree on the same August admin-2 data: UA 9147 vs 7227, SD 349 vs 265, YE 816 vs 691 (identical row counts, different `events` values). Production is currently seeded from the snapshot, because HAPI bot-blocks Railway egress (#5713, #5769, #5772), so a bot-blocked tick publishes different numbers than a healthy one would. This PR neither causes nor changes that; it is filed separately.

## Follow-up

This PR deliberately adds **no** tracker entries and touches no snapshot. Once this is deployed and the data is confirmed live, a second PR adds 10 new crisis trackers (Sahel, Horn of Africa, Hormuz/Gulf, Myanmar, Haiti, Lebanon–Israel, DR Congo, Nigeria, Afghanistan, Palestine), taking `/crises/` from 4 to 14. Because the country list is now derived, that follow-up is a pure data change.

https://claude.ai/code/session_01BXisqhA6TY13kHcSpF9p29
