### PR TITLE
fix(seed): keep physical divergence on schedule

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -1286,12 +1286,12 @@ Recovery is accepted only when:
 |---|---|
 | **Service name** | `seed-bundle-macro` |
 | **Start command** | `node scripts/seed-bundle-macro.mjs` |
-| **Cron schedule** | `0 8 * * *` (daily 08:00 UTC) |
+| **Cron schedule** | `0 8,9 * * *` (daily 08:00 and 09:00 UTC) |
 | **Watch paths** | `scripts/**`, `shared/**` |
 | **Replaces** | 6 services |
 | **Net savings** | 5 slots |
 | **Members** | BIS Data (12h), CBR Rates (daily), BoC Valet (daily), StatCan WDS (daily), China Macro (36h), China Release Calendar (36h), China Policy Events (6h), BIS Extended (12h), BLS Series (daily), Eurostat (daily), Eurostat House Prices (7d), Eurostat Government Debt (2d), Eurostat Industrial Production (daily), IMF Macro (30d), National Debt (30d), FAO FFPI (daily), World Bank External Debt (30d), BIS LBS (7d), FATF Listing (30d), Education Attainment (7d) |
-| **Wall budget** | 570 seconds. The runner defers a section when its timeout plus 10-second kill grace cannot fit before Railway's 10-minute limit. Education stays last on six UTC days so a persistent failure in the new flag-dark producer cannot starve established production members; it gets first priority each Sunday UTC so sustained production load cannot defer its first envelope forever. |
+| **Wall budget** | 570 seconds. The runner defers a section when its timeout plus 10-second kill grace cannot fit before Railway's 10-minute limit. Physical Premiums runs first with 80 seconds of admission headroom. Education gets first priority at 08:00 each Sunday UTC, with Physical second. The 09:00 retry always puts Physical first, so a deferred run has another full admission window even when Education fails. Completed members skip through their interval gates. |
 
 ### Bundle 9: seed-bundle-health
 

--- a/scripts/_macro-bundle-order.mjs
+++ b/scripts/_macro-bundle-order.mjs
@@ -1,0 +1,15 @@
+export const EDUCATION_PRIORITY_UTC_DAY = 0;
+export const EDUCATION_PRIORITY_UTC_HOUR = 8;
+
+export function orderMacroSections(
+  runAt,
+  educationSection,
+  physicalPremiumSection,
+  macroSections,
+) {
+  const educationRunsFirst = runAt.getUTCDay() === EDUCATION_PRIORITY_UTC_DAY
+    && runAt.getUTCHours() === EDUCATION_PRIORITY_UTC_HOUR;
+  return educationRunsFirst
+    ? [educationSection, physicalPremiumSection, ...macroSections]
+    : [physicalPremiumSection, ...macroSections, educationSection];
+}

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -666,6 +666,7 @@
       "scripts/_eurostat-utils.mjs",
       "scripts/_html-entities.mjs",
       "scripts/_imf-weo-content-age-helpers.mjs",
+      "scripts/_macro-bundle-order.mjs",
       "scripts/_proxy-utils.cjs",
       "scripts/_seed-contract.mjs",
       "scripts/_seed-envelope-source.mjs",
@@ -717,6 +718,7 @@
       "scripts/shared/sovereign-status.json",
       "shared/iso2-to-iso3.json"
     ],
+    "cronSchedule": "0 8,9 * * *",
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#bundle-8-seed-bundle-macro"
   },
   {

--- a/scripts/seed-bundle-macro.mjs
+++ b/scripts/seed-bundle-macro.mjs
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 import { CHINA_MACRO_CACHE_KEY } from './_china-macro-contract.mjs';
+import { orderMacroSections } from './_macro-bundle-order.mjs';
 import { EDUCATION_SECTION_TIMEOUT_MS } from './seed-education-attainment.mjs';
 import { PHYSICAL_PREMIUM_SECTION_TIMEOUT_MS } from './seed-physical-premiums.mjs';
 
-const EDUCATION_PRIORITY_UTC_DAY = 0;
 const EDUCATION_SECTION = { label: 'Education-Attainment', script: 'seed-education-attainment.mjs', seedMetaKey: 'resilience:education-attainment', canonicalKey: 'resilience:education-attainment:v1', completionMetaKey: 'seed-completion:resilience:education-attainment', intervalMs: 7 * DAY, timeoutMs: EDUCATION_SECTION_TIMEOUT_MS };
+// SGE SHAU/SHAG daily PM benchmarks joined only to the already-seeded
+// commodity and FX snapshots. Keep this section outside MACRO_SECTIONS so it
+// always receives an early admission slot with 80 seconds of bundle headroom.
+const PHYSICAL_PREMIUM_SECTION = { label: 'Physical-Premiums', script: 'seed-physical-premiums.mjs', seedMetaKey: 'market:physical-premium', canonicalKey: 'market:physical-premium:v1', completionMetaKey: 'seed-completion:market:physical-premium', intervalMs: DAY, timeoutMs: PHYSICAL_PREMIUM_SECTION_TIMEOUT_MS };
 
 const MACRO_SECTIONS = [
   { label: 'BIS-Data', script: 'seed-bis-data.mjs', seedMetaKey: 'economic:bis', canonicalKey: 'economic:bis:policy:v1', completionMetaKey: 'seed-completion:economic:bis', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
@@ -33,12 +37,6 @@ const MACRO_SECTIONS = [
   { label: 'China-Policy-Events', script: 'seed-china-policy-events.mjs', seedMetaKey: 'china:policy-events', canonicalKey: 'china:policy-events:v1', intervalMs: 6 * HOUR, timeoutMs: 220_000 },
   { label: 'BIS-Extended', script: 'seed-bis-extended.mjs', seedMetaKey: 'economic:bis-extended', canonicalKey: 'economic:bis:dsr:v1', completionMetaKey: 'seed-completion:economic:bis-extended', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
   { label: 'BLS-Series', script: 'seed-bls-series.mjs', seedMetaKey: 'economic:bls-series', canonicalKey: 'bls:series:v1', completionMetaKey: 'seed-completion:economic:bls-series', intervalMs: DAY, timeoutMs: 120_000 },
-  // SGE SHAU/SHAG daily PM benchmarks joined only to the already-seeded
-  // commodity and FX snapshots. The seeder fails closed unless the deployment
-  // has explicitly activated the documented redistribution/display license.
-  // The fetch, canonical switch, three derived Redis waves, and shared
-  // bookkeeping all fit this exported structural budget with failure headroom.
-  { label: 'Physical-Premiums', script: 'seed-physical-premiums.mjs', seedMetaKey: 'market:physical-premium', canonicalKey: 'market:physical-premium:v1', completionMetaKey: 'seed-completion:market:physical-premium', intervalMs: DAY, timeoutMs: PHYSICAL_PREMIUM_SECTION_TIMEOUT_MS },
   { label: 'Eurostat', script: 'seed-eurostat-country-data.mjs', seedMetaKey: 'economic:eurostat-country-data', canonicalKey: 'economic:eurostat-country-data:v1', intervalMs: DAY, timeoutMs: 300_000 },
   { label: 'Eurostat-HousePrices', script: 'seed-eurostat-house-prices.mjs', seedMetaKey: 'economic:eurostat-house-prices', canonicalKey: 'economic:eurostat:house-prices:v1', intervalMs: 7 * DAY, timeoutMs: 300_000 },
   { label: 'Eurostat-GovDebtQ', script: 'seed-eurostat-gov-debt-q.mjs', seedMetaKey: 'economic:eurostat-gov-debt-q', canonicalKey: 'economic:eurostat:gov-debt-q:v1', intervalMs: 2 * DAY, timeoutMs: 300_000 },
@@ -62,14 +60,14 @@ const MACRO_SECTIONS = [
 
 // Education is normally last so a persistent failure in the new flag-dark
 // producer cannot starve established production members every day. Give it
-// first priority on one UTC day each week so sustained production load cannot
-// defer its first successful envelope forever. A persistent education outage
-// can consume at most one day's first slot per week; production keeps the other
-// six days.
-const educationRunsFirst = new Date().getUTCDay() === EDUCATION_PRIORITY_UTC_DAY;
-const sections = educationRunsFirst
-  ? [EDUCATION_SECTION, ...MACRO_SECTIONS]
-  : [...MACRO_SECTIONS, EDUCATION_SECTION];
+// first priority on the 08:00 Sunday tick. The 09:00 retry always restores
+// Physical to the first slot, even if Education failed and remains due.
+const sections = orderMacroSections(
+  new Date(),
+  EDUCATION_SECTION,
+  PHYSICAL_PREMIUM_SECTION,
+  MACRO_SECTIONS,
+);
 
 await runBundle('macro', sections, {
   // Railway kills cron containers at 10 minutes. Defer sections whose full

--- a/tests/physical-premiums-registration.test.mjs
+++ b/tests/physical-premiums-registration.test.mjs
@@ -4,6 +4,11 @@ import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 
 import { __testing__ as health } from '../api/health.js';
+import {
+  EDUCATION_PRIORITY_UTC_DAY,
+  EDUCATION_PRIORITY_UTC_HOUR,
+  orderMacroSections,
+} from '../scripts/_macro-bundle-order.mjs';
 import { PHYSICAL_DIVERGENCE_PAPER_MAX_AGE_MS } from '../shared/physical-divergence-staleness.js';
 
 const root = resolve(import.meta.dirname, '..');
@@ -35,6 +40,24 @@ describe('physical premium production registration', () => {
     assert.ok(macro.watchPatterns.includes('scripts/shared/physical-divergence-contract.js'));
   });
 
+  it('protects the physical publisher with an early slot and one retry window', () => {
+    const registry = JSON.parse(read('scripts/railway-services.json'));
+    const macro = registry.find((entry) => entry.entry === 'scripts/seed-bundle-macro.mjs');
+    const orderAt = (instant) => orderMacroSections(
+      new Date(instant),
+      'Education',
+      'Physical',
+      ['BIS', 'China'],
+    );
+
+    assert.equal(macro?.cronSchedule, '0 8,9 * * *');
+    assert.equal(EDUCATION_PRIORITY_UTC_DAY, 0);
+    assert.equal(EDUCATION_PRIORITY_UTC_HOUR, 8);
+    assert.deepEqual(orderAt('2026-09-06T08:00:00Z'), ['Education', 'Physical', 'BIS', 'China']);
+    assert.deepEqual(orderAt('2026-09-06T09:00:00Z'), ['Physical', 'BIS', 'China', 'Education']);
+    assert.deepEqual(orderAt('2026-09-07T08:00:00Z'), ['Physical', 'BIS', 'China', 'Education']);
+  });
+
   it('aligns paper freshness with the daily publisher and health alarm', () => {
     const bundle = read('scripts/seed-bundle-macro.mjs');
     const runbook = read('docs/railway-seed-consolidation-runbook.md');
@@ -47,8 +70,8 @@ describe('physical premium production registration', () => {
     );
     assert.match(
       runbook,
-      /seed-bundle-macro[\s\S]*?`0 8 \* \* \*` \(daily 08:00 UTC\)/,
-      'the documented Railway publisher cadence must stay daily',
+      /seed-bundle-macro[\s\S]*?`0 8,9 \* \* \*` \(daily 08:00 and 09:00 UTC\)/,
+      'the documented Railway invocation cadence must include one bounded retry',
     );
     assert.equal(PHYSICAL_DIVERGENCE_PAPER_MAX_AGE_MS, 36 * 60 * 60 * 1000);
     assert.match(

--- a/tests/seed-education-attainment.test.mjs
+++ b/tests/seed-education-attainment.test.mjs
@@ -205,14 +205,13 @@ describe('fetch and Railway bundle budgets', () => {
       bundleSource,
       /Education-Attainment[^\n]+timeoutMs:\s*EDUCATION_SECTION_TIMEOUT_MS/,
     );
-    assert.match(bundleSource, /EDUCATION_PRIORITY_UTC_DAY\s*=\s*0/);
     assert.match(
       bundleSource,
-      /educationRunsFirst[\s\S]+\? \[EDUCATION_SECTION, \.\.\.MACRO_SECTIONS\][\s\S]+: \[\.\.\.MACRO_SECTIONS, EDUCATION_SECTION\]/,
+      /orderMacroSections\([\s\S]+EDUCATION_SECTION,[\s\S]+PHYSICAL_PREMIUM_SECTION,[\s\S]+MACRO_SECTIONS/,
     );
     assert.match(
       bundleSource,
-      /normally last[\s\S]+first priority on one UTC day each week[\s\S]+production keeps the other[\s\S]+six days/,
+      /normally last[\s\S]+first priority on the 08:00 Sunday tick[\s\S]+09:00 retry always restores[\s\S]+Physical to the first slot/,
     );
   });
 });

--- a/tests/statcan-wds.test.mjs
+++ b/tests/statcan-wds.test.mjs
@@ -409,7 +409,7 @@ test('the StatCan and BoC EMPTY waivers are retired with independent issue owner
     assert.doesNotMatch(row.expiresAt ?? '', /T13:00/, `${row.name} must not anchor on a 13:00 tick`);
     assert.doesNotMatch(row.reason ?? '', /13:00/, `${row.name} must not cite a 13:00 tick`);
   }
-  assert.match(runbook, /0 8 \* \* \*[^\n]*daily 08:00 UTC/);
+  assert.match(runbook, /0 8,9 \* \* \*[^\n]*daily 08:00 and 09:00 UTC/);
 });
 
 test('STATCAN_MAX_CONTENT_AGE_MIN clears retained healthy cycles, catches a missed release, and is wired into the seeder', () => {


### PR DESCRIPTION
## Summary

Physical divergence could remain in `SEED_ERROR` even when its sources were usable because the once-daily macro bundle reached Physical Premiums too late to admit its protected 490-second execution window. Normal ticks now offer Physical Premiums first, while Education keeps its existing first slot only at 08:00 UTC on Sunday. A second 09:00 UTC tick gives a deferred Physical run one more full admission window; members that already completed skip through their existing interval gates.

## Safety boundaries

- Keep the Physical source timeout at 480 seconds, the 10-second kill grace, and the 570-second bundle budget.
- Keep the 36-hour input freshness deadline and strict health classification unchanged.
- Reserve 80 seconds of bundle headroom when Physical is first.
- Put Physical first on the 09:00 retry even if Education failed at 08:00.

## Validation

- 185 affected tests pass, including executable Sunday 08:00, Sunday 09:00, and ordinary daily ordering cases, bundle admission, completion attestation, Railway registry coverage, and watch-path closure.
- `npm run typecheck`, `npm run typecheck:api`, and `npm run lint:boundaries` pass.
- The full data suite reached 29,948 passes and exposed one static-audit incompatibility in the first helper signature. That signature was repaired, and the failed audit passed in the final affected test gate.
- `git diff --check origin/main...HEAD` passes.

## Post-deploy monitoring and validation

After merge, confirm that Railway Registry Sync applies `0 8,9 * * *` and that the active `seed-bundle-macro` deployment manifest points to the merged revision. Observe natural scheduled runs for 48 hours, including at least two 09:00 retry ticks; do not use a local `railway run` as production proof.

Acceptance requires:

- normal 08:00 ticks offer `Physical-Premiums` first;
- Sunday 08:00 offers Education first and Physical second;
- every 09:00 tick offers Physical first, while successful members skip through freshness gates;
- logs do not repeat `Physical-Premiums Deferred, needs 490s` across both daily ticks; and
- `physicalDivergence` leaves `SEED_ERROR` after a successful natural run, with at least two records and a future `inputFreshUntil`.

If the second tick causes repeated source traffic or unexpected overlap, restore the cron to `0 8 * * *` but keep the protected Physical ordering, then diagnose the interval gate. If Registry Sync does not converge, stop and repair Railway configuration only with explicit production authority.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
