### PR TITLE
fix(conflict): invalidate stale HAPI coverage markers

### DIFF
--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -832,9 +832,17 @@ export async function fetchAllHumanitarianSummaries({
     console.warn(`  HAPI freshness marker read failed: ${error.message}`);
     return null;
   });
+  const requiredCountryContract = [...requiredCountryCodes].sort();
   if (
     Number.isFinite(Number(previousMarker?.updatedAt))
     && nowMs - Number(previousMarker.updatedAt) < HAPI_REFRESH_INTERVAL_MS
+    && Number(previousMarker?.requiredCountriesTotal) === requiredCountryCodes.length
+    && Number(previousMarker?.requiredCountriesCovered) >= requiredCountryCodes.length
+    && Array.isArray(previousMarker?.requiredCountryCodes)
+    && previousMarker.requiredCountryCodes.length === requiredCountryContract.length
+    && [...previousMarker.requiredCountryCodes]
+      .sort()
+      .every((countryCode, index) => countryCode === requiredCountryContract[index])
   ) {
     console.log(`  Humanitarian: recent bulk snapshot still fresh (${Object.keys(previousMarker).length > 0 ? previousMarker.countriesCovered ?? 'unknown' : 'unknown'} countries)`);
     return null;
@@ -1177,6 +1185,7 @@ export async function fetchAll({
       {
         countriesCovered: Object.keys(ha).length,
         requiredCountriesCovered,
+        requiredCountryCodes: [...HAPI_REQUIRED_COUNTRIES].sort(),
         requiredCountriesTotal: HAPI_REQUIRED_COUNTRIES.length,
         updatedAt: Date.now(),
       },

--- a/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
+++ b/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
@@ -95,6 +95,10 @@ test('humanitarian health reports partial target-country coverage', () => {
     seedSource,
     /HAPI_SEED_META_TTL_SECONDS,\s*requiredCountriesCovered,\s*HAPI_SEED_META_KEY/,
   );
+  assert.match(
+    seedSource,
+    /requiredCountryCodes:\s*\[\.\.\.HAPI_REQUIRED_COUNTRIES\]\.sort\(\)/,
+  );
   assert.equal(
     minRecordCount,
     HAPI_REQUIRED_COUNTRIES.length,
@@ -947,6 +951,64 @@ test('HAPI backoff records the fallback rejection status when the national sweep
   assert.equal(backoff.retryAt, NOW + HAPI_FAILURE_BACKOFF_MS);
 });
 
+test('HAPI ingestion refreshes when a fresh marker has a missing, changed, or incomplete coverage contract', async () => {
+  const previousMarkers = [
+    {
+      updatedAt: NOW - HAPI_REFRESH_INTERVAL_MS + 1,
+      requiredCountriesCovered: 2,
+      requiredCountriesTotal: 2,
+    },
+    {
+      updatedAt: NOW - HAPI_REFRESH_INTERVAL_MS + 1,
+      requiredCountriesCovered: 1,
+      requiredCountryCodes: ['SD'],
+      requiredCountriesTotal: 1,
+    },
+    {
+      updatedAt: NOW - HAPI_REFRESH_INTERVAL_MS + 1,
+      requiredCountriesCovered: 1,
+      requiredCountryCodes: ['SD', 'UA'],
+      requiredCountriesTotal: 2,
+    },
+    {
+      updatedAt: NOW - HAPI_REFRESH_INTERVAL_MS + 1,
+      requiredCountriesCovered: 2,
+      requiredCountryCodes: ['SD', 'YE'],
+      requiredCountriesTotal: 2,
+    },
+    {
+      updatedAt: NOW - HAPI_REFRESH_INTERVAL_MS + 1,
+      requiredCountriesCovered: 3,
+      requiredCountryCodes: ['SD', 'UA', 'YE'],
+      requiredCountriesTotal: 3,
+    },
+  ];
+
+  for (const previousMarker of previousMarkers) {
+    let calls = 0;
+    const result = await fetchAllHumanitarianSummaries({
+      now: () => NOW,
+      countryCodes: ['SD', 'UA'],
+      pace: async () => {},
+      loadPreviousMarker: async () => previousMarker,
+      loadFailureBackoff: async () => null,
+      writeFailureBackoff: async () => assert.fail('complete coverage must not write a failure backoff'),
+      preserveLastGood: async () => assert.fail('complete coverage must not extend stale rows'),
+      fetchFn: async (url) => {
+        calls += 1;
+        const parsed = new URL(url);
+        const data = parsed.searchParams.get('admin_level') === '0'
+          ? [hapiRow('SDN'), hapiRow('UKR')]
+          : [];
+        return new Response(JSON.stringify({ data }), { status: 200 });
+      },
+    });
+
+    assert.equal(calls, 2);
+    assert.deepEqual(Object.keys(result).sort(), ['SD', 'UA']);
+  }
+});
+
 test('HAPI ingestion skips network calls during success and failure backoff windows', async () => {
   let calls = 0;
   const fetchFn = async () => {
@@ -958,7 +1020,12 @@ test('HAPI ingestion skips network calls during success and failure backoff wind
     now: () => NOW,
     countryCodes: ['SD'],
     pace: async () => {},
-    loadPreviousMarker: async () => ({ updatedAt: NOW - HAPI_REFRESH_INTERVAL_MS + 1 }),
+    loadPreviousMarker: async () => ({
+      updatedAt: NOW - HAPI_REFRESH_INTERVAL_MS + 1,
+      requiredCountriesCovered: 1,
+      requiredCountryCodes: ['SD'],
+      requiredCountriesTotal: 1,
+    }),
     loadFailureBackoff: async () => null,
     fetchFn,
   });


### PR DESCRIPTION
## Summary

A newly deployed HAPI coverage contract now forces its first refresh instead of trusting a recent success marker from an older country set. The marker records the canonical required-country list, and freshness now requires exact country membership plus complete required coverage. Active provider backoff remains authoritative, while an unchanged complete contract keeps the existing two-hour freshness skip.

## Validation

- Reproduced the production failure first: a fresh legacy marker caused 0 HAPI requests when 2 were required.
- Added contract-transition coverage for missing identity, growth, shrink, incomplete coverage, and same-size country replacement.
- `node --test tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs tests/seed-fetch-deadline-budget-invariants.test.mjs` (36 passed)
- `node_modules/.bin/biome lint scripts/seed-conflict-intel.mjs tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs`
- `npm run typecheck`

## Post-Deploy Monitoring & Validation

- **Logs:** watch the first natural `seed-conflict-intel` run for `Humanitarian:` coverage output. A legacy marker must not produce `recent bulk snapshot still fresh`; after a successful publish, the next run inside two hours should produce that skip.
- **Health and marker:** confirm `humanitarianSummary` reaches `OK`, required coverage is at least 41, and the aggregate marker contains the current sorted `requiredCountryCodes` list.
- **Failure signals:** old 38-country coverage remains accepted, the new marker lacks `requiredCountryCodes`, a valid new marker does not restore the freshness skip, or the service repeatedly calls HAPI inside the two-hour window.
- **Mitigation trigger:** keep production acceptance open if the first eligible cron does not attempt the refresh. Roll back only if a valid current marker causes repeated provider calls; provider failures continue through the existing last-good and backoff path.
- **Window and owner:** the WorldMonitor release operator observes the first natural cron and the following cron. No manual seeder call is required.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
