### PR TITLE
fix(advisories): stabilize hourly security seed

### DIFF
--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1547,6 +1547,33 @@
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-43-not-bundled"
   },
   {
+    "entry": "scripts/seed-security-advisories.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-security-advisories",
+    "requiredEnv": [
+      "UPSTASH_REDIS_REST_URL",
+      "UPSTASH_REDIS_REST_TOKEN"
+    ],
+    "watchPatterns": [
+      "scripts/_html-entities.mjs",
+      "scripts/_proxy-utils.cjs",
+      "scripts/_seed-contract.mjs",
+      "scripts/_seed-envelope-source.mjs",
+      "scripts/_seed-utils.mjs",
+      "scripts/lib/llm-telemetry.cjs",
+      "scripts/nixpacks.toml",
+      "scripts/package-lock.json",
+      "scripts/package.json",
+      "scripts/seed-security-advisories.mjs",
+      "scripts/shared/country-names.json",
+      "scripts/shared/rss-allowed-domains.json",
+      "shared/country-names.json",
+      "shared/rss-allowed-domains.json"
+    ],
+    "cronSchedule": "0 * * * *",
+    "documentedAt": "scripts/seed-security-advisories.mjs"
+  },
+  {
     "entry": "scripts/seed-service-statuses.mjs",
     "deployMode": "nixpacks-root-repo",
     "lifecycle": "planned",

--- a/scripts/seed-security-advisories.mjs
+++ b/scripts/seed-security-advisories.mjs
@@ -18,10 +18,9 @@ const PER_SOURCE_DISPLAY_LIMIT = 15;
 // that floor before replacing the last-good global level index. This still
 // tolerates normal source differences while rejecting a partial-feed blackout.
 export const MIN_ADVISORY_COUNTRY_COVERAGE = 100;
-// One MiB leaves roughly 4 KiB for each entry in the current 219-country
-// State Department register while bounding an allowed upstream's processing
-// and memory use before XML parsing.
-export const MAX_ADVISORY_FEED_BYTES = 1024 * 1024;
+// Two MiB accepts the current ~1.1 MiB State Department register while still
+// bounding an allowed upstream's processing and memory use before XML parsing.
+export const MAX_ADVISORY_FEED_BYTES = 2 * 1024 * 1024;
 
 const ALLOWED_DOMAINS = new Set(loadSharedConfig('rss-allowed-domains.json'));
 

--- a/tests/railway-watch-path-audit.test.mjs
+++ b/tests/railway-watch-path-audit.test.mjs
@@ -1462,6 +1462,7 @@ describe('critical ingestion Railway registry contract', () => {
   const expected = new Map([
     ['seed-conflict-intel', '*/15 * * * *'],
     ['seed-gdelt-intel', '*/15 * * * *'],
+    ['seed-security-advisories', '0 * * * *'],
     ['seed-supply-chain-trade', '0 */6 * * *'],
     ['seed-comtrade-bilateral-hs4', '0 6 1 * *'],
     ['seed-bundle-market-backup', '*/5 * * * *'],

--- a/tests/security-advisory-register-coverage.test.mjs
+++ b/tests/security-advisory-register-coverage.test.mjs
@@ -166,6 +166,11 @@ describe('seed-security-advisories — advisory level index coverage', () => {
       text: async () => xml,
     }));
 
+    assert.equal(
+      MAX_ADVISORY_FEED_BYTES,
+      2 * 1024 * 1024,
+      'feed limit must stay at the reviewed two MiB bound',
+    );
     assert.ok(bytes > 1024 * 1024, 'fixture must exceed the former one MiB limit');
     assert.ok(bytes <= MAX_ADVISORY_FEED_BYTES, 'fixture must remain inside the configured limit');
     assert.equal(mapped.length, REGISTER.length);

--- a/tests/security-advisory-register-coverage.test.mjs
+++ b/tests/security-advisory-register-coverage.test.mjs
@@ -156,6 +156,22 @@ describe('seed-security-advisories — advisory level index coverage', () => {
     assert.equal(byCountry.TH, 'normal');
   });
 
+  it('accepts a one MiB-plus country register within the bounded response budget', async () => {
+    const xml = rssFor(registerItems()).replace('</channel>', `${' '.repeat(1_100_000)}</channel>`);
+    const bytes = Buffer.byteLength(xml, 'utf8');
+    const mapped = await fetchFeed(STATE_DEPT, async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: (name) => name === 'content-length' ? String(bytes) : null },
+      text: async () => xml,
+    }));
+
+    assert.ok(bytes > 1024 * 1024, 'fixture must exceed the former one MiB limit');
+    assert.ok(bytes <= MAX_ADVISORY_FEED_BYTES, 'fixture must remain inside the configured limit');
+    assert.equal(mapped.length, REGISTER.length);
+    assert.ok(Object.keys(buildByCountryMap(mapped)).length >= REGISTER.length - 1);
+  });
+
   it('uses the injected fetcher for every feed', async () => {
     let requestCount = 0;
     const report = await fetchAll({


### PR DESCRIPTION
## Why

The production `securityAdvisories` dataset stayed on its last-good metadata and crossed the 120-minute stale threshold for two independent reasons:

- The hourly service still used broad `scripts/**` and `shared/**` watch paths. Unrelated script merges created replacement builds and delayed the next natural cron run.
- The State Department country register is now 1,050,725 bytes, slightly above the former 1 MiB response limit. During the observed run, that source failed with `RESPONSE_TOO_LARGE` while Smartraveller returned HTTP 503, so the unchanged 100-country gate correctly rejected the incomplete result.

## Scope

- Register `seed-security-advisories` in the Railway desired-state inventory with its exact transitive watch closure and existing hourly cron.
- Raise only the bounded advisory-feed response limit from 1 MiB to 2 MiB.
- Keep the 100-country validation gate, 120-minute health threshold, TTL, and last-good preservation unchanged.
- Add regression coverage for registry management, exact deploy closure, the current feed size, and the reviewed 2 MiB upper bound.

## Blast Radius

- Runtime change is limited to the security-advisory seeder's per-feed response budget.
- Deployment configuration change is limited to the `seed-security-advisories` watch list; the cron remains `0 * * * *`.
- The local desired-state audit reports only the expected watch-path drift for this service. No apply or production mutation was performed.
- Production acceptance still requires merge, desired-state reconciliation, deployment, and a natural hourly run that advances the seed metadata.

## Verification

- `node --test` focused deployment and advisory suite: 318 passed.
- `tsx --test` registry, packaging, and source-contract suite: 208 passed.
- Pre-push gates passed, including browser and API type checks, changed tests, Unicode safety, generated-code freshness, and version sync.
- Full code review found one P2 test guard weakness; it was fixed by pinning the expected 2 MiB limit. No P0, P1, or P2 finding remains.
