### PR TITLE
fix(map): stop NaN coordinates reaching crawlable share URLs

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -4824,7 +4824,9 @@ export class MapComponent {
     const coords = projection.invert(
       projectionPointAtScreenCentre(width, height, this.state.pan),
     );
-    if (!coords) return null;
+    // A 0x0 container (hidden or not yet laid out) makes getProjection scale 0,
+    // and d3 then inverts to [NaN, NaN] rather than null (#7660).
+    if (!coords || !Number.isFinite(coords[0]) || !Number.isFinite(coords[1])) return null;
     return { lon: coords[0], lat: coords[1] };
   }
 

--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -180,7 +180,7 @@ export function buildMapUrl(
   }
   const params = new URLSearchParams();
 
-  if (state.center) {
+  if (state.center && Number.isFinite(state.center.lat) && Number.isFinite(state.center.lon)) {
     params.set('lat', state.center.lat.toFixed(4));
     params.set('lon', state.center.lon.toFixed(4));
   }

--- a/tests/urlState.test.mts
+++ b/tests/urlState.test.mts
@@ -94,6 +94,51 @@ describe('parseMapUrlState chokepoint param', () => {
   });
 });
 
+describe('buildMapUrl non-finite centre (#7660)', () => {
+  const base = 'https://worldmonitor.app/dashboard';
+  const baseState = {
+    view: 'global' as const,
+    zoom: 2,
+    timeRange: '24h' as const,
+    layers: EMPTY_LAYERS,
+  };
+
+  it('omits lat/lon when the centre is NaN', () => {
+    const url = buildMapUrl(base, { ...baseState, center: { lat: NaN, lon: NaN } });
+    const params = new URL(url).searchParams;
+    assert.equal(params.get('lat'), null);
+    assert.equal(params.get('lon'), null);
+    assert.ok(!url.includes('NaN'), `url must not contain NaN: ${url}`);
+  });
+
+  it('omits lat/lon when only one coordinate is non-finite', () => {
+    for (const center of [
+      { lat: NaN, lon: 12.5 },
+      { lat: 51.5, lon: NaN },
+      { lat: Infinity, lon: 0 },
+      { lat: 0, lon: -Infinity },
+    ]) {
+      const url = buildMapUrl(base, { ...baseState, center });
+      assert.ok(!url.includes('NaN'), `url must not contain NaN: ${url}`);
+      assert.ok(!url.includes('Infinity'), `url must not contain Infinity: ${url}`);
+    }
+  });
+
+  it('still emits a finite centre', () => {
+    const url = buildMapUrl(base, { ...baseState, center: { lat: 51.5074, lon: -0.1278 } });
+    const params = new URL(url).searchParams;
+    assert.equal(params.get('lat'), '51.5074');
+    assert.equal(params.get('lon'), '-0.1278');
+  });
+
+  it('round-trips a NaN centre to a parse that yields no coordinates', () => {
+    const url = buildMapUrl(base, { ...baseState, center: { lat: NaN, lon: NaN } });
+    const state = parseMapUrlState(new URL(url).search, EMPTY_LAYERS);
+    assert.equal(state.lat, undefined);
+    assert.equal(state.lon, undefined);
+  });
+});
+
 describe('buildMapUrl expanded param', () => {
   const base = 'https://worldmonitor.app/dashboard';
   const baseState = {


### PR DESCRIPTION
Sharing the map while its container was hidden or not yet laid out produced a URL like `/index?lat=NaN&lon=NaN&zoom=2.50&view=america`. Googlebot crawled those, and they now sit among the 512 not-found URLs in Search Console.

`Map.getCenter` builds a d3 projection from the measured container size. A 0x0 container makes `getProjection` compute `scale = min(0 / 2π, 0 / (128π / 180)) = 0`, and d3 inverts a zero-scale projection to `[NaN, NaN]` rather than null, so the existing `if (!coords)` guard could not catch it because an array is always truthy. `buildMapUrl` then guarded on `if (state.center)`, a truthiness check on the container rather than the values it holds, and `NaN.toFixed(4)` returns the string `"NaN"`.

Both now require finite coordinates, matching `normalizeCenter` in `src/embed/embed-url.ts`, which has always applied this check and is why the embed builder was never affected. The parser already discards non-finite `lat`/`lon`, so omitting the pair is what a reader would have inferred anyway. `zoom` has the same unguarded shape but no evidence of going non-finite, so it is left alone rather than shipping a speculative guard.

Verified against the repo's own d3: a 0x0, zero-width, or zero-height container now returns null instead of NaN coordinates. `tests/urlState.test.mts` moves from 20/22 to 22/22, with the failing case committed before the fix so the history carries the repro. No regressions in `url-sync-initial` (22/22) or `route-explorer-url-state` (19/19), and `tsc --noEmit` is clean.

Related: #7660

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
