### PR TITLE
feat(crises): expand the bounded crisis trackers from 4 to 14

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -598,7 +598,7 @@ const SEED_META = {
   // an earlier 720min value left exactly that blind spot). 300 (5h) is ~10x
   // the HAPI refresh interval (headroom for missed/lock-contended ticks) while staying
   // a full hour below the 6h data-expiry floor.
-  humanitarianSummary: { key: 'seed-meta:conflict:humanitarian',  maxStaleMin: 300, minRecordCount: 23 },
+  humanitarianSummary: { key: 'seed-meta:conflict:humanitarian',  maxStaleMin: 300, minRecordCount: 41 },
   chinaCoverage:   { key: 'seed-meta:health:china-coverage',   maxStaleMin: 180 },
   // Always-on loop publishes every few seconds. Five minutes tolerates deploy
   // churn while still detecting a stopped worker well before leases age out.

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -4285,7 +4285,10 @@ ${snapshotSection}
   });
 }
 
-function renderToolsIndex({ baseUrl, lastmod }) {
+// Counts come from the registries this same build renders, never a frozen
+// literal: the hub card is the one place a stale number reads as a factual
+// claim about the corpus rather than as prose.
+function renderToolsIndex({ baseUrl, lastmod, crisisCount, chokepointCount }) {
   const path = '/tools/';
   const description = 'Focused World Monitor tools for current natural hazards, country-level airspace disruption, and geographic signal convergence, backed by maintained first-party data contracts.';
   const body = `      <p class="eyebrow">Live intelligence tools</p>
@@ -4295,8 +4298,8 @@ function renderToolsIndex({ baseUrl, lastmod }) {
         <a class="card" href="/tools/natural-hazard-pulse/"><strong>Natural-hazard pulse</strong><br><span>Worldwide or approximate country filter</span></a>
         <a class="card" href="/tools/airspace-disruption-checker/"><strong>Airspace-disruption checker</strong><br><span>Commercial airport disruption and observed military flights</span></a>
         <a class="card" href="/tools/signal-convergence/"><strong>Geographic signal convergence</strong><br><span>Named multi-domain correlation score</span></a>
-        <a class="card" href="/chokepoints/"><strong>Maritime chokepoint status</strong><br><span>13 canonical waterways</span></a>
-        <a class="card" href="/crises/"><strong>Bounded crisis trackers</strong><br><span>Four curated geographic scopes</span></a>
+        <a class="card" href="/chokepoints/"><strong>Maritime chokepoint status</strong><br><span>${chokepointCount} canonical waterways</span></a>
+        <a class="card" href="/crises/"><strong>Bounded crisis trackers</strong><br><span>${crisisCount} curated geographic scopes</span></a>
       </div>
       <h2>How these tools work</h2>
       <p>Each tool asks one narrow operational question — what natural hazards are open right now, is a country's monitored airspace disrupted, where independent streams converge — and answers it from a maintained World Monitor contract. Results are labelled with their source and retrieval time, unavailable data is reported as unavailable rather than zero, and independent signals are never combined into a single opaque threat score unless the tool names that combination explicitly.</p>
@@ -5003,6 +5006,8 @@ export async function buildCorpus({
     renderToolsIndex({
       baseUrl,
       lastmod: data.lastmod.tools,
+      crisisCount: data.crises.length,
+      chokepointCount: data.chokepoints.length,
     }),
   );
   writeGeneratedFile(

--- a/scripts/shared/crawlable-crises.json
+++ b/scripts/shared/crawlable-crises.json
@@ -6,8 +6,14 @@
     "description": "Monthly conflict pulse for Iran and Israel: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed two-country scope.",
     "overview": "This tracker keeps a deliberately narrow geographic boundary: it compares the latest available monthly conflict summaries for Iran and Israel. It does not claim to capture every regional spillover event, diplomatic development, or military movement.",
     "coverage": [
-      { "code": "IR", "name": "Iran" },
-      { "code": "IL", "name": "Israel" }
+      {
+        "code": "IR",
+        "name": "Iran"
+      },
+      {
+        "code": "IL",
+        "name": "Israel"
+      }
     ],
     "dashboardPath": "/?country=IR&expanded=1"
   },
@@ -18,8 +24,14 @@
     "description": "Monthly conflict pulse for Ukraine and Russia: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed two-country scope.",
     "overview": "This tracker compares the latest available monthly conflict summaries for Ukraine and Russia. The totals reflect the maintained humanitarian dataset's country records and are not a battlefield map, casualty estimate, or prediction.",
     "coverage": [
-      { "code": "UA", "name": "Ukraine" },
-      { "code": "RU", "name": "Russia" }
+      {
+        "code": "UA",
+        "name": "Ukraine"
+      },
+      {
+        "code": "RU",
+        "name": "Russia"
+      }
     ],
     "dashboardPath": "/?country=UA&expanded=1"
   },
@@ -30,10 +42,22 @@
     "description": "Monthly conflict pulse for Yemen, Saudi Arabia, Djibouti and Eritrea — the fixed four-country boundary around the Red Sea and the Bab el-Mandeb strait.",
     "overview": "This tracker uses a fixed four-country boundary around the Red Sea and Bab el-Mandeb. It provides country-level humanitarian conflict context; maritime warnings and vessel disruptions remain separate live signals on the chokepoint pages and dashboard.",
     "coverage": [
-      { "code": "YE", "name": "Yemen" },
-      { "code": "SA", "name": "Saudi Arabia" },
-      { "code": "DJ", "name": "Djibouti" },
-      { "code": "ER", "name": "Eritrea" }
+      {
+        "code": "YE",
+        "name": "Yemen"
+      },
+      {
+        "code": "SA",
+        "name": "Saudi Arabia"
+      },
+      {
+        "code": "DJ",
+        "name": "Djibouti"
+      },
+      {
+        "code": "ER",
+        "name": "Eritrea"
+      }
     ],
     "dashboardPath": "/?chokepoint=bab_el_mandeb"
   },
@@ -44,8 +68,203 @@
     "description": "Monthly conflict pulse for Sudan: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
     "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Sudan. It is a country-level pulse, not a comprehensive incident ledger, displacement estimate, or forecast.",
     "coverage": [
-      { "code": "SD", "name": "Sudan" }
+      {
+        "code": "SD",
+        "name": "Sudan"
+      }
     ],
     "dashboardPath": "/?country=SD&expanded=1"
+  },
+  {
+    "slug": "lebanon-israel-escalation",
+    "title": "Lebanon–Israel escalation tracker",
+    "shortTitle": "Lebanon–Israel escalation",
+    "description": "Monthly conflict pulse for Lebanon and Israel: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed two-country scope.",
+    "overview": "This tracker compares the latest available monthly conflict summaries for Lebanon and Israel. Lebanon's figures are aggregated from subnational humanitarian records; the tracker does not attempt to attribute events to specific parties, and cross-border exchanges appear only as each country's own recorded totals.",
+    "coverage": [
+      {
+        "code": "LB",
+        "name": "Lebanon"
+      },
+      {
+        "code": "IL",
+        "name": "Israel"
+      }
+    ],
+    "dashboardPath": "/?country=LB&expanded=1"
+  },
+  {
+    "slug": "hormuz-gulf-security",
+    "title": "Strait of Hormuz security tracker",
+    "shortTitle": "Hormuz and Gulf security",
+    "description": "Monthly conflict pulse for Iran, Iraq and the six Gulf Cooperation Council littoral states around the Strait of Hormuz.",
+    "overview": "This tracker uses a fixed eight-country boundary around the Persian Gulf and the Strait of Hormuz. It provides country-level humanitarian conflict context; tanker traffic, maritime warnings and vessel disruptions remain separate live signals on the chokepoint pages and dashboard.",
+    "coverage": [
+      {
+        "code": "IR",
+        "name": "Iran"
+      },
+      {
+        "code": "IQ",
+        "name": "Iraq"
+      },
+      {
+        "code": "SA",
+        "name": "Saudi Arabia"
+      },
+      {
+        "code": "QA",
+        "name": "Qatar"
+      },
+      {
+        "code": "KW",
+        "name": "Kuwait"
+      },
+      {
+        "code": "AE",
+        "name": "United Arab Emirates"
+      },
+      {
+        "code": "OM",
+        "name": "Oman"
+      },
+      {
+        "code": "BH",
+        "name": "Bahrain"
+      }
+    ],
+    "dashboardPath": "/?chokepoint=hormuz_strait"
+  },
+  {
+    "slug": "sahel-insurgency",
+    "title": "Sahel insurgency tracker",
+    "shortTitle": "Sahel insurgency",
+    "description": "Monthly conflict pulse for Burkina Faso, Mali and Niger: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed three-country scope.",
+    "overview": "This tracker covers the central Sahel states of Burkina Faso, Mali and Niger, whose insurgencies cross shared borders. Totals are aggregated from subnational humanitarian records and are not a territorial control map, a displacement estimate, or a forecast.",
+    "coverage": [
+      {
+        "code": "BF",
+        "name": "Burkina Faso"
+      },
+      {
+        "code": "ML",
+        "name": "Mali"
+      },
+      {
+        "code": "NE",
+        "name": "Niger"
+      }
+    ],
+    "dashboardPath": "/?country=BF&expanded=1"
+  },
+  {
+    "slug": "horn-of-africa",
+    "title": "Horn of Africa conflict tracker",
+    "shortTitle": "Horn of Africa",
+    "description": "Monthly conflict pulse for Ethiopia, Somalia, South Sudan and Eritrea: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed four-country scope.",
+    "overview": "This tracker keeps a fixed four-country boundary across the Horn of Africa. Ethiopia, Somalia and South Sudan report through subnational humanitarian records while Eritrea reports nationally, so a country showing zero recorded events reflects the maintained dataset rather than an absence of risk.",
+    "coverage": [
+      {
+        "code": "ET",
+        "name": "Ethiopia"
+      },
+      {
+        "code": "SO",
+        "name": "Somalia"
+      },
+      {
+        "code": "SS",
+        "name": "South Sudan"
+      },
+      {
+        "code": "ER",
+        "name": "Eritrea"
+      }
+    ],
+    "dashboardPath": "/?country=ET&expanded=1"
+  },
+  {
+    "slug": "myanmar-civil-war",
+    "title": "Myanmar civil war tracker",
+    "shortTitle": "Myanmar civil war",
+    "description": "Monthly conflict pulse for Myanmar: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Myanmar, aggregated from subnational records. It is a country-level pulse, not a comprehensive incident ledger, a territorial control map, or a forecast.",
+    "coverage": [
+      {
+        "code": "MM",
+        "name": "Myanmar"
+      }
+    ],
+    "dashboardPath": "/?country=MM&expanded=1"
+  },
+  {
+    "slug": "haiti-gang-crisis",
+    "title": "Haiti security crisis tracker",
+    "shortTitle": "Haiti security crisis",
+    "description": "Monthly conflict pulse for Haiti: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Haiti, aggregated from subnational records. Armed-group territorial control and displacement are tracked separately by humanitarian agencies and are not represented in these counts.",
+    "coverage": [
+      {
+        "code": "HT",
+        "name": "Haiti"
+      }
+    ],
+    "dashboardPath": "/?country=HT&expanded=1"
+  },
+  {
+    "slug": "drc-eastern-conflict",
+    "title": "DR Congo conflict tracker",
+    "shortTitle": "DR Congo conflict",
+    "description": "Monthly conflict pulse for the Democratic Republic of the Congo: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for the Democratic Republic of the Congo, aggregated from subnational records across the whole country rather than the eastern provinces alone.",
+    "coverage": [
+      {
+        "code": "CD",
+        "name": "Democratic Republic of the Congo"
+      }
+    ],
+    "dashboardPath": "/?country=CD&expanded=1"
+  },
+  {
+    "slug": "nigeria-security-crisis",
+    "title": "Nigeria security crisis tracker",
+    "shortTitle": "Nigeria security crisis",
+    "description": "Monthly conflict pulse for Nigeria: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Nigeria, aggregated from subnational records. It combines the north-eastern insurgency, banditry and communal violence into one national total and does not separate them.",
+    "coverage": [
+      {
+        "code": "NG",
+        "name": "Nigeria"
+      }
+    ],
+    "dashboardPath": "/?country=NG&expanded=1"
+  },
+  {
+    "slug": "afghanistan-crisis",
+    "title": "Afghanistan crisis tracker",
+    "shortTitle": "Afghanistan crisis",
+    "description": "Monthly conflict pulse for Afghanistan: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Afghanistan, aggregated from subnational records. Economic collapse, returnee flows and restrictions on women are central to the humanitarian picture and are not captured by conflict-event counts.",
+    "coverage": [
+      {
+        "code": "AF",
+        "name": "Afghanistan"
+      }
+    ],
+    "dashboardPath": "/?country=AF&expanded=1"
+  },
+  {
+    "slug": "palestine-gaza-crisis",
+    "title": "Palestine crisis tracker",
+    "shortTitle": "Palestine crisis",
+    "description": "Monthly conflict pulse for the Occupied Palestinian Territory: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded scope.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for the Occupied Palestinian Territory, aggregated from subnational records covering Gaza and the West Bank together. Recorded event counts are not casualty estimates and are known to lag and undercount during periods of restricted access.",
+    "coverage": [
+      {
+        "code": "PS",
+        "name": "Palestine"
+      }
+    ],
+    "dashboardPath": "/?country=PS&expanded=1"
   }
 ]

--- a/shared/crawlable-crises.json
+++ b/shared/crawlable-crises.json
@@ -6,8 +6,14 @@
     "description": "Monthly conflict pulse for Iran and Israel: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed two-country scope.",
     "overview": "This tracker keeps a deliberately narrow geographic boundary: it compares the latest available monthly conflict summaries for Iran and Israel. It does not claim to capture every regional spillover event, diplomatic development, or military movement.",
     "coverage": [
-      { "code": "IR", "name": "Iran" },
-      { "code": "IL", "name": "Israel" }
+      {
+        "code": "IR",
+        "name": "Iran"
+      },
+      {
+        "code": "IL",
+        "name": "Israel"
+      }
     ],
     "dashboardPath": "/?country=IR&expanded=1"
   },
@@ -18,8 +24,14 @@
     "description": "Monthly conflict pulse for Ukraine and Russia: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed two-country scope.",
     "overview": "This tracker compares the latest available monthly conflict summaries for Ukraine and Russia. The totals reflect the maintained humanitarian dataset's country records and are not a battlefield map, casualty estimate, or prediction.",
     "coverage": [
-      { "code": "UA", "name": "Ukraine" },
-      { "code": "RU", "name": "Russia" }
+      {
+        "code": "UA",
+        "name": "Ukraine"
+      },
+      {
+        "code": "RU",
+        "name": "Russia"
+      }
     ],
     "dashboardPath": "/?country=UA&expanded=1"
   },
@@ -30,10 +42,22 @@
     "description": "Monthly conflict pulse for Yemen, Saudi Arabia, Djibouti and Eritrea — the fixed four-country boundary around the Red Sea and the Bab el-Mandeb strait.",
     "overview": "This tracker uses a fixed four-country boundary around the Red Sea and Bab el-Mandeb. It provides country-level humanitarian conflict context; maritime warnings and vessel disruptions remain separate live signals on the chokepoint pages and dashboard.",
     "coverage": [
-      { "code": "YE", "name": "Yemen" },
-      { "code": "SA", "name": "Saudi Arabia" },
-      { "code": "DJ", "name": "Djibouti" },
-      { "code": "ER", "name": "Eritrea" }
+      {
+        "code": "YE",
+        "name": "Yemen"
+      },
+      {
+        "code": "SA",
+        "name": "Saudi Arabia"
+      },
+      {
+        "code": "DJ",
+        "name": "Djibouti"
+      },
+      {
+        "code": "ER",
+        "name": "Eritrea"
+      }
     ],
     "dashboardPath": "/?chokepoint=bab_el_mandeb"
   },
@@ -44,8 +68,203 @@
     "description": "Monthly conflict pulse for Sudan: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
     "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Sudan. It is a country-level pulse, not a comprehensive incident ledger, displacement estimate, or forecast.",
     "coverage": [
-      { "code": "SD", "name": "Sudan" }
+      {
+        "code": "SD",
+        "name": "Sudan"
+      }
     ],
     "dashboardPath": "/?country=SD&expanded=1"
+  },
+  {
+    "slug": "lebanon-israel-escalation",
+    "title": "Lebanon–Israel escalation tracker",
+    "shortTitle": "Lebanon–Israel escalation",
+    "description": "Monthly conflict pulse for Lebanon and Israel: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed two-country scope.",
+    "overview": "This tracker compares the latest available monthly conflict summaries for Lebanon and Israel. Lebanon's figures are aggregated from subnational humanitarian records; the tracker does not attempt to attribute events to specific parties, and cross-border exchanges appear only as each country's own recorded totals.",
+    "coverage": [
+      {
+        "code": "LB",
+        "name": "Lebanon"
+      },
+      {
+        "code": "IL",
+        "name": "Israel"
+      }
+    ],
+    "dashboardPath": "/?country=LB&expanded=1"
+  },
+  {
+    "slug": "hormuz-gulf-security",
+    "title": "Strait of Hormuz security tracker",
+    "shortTitle": "Hormuz and Gulf security",
+    "description": "Monthly conflict pulse for Iran, Iraq and the six Gulf Cooperation Council littoral states around the Strait of Hormuz.",
+    "overview": "This tracker uses a fixed eight-country boundary around the Persian Gulf and the Strait of Hormuz. It provides country-level humanitarian conflict context; tanker traffic, maritime warnings and vessel disruptions remain separate live signals on the chokepoint pages and dashboard.",
+    "coverage": [
+      {
+        "code": "IR",
+        "name": "Iran"
+      },
+      {
+        "code": "IQ",
+        "name": "Iraq"
+      },
+      {
+        "code": "SA",
+        "name": "Saudi Arabia"
+      },
+      {
+        "code": "QA",
+        "name": "Qatar"
+      },
+      {
+        "code": "KW",
+        "name": "Kuwait"
+      },
+      {
+        "code": "AE",
+        "name": "United Arab Emirates"
+      },
+      {
+        "code": "OM",
+        "name": "Oman"
+      },
+      {
+        "code": "BH",
+        "name": "Bahrain"
+      }
+    ],
+    "dashboardPath": "/?chokepoint=hormuz_strait"
+  },
+  {
+    "slug": "sahel-insurgency",
+    "title": "Sahel insurgency tracker",
+    "shortTitle": "Sahel insurgency",
+    "description": "Monthly conflict pulse for Burkina Faso, Mali and Niger: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed three-country scope.",
+    "overview": "This tracker covers the central Sahel states of Burkina Faso, Mali and Niger, whose insurgencies cross shared borders. Totals are aggregated from subnational humanitarian records and are not a territorial control map, a displacement estimate, or a forecast.",
+    "coverage": [
+      {
+        "code": "BF",
+        "name": "Burkina Faso"
+      },
+      {
+        "code": "ML",
+        "name": "Mali"
+      },
+      {
+        "code": "NE",
+        "name": "Niger"
+      }
+    ],
+    "dashboardPath": "/?country=BF&expanded=1"
+  },
+  {
+    "slug": "horn-of-africa",
+    "title": "Horn of Africa conflict tracker",
+    "shortTitle": "Horn of Africa",
+    "description": "Monthly conflict pulse for Ethiopia, Somalia, South Sudan and Eritrea: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a fixed four-country scope.",
+    "overview": "This tracker keeps a fixed four-country boundary across the Horn of Africa. Ethiopia, Somalia and South Sudan report through subnational humanitarian records while Eritrea reports nationally, so a country showing zero recorded events reflects the maintained dataset rather than an absence of risk.",
+    "coverage": [
+      {
+        "code": "ET",
+        "name": "Ethiopia"
+      },
+      {
+        "code": "SO",
+        "name": "Somalia"
+      },
+      {
+        "code": "SS",
+        "name": "South Sudan"
+      },
+      {
+        "code": "ER",
+        "name": "Eritrea"
+      }
+    ],
+    "dashboardPath": "/?country=ET&expanded=1"
+  },
+  {
+    "slug": "myanmar-civil-war",
+    "title": "Myanmar civil war tracker",
+    "shortTitle": "Myanmar civil war",
+    "description": "Monthly conflict pulse for Myanmar: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Myanmar, aggregated from subnational records. It is a country-level pulse, not a comprehensive incident ledger, a territorial control map, or a forecast.",
+    "coverage": [
+      {
+        "code": "MM",
+        "name": "Myanmar"
+      }
+    ],
+    "dashboardPath": "/?country=MM&expanded=1"
+  },
+  {
+    "slug": "haiti-gang-crisis",
+    "title": "Haiti security crisis tracker",
+    "shortTitle": "Haiti security crisis",
+    "description": "Monthly conflict pulse for Haiti: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Haiti, aggregated from subnational records. Armed-group territorial control and displacement are tracked separately by humanitarian agencies and are not represented in these counts.",
+    "coverage": [
+      {
+        "code": "HT",
+        "name": "Haiti"
+      }
+    ],
+    "dashboardPath": "/?country=HT&expanded=1"
+  },
+  {
+    "slug": "drc-eastern-conflict",
+    "title": "DR Congo conflict tracker",
+    "shortTitle": "DR Congo conflict",
+    "description": "Monthly conflict pulse for the Democratic Republic of the Congo: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for the Democratic Republic of the Congo, aggregated from subnational records across the whole country rather than the eastern provinces alone.",
+    "coverage": [
+      {
+        "code": "CD",
+        "name": "Democratic Republic of the Congo"
+      }
+    ],
+    "dashboardPath": "/?country=CD&expanded=1"
+  },
+  {
+    "slug": "nigeria-security-crisis",
+    "title": "Nigeria security crisis tracker",
+    "shortTitle": "Nigeria security crisis",
+    "description": "Monthly conflict pulse for Nigeria: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Nigeria, aggregated from subnational records. It combines the north-eastern insurgency, banditry and communal violence into one national total and does not separate them.",
+    "coverage": [
+      {
+        "code": "NG",
+        "name": "Nigeria"
+      }
+    ],
+    "dashboardPath": "/?country=NG&expanded=1"
+  },
+  {
+    "slug": "afghanistan-crisis",
+    "title": "Afghanistan crisis tracker",
+    "shortTitle": "Afghanistan crisis",
+    "description": "Monthly conflict pulse for Afghanistan: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded country-level view.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for Afghanistan, aggregated from subnational records. Economic collapse, returnee flows and restrictions on women are central to the humanitarian picture and are not captured by conflict-event counts.",
+    "coverage": [
+      {
+        "code": "AF",
+        "name": "Afghanistan"
+      }
+    ],
+    "dashboardPath": "/?country=AF&expanded=1"
+  },
+  {
+    "slug": "palestine-gaza-crisis",
+    "title": "Palestine crisis tracker",
+    "shortTitle": "Palestine crisis",
+    "description": "Monthly conflict pulse for the Occupied Palestinian Territory: recorded events, political violence and fatalities from HAPI/HDX humanitarian summaries in a bounded scope.",
+    "overview": "This tracker reports the latest available monthly humanitarian conflict summary for the Occupied Palestinian Territory, aggregated from subnational records covering Gaza and the West Bank together. Recorded event counts are not casualty estimates and are known to lag and undercount during periods of restricted access.",
+    "coverage": [
+      {
+        "code": "PS",
+        "name": "Palestine"
+      }
+    ],
+    "dashboardPath": "/?country=PS&expanded=1"
   }
 ]

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -1742,7 +1742,12 @@ describe('crawlable corpus generator', () => {
       assert.equal(manifest.sections.countries.count, 196);
       assert.equal(manifest.sections.countryInstabilityIndex.count, 1);
       assert.equal(manifest.sections.chokepoints.count, 13);
-      assert.equal(manifest.sections.crises.count, 4);
+      // Derived, not frozen: a frozen count is exactly the drift #7656 removed from
+      // the seeder, where a hand-maintained copy of this registry silently diverged.
+      assert.equal(
+        manifest.sections.crises.count,
+        JSON.parse(read(repoRoot, 'shared/crawlable-crises.json')).length,
+      );
       assert.equal(manifest.sections.tools.count, 3);
       assert.equal(manifest.sections.research.count, 1);
       assert.equal(manifest.sections.useCases.count, 3);
@@ -4624,7 +4629,11 @@ describe('crawlable corpus generator', () => {
       }),
       'source-page lastmod must include manifest, renderer, origin, catalog-input, and shared-template changes',
     );
-    assert.equal(data.crises.length, 4);
+    assert.equal(
+      data.crises.length,
+      JSON.parse(read(repoRoot, 'shared/crawlable-crises.json')).length,
+      'the loaded crisis set must match the registry, never a frozen count',
+    );
     assert.ok(data.crises.some((crisis) => crisis.slug === 'ukraine-war' && crisis.coverage.some((country) => country.code === 'UA')));
     assert.ok(data.countryBounds.some((country) => country.code === 'JP' && country.bounds[0] === 31.11));
     assert.ok(!data.countryBounds.some((country) => country.code === 'US'));

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -4223,6 +4223,19 @@ describe('crawlable corpus generator', () => {
 
       const toolsIndex = read(outDir, 'tools/index.html');
       assert.match(toolsIndex, /<h1>Check a current operational signal<\/h1>/);
+      // The hub cards state corpus sizes as fact, so they must track the registries
+      // this same build rendered. A literal here shipped "Four curated geographic
+      // scopes" against a 14-tracker corpus.
+      assert.match(
+        toolsIndex,
+        new RegExp(`href="/crises/"[^]*?<span>${corpus.crises.length} curated geographic scopes</span>`),
+        'the tools hub crisis count must match the rendered registry',
+      );
+      assert.match(
+        toolsIndex,
+        new RegExp(`href="/chokepoints/"[^]*?<span>${corpus.chokepoints.length} canonical waterways</span>`),
+        'the tools hub chokepoint count must match the rendered registry',
+      );
       assertDefaultSpeakable(
         jsonLdObjects(toolsIndex).find((entry) => entry['@type'] === 'CollectionPage'),
         'tools hub CollectionPage',


### PR DESCRIPTION
Follows #7656. That PR removed the reason 13 conflict countries were dark and made `shared/crawlable-crises.json` the single source of truth for which countries HAPI must fetch, so this one is a pure data change: adding an entry now pulls its countries into the seeder automatically.

## The ten new trackers

| tracker | scope |
|---|---|
| Lebanon–Israel escalation | LB, IL |
| Strait of Hormuz security | IR, IQ, SA, QA, KW, AE, OM, BH |
| Sahel insurgency | BF, ML, NE |
| Horn of Africa | ET, SO, SS, ER |
| Myanmar civil war | MM |
| Haiti security crisis | HT |
| DR Congo conflict | CD |
| Nigeria security crisis | NG |
| Afghanistan crisis | AF |
| Palestine crisis | PS |

Regional scopes for the Sahel and the Horn because those insurgencies cross the borders in question, and a chokepoint scope for Hormuz that mirrors the existing Red Sea tracker and links to `hormuz_strait`.

## The health contract moved, and that is the guard working

The registry now drives 28 countries, so `HAPI_REQUIRED_COUNTRIES` grows 23 → 41 and `api/health.js`'s `humanitarianSummary.minRecordCount` tracks it.

Worth being explicit about how that surfaced: adding the entries made `tests/seed-conflict-intel-hapi-circuit-breaker` fail immediately with *"health.js minRecordCount must track the guaranteed-coverage contract, not a frozen count"*. That is precisely the drift #7656 was about, caught by a test instead of by a silently empty page months later.

**Verified 41 is achievable, not aspirational.** Ran the real seeder path against live HAPI with stubbed Redis: `44/44 countries (41/41 required)`. The six countries the new trackers add all return real August 2026 data:

```
LB  643 events / 33 fatalities      QA  0 / 0
KW    4 / 0                         AE  1 / 0
OM   13 / 2                         BH  36 / 0
```

## Frozen counts replaced with derived ones

`tests/crawlable-corpus.test.mjs` had two hardcoded `4`s. I derived both from the registry instead of re-freezing them at 14. A hardcoded count is exactly the failure mode #7656 fixed in the seeder, and bumping the number would have rebuilt the same trap one layer over.

## Verification

- `crawlable-corpus` 86/86, `seed-conflict-intel-hapi-circuit-breaker` 31/31, run separately.
- Corpus builds all 14 pages: `196 countries, 13 chokepoints, 14 crisis trackers, ...`, and the `/crises/` index renders 14 cards with correct coverage lists.
- Build output under `public/` is gitignored, so the diff is four source files.

## Expected state on merge

The 10 new pages ship their scope, boundary prose and JSON-LD immediately, and fail closed on metrics until the next pulse freeze captures their month. That is the documented behaviour, and `renderCrisisPage` handles it (`hasPulse === false` renders "Waiting for published pulse" and the client-side script fills live values).

To make them ship *with* numbers, the sequence after merge is: Railway redeploys the seeder with the 6 new countries, then dispatch `crawlable-pulse-refresh` to capture them into `docs/snapshots/`.

## Note on current production state

`humanitarianSummary` is in `SEED_ERROR` right now, in a 2h HAPI failure backoff. Per `/api/health?history=1` it began at **14:33:26Z, thirteen minutes before #7656 merged at 14:46:05Z**, and the prior 24h of failure snapshots are clean — so it is not caused by that change. The probable trigger is my own verification probing, which used the production `app_identifier` (`wm-crisis-tracker`) that HAPI rate-limits per client. It should clear on its own around 16:33Z; I am watching production to confirm.

https://claude.ai/code/session_01BXisqhA6TY13kHcSpF9p29