### PR TITLE
fix(prediction): restore Kalshi country coverage

### DIFF
--- a/scripts/_prediction-country-index.mjs
+++ b/scripts/_prediction-country-index.mjs
@@ -219,6 +219,51 @@ export function buildCountryMarketIndex(markets, {
   return index;
 }
 
+export function selectKalshiSeriesTickers(series, targetCountryCodes, {
+  perCountryLimit = 2,
+  countries = countryCodes,
+} = {}) {
+  const targets = new Set((targetCountryCodes ?? []).map((code) => String(code).toUpperCase()));
+  const limit = Math.max(0, Math.floor(Number(perCountryLimit) || 0));
+  if (!Array.isArray(series) || targets.size === 0 || limit === 0) return [];
+
+  const matchers = compileCountryMatchers(countries)
+    .filter(({ countryCode }) => targets.has(countryCode));
+  const rankedByCountry = new Map(matchers.map(({ countryCode }) => [countryCode, []]));
+
+  for (const entry of series) {
+    const ticker = String(entry?.ticker ?? '').trim();
+    if (!ticker || String(entry?.category ?? '').toLowerCase() === 'sports') continue;
+    const title = [entry?.title, ...(Array.isArray(entry?.tags) ? entry.tags : [])]
+      .map((part) => String(part ?? '').trim())
+      .filter(Boolean)
+      .join(' ');
+    const parsedVolume = Number(entry?.volume_fp);
+    const candidate = {
+      title,
+      yesPrice: 50,
+      volume: Number.isFinite(parsedVolume) ? parsedVolume : 0,
+    };
+    if (!shouldInclude(candidate)) continue;
+
+    for (const [countryCode, match] of countryMatches(normalizeSearchText(title), matchers)) {
+      rankedByCountry.get(countryCode)?.push({ ticker, title, ...match, volume: candidate.volume });
+    }
+  }
+
+  const selected = new Set();
+  for (const { countryCode } of matchers) {
+    rankedByCountry.get(countryCode)
+      ?.sort((left, right) => right.matchStrength - left.matchStrength
+        || right.volume - left.volume
+        || left.title.localeCompare(right.title)
+        || left.ticker.localeCompare(right.ticker))
+      .slice(0, limit)
+      .forEach(({ ticker }) => selected.add(ticker));
+  }
+  return [...selected];
+}
+
 /**
  * Build the country index only when every source segment succeeded.
  * A partial fetch must yield `{}` so `skipWhenEmpty` retains the last-good

--- a/scripts/_prediction-country-index.mjs
+++ b/scripts/_prediction-country-index.mjs
@@ -221,11 +221,20 @@ export function buildCountryMarketIndex(markets, {
 
 export function selectKalshiSeriesTickers(series, targetCountryCodes, {
   perCountryLimit = 2,
+  totalLimit = Number.POSITIVE_INFINITY,
+  excludedTickers = [],
   countries = countryCodes,
 } = {}) {
   const targets = new Set((targetCountryCodes ?? []).map((code) => String(code).toUpperCase()));
   const limit = Math.max(0, Math.floor(Number(perCountryLimit) || 0));
-  if (!Array.isArray(series) || targets.size === 0 || limit === 0) return [];
+  const parsedTotalLimit = Number(totalLimit);
+  const maxSelected = Number.isFinite(parsedTotalLimit)
+    ? Math.max(0, Math.floor(parsedTotalLimit))
+    : Number.POSITIVE_INFINITY;
+  const excluded = new Set((excludedTickers ?? [])
+    .map((ticker) => String(ticker).trim())
+    .filter(Boolean));
+  if (!Array.isArray(series) || targets.size === 0 || limit === 0 || maxSelected === 0) return [];
 
   const matchers = compileCountryMatchers(countries)
     .filter(({ countryCode }) => targets.has(countryCode));
@@ -233,7 +242,7 @@ export function selectKalshiSeriesTickers(series, targetCountryCodes, {
 
   for (const entry of series) {
     const ticker = String(entry?.ticker ?? '').trim();
-    if (!ticker || String(entry?.category ?? '').toLowerCase() === 'sports') continue;
+    if (!ticker || excluded.has(ticker) || String(entry?.category ?? '').toLowerCase() === 'sports') continue;
     const title = [entry?.title, ...(Array.isArray(entry?.tags) ? entry.tags : [])]
       .map((part) => String(part ?? '').trim())
       .filter(Boolean)
@@ -259,7 +268,10 @@ export function selectKalshiSeriesTickers(series, targetCountryCodes, {
         || left.title.localeCompare(right.title)
         || left.ticker.localeCompare(right.ticker))
       .slice(0, limit)
-      .forEach(({ ticker }) => selected.add(ticker));
+      .forEach(({ ticker }) => {
+        if (selected.size < maxSelected) selected.add(ticker);
+      });
+    if (selected.size >= maxSelected) break;
   }
   return [...selected];
 }

--- a/scripts/_prediction-upstream.mjs
+++ b/scripts/_prediction-upstream.mjs
@@ -2,6 +2,8 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_POLYMARKET_LIMIT = 100;
 const DEFAULT_KALSHI_PAGE_SIZE = 200;
 const DEFAULT_KALSHI_MAX_PAGES = 5;
+const DEFAULT_KALSHI_MARKETS_PAGE_SIZE = 1000;
+const DEFAULT_KALSHI_SERIES_MARKET_MAX_PAGES = 5;
 
 function requestHeaders(userAgent) {
   return { Accept: 'application/json', 'User-Agent': userAgent };
@@ -81,4 +83,82 @@ export async function fetchKalshiEvents({
   }
 
   return events;
+}
+
+export async function fetchKalshiSeries({
+  fetchFn = globalThis.fetch,
+  baseUrl,
+  userAgent,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  const params = new URLSearchParams({ include_volume: 'true' });
+  const response = await fetchFn(`${baseUrl.replace(/\/$/, '')}/series?${params}`, {
+    headers: requestHeaders(userAgent),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) throw new Error(`Kalshi HTTP ${response.status}`);
+  const data = await response.json();
+  if (!Array.isArray(data?.series)) {
+    throw new Error('Kalshi invalid payload: expected series array');
+  }
+  return data.series;
+}
+
+export async function fetchKalshiMarketsBySeries(seriesTickers, {
+  fetchFn = globalThis.fetch,
+  baseUrl,
+  userAgent,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  pageSize = DEFAULT_KALSHI_MARKETS_PAGE_SIZE,
+  maxPagesPerSeries = DEFAULT_KALSHI_SERIES_MARKET_MAX_PAGES,
+} = {}) {
+  const markets = [];
+  const uniqueTickers = [...new Set((seriesTickers ?? [])
+    .map((ticker) => String(ticker).trim())
+    .filter(Boolean))];
+
+  for (const seriesTicker of uniqueTickers) {
+    const seenCursors = new Set();
+    let cursor = '';
+
+    for (let page = 0; page < maxPagesPerSeries; page += 1) {
+      const params = new URLSearchParams({
+        status: 'open',
+        series_ticker: seriesTicker,
+        limit: String(pageSize),
+        mve_filter: 'exclude',
+      });
+      if (cursor) params.set('cursor', cursor);
+
+      const response = await fetchFn(`${baseUrl.replace(/\/$/, '')}/markets?${params}`, {
+        headers: requestHeaders(userAgent),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!response.ok) throw new Error(`Kalshi HTTP ${response.status}`);
+      const data = await response.json();
+      if (!Array.isArray(data?.markets)) {
+        throw new Error('Kalshi invalid payload: expected markets array');
+      }
+      markets.push(...data.markets);
+
+      const nextCursor = typeof data.cursor === 'string' ? data.cursor.trim() : '';
+      if (!nextCursor) {
+        cursor = '';
+        break;
+      }
+      if (seenCursors.has(nextCursor)) {
+        throw new Error(`Kalshi markets repeated cursor for ${seriesTicker}`);
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    }
+
+    if (cursor) {
+      throw new Error(
+        `Kalshi markets pagination exceeded ${maxPagesPerSeries} pages for ${seriesTicker}`,
+      );
+    }
+  }
+
+  return markets;
 }

--- a/scripts/_prediction-upstream.mjs
+++ b/scripts/_prediction-upstream.mjs
@@ -111,17 +111,27 @@ export async function fetchKalshiMarketsBySeries(seriesTickers, {
   timeoutMs = DEFAULT_TIMEOUT_MS,
   pageSize = DEFAULT_KALSHI_MARKETS_PAGE_SIZE,
   maxPagesPerSeries = DEFAULT_KALSHI_SERIES_MARKET_MAX_PAGES,
+  maxRequests = Number.POSITIVE_INFINITY,
+  onRequest,
 } = {}) {
   const markets = [];
   const uniqueTickers = [...new Set((seriesTickers ?? [])
     .map((ticker) => String(ticker).trim())
     .filter(Boolean))];
+  const parsedMaxRequests = Number(maxRequests);
+  const requestLimit = Number.isFinite(parsedMaxRequests)
+    ? Math.max(0, Math.floor(parsedMaxRequests))
+    : Number.POSITIVE_INFINITY;
+  let requestCount = 0;
 
   for (const seriesTicker of uniqueTickers) {
     const seenCursors = new Set();
     let cursor = '';
 
     for (let page = 0; page < maxPagesPerSeries; page += 1) {
+      if (requestCount >= requestLimit) {
+        throw new Error(`Kalshi markets request budget exceeded ${requestLimit} requests`);
+      }
       const params = new URLSearchParams({
         status: 'open',
         series_ticker: seriesTicker,
@@ -130,6 +140,8 @@ export async function fetchKalshiMarketsBySeries(seriesTickers, {
       });
       if (cursor) params.set('cursor', cursor);
 
+      requestCount += 1;
+      onRequest?.({ requestCount, seriesTicker, page: page + 1 });
       const response = await fetchFn(`${baseUrl.replace(/\/$/, '')}/markets?${params}`, {
         headers: requestHeaders(userAgent),
         signal: AbortSignal.timeout(timeoutMs),

--- a/scripts/seed-prediction-markets.mjs
+++ b/scripts/seed-prediction-markets.mjs
@@ -37,6 +37,9 @@ const GAMMA_BASE = 'https://gamma-api.polymarket.com';
 const KALSHI_BASE = 'https://api.elections.kalshi.com/trade-api/v2';
 const FETCH_TIMEOUT = 10_000;
 const TAG_DELAY_MS = 300;
+const MAX_KALSHI_COUNTRY_REQUESTS = 24;
+const MAX_KALSHI_COUNTRY_ROUNDS = 4;
+const KALSHI_COUNTRY_LOCK_TTL_MS = 300_000;
 
 const GEOPOLITICAL_TAGS = predictionTags.geopolitical;
 const TECH_TAGS = predictionTags.tech;
@@ -138,20 +141,49 @@ async function fetchKalshiCountryMarkets(targetCountryCodes) {
       userAgent: CHROME_UA,
       timeoutMs: FETCH_TIMEOUT,
     });
-    const seriesTickers = selectKalshiSeriesTickers(series, targetCountryCodes);
-    console.log(
-      `  [kalshi] hydrating ${seriesTickers.length} country series for ${targetCountryCodes.length} countries`,
-    );
-    const seriesMarkets = await fetchKalshiMarketsBySeries(seriesTickers, {
-      baseUrl: KALSHI_BASE,
-      userAgent: CHROME_UA,
-      timeoutMs: FETCH_TIMEOUT,
-    });
-    return {
-      countryCandidates: seriesMarkets
+    const pendingCountryCodes = new Set(targetCountryCodes);
+    const triedSeriesTickers = [];
+    const countryCandidates = [];
+    let requestsUsed = 0;
+
+    for (
+      let round = 1;
+      round <= MAX_KALSHI_COUNTRY_ROUNDS
+        && pendingCountryCodes.size > 0
+        && requestsUsed < MAX_KALSHI_COUNTRY_REQUESTS;
+      round += 1
+    ) {
+      const seriesTickers = selectKalshiSeriesTickers(series, [...pendingCountryCodes], {
+        perCountryLimit: 1,
+        excludedTickers: triedSeriesTickers,
+        totalLimit: MAX_KALSHI_COUNTRY_REQUESTS - requestsUsed,
+      });
+      if (seriesTickers.length === 0) break;
+      triedSeriesTickers.push(...seriesTickers);
+      console.log(
+        `  [kalshi] hydrating ${seriesTickers.length} country series in round ${round}`,
+      );
+      const seriesMarkets = await fetchKalshiMarketsBySeries(seriesTickers, {
+        baseUrl: KALSHI_BASE,
+        userAgent: CHROME_UA,
+        timeoutMs: FETCH_TIMEOUT,
+        maxRequests: MAX_KALSHI_COUNTRY_REQUESTS - requestsUsed,
+        onRequest: () => { requestsUsed += 1; },
+      });
+      countryCandidates.push(...seriesMarkets
         .filter((market) => market.market_type === 'binary' && market.status === 'active')
         .map((market) => kalshiCountryCandidate(market))
-        .filter(Boolean),
+        .filter(Boolean));
+
+      for (const countryCode of Object.keys(buildCountryMarketIndex(countryCandidates))) {
+        pendingCountryCodes.delete(countryCode);
+      }
+    }
+    console.log(
+      `  [kalshi] country series used ${requestsUsed}/${MAX_KALSHI_COUNTRY_REQUESTS} requests; ${pendingCountryCodes.size} countries remain uncovered`,
+    );
+    return {
+      countryCandidates,
       complete: true,
     };
   } catch (err) {
@@ -302,7 +334,7 @@ async function markCountryIndexActivated(data) {
 
 await runSeed('prediction', 'markets', CANONICAL_KEY, fetchAllPredictions, {
   ttlSeconds: CACHE_TTL,
-  lockTtlMs: 60_000,
+  lockTtlMs: KALSHI_COUNTRY_LOCK_TTL_MS,
   // Population requirement + #5733 category-integrity gate. Lives in
   // _prediction-classify.mjs so the gate is unit-testable (this module runs
   // runSeed at import time, so a test can never import it).

--- a/scripts/seed-prediction-markets.mjs
+++ b/scripts/seed-prediction-markets.mjs
@@ -10,9 +10,16 @@ import {
   isExcluded, parseYesPrice, parseKalshiYesPrice, parsePredictionMarketVolume,
   selectPricedKalshiMarket, isExpired,
 } from './_prediction-scoring.mjs';
-import { countCountryMarkets, projectCountryMarketIndex } from './_prediction-country-index.mjs';
+import {
+  buildCountryMarketIndex,
+  countCountryMarkets,
+  projectCountryMarketIndex,
+  selectKalshiSeriesTickers,
+} from './_prediction-country-index.mjs';
 import {
   fetchKalshiEvents as fetchKalshiEventPages,
+  fetchKalshiMarketsBySeries,
+  fetchKalshiSeries,
   fetchPolymarketEventsByTag,
 } from './_prediction-upstream.mjs';
 import { getOptionalUpstashCreds, upstashCommand } from './_upstash-rest.mjs';
@@ -61,6 +68,24 @@ function kalshiTitle(marketTitle, eventTitle) {
   return `${eventTitle}: ${marketTitle}`;
 }
 
+function kalshiCountryCandidate(market, eventTitle) {
+  const yesPrice = parseKalshiYesPrice(market);
+  if (yesPrice === null) return null;
+  const marketTitle = eventTitle
+    ? market.yes_sub_title || market.title || ''
+    : market.title || market.yes_sub_title || '';
+  return {
+    title: kalshiTitle(marketTitle, eventTitle),
+    yesPrice,
+    volume: parseFloat(market.volume_fp) || 0,
+    url: `https://kalshi.com/markets/${market.ticker}`,
+    endDate: market.close_time ?? undefined,
+    tags: [],
+    source: 'kalshi',
+    eventKey: `kalshi:${market.event_ticker || market.ticker}`,
+  };
+}
+
 async function fetchKalshiMarkets() {
   const { events, complete } = await fetchKalshiEvents();
   const featured = [];
@@ -81,19 +106,8 @@ async function fetchKalshiMarkets() {
 
     const eventKey = `kalshi:${event.event_ticker || event.ticker || event.id || event.title}`;
     for (const market of binaryActive) {
-      const candidatePrice = parseKalshiYesPrice(market);
-      if (candidatePrice === null) continue;
-      const marketTitle = market.yes_sub_title || market.title || '';
-      countryCandidates.push({
-        title: kalshiTitle(marketTitle, event.title),
-        yesPrice: candidatePrice,
-        volume: parseFloat(market.volume_fp) || 0,
-        url: `https://kalshi.com/markets/${market.ticker}`,
-        endDate: market.close_time ?? undefined,
-        tags: [],
-        source: 'kalshi',
-        eventKey,
-      });
+      const candidate = kalshiCountryCandidate(market, event.title);
+      if (candidate) countryCandidates.push({ ...candidate, eventKey });
     }
 
     const volume = parseFloat(topMarket.volume_fp) || 0;
@@ -114,6 +128,36 @@ async function fetchKalshiMarkets() {
   }
 
   return { featured, countryCandidates, complete };
+}
+
+async function fetchKalshiCountryMarkets(targetCountryCodes) {
+  if (targetCountryCodes.length === 0) return { countryCandidates: [], complete: true };
+  try {
+    const series = await fetchKalshiSeries({
+      baseUrl: KALSHI_BASE,
+      userAgent: CHROME_UA,
+      timeoutMs: FETCH_TIMEOUT,
+    });
+    const seriesTickers = selectKalshiSeriesTickers(series, targetCountryCodes);
+    console.log(
+      `  [kalshi] hydrating ${seriesTickers.length} country series for ${targetCountryCodes.length} countries`,
+    );
+    const seriesMarkets = await fetchKalshiMarketsBySeries(seriesTickers, {
+      baseUrl: KALSHI_BASE,
+      userAgent: CHROME_UA,
+      timeoutMs: FETCH_TIMEOUT,
+    });
+    return {
+      countryCandidates: seriesMarkets
+        .filter((market) => market.market_type === 'binary' && market.status === 'active')
+        .map((market) => kalshiCountryCandidate(market))
+        .filter(Boolean),
+      complete: true,
+    };
+  } catch (err) {
+    console.warn(`  [kalshi] error fetching country series: ${err.message}`);
+    return { countryCandidates: [], complete: false };
+  }
 }
 
 async function fetchAllPredictions() {
@@ -195,7 +239,16 @@ async function fetchAllPredictions() {
   if (!kalshiMarkets.complete) countryProjectionComplete = false;
   console.log(`  [kalshi] ${kalshiMarkets.featured.length} featured markets`);
   markets.push(...kalshiMarkets.featured);
+  const polymarketCountryCodes = Object.keys(buildCountryMarketIndex(countryCandidates));
+  const coveredKalshiCountryCodes = new Set(
+    Object.keys(buildCountryMarketIndex(kalshiMarkets.countryCandidates)),
+  );
+  const uncoveredCountryCodes = polymarketCountryCodes
+    .filter((countryCode) => !coveredKalshiCountryCodes.has(countryCode));
+  const kalshiCountryMarkets = await fetchKalshiCountryMarkets(uncoveredCountryCodes);
+  if (!kalshiCountryMarkets.complete) countryProjectionComplete = false;
   countryCandidates.push(...kalshiMarkets.countryCandidates);
+  countryCandidates.push(...kalshiCountryMarkets.countryCandidates);
 
   console.log(`  total raw markets: ${markets.length}`);
 

--- a/tests/prediction-country-index.test.mjs
+++ b/tests/prediction-country-index.test.mjs
@@ -5,6 +5,7 @@ import {
   buildCountryMarketIndex,
   countCountryMarkets,
   projectCountryMarketIndex,
+  selectKalshiSeriesTickers,
 } from '../scripts/_prediction-country-index.mjs';
 
 const NOW = Date.parse('2026-08-31T00:00:00Z');
@@ -258,5 +259,36 @@ describe('projectCountryMarketIndex', () => {
   it('projects the country index when every source segment succeeded', () => {
     const index = projectCountryMarketIndex([usMarket], { complete: true, now: NOW });
     assert.deepEqual(index.US.map((entry) => entry.title), [usMarket.title]);
+  });
+});
+
+describe('selectKalshiSeriesTickers', () => {
+  it('selects two liquid non-sports series for each requested country', () => {
+    const series = [
+      { ticker: 'KXIRANSPORT', title: 'Iran match winner', category: 'Sports', volume_fp: '90000000' },
+      { ticker: 'KXIRANSTALE', title: 'Ali Khamenei out?', tags: ['Iran'], category: 'Politics', volume_fp: '54513052' },
+      { ticker: 'KXIRANDEAL', title: 'US Iran nuclear deal', tags: ['Iran'], category: 'World', volume_fp: '21065356' },
+      { ticker: 'KXIRANLOW', title: 'Iran trade agreement', category: 'World', volume_fp: '4999' },
+      { ticker: 'KXLEBANONPARLI', title: 'Lebanon parliament', category: 'Elections', volume_fp: '28888' },
+      { ticker: 'KXLEBUSFLIGHT', title: 'Lebanon-US flight resumption', category: 'World', volume_fp: '11181' },
+      { ticker: 'KXFRANCE', title: 'France election', category: 'Elections', volume_fp: '500000' },
+    ];
+
+    assert.deepEqual(
+      selectKalshiSeriesTickers(series, ['IR', 'LB']),
+      ['KXIRANSTALE', 'KXIRANDEAL', 'KXLEBANONPARLI', 'KXLEBUSFLIGHT'],
+    );
+    assert.deepEqual(selectKalshiSeriesTickers(series, ['LB']), ['KXLEBANONPARLI', 'KXLEBUSFLIGHT']);
+  });
+
+  it('deduplicates a series that matches more than one requested country', () => {
+    const series = [{
+      ticker: 'KXUSIRAN',
+      title: 'United States and Iran nuclear deal',
+      category: 'World',
+      volume_fp: '100000',
+    }];
+
+    assert.deepEqual(selectKalshiSeriesTickers(series, ['US', 'IR']), ['KXUSIRAN']);
   });
 });

--- a/tests/prediction-country-index.test.mjs
+++ b/tests/prediction-country-index.test.mjs
@@ -292,4 +292,35 @@ describe('selectKalshiSeriesTickers', () => {
 
     assert.deepEqual(selectKalshiSeriesTickers(series, ['US', 'IR']), ['KXUSIRAN']);
   });
+
+  it('selects the next ranked series after an earlier series produced no eligible markets', () => {
+    const series = [
+      { ticker: 'KXIRANEMPTY', title: 'Iran agreement', category: 'World', volume_fp: '50000' },
+      { ticker: 'KXIRANACTIVE', title: 'Iran election', category: 'Elections', volume_fp: '40000' },
+      { ticker: 'KXLEBANONACTIVE', title: 'Lebanon election', category: 'Elections', volume_fp: '30000' },
+    ];
+
+    assert.deepEqual(
+      selectKalshiSeriesTickers(series, ['IR', 'LB'], {
+        perCountryLimit: 1,
+        excludedTickers: ['KXIRANEMPTY'],
+      }),
+      ['KXIRANACTIVE', 'KXLEBANONACTIVE'],
+    );
+  });
+
+  it('caps a selection round by the remaining global request budget', () => {
+    const series = [
+      { ticker: 'KXIRAN', title: 'Iran election', category: 'Elections', volume_fp: '50000' },
+      { ticker: 'KXLEBANON', title: 'Lebanon election', category: 'Elections', volume_fp: '40000' },
+    ];
+
+    assert.deepEqual(
+      selectKalshiSeriesTickers(series, ['IR', 'LB'], {
+        perCountryLimit: 1,
+        totalLimit: 1,
+      }),
+      ['KXIRAN'],
+    );
+  });
 });

--- a/tests/prediction-country-index.test.mjs
+++ b/tests/prediction-country-index.test.mjs
@@ -263,12 +263,13 @@ describe('projectCountryMarketIndex', () => {
 });
 
 describe('selectKalshiSeriesTickers', () => {
-  it('selects two liquid non-sports series for each requested country', () => {
+  it('selects two high-volume non-sports series for each requested country', () => {
     const series = [
       { ticker: 'KXIRANSPORT', title: 'Iran match winner', category: 'Sports', volume_fp: '90000000' },
       { ticker: 'KXIRANSTALE', title: 'Ali Khamenei out?', tags: ['Iran'], category: 'Politics', volume_fp: '54513052' },
       { ticker: 'KXIRANDEAL', title: 'US Iran nuclear deal', tags: ['Iran'], category: 'World', volume_fp: '21065356' },
       { ticker: 'KXIRANLOW', title: 'Iran trade agreement', category: 'World', volume_fp: '4999' },
+      { ticker: 'KXIRANUNKNOWN', title: 'A new Iran agreement', category: 'World' },
       { ticker: 'KXLEBANONPARLI', title: 'Lebanon parliament', category: 'Elections', volume_fp: '28888' },
       { ticker: 'KXLEBUSFLIGHT', title: 'Lebanon-US flight resumption', category: 'World', volume_fp: '11181' },
       { ticker: 'KXFRANCE', title: 'France election', category: 'Elections', volume_fp: '500000' },

--- a/tests/prediction-market-classification.test.mjs
+++ b/tests/prediction-market-classification.test.mjs
@@ -614,6 +614,8 @@ describe('the seeder is wired to the tested pool-building path', () => {
     assert.match(source, /onPageError:[\s\S]{0,180}complete = false/);
     assert.match(source, /return \{ events: \[\], complete: false \}/);
     assert.match(source, /if \(!kalshiMarkets\.complete\) countryProjectionComplete = false/);
+    assert.match(source, /selectKalshiSeriesTickers\(/);
+    assert.match(source, /fetchKalshiMarketsBySeries\(/);
     assert.match(source, /key:\s*COUNTRY_INDEX_KEY/);
     assert.match(source, /metaKey:\s*COUNTRY_INDEX_META_KEY/);
     assert.match(source, /skipWhenEmpty:\s*true/);

--- a/tests/prediction-market-classification.test.mjs
+++ b/tests/prediction-market-classification.test.mjs
@@ -616,6 +616,10 @@ describe('the seeder is wired to the tested pool-building path', () => {
     assert.match(source, /if \(!kalshiMarkets\.complete\) countryProjectionComplete = false/);
     assert.match(source, /selectKalshiSeriesTickers\(/);
     assert.match(source, /fetchKalshiMarketsBySeries\(/);
+    assert.match(source, /excludedTickers:\s*triedSeriesTickers/);
+    assert.match(source, /totalLimit:\s*MAX_KALSHI_COUNTRY_REQUESTS - requestsUsed/);
+    assert.match(source, /maxRequests:\s*MAX_KALSHI_COUNTRY_REQUESTS - requestsUsed/);
+    assert.match(source, /lockTtlMs:\s*KALSHI_COUNTRY_LOCK_TTL_MS/);
     assert.match(source, /key:\s*COUNTRY_INDEX_KEY/);
     assert.match(source, /metaKey:\s*COUNTRY_INDEX_META_KEY/);
     assert.match(source, /skipWhenEmpty:\s*true/);

--- a/tests/prediction-upstream.test.mjs
+++ b/tests/prediction-upstream.test.mjs
@@ -167,9 +167,13 @@ describe('prediction-market upstream coverage', () => {
   });
 
   it('rejects an incomplete selected-series hydration', async () => {
+    let calls = 0;
     await assert.rejects(
       fetchKalshiMarketsBySeries(['KXIRAN'], {
-        fetchFn: async () => Response.json({ markets: [{ ticker: 'IRAN-1' }], cursor: 'never-ends' }),
+        fetchFn: async () => Response.json({
+          markets: [{ ticker: `IRAN-${calls + 1}` }],
+          cursor: `page-${++calls}`,
+        }),
         baseUrl: 'https://kalshi.example.test',
         userAgent: 'test',
         maxPagesPerSeries: 2,

--- a/tests/prediction-upstream.test.mjs
+++ b/tests/prediction-upstream.test.mjs
@@ -182,6 +182,23 @@ describe('prediction-market upstream coverage', () => {
     );
   });
 
+  it('bounds requests across all selected series', async () => {
+    let calls = 0;
+    await assert.rejects(
+      fetchKalshiMarketsBySeries(['KXIRAN', 'KXLEBANON'], {
+        fetchFn: async () => Response.json({
+          markets: [{ ticker: `MARKET-${++calls}` }],
+          cursor: calls === 1 ? 'next-page' : '',
+        }),
+        baseUrl: 'https://kalshi.example.test',
+        userAgent: 'test',
+        maxRequests: 2,
+      }),
+      /Kalshi markets request budget exceeded 2 requests/,
+    );
+    assert.equal(calls, 2);
+  });
+
   it('rejects malformed Kalshi series and market payloads', async () => {
     await assert.rejects(
       fetchKalshiSeries({

--- a/tests/prediction-upstream.test.mjs
+++ b/tests/prediction-upstream.test.mjs
@@ -3,6 +3,8 @@ import { describe, it } from 'node:test';
 
 import {
   fetchKalshiEvents,
+  fetchKalshiMarketsBySeries,
+  fetchKalshiSeries,
   fetchPolymarketEventsByTag,
 } from '../scripts/_prediction-upstream.mjs';
 
@@ -114,6 +116,85 @@ describe('prediction-market upstream coverage', () => {
     });
 
     assert.deepEqual(events, []);
+  });
+
+  it('loads the complete Kalshi series catalog with volume metadata', async () => {
+    let requestedUrl = '';
+    const series = await fetchKalshiSeries({
+      fetchFn: async (url) => {
+        requestedUrl = String(url);
+        return Response.json({ series: [{ ticker: 'KXUSAIRANAGREEMENT' }] });
+      },
+      baseUrl: 'https://kalshi.example.test',
+      userAgent: 'test',
+    });
+
+    assert.deepEqual(series, [{ ticker: 'KXUSAIRANAGREEMENT' }]);
+    assert.equal(new URL(requestedUrl).pathname, '/series');
+    assert.equal(new URL(requestedUrl).searchParams.get('include_volume'), 'true');
+  });
+
+  it('hydrates selected Kalshi series sequentially and follows each cursor', async () => {
+    const urls = [];
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    const pages = new Map([
+      ['KXIRAN:', { markets: [{ ticker: 'IRAN-1' }], cursor: 'iran-next' }],
+      ['KXIRAN:iran-next', { markets: [{ ticker: 'IRAN-2' }], cursor: '' }],
+      ['KXLEBANON:', { markets: [{ ticker: 'LEBANON-1' }], cursor: '' }],
+    ]);
+    const markets = await fetchKalshiMarketsBySeries(['KXIRAN', 'KXLEBANON', 'KXIRAN'], {
+      fetchFn: async (url) => {
+        urls.push(String(url));
+        activeRequests += 1;
+        maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+        await Promise.resolve();
+        activeRequests -= 1;
+        const parsed = new URL(url);
+        const key = `${parsed.searchParams.get('series_ticker')}:${parsed.searchParams.get('cursor') ?? ''}`;
+        return Response.json(pages.get(key));
+      },
+      baseUrl: 'https://kalshi.example.test',
+      userAgent: 'test',
+    });
+
+    assert.deepEqual(markets.map((market) => market.ticker), ['IRAN-1', 'IRAN-2', 'LEBANON-1']);
+    assert.equal(maxActiveRequests, 1);
+    assert.equal(urls.length, 3);
+    assert.equal(new URL(urls[0]).searchParams.get('status'), 'open');
+    assert.equal(new URL(urls[0]).searchParams.get('limit'), '1000');
+    assert.equal(new URL(urls[0]).searchParams.get('mve_filter'), 'exclude');
+  });
+
+  it('rejects an incomplete selected-series hydration', async () => {
+    await assert.rejects(
+      fetchKalshiMarketsBySeries(['KXIRAN'], {
+        fetchFn: async () => Response.json({ markets: [{ ticker: 'IRAN-1' }], cursor: 'never-ends' }),
+        baseUrl: 'https://kalshi.example.test',
+        userAgent: 'test',
+        maxPagesPerSeries: 2,
+      }),
+      /Kalshi markets pagination exceeded 2 pages for KXIRAN/,
+    );
+  });
+
+  it('rejects malformed Kalshi series and market payloads', async () => {
+    await assert.rejects(
+      fetchKalshiSeries({
+        fetchFn: async () => Response.json({}),
+        baseUrl: 'https://kalshi.example.test',
+        userAgent: 'test',
+      }),
+      /Kalshi invalid payload: expected series array/,
+    );
+    await assert.rejects(
+      fetchKalshiMarketsBySeries(['KXIRAN'], {
+        fetchFn: async () => Response.json({}),
+        baseUrl: 'https://kalshi.example.test',
+        userAgent: 'test',
+      }),
+      /Kalshi invalid payload: expected markets array/,
+    );
   });
 
   it('requests 100 Polymarket events per tag instead of truncating at 20', async () => {


### PR DESCRIPTION
## Why

Country briefs could show only Polymarket even when Kalshi had active markets for the same country.

The country index already preserved provider diversity. The loss happened earlier in the producer. It read only the first five Kalshi event pages. Current Kalshi data has about 75 pages of open events, and eligible Iran and Lebanon events first appeared after that window.

## Scope

- Load the Kalshi series catalog after the existing event fetch.
- Find high-volume non-sports series for countries that Polymarket covers but the initial Kalshi pages do not cover.
- Hydrate one ranked series per still-uncovered country in each round.
- Try lower-ranked series when an earlier series has no eligible active market.
- Stop after four rounds or 24 Kalshi market requests.
- Hydrate selected series in sequence and add the markets to the shared country index.
- Keep the featured prediction-market feed on its existing first-five-page path.
- Keep the last good country index when a targeted fetch is incomplete.
- Add unit and wiring tests for selection, fallback, request bounds, cursor paging, sequential hydration, malformed data, and incomplete fetches.

## Tradeoffs

- This is a bounded coverage repair. It does not scan every Kalshi market on every seed run.
- A live full-market scan was still incomplete after 80,000 markets and took about 28 seconds. Concurrent series hydration also caused Kalshi rate limits.
- The producer uses at most four ranked fallback rounds and 24 Kalshi market requests. This improves country provider coverage while keeping request volume controlled.
- The targeted fetch adds work to the country-index path. A five-minute seed lock, the fetch deadline, and the last-good publication guard limit the failure effect.

## Blast Radius

- Prediction-market seeder discovery and country-index publication change.
- The browser UI, RPC contract, featured market pools, and cache key do not change.
- A failed targeted fetch blocks only the new country-index projection and preserves the last good index.

## Verification

- `tsx --test --test-timeout=120000 tests/prediction-country-index.test.mjs tests/prediction-upstream.test.mjs tests/prediction-market-classification.test.mjs` passed, 101 tests.
- `npm run typecheck` passed.
- `npm run typecheck:api` passed in the pre-push gate.
- `npm run lint:boundaries` passed.
- `npm run test:data` passed on the current-main tree, 30,129 tests with 30,089 passes, 40 skips, and 0 failures.
- Biome, syntax checks, and `git diff --check origin/main...HEAD` passed.
- Live helper-chain validation selected and hydrated active Iran and Lebanon Kalshi series. The built country index then contained both Polymarket and Kalshi for IR and LB.
- Review findings about empty-series fallback and unbounded requests were repaired in commit `84551c544`.

## Post-Deploy Monitoring & Validation

- Owner is the maintainer or on-call engineer for the first two production cron runs after deploy.
- Check Railway logs for `[kalshi] hydrating`, `error fetching country series`, `country index:`, `FETCH FAILED`, and `PUBLISH BLOCKED`.
- Check `predictionCountryMarkets` health or `seed-meta:prediction:markets-country-index` for a nonzero record count and current freshness.
- Check the country-market RPC for IR and LB. Healthy output contains both `MARKET_SOURCE_POLYMARKET` and `MARKET_SOURCE_KALSHI`.
- Watch total seeder duration. Failure is a targeted fetch error, a fetch phase near or over its deadline, stale health, or a one-provider IR or LB result.
- If failure continues, revert the targeted series path. The last-good guard must keep the prior country index available during recovery.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
