### PR TITLE
fix(country): restore military activity in briefs

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1536,6 +1536,7 @@ export class App {
     this.dataLoader = new DataLoaderManager(this.state, {
       renderCriticalBanner: (postures) => this.panelLayout.renderCriticalBanner(postures),
       refreshOpenCountryBrief: () => this.countryIntel.refreshOpenBrief(),
+      refreshOpenCountryMilitary: () => this.countryIntel.refreshOpenMilitaryActivity(),
       refreshOpenCountryTimeline: () => this.countryIntel.refreshOpenTimeline(),
     });
 

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -1193,6 +1193,15 @@ export class CountryIntelManager implements AppModule {
       });
   }
 
+  refreshOpenMilitaryActivity(): void {
+    const page = this.ctx.countryBriefPage;
+    if (!page?.isVisible()) return;
+    const code = page.getCode();
+    if (!code || code === '__loading__' || code === '__error__') return;
+    const country = page.getName() ?? TIER1_COUNTRIES[code] ?? CountryIntelManager.resolveCountryName(code);
+    page.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
+  }
+
   refreshOpenTimeline(): void {
     const page = this.ctx.countryBriefPage;
     if (!page?.isVisible()) return;

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -325,6 +325,7 @@ const IRAN_ATTACKS_ENABLED = import.meta.env.VITE_ENABLE_IRAN_ATTACKS === 'true'
 export interface DataLoaderCallbacks {
   renderCriticalBanner: (postures: TheaterPostureSummary[]) => void;
   refreshOpenCountryBrief: () => void;
+  refreshOpenCountryMilitary?: () => void;
   refreshOpenCountryTimeline?: () => void;
 }
 
@@ -3345,6 +3346,7 @@ export class DataLoaderManager implements AppModule {
           vessels: vesselData.vessels,
           vesselClusters: vesselData.clusters,
         };
+        this.callbacks.refreshOpenCountryMilitary?.();
         this.callbacks.refreshOpenCountryTimeline?.();
         fetchUSNIFleetReport().then((report) => {
           if (report) this.ctx.intelligenceCache.usniFleet = report;
@@ -3873,6 +3875,7 @@ export class DataLoaderManager implements AppModule {
         vessels: vesselData.vessels,
         vesselClusters: vesselData.clusters,
       };
+      this.callbacks.refreshOpenCountryMilitary?.();
       this.callbacks.refreshOpenCountryTimeline?.();
       fetchUSNIFleetReport().then((report) => {
         if (report) this.ctx.intelligenceCache.usniFleet = report;

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -542,14 +542,17 @@ export function installWebApiRedirect(): void {
         // rely on the relative-path branch above for origin recovery. Keep the
         // same fallback here: browser extensions and network policy can block
         // api.worldmonitor.app while the page's own /api/ route remains usable.
+        // Only idempotent methods may retry automatically: replaying a mutation
+        // whose response was lost could enqueue or apply it twice server-side.
         if (input.startsWith(`${API_BASE}/api/`)) {
           const pathAndSearch = input.slice(API_BASE.length);
+          const method = (init?.method ?? 'GET').toUpperCase();
           const enriched = await enrichInitForPremium(pathAndSearch, init);
-          return fetchWithRedirectFallback(
-            input,
-            pathAndSearch,
-            enriched ? withCredentials(enriched) : withCredentials(init),
-          );
+          const initWithCredentials = enriched ? withCredentials(enriched) : withCredentials(init);
+          if (method === 'GET' || method === 'HEAD') {
+            return fetchWithRedirectFallback(input, pathAndSearch, initWithCredentials);
+          }
+          return nativeFetch(input, initWithCredentials);
         }
       }
       if (input instanceof URL) {

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -538,12 +538,18 @@ export function installWebApiRedirect(): void {
           const enriched = await enrichInitForPremium(input, init);
           return fetchWithRedirectFallback(`${API_BASE}${input}`, input, enriched ? withCredentials(enriched) : withCredentials(init));
         }
-        // Absolute URL already targeting the API base (generated clients call fetch
-        // with full URLs like https://api.worldmonitor.app/api/...) — just inject auth.
+        // Generated clients construct an absolute API-base URL, so they cannot
+        // rely on the relative-path branch above for origin recovery. Keep the
+        // same fallback here: browser extensions and network policy can block
+        // api.worldmonitor.app while the page's own /api/ route remains usable.
         if (input.startsWith(`${API_BASE}/api/`)) {
           const pathAndSearch = input.slice(API_BASE.length);
           const enriched = await enrichInitForPremium(pathAndSearch, init);
-          return nativeFetch(input, enriched ? withCredentials(enriched) : withCredentials(init));
+          return fetchWithRedirectFallback(
+            input,
+            pathAndSearch,
+            enriched ? withCredentials(enriched) : withCredentials(init),
+          );
         }
       }
       if (input instanceof URL) {

--- a/tests/dom/country-intel-infrastructure-preload.test.mts
+++ b/tests/dom/country-intel-infrastructure-preload.test.mts
@@ -121,9 +121,11 @@ function createBriefHarness(code: string) {
   let visible = false;
   let activeCode = '';
   const infrastructureUpdates: string[] = [];
+  const militaryUpdates: Array<{ ownFlights: number; foreignFlights: number }> = [];
   const newsUpdates: string[] = [];
   const page = {
     getCode: () => activeCode,
+    getName: () => code === 'US' ? 'United States' : activeCode,
     isVisible: () => visible,
     hide: () => {
       visible = false;
@@ -143,7 +145,9 @@ function createBriefHarness(code: string) {
     updateNews: () => {
       newsUpdates.push(activeCode);
     },
-    updateMilitaryActivity: () => {},
+    updateMilitaryActivity: (summary: { ownFlights: number; foreignFlights: number }) => {
+      militaryUpdates.push(summary);
+    },
     updateEconomicIndicators: () => {},
     updateStock: () => {},
     updateMarkets: () => {},
@@ -178,7 +182,10 @@ function createBriefHarness(code: string) {
   Reflect.set(manager, 'fetchCommodityVulnerability', () => {});
   Reflect.set(manager, 'mountCountryTimeline', () => {});
   return {
+    ctx,
     infrastructureUpdates,
+    manager,
+    militaryUpdates,
     newsUpdates,
     open: () => manager.openCountryBriefByCode(code, code, { trackAnalytics: false }),
   };
@@ -235,5 +242,24 @@ describe('CountryIntelManager infrastructure preload barrier', () => {
     await vi.waitFor(() => expect(infrastructureUpdates).toEqual(['AE', 'AE']));
     await pendingOpen;
     expect(infrastructureUpdates).toEqual(['AE', 'AE']);
+  });
+
+  it('refreshes the visible military card from the current military cache', async () => {
+    geometryMocks.preloadCountryGeometry.mockResolvedValue(undefined);
+    infraMocks.preloadInfrastructureTables.mockResolvedValue(undefined);
+    const { ctx, manager, militaryUpdates, open } = createBriefHarness('US');
+    await open();
+    militaryUpdates.length = 0;
+    ctx.intelligenceCache.military = {
+      flights: [{ lat: 40, lon: -100, operatorCountry: 'United States' }],
+      flightClusters: [],
+      vessels: [],
+      vesselClusters: [],
+    } as never;
+
+    manager.refreshOpenMilitaryActivity();
+
+    expect(militaryUpdates).toHaveLength(1);
+    expect(militaryUpdates[0]).toEqual(expect.objectContaining({ ownFlights: 1, foreignFlights: 0 }));
   });
 });

--- a/tests/dom/data-loader-timeline-refresh.test.mts
+++ b/tests/dom/data-loader-timeline-refresh.test.mts
@@ -202,6 +202,7 @@ const conflictData = {
 const flight = { id: 'flight-1', lat: 51.5, lon: -0.1 } as never;
 
 async function makeLoader() {
+  const refreshOpenCountryMilitary = vi.fn();
   const refreshOpenCountryTimeline = vi.fn();
   const ctx = {
     intelligenceCache: {},
@@ -224,9 +225,10 @@ async function makeLoader() {
   const loader = new DataLoaderManager(ctx, {
     renderCriticalBanner: () => undefined,
     refreshOpenCountryBrief: () => undefined,
+    refreshOpenCountryMilitary,
     refreshOpenCountryTimeline,
   });
-  return { loader, ctx, refreshOpenCountryTimeline };
+  return { loader, ctx, refreshOpenCountryMilitary, refreshOpenCountryTimeline };
 }
 
 describe('DataLoaderManager cache-to-timeline callbacks', () => {
@@ -321,7 +323,7 @@ describe('DataLoaderManager cache-to-timeline callbacks', () => {
 
   it('invokes refreshOpenCountryTimeline after loadMilitary assigns tracks', async () => {
     mocks.fetchMilitaryFlights.mockResolvedValueOnce({ flights: [flight], clusters: [] });
-    const { loader, ctx, refreshOpenCountryTimeline } = await makeLoader();
+    const { loader, ctx, refreshOpenCountryMilitary, refreshOpenCountryTimeline } = await makeLoader();
     refreshOpenCountryTimeline.mockImplementation(() => {
       expect(ctx.intelligenceCache.military).toEqual({
         flights: [flight],
@@ -334,12 +336,13 @@ describe('DataLoaderManager cache-to-timeline callbacks', () => {
     await loader.loadMilitary();
 
     expect(refreshOpenCountryTimeline).toHaveBeenCalledOnce();
+    expect(refreshOpenCountryMilitary).toHaveBeenCalledOnce();
     expect(ctx.intelligenceCache.military?.flights).toEqual([flight]);
   });
 
   it('invokes refreshOpenCountryTimeline after the intelligence military path assigns cache', async () => {
     mocks.fetchMilitaryFlights.mockResolvedValueOnce({ flights: [flight], clusters: [] });
-    const { loader, ctx, refreshOpenCountryTimeline } = await makeLoader();
+    const { loader, ctx, refreshOpenCountryMilitary, refreshOpenCountryTimeline } = await makeLoader();
     refreshOpenCountryTimeline.mockImplementation(() => {
       expect(ctx.intelligenceCache.military).toEqual({
         flights: [flight],
@@ -352,6 +355,7 @@ describe('DataLoaderManager cache-to-timeline callbacks', () => {
     await loader.loadIntelligenceSignals();
 
     expect(refreshOpenCountryTimeline).toHaveBeenCalledOnce();
+    expect(refreshOpenCountryMilitary).toHaveBeenCalledOnce();
     expect(ctx.intelligenceCache.military?.flights).toEqual([flight]);
   });
 });

--- a/tests/dom/runtime-web-api-base-loopback.test.mts
+++ b/tests/dom/runtime-web-api-base-loopback.test.mts
@@ -238,6 +238,40 @@ describe('installWebApiRedirect on deployed WorldMonitor pages', () => {
     expect(await response.json()).toEqual({ flights: [{ id: 'flight-1' }] });
     expect(seen).toEqual([`${REMOTE_API}${path}`, path]);
   });
+
+  it('does not replay a mutation request (POST) on the page origin after an API-host failure', async () => {
+    const pageOrigin = 'https://www.worldmonitor.app';
+    const path = '/api/scenario/v1/run-scenario';
+    const seen: string[] = [];
+    window.fetch = (async (input: RequestInfo | URL) => {
+      const target = hrefOf(input);
+      seen.push(target);
+      if (target.startsWith(REMOTE_API)) throw new TypeError('Failed to fetch');
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const runtime = await loadRuntimeWith({
+      apiBase: REMOTE_API,
+      hostname: 'www.worldmonitor.app',
+      protocol: 'https:',
+    });
+    Object.assign(window.location, {
+      hostname: 'www.worldmonitor.app',
+      host: 'www.worldmonitor.app',
+      protocol: 'https:',
+      href: `${pageOrigin}/dashboard`,
+      origin: pageOrigin,
+    });
+
+    runtime.installWebApiRedirect();
+
+    await expect(window.fetch(`${REMOTE_API}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scenario: 'hormuz_strait' }),
+    })).rejects.toThrow('Failed to fetch');
+    expect(seen).toEqual([`${REMOTE_API}${path}`]);
+  });
 });
 
 describe('HTTPS loopback uses the web API path, not the sidecar', () => {

--- a/tests/dom/runtime-web-api-base-loopback.test.mts
+++ b/tests/dom/runtime-web-api-base-loopback.test.mts
@@ -192,6 +192,54 @@ describe('installWebApiRedirect on numeric loopback bases', () => {
   }
 });
 
+describe('installWebApiRedirect on deployed WorldMonitor pages', () => {
+  const originalFetch = window.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    delete (window as unknown as Record<string, unknown>).__wmWebRedirectPatched;
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('retries an absolute generated RPC request on the page origin after an API-host network failure', async () => {
+    const pageOrigin = 'https://www.worldmonitor.app';
+    const path = '/api/military/v1/list-military-flights?sw_lat=-90&sw_lon=-180&ne_lat=90&ne_lon=180';
+    const seen: string[] = [];
+    window.fetch = (async (input: RequestInfo | URL) => {
+      const target = hrefOf(input);
+      seen.push(target);
+      if (target.startsWith(REMOTE_API)) throw new TypeError('Failed to fetch');
+      return new Response(JSON.stringify({ flights: [{ id: 'flight-1' }] }), { status: 200 });
+    }) as typeof fetch;
+
+    const runtime = await loadRuntimeWith({
+      apiBase: REMOTE_API,
+      hostname: 'www.worldmonitor.app',
+      protocol: 'https:',
+    });
+    Object.assign(window.location, {
+      hostname: 'www.worldmonitor.app',
+      host: 'www.worldmonitor.app',
+      protocol: 'https:',
+      href: `${pageOrigin}/dashboard`,
+      origin: pageOrigin,
+    });
+
+    runtime.installWebApiRedirect();
+
+    const response = await window.fetch(`${REMOTE_API}${path}`);
+
+    expect(await response.json()).toEqual({ flights: [{ id: 'flight-1' }] });
+    expect(seen).toEqual([`${REMOTE_API}${path}`, path]);
+  });
+});
+
 describe('HTTPS loopback uses the web API path, not the sidecar', () => {
   beforeEach(() => {
     vi.resetModules();


### PR DESCRIPTION
## Summary

Country briefs now recover military flights and bases when the dedicated API host is blocked but the page's own API route is available. An open brief also refreshes its Military Activity card as soon as the shared military cache is assigned, instead of keeping the initial zero snapshot.

The production reproduction showed zero U.S. flights and no nearby bases while the public full-world military endpoint returned more than 150 flights.

## Validation

- Focused transport regression proved an absolute generated RPC request retries on the page origin after a network failure.
- Focused brief regressions proved both military load paths refresh the visible card from the assigned cache.
- `npm run test:dom` — 105 files and 821 tests passed.
- `npm run typecheck`
- `npm run typecheck:dom-tests`
- `npm run lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)