### PR TITLE
sec(ci): keep deployment_status jobs free of npm cache writes (#7593)

### DIFF
--- a/.github/workflows/mcp-live-smoke.yml
+++ b/.github/workflows/mcp-live-smoke.yml
@@ -95,6 +95,14 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event_name == 'deployment_status' && github.event.deployment.sha || github.sha }}
+      # Deliberately NO `cache:` on setup-node and no npm ci anywhere in this
+      # job (#7593): a deployment_status run is privileged — repo secrets and a
+      # write-capable GITHUB_TOKEN are in scope — and the step above checks out
+      # github.event.deployment.sha, so a dependency install here would resolve
+      # THAT commit's lockfile and could write its package cache into the
+      # shared scope that main-branch runs restore from. The probe needs
+      # nothing from npm; the absence is pinned by
+      # tests/ci-workflow-coverage.test.mts.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -461,6 +461,29 @@ describe('deployment_status triggers — npm cache scope hygiene (#7593)', () =>
     return /^ {2}deployment_status:(?:[ \t]*#[^\n]*)?\s*$/m.test(block);
   };
 
+  // The two ban patterns and the single detection path both tests below read.
+  // The sweep asserts real workflows stay clean; the self-test asserts the
+  // patterns can still fire, so a corrupted pattern reddens this suite
+  // instead of silently covering nothing.
+  const CACHE_BAN_PATTERN = /^[ \t]+cache:[ \t]*(?!false\b)\S/m;
+  // `npm i` resolves the deployed SHA's lockfile exactly like `npm install`,
+  // so the alias spelling is banned too; the word boundaries keep `npm info`,
+  // `npm init` and `pnpm i` out of the ban.
+  const NPM_INSTALL_BAN_PATTERN = /\bnpm (?:ci|install|i)\b/;
+
+  const deploymentCacheProblems = (executable: string): string[] => {
+    const problems: string[] = [];
+    if (CACHE_BAN_PATTERN.test(executable)) {
+      problems.push(
+        'a step carries a truthy `cache:` input, so a privileged deployment_status run could save a package cache resolved from github.event.deployment.sha',
+      );
+    }
+    if (NPM_INSTALL_BAN_PATTERN.test(executable)) {
+      problems.push("the job runs npm ci/install, resolving the deployed SHA's lockfile instead of main's");
+    }
+    return problems;
+  };
+
   it('keeps every deployment_status-triggered workflow free of package-cache writes and lockfile installs (#7593)', () => {
     const scanned: string[] = [];
     const offenders: string[] = [];
@@ -472,16 +495,7 @@ describe('deployment_status triggers — npm cache scope hygiene (#7593)', () =>
       if (!triggersOnDeploymentStatus(source)) continue;
       scanned.push(file);
 
-      const executable = executableText(source);
-      const problems: string[] = [];
-      if (/^[ \t]+cache:[ \t]*(?!false\b)\S/m.test(executable)) {
-        problems.push(
-          'a step carries a truthy `cache:` input, so a privileged deployment_status run could save a package cache resolved from github.event.deployment.sha',
-        );
-      }
-      if (/\bnpm (?:ci|install)\b/.test(executable)) {
-        problems.push("the job runs npm ci/install, resolving the deployed SHA's lockfile instead of main's");
-      }
+      const problems = deploymentCacheProblems(executableText(source));
       if (problems.length > 0) offenders.push(`${file}\n    - ${problems.join('\n    - ')}`);
     }
 
@@ -499,6 +513,59 @@ describe('deployment_status triggers — npm cache scope hygiene (#7593)', () =>
       '#7593: a deployment_status trigger is privileged (repo secrets, write-capable GITHUB_TOKEN) and these workflows check out github.event.deployment.sha, so resolving dependencies there could write a package cache built from a non-main lockfile into the shared scope main-branch runs restore from. PR #7591 shipped that shape and #7605 reverted it; if one of these workflows genuinely needs npm, extend this guard deliberately:\n' +
         offenders.join('\n'),
     );
+  });
+
+  // The sweep only asserts the absence of offenders, so a ban pattern that
+  // stopped matching (lost indentation anchor, dropped alternation branch)
+  // would keep this suite green while the guard detects nothing. This
+  // self-test feeds inline sources through the same deploymentCacheProblems
+  // path the sweep uses and pins the firing half of the guard.
+  it('keeps the ban patterns load-bearing: offenders fire and safe look-alikes stay silent (#7593)', () => {
+    const cacheProblem =
+      'a step carries a truthy `cache:` input, so a privileged deployment_status run could save a package cache resolved from github.event.deployment.sha';
+    const npmProblem = "the job runs npm ci/install, resolving the deployed SHA's lockfile instead of main's";
+
+    const offender = [
+      'name: offender',
+      'on:',
+      '  deployment_status:',
+      'jobs:',
+      '  smoke:',
+      '    steps:',
+      '      - uses: actions/setup-node@v4',
+      '        with:',
+      "          cache: 'npm'",
+      '      - run: npm ci --ignore-scripts --omit=optional',
+    ].join('\n');
+    assert.deepEqual(deploymentCacheProblems(executableText(offender)), [cacheProblem, npmProblem]);
+
+    const aliasOffender = offender.replace(
+      'npm ci --ignore-scripts --omit=optional',
+      'npm i --omit=optional',
+    );
+    assert.ok(
+      deploymentCacheProblems(executableText(aliasOffender)).includes(npmProblem),
+      'npm i must be flagged the same as npm install',
+    );
+
+    for (const safe of [
+      '        with:\n          cache: false',
+      "      # cache: 'npm'",
+      '        with:\n          cache-dependency-path: package-lock.json',
+      '      - run: npm run build',
+    ]) {
+      assert.deepEqual(deploymentCacheProblems(executableText(safe)), [], `must not flag safe input:\n${safe}`);
+    }
+
+    // Both trigger spellings must stay recognized through a trailing YAML
+    // comment, and a flow list without deployment_status must not be swept.
+    assert.equal(
+      triggersOnDeploymentStatus('on: # deploy hook\n  deployment_status: # success only'),
+      true,
+      'a trailing comment on either trigger line must not hide a deployment_status trigger',
+    );
+    assert.equal(triggersOnDeploymentStatus('on: [push, deployment_status]'), true);
+    assert.equal(triggersOnDeploymentStatus('on: [push, workflow_dispatch]'), false);
   });
 });
 

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -4,6 +4,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsDir = resolve(root, '.github/workflows');
@@ -439,13 +440,26 @@ describe('MCP live smoke — the production detection net', () => {
 // ever genuinely needs npm, extend this guard consciously with the
 // event-scoping argument rather than special-casing around it.
 describe('deployment_status triggers — npm cache scope hygiene (#7593)', () => {
-  // YAML comment lines are not executable: the workflows themselves explain
-  // the absence ("no npm ci", #7593) and must not self-trip the guard.
+  // Comment lines are not executable: the workflows themselves explain the
+  // absence ("no npm ci", #7593) and must not self-trip the guard. Round-trip
+  // through the YAML parser, which drops comments AND normalizes flow-map
+  // inputs (with: {cache: 'npm'}) into the same block form the ban patterns
+  // match, so neither spelling can hide behind syntax. If a future workflow
+  // carries YAML this parser rejects, fall back to the plain comment-line
+  // filter: weaker (comments survive), but the ban patterns themselves stay
+  // fail-closed on whatever text remains.
   const executableText = (source: string): string =>
-    source
-      .split('\n')
-      .filter((line) => !/^\s*#/.test(line))
-      .join('\n');
+  {
+    try {
+      const doc = YAML.parse(source);
+      return doc == null ? '' : YAML.stringify(doc);
+    } catch {
+      return source
+        .split('\n')
+        .filter((line) => !/^\s*#/.test(line))
+        .join('\n');
+    }
+  }
 
   // Block-style (`on:\n  deployment_status:`) and flow-style (`on: [ … ]`)
   // triggers; the block is the `on:` value up to the next column-0 key. Both
@@ -465,11 +479,16 @@ describe('deployment_status triggers — npm cache scope hygiene (#7593)', () =>
   // The sweep asserts real workflows stay clean; the self-test asserts the
   // patterns can still fire, so a corrupted pattern reddens this suite
   // instead of silently covering nothing.
-  const CACHE_BAN_PATTERN = /^[ \t]+cache:[ \t]*(?!false\b)\S/m;
+  // After the YAML round-trip a truthy cache input always appears as a
+  // block-mapping key, so the line-start anchor no longer depends on the
+  // author's block vs flow-map spelling. Only falsy scalars (false, null, ~)
+  // are exempt.
+  const CACHE_BAN_PATTERN = /^[ \t]*cache:[ \t]*(?!false\b)(?!null\b)(?!~)[^\s#]/m;
   // `npm i` resolves the deployed SHA's lockfile exactly like `npm install`,
-  // so the alias spelling is banned too; the word boundaries keep `npm info`,
-  // `npm init` and `pnpm i` out of the ban.
-  const NPM_INSTALL_BAN_PATTERN = /\bnpm (?:ci|install|i)\b/;
+  // so the alias spelling is banned too, under any shell whitespace
+  // (double space or a tab before the verb is the same command). The word
+  // boundaries keep npm info, npm init and pnpm i out of the ban.
+  const NPM_INSTALL_BAN_PATTERN = /\bnpm[ \t]+(?:ci|install|i)\b/;
 
   const deploymentCacheProblems = (executable: string): string[] => {
     const problems: string[] = [];
@@ -539,6 +558,23 @@ describe('deployment_status triggers — npm cache scope hygiene (#7593)', () =>
     ].join('\n');
     assert.deepEqual(deploymentCacheProblems(executableText(offender)), [cacheProblem, npmProblem]);
 
+    // Flow-map syntax must trip the same bans: the parser normalizes the
+    // mapping, so the block-style fixture reshaped into a flow map detects
+    // identically (review finding: line-anchored pattern missed
+    // with: {node-version: '24', cache: 'npm'}).
+    const flowMapOffender = [
+      "name: flow-map-offender",
+      'on:',
+      '  deployment_status:',
+      'jobs:',
+      '  smoke:',
+      '    steps:',
+      "      - uses: actions/setup-node@v4",
+      "        with: { node-version: '24', cache: 'npm' }",
+      "      - run: npm ci --ignore-scripts --omit=optional",
+    ].join('\n');
+    assert.deepEqual(deploymentCacheProblems(executableText(flowMapOffender)), [cacheProblem, npmProblem]);
+
     const aliasOffender = offender.replace(
       'npm ci --ignore-scripts --omit=optional',
       'npm i --omit=optional',
@@ -548,11 +584,24 @@ describe('deployment_status triggers — npm cache scope hygiene (#7593)', () =>
       'npm i must be flagged the same as npm install',
     );
 
+    // Shell whitespace between npm and the verb is legal and equally
+    // dangerous: double space and tab must fire like the single-space form
+    // (review finding: literal single space escaped detection).
+    for (const spaced of ['npm  ci --ignore-scripts', 'npm\tinstall --no-audit', 'npm\ti']) {
+      assert.ok(
+        deploymentCacheProblems(executableText(offender.replace('npm ci --ignore-scripts --omit=optional', spaced)))
+          .includes(npmProblem),
+        'irregular shell whitespace before the npm verb must not escape the ban: ' + spaced,
+      );
+    }
+
     for (const safe of [
       '        with:\n          cache: false',
       "      # cache: 'npm'",
       '        with:\n          cache-dependency-path: package-lock.json',
       '      - run: npm run build',
+      "      - run: pnpm i --frozen-lockfile",
+      "      - run: npm info webpack",
     ]) {
       assert.deepEqual(deploymentCacheProblems(executableText(safe)), [], `must not flag safe input:\n${safe}`);
     }

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -428,6 +428,80 @@ describe('MCP live smoke — the production detection net', () => {
   });
 });
 
+// #7593: a `deployment_status` trigger is privileged — repo secrets and a
+// write-capable GITHUB_TOKEN are in scope — and these workflows check out
+// `github.event.deployment.sha`, so a dependency install there would resolve
+// THAT commit's lockfile and could write its package cache into the shared
+// Actions cache scope that main-branch runs restore from. PR #7591 shipped
+// exactly that shape (`cache: 'npm'` + `npm ci --ignore-scripts`) and the
+// #7605 emergency revert removed it; this guard keeps it from coming back.
+// Deliberately file-level and fail-closed: if a deployment_status workflow
+// ever genuinely needs npm, extend this guard consciously with the
+// event-scoping argument rather than special-casing around it.
+describe('deployment_status triggers — npm cache scope hygiene (#7593)', () => {
+  // YAML comment lines are not executable: the workflows themselves explain
+  // the absence ("no npm ci", #7593) and must not self-trip the guard.
+  const executableText = (source: string): string =>
+    source
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n');
+
+  // Block-style (`on:\n  deployment_status:`) and flow-style (`on: [ … ]`)
+  // triggers; the block is the `on:` value up to the next column-0 key. Both
+  // forms tolerate a trailing YAML comment (`on: # ...`,
+  // `deployment_status: # ...`) — the guard is fail-closed, so a comment must
+  // never silently exclude a workflow from the sweep.
+  const triggersOnDeploymentStatus = (source: string): boolean => {
+    const flow = source.match(/^on:[ \t]*(?:#[^\n]*)?\s*\[([^\]]*)\]/m);
+    if (flow) return /['"]?deployment_status['"]?/.test(flow[1]);
+    const onIndex = source.search(/^on:(?:[ \t]*#[^\n]*)?\s*$/m);
+    if (onIndex === -1) return false;
+    const block = source.slice(onIndex).split(/\n(?=\S)/)[0];
+    return /^ {2}deployment_status:(?:[ \t]*#[^\n]*)?\s*$/m.test(block);
+  };
+
+  it('keeps every deployment_status-triggered workflow free of package-cache writes and lockfile installs (#7593)', () => {
+    const scanned: string[] = [];
+    const offenders: string[] = [];
+
+    for (const file of readdirSync(workflowsDir)
+      .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+      .sort()) {
+      const source = read(resolve(workflowsDir, file));
+      if (!triggersOnDeploymentStatus(source)) continue;
+      scanned.push(file);
+
+      const executable = executableText(source);
+      const problems: string[] = [];
+      if (/^[ \t]+cache:[ \t]*(?!false\b)\S/m.test(executable)) {
+        problems.push(
+          'a step carries a truthy `cache:` input, so a privileged deployment_status run could save a package cache resolved from github.event.deployment.sha',
+        );
+      }
+      if (/\bnpm (?:ci|install)\b/.test(executable)) {
+        problems.push("the job runs npm ci/install, resolving the deployed SHA's lockfile instead of main's");
+      }
+      if (problems.length > 0) offenders.push(`${file}\n    - ${problems.join('\n    - ')}`);
+    }
+
+    // Not vacuous: mcp-live-smoke.yml's deployment_status trigger is pinned
+    // by the describe above, so if the sweep stops seeing that file the
+    // trigger parser has broken and this guard is green while covering
+    // nothing.
+    assert.ok(
+      scanned.includes('mcp-live-smoke.yml'),
+      'the sweep matched no workflows — mcp-live-smoke.yml still triggers on deployment_status, so the trigger parser here is broken and this guard covers nothing',
+    );
+    assert.deepEqual(
+      offenders,
+      [],
+      '#7593: a deployment_status trigger is privileged (repo secrets, write-capable GITHUB_TOKEN) and these workflows check out github.event.deployment.sha, so resolving dependencies there could write a package cache built from a non-main lockfile into the shared scope main-branch runs restore from. PR #7591 shipped that shape and #7605 reverted it; if one of these workflows genuinely needs npm, extend this guard deliberately:\n' +
+        offenders.join('\n'),
+    );
+  });
+});
+
 describe('CI workflow coverage', () => {
   it('stages the regenerated main sitemap in the weekly pulse PR', () => {
     const pulseWorkflow = read(resolve(workflowsDir, 'crawlable-pulse-refresh.yml'));


### PR DESCRIPTION
Closes #7593

## Summary

#7593 asked for a deliberate look at the `deployment_status`-triggered MCP live smoke that (as of PR #7591) ran `actions/setup-node` with `cache: 'npm'` + `npm ci --ignore-scripts` — a privileged event (repo secrets, write-capable `GITHUB_TOKEN`) checking out `github.event.deployment.sha`, able to resolve a non-main lockfile and write its package cache into the default-branch Actions cache scope that main-branch runs restore from.

**Finding: the exposure is already gone from `main`.** The #7605 emergency revert (2026-09-03, ~5h after #7591 merged) removed both `cache: 'npm'` and the `npm ci` step; the smoke is dependency-free again (the probe scripts import only `node:` builtins and relative modules). Both `deployment_status` workflows (`mcp-live-smoke.yml`, `indexnow-submit.yml`) are install-free, so neither mitigation proposed in the issue (drop the cache / pin the cache key) is needed — a stronger form of the first one already shipped.

This PR finishes the issue's own recording requirement:

1. **Workflow comment** — `.github/workflows/mcp-live-smoke.yml` documents at the `setup-node` step *why* the job deliberately has no `cache:` and no `npm ci` (#7593), so the next reader does not re-derive it.
2. **Regression guard** — `tests/ci-workflow-coverage.test.mts` sweeps every workflow declaring a `deployment_status:` trigger (block or flow style, tolerant of trailing YAML comments) and fails if any carries a truthy `cache:` input or an `npm ci` / `npm install` / `npm i` run. File-level and fail-closed by design; non-vacuous via a pin on `mcp-live-smoke.yml`.
3. **Self-test of the guard** — a second test feeds inline fixtures through the same detection path: the #7591 shape fires both ban messages, `npm i` fires, negative controls (`cache: false`, comment lines, `cache-dependency-path`, `npm run`) stay silent, and trigger-variant parsing is pinned. (Applied from code-review finding #1 — a guard that never proves it can fire can rot green.)

## Verification

- Guard teeth proven twice against temporary fixtures: reintroducing the #7591 shape reddens the suite and flags both patterns (also with comment-suffixed trigger lines).
- Focused file: `tsx --test tests/ci-workflow-coverage.test.mts` -> 38/38 pass.
- Full gate: `npm run test:data` -> 30,035 pass / 0 fail / 40 env-gated skips (CI-parity: the unit job runs without `.env.local`).
- Lint: `npm run lint` + `lint:boundaries` + `lint:safe-html` -> exit 0 (pre-existing warnings untouched, none in this diff).
- Tiered pre-push gate green (typecheck, unicode scan, changed-tests, version sync).

## Code review

Full multi-reviewer review (correctness, testing, maintainability, project-standards, adversarial, agent-native, learnings; per-finding independent validation). Findings #1 (P1: detection half could rot green) and #2 (P3: `npm i` alias escaped the ban) applied in 3640d8532. Finding #3 (pin `indexnow-submit.yml` inside the sweep) dropped by validation — `tests/indexnow-submit.test.mjs:488-489` already pins that workflow's `deployment_status:` block shape in CI.

## Known Residuals

Accepted, informational — no current instance in the repo (all 44 workflows use column-0 block `on:`):

- The trigger parser recognizes block-style (2-space) and flow-list `on:` forms only; a flow-map (`on: {deployment_status: ...}`) or quoted key would be silently un-scanned.
- The file-level sweep cannot see `npm ci` inside composite actions or called scripts.
- The `cache:` ban is value-based, so any action input named `cache:` with a truthy value in a deployment_status workflow trips the guard (fail-closed false-alarm surface).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — the change adds no runtime behavior: a YAML comment and test-only guards. The guard runs in the `unit` CI job on every PR; its failure signal is a red `unit` job naming `#7593`. Rollback: revert the two commits; no data, config, or deploy behavior changes.
