### PR TITLE
fix(insights): recover from digest sentinel races

### DIFF
--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1469,6 +1469,7 @@
       "scripts/seed-insights.mjs",
       "scripts/shared/brief-llm-core.js",
       "scripts/shared/country-names.json",
+      "scripts/shared/digest-acceptance.mjs",
       "scripts/shared/diplomacy-keywords.json",
       "scripts/shared/geo-extract.mjs",
       "scripts/shared/publisher-families.js",

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -774,7 +774,7 @@ async function warmDigestCache(language = 'en') {
   }
 }
 
-async function readOrWarmDigest(language) {
+export async function readOrWarmDigest(language) {
   const key = digestKeyForLanguage(language);
   let digest = await readDigestFromRedis(key);
   if (digest) return digest;

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -21,6 +21,7 @@ import {
   ENTITY_BIGRAMS,
 } from './_clustering.mjs';
 import { MIN_CORROBORATING_PUBLISHERS } from './shared/publisher-families.js';
+import { isAcceptableDigest } from './shared/digest-acceptance.mjs';
 import { extractCountryCode } from './shared/geo-extract.mjs';
 import { buildChinaNewsCoverage } from './_china-news-coverage.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
@@ -385,7 +386,13 @@ async function readDigestFromRedis(key = DIGEST_KEY) {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
+  if (!data.result) return null;
+  try {
+    const digest = unwrapEnvelope(JSON.parse(data.result)).data;
+    return isAcceptableDigest(digest) ? digest : null;
+  } catch {
+    return null;
+  }
 }
 
 async function readExistingInsights() {
@@ -764,14 +771,21 @@ async function warmDigestCache(language = 'en') {
       headers,
       signal: AbortSignal.timeout(30_000),
     });
-    if (resp.ok) console.log(`  ${language} digest cache warmed via RPC`);
-    else {
+    if (resp.ok) {
+      const digest = await resp.json();
+      if (isAcceptableDigest(digest)) {
+        console.log(`  ${language} digest cache warmed via RPC`);
+        return digest;
+      }
+      console.warn(`  Digest warm returned no acceptable ${language} digest`);
+    } else {
       const keyNote = RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
       console.warn(`  Digest warm failed: HTTP ${resp.status}${keyNote}`);
     }
   } catch (err) {
     console.warn(`  Digest warm failed: ${err.message}`);
   }
+  return null;
 }
 
 export async function readOrWarmDigest(language) {
@@ -779,9 +793,13 @@ export async function readOrWarmDigest(language) {
   let digest = await readDigestFromRedis(key);
   if (digest) return digest;
   console.log(`  ${language} digest not in Redis, warming cache via RPC...`);
-  await warmDigestCache(language);
+  const warmedDigest = await warmDigestCache(language);
+  // The RPC response has passed the endpoint's current revocation filter.
+  // Return it before any Redis readback can discard it or replace it with the
+  // unfiltered canonical body.
+  if (warmedDigest) return warmedDigest;
   // Wait for the Edge write to propagate before the readback. This is the
-  // existing full/en warm-cache contract, now reused for the Chinese digest.
+  // fallback when the RPC response did not contain an acceptable digest.
   await new Promise(r => setTimeout(r, 3_000));
   digest = await readDigestFromRedis(key);
   return digest;
@@ -821,6 +839,15 @@ export function normalizeDigestItemsForInsights(items) {
     corroborationCount: item.corroborationCount ?? item.storyMeta?.sourceCount,
     storyMeta: item.storyMeta,
   })).filter(item => item.title.length > 10);
+}
+
+export function digestItemsForInsights(digest) {
+  if (Array.isArray(digest)) return digest;
+  if (digest?.categories && typeof digest.categories === 'object') {
+    return Object.values(digest.categories)
+      .flatMap(bucket => (Array.isArray(bucket?.items) ? bucket.items : []));
+  }
+  return digest?.items || digest?.articles || digest?.headlines || [];
 }
 
 /**
@@ -880,17 +907,7 @@ async function fetchInsights() {
   });
 
   // Digest shape: { categories: { politics: { items: [...] }, ... }, feedStatuses, generatedAt }
-  let items;
-  if (Array.isArray(digest)) {
-    items = digest;
-  } else if (digest.categories && typeof digest.categories === 'object') {
-    items = [];
-    for (const bucket of Object.values(digest.categories)) {
-      if (Array.isArray(bucket.items)) items.push(...bucket.items);
-    }
-  } else {
-    items = digest.items || digest.articles || digest.headlines || [];
-  }
+  const items = digestItemsForInsights(digest);
 
   if (items.length === 0) {
     const keys = typeof digest === 'object' && digest !== null ? Object.keys(digest).join(', ') : typeof digest;

--- a/scripts/shared/digest-acceptance.d.mts
+++ b/scripts/shared/digest-acceptance.d.mts
@@ -1,0 +1,6 @@
+export interface DigestLike {
+  categories?: Record<string, { items?: unknown[] } | null>;
+}
+
+export declare function countDigestItems(data: DigestLike): number;
+export declare function isAcceptableDigest(data: DigestLike | null | undefined): boolean;

--- a/scripts/shared/digest-acceptance.mjs
+++ b/scripts/shared/digest-acceptance.mjs
@@ -1,0 +1,16 @@
+/** Total items across every category bucket. */
+export function countDigestItems(data) {
+  // Redis is external input. A malformed bucket must count as empty instead
+  // of aborting the acceptance check for the complete digest.
+  return Object.values(data.categories ?? {}).reduce((sum, bucket) => (
+    sum + (Array.isArray(bucket?.items) ? bucket.items.length : 0)
+  ), 0);
+}
+
+/** Structural acceptance: at least one category and at least one item. */
+export function isAcceptableDigest(data) {
+  if (!data || typeof data !== 'object') return false;
+  const categories = data.categories;
+  if (!categories || typeof categories !== 'object') return false;
+  return Object.keys(categories).length >= 1 && countDigestItems(data) >= 1;
+}

--- a/server/worldmonitor/news/v1/_lastgood.ts
+++ b/server/worldmonitor/news/v1/_lastgood.ts
@@ -7,11 +7,19 @@
  * six-hour last-good value masked the gap for humans, but programmatic
  * consumers and cold isolates did not have an accepted snapshot.
  *
- * This module owns the pure policy: which key, when a candidate is
- * accepted, when an accepted snapshot may replace a live one, when a
- * snapshot is still servable, and how a revocation filters items. All I/O
- * lives in the caller.
+ * This module owns the pure last-good policy: which key, when an accepted
+ * snapshot may replace a live one, when a snapshot is still servable, and
+ * how a revocation filters items. The structural acceptance rule is shared
+ * with seed-insights; all I/O lives in the callers.
  */
+
+import {
+  countDigestItems,
+  isAcceptableDigest,
+  type DigestLike,
+} from '../../../../scripts/shared/digest-acceptance.mjs';
+
+export { countDigestItems, isAcceptableDigest, type DigestLike };
 
 /** Redis TTL for the accepted snapshot. Six hours, per the contract. */
 export const LASTGOOD_TTL_S = 6 * 60 * 60;
@@ -139,27 +147,6 @@ export function parseAcceptedSnapshot<T extends DigestLike = DigestLike>(
   const data = (value as Record<string, unknown>).data;
   if (!data || typeof data !== 'object') return null;
   return { ...meta, data: data as T };
-}
-
-export interface DigestLike {
-  categories?: Record<string, { items?: unknown[] }>;
-}
-
-/** Total items across every category bucket. */
-export function countDigestItems(data: DigestLike): number {
-  // `b?.` matters: this runs over bodies read back from Redis, where a bucket
-  // can be null/malformed. A throw here propagates out of the servability
-  // gate and can abort EVERY fallback tier for the request.
-  return Object.values(data.categories ?? {}).reduce((sum, b) => sum + (b?.items?.length ?? 0), 0);
-}
-
-/** Structural acceptance: at least one category AND at least one item. */
-export function isAcceptableDigest(data: DigestLike | null | undefined): boolean {
-  if (!data || typeof data !== 'object') return false;
-  const categories = data.categories;
-  if (!categories || typeof categories !== 'object') return false;
-  const catCount = Object.keys(categories).length;
-  return catCount >= 1 && countDigestItems(data) >= 1;
 }
 
 /**

--- a/tests/digest-lastgood.test.mts
+++ b/tests/digest-lastgood.test.mts
@@ -49,8 +49,12 @@ describe('durable last-good policy (#7084)', () => {
   it('accepts only structurally valid digests with real content', () => {
     assert.ok(isAcceptableDigest(ONE_ITEM));
     assert.ok(isAcceptableDigest(RICHER));
+    assert.ok(isAcceptableDigest({ categories: { malformed: null, ...ONE_ITEM.categories } }));
     assert.ok(!isAcceptableDigest({ categories: {} }));
     assert.ok(!isAcceptableDigest({ categories: { politics: { items: [] } } }));
+    assert.ok(!isAcceptableDigest({ categories: { politics: { items: 'not-an-array' } } } as any));
+    assert.ok(!isAcceptableDigest({ categories: { politics: { items: { length: 1 } } } } as any));
+    assert.ok(!isAcceptableDigest({ categories: { politics: null } }));
     assert.ok(!isAcceptableDigest(null));
     assert.ok(!isAcceptableDigest(undefined));
     assert.ok(!isAcceptableDigest({}));

--- a/tests/seed-insights-digest-acquisition.test.mjs
+++ b/tests/seed-insights-digest-acquisition.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { readOrWarmDigest } from '../scripts/seed-insights.mjs';
+import { digestItemsForInsights, readOrWarmDigest } from '../scripts/seed-insights.mjs';
 
 const NEGATIVE_SENTINEL = '__WM_NEG__';
 const ACCEPTED_DIGEST = {
@@ -12,12 +12,19 @@ const ACCEPTED_DIGEST = {
   },
   coverage: { servedStale: true },
 };
+const ACCEPTED_REREAD = {
+  categories: {
+    politics: {
+      items: [{ title: 'Accepted canonical story', link: 'https://example.test/canonical' }],
+    },
+  },
+};
 
 function redisResponse(value) {
   return new Response(JSON.stringify({ result: value == null ? null : JSON.stringify(value) }));
 }
 
-function installDigestFetch(t, redisValues) {
+function installDigestFetch(t, redisValues, warmValue = ACCEPTED_DIGEST) {
   const previousEnv = {
     apiBaseUrl: process.env.API_BASE_URL,
     redisUrl: process.env.UPSTASH_REDIS_REST_URL,
@@ -38,6 +45,7 @@ function installDigestFetch(t, redisValues) {
   });
 
   const calls = [];
+  let waits = 0;
   let redisRead = 0;
   t.mock.method(globalThis, 'fetch', async (input) => {
     const url = String(input);
@@ -48,28 +56,20 @@ function installDigestFetch(t, redisValues) {
       return redisResponse(value);
     }
     if (url.startsWith('https://api.example.test/api/news/v1/list-feed-digest')) {
-      return new Response(JSON.stringify(ACCEPTED_DIGEST));
+      return new Response(JSON.stringify(warmValue));
     }
     throw new Error(`Unexpected fetch: ${url}`);
   });
   t.mock.method(globalThis, 'setTimeout', (callback) => {
+    waits += 1;
     callback();
     return 0;
   });
-  return calls;
+  return { calls, waitCount: () => waits };
 }
 
-test('a digest negative-cache sentinel is a miss and triggers the warm RPC', async (t) => {
-  const calls = installDigestFetch(t, [NEGATIVE_SENTINEL, NEGATIVE_SENTINEL]);
-
-  const digest = await readOrWarmDigest('en');
-
-  assert.deepEqual(digest, ACCEPTED_DIGEST);
-  assert.equal(calls.filter(url => url.includes('/list-feed-digest')).length, 1);
-});
-
-test('an accepted warm response wins when Redis readback contains the sentinel', async (t) => {
-  const calls = installDigestFetch(t, [null, NEGATIVE_SENTINEL]);
+test('an accepted warm response is returned without a Redis readback', async (t) => {
+  const { calls, waitCount } = installDigestFetch(t, [NEGATIVE_SENTINEL]);
 
   const digest = await readOrWarmDigest('en');
 
@@ -77,6 +77,43 @@ test('an accepted warm response wins when Redis readback contains the sentinel',
   assert.deepEqual(calls.map(url => new URL(url).hostname), [
     'redis.example.test',
     'api.example.test',
+  ]);
+  assert.equal(waitCount(), 0);
+});
+
+test('an unacceptable warm response falls back to an accepted Redis readback', async (t) => {
+  const { calls, waitCount } = installDigestFetch(t, [null, ACCEPTED_REREAD], {
+    categories: { politics: { items: 'not-an-array' } },
+  });
+
+  const digest = await readOrWarmDigest('en');
+
+  assert.deepEqual(digest, ACCEPTED_REREAD);
+  assert.deepEqual(calls.map(url => new URL(url).hostname), [
+    'redis.example.test',
+    'api.example.test',
     'redis.example.test',
   ]);
+  assert.equal(waitCount(), 1);
+});
+
+test('negative sentinels and malformed digests never escape acquisition', async (t) => {
+  installDigestFetch(t, [NEGATIVE_SENTINEL, {
+    categories: { politics: { items: { length: 1 } } },
+  }], NEGATIVE_SENTINEL);
+
+  const digest = await readOrWarmDigest('en');
+
+  assert.equal(digest, null);
+});
+
+test('accepted digests ignore malformed category buckets during item extraction', () => {
+  const validItem = ACCEPTED_DIGEST.categories.politics.items[0];
+
+  assert.deepEqual(digestItemsForInsights({
+    categories: {
+      malformed: null,
+      politics: { items: [validItem] },
+    },
+  }), [validItem]);
 });

--- a/tests/seed-insights-digest-acquisition.test.mjs
+++ b/tests/seed-insights-digest-acquisition.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readOrWarmDigest } from '../scripts/seed-insights.mjs';
+
+const NEGATIVE_SENTINEL = '__WM_NEG__';
+const ACCEPTED_DIGEST = {
+  categories: {
+    politics: {
+      items: [{ title: 'Accepted last-good story', link: 'https://example.test/story' }],
+    },
+  },
+  coverage: { servedStale: true },
+};
+
+function redisResponse(value) {
+  return new Response(JSON.stringify({ result: value == null ? null : JSON.stringify(value) }));
+}
+
+function installDigestFetch(t, redisValues) {
+  const previousEnv = {
+    apiBaseUrl: process.env.API_BASE_URL,
+    redisUrl: process.env.UPSTASH_REDIS_REST_URL,
+    redisToken: process.env.UPSTASH_REDIS_REST_TOKEN,
+  };
+  process.env.API_BASE_URL = 'https://api.example.test';
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  t.after(() => {
+    for (const [name, value] of Object.entries({
+      API_BASE_URL: previousEnv.apiBaseUrl,
+      UPSTASH_REDIS_REST_URL: previousEnv.redisUrl,
+      UPSTASH_REDIS_REST_TOKEN: previousEnv.redisToken,
+    })) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+
+  const calls = [];
+  let redisRead = 0;
+  t.mock.method(globalThis, 'fetch', async (input) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.startsWith('https://redis.example.test/get/')) {
+      const value = redisValues[Math.min(redisRead, redisValues.length - 1)];
+      redisRead += 1;
+      return redisResponse(value);
+    }
+    if (url.startsWith('https://api.example.test/api/news/v1/list-feed-digest')) {
+      return new Response(JSON.stringify(ACCEPTED_DIGEST));
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  t.mock.method(globalThis, 'setTimeout', (callback) => {
+    callback();
+    return 0;
+  });
+  return calls;
+}
+
+test('a digest negative-cache sentinel is a miss and triggers the warm RPC', async (t) => {
+  const calls = installDigestFetch(t, [NEGATIVE_SENTINEL, NEGATIVE_SENTINEL]);
+
+  const digest = await readOrWarmDigest('en');
+
+  assert.deepEqual(digest, ACCEPTED_DIGEST);
+  assert.equal(calls.filter(url => url.includes('/list-feed-digest')).length, 1);
+});
+
+test('an accepted warm response wins when Redis readback contains the sentinel', async (t) => {
+  const calls = installDigestFetch(t, [null, NEGATIVE_SENTINEL]);
+
+  const digest = await readOrWarmDigest('en');
+
+  assert.deepEqual(digest, ACCEPTED_DIGEST);
+  assert.deepEqual(calls.map(url => new URL(url).hostname), [
+    'redis.example.test',
+    'api.example.test',
+    'redis.example.test',
+  ]);
+});


### PR DESCRIPTION
## Summary

Natural `seed-insights` runs could exit 75 when the digest cache briefly contained `__WM_NEG__`. The truthy sentinel also stopped the warm RPC, so the seeder could not repair its own input and `newsInsights` kept aging past its 30-minute limit.

The seeder now treats sentinels, malformed values, and empty digests as cache misses. It returns an accepted warm RPC body immediately, which preserves the endpoint's current revocation filter, and shares the durable last-good structural acceptance rule instead of maintaining a weaker reader-specific check. The six-hour last-good policy and the 30-minute `newsInsights` freshness limit are unchanged.

Railway now watches the shared acceptance module, so a change to that runtime dependency redeploys `seed-insights`.

## Type of change

- [x] Bug fix
- [x] CI / Build / Infrastructure

## Affected areas

- [x] AI Insights / World Brief
- [x] Other: Railway `seed-insights` runtime packaging

## Verification

- Exact Redis sentinel, valid HTTP 200 warm response, and sentinel readback regression: 62 tests passed.
- Railway scripts packaging and import closure: 190 tests passed.
- Full data suite: 30,038 passed, 40 skipped, 0 failed.
- `npm run typecheck` and `npm run typecheck:api` passed.
- The repository pre-push gate passed, including boundaries, API bundles, changed tests, server tests, generated-code freshness, and version sync.
- Full correctness, testing, maintainability, standards, performance, reliability, and adversarial review found no remaining P0, P1, or P2 items.

## Post-deploy validation

Do not start the seeder manually. After merge and deployment, observe the next natural 10-minute `seed-insights` run and one additional interval if needed.

Healthy evidence:

- The scheduled run completes without `Digest has no items (shape: string)`, deterministic digest retries, or exit 75.
- `seed-meta:newsInsights.lastSuccessAt` advances on the natural run.
- Compact health reports `newsInsights` below the unchanged 30-minute maximum.

Failure evidence:

- The shape-string error or exit 75 returns.
- `lastSuccessAt` does not advance across two natural intervals.
- `newsInsights` remains older than 30 minutes.

Production acceptance remains pending until this natural-run evidence exists.

## Checklist

- [ ] Tested on the deployed worldmonitor.app variant; pending merge and natural Railway run
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] No health probe or activation contract changed

Documentation alignment: N/A. This PR does not publish or change documentation claims.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
