### PR TITLE
fix(x): migrate lower same-day coverage models

### DIFF
--- a/docker/redis-rest-proxy.mjs
+++ b/docker/redis-rest-proxy.mjs
@@ -284,27 +284,52 @@ const X_POST_BUDGET_RESERVE_SCRIPT = [
   '  local serverNowMs = (tonumber(serverTime[1]) * 1000) + math.floor(tonumber(serverTime[2]) / 1000)',
   '  if serverNowMs >= deadlineMs then return {0, dayUsed, monthUsed, 7, coverageHeld, ""} end',
   'end',
-  'if coverageRaw == false and coverageTotal > 0 then',
-  '  coverageHeld = coverageTotal',
-  '  redis.call("set", KEYS[5], coverageHeld, "EXAT", tonumber(ARGV[5]))',
-  '  redis.call("set", KEYS[9], coverageModel, "EXAT", tonumber(ARGV[5]))',
+  'local coverageEffectiveHeld = coverageHeld',
+  'local coverageShouldWrite = false',
+  'local hasCoverageState = coverageRaw ~= false or coverageModelRaw ~= false',
+  'if hasCoverageState then',
+  '  if (coverageRaw == false) ~= (coverageModelRaw == false) then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '  local canonicalHeld = coverageRaw == "0" or string.match(coverageRaw, "^[1-9]%d*$") ~= nil',
+  '  local storedTotalRaw = string.match(coverageModelRaw, "^fixed%-slots%-v1:([1-9]%d*)$")',
+  '  local storedTotal = tonumber(storedTotalRaw)',
+  '  if not canonicalHeld or storedTotal == nil or storedTotal > dailyLimit then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '  if coverageHeld > storedTotal then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '  if coverageTotal > 0 then',
+  '    local requestedTotalRaw = string.match(coverageModel, "^fixed%-slots%-v1:([1-9]%d*)$")',
+  '    local requestedTotal = tonumber(requestedTotalRaw)',
+  '    if requestedTotal == nil or requestedTotal ~= coverageTotal or requestedTotal > dailyLimit or storedTotal < coverageTotal then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '    local spent = storedTotal - coverageHeld',
+  '    if spent > coverageTotal then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '    coverageEffectiveHeld = coverageTotal - spent',
+  '    coverageShouldWrite = storedTotal > coverageTotal',
+  '  end',
+  'elseif coverageTotal > 0 then',
+  '  local requestedTotalRaw = string.match(coverageModel, "^fixed%-slots%-v1:([1-9]%d*)$")',
+  '  local requestedTotal = tonumber(requestedTotalRaw)',
+  '  if requestedTotal == nil or requestedTotal ~= coverageTotal or requestedTotal > dailyLimit then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '  coverageEffectiveHeld = coverageTotal',
+  '  coverageShouldWrite = true',
   'end',
-  'if hasCoverageUnit and coverageModelRaw ~= false and coverageModelRaw ~= coverageModel then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
-  'if hasCoverageUnit and coverageRaw ~= false and coverageModelRaw == false then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
   'local coverageAccounted = hasCoverageUnit and redis.call("exists", KEYS[6]) == 1',
   'if coverageAccounted then return {0, dayUsed, monthUsed, 3, coverageHeld, ""} end',
-  'local coverageAfter = coverageHeld',
-  'if hasCoverageUnit then coverageAfter = math.max(0, coverageHeld - coverageUnit) end',
+  'if hasCoverageUnit and coverageEffectiveHeld < coverageUnit then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  'local coverageAfter = coverageEffectiveHeld',
+  'if hasCoverageUnit then coverageAfter = coverageEffectiveHeld - coverageUnit end',
   'local oncePerDay = ARGV[8] == "1"',
   'if oncePerDay and redis.call("exists", KEYS[4]) == 1 then return {0, dayUsed, monthUsed, 3, coverageHeld} end',
-  'if dayUsed + requested + coverageAfter > dailyLimit then return {0, dayUsed, monthUsed, 1, coverageHeld} end',
-  'if monthUsed + requested + coverageAfter > monthlyLimit then return {0, dayUsed, monthUsed, 2, coverageHeld} end',
+  'if dayUsed + requested + coverageAfter > dailyLimit then return {0, dayUsed, monthUsed, 1, coverageEffectiveHeld} end',
+  'if monthUsed + requested + coverageAfter > monthlyLimit then return {0, dayUsed, monthUsed, 2, coverageEffectiveHeld} end',
   'dayUsed = redis.call("incrby", KEYS[1], requested)',
   'monthUsed = redis.call("incrby", KEYS[2], requested)',
   'redis.call("expireat", KEYS[1], tonumber(ARGV[5]))',
   'redis.call("expireat", KEYS[2], tonumber(ARGV[6]))',
-  'if hasCoverageUnit then',
+  'if coverageShouldWrite or hasCoverageUnit then',
   '  redis.call("set", KEYS[5], coverageAfter, "EXAT", tonumber(ARGV[5]))',
+  'end',
+  'if coverageShouldWrite then',
+  '  redis.call("set", KEYS[9], coverageModel, "EXAT", tonumber(ARGV[5]))',
+  'end',
+  'if hasCoverageUnit then',
   '  redis.call("set", KEYS[6], "1", "EXAT", tonumber(ARGV[5]))',
   'end',
   'redis.call("set", KEYS[3], requested, "EX", tonumber(ARGV[7]))',
@@ -369,6 +394,83 @@ const X_POST_BUDGET_STATUS_SCRIPT = [
   'local dayUsed = tonumber(redis.call("get", KEYS[1]) or "0")',
   'local monthUsed = tonumber(redis.call("get", KEYS[2]) or "0")',
   'local coverageRaw = redis.call("get", KEYS[3])',
+  'local coverageHeld = 0',
+  'local coverageState = 0',
+  'if coverageRaw ~= false then',
+  '  local canonicalHeld = coverageRaw == "0" or string.match(coverageRaw, "^[1-9]%d*$") ~= nil',
+  '  local parsedHeld = tonumber(coverageRaw)',
+  '  if canonicalHeld and parsedHeld ~= nil and parsedHeld <= 9007199254740991 then',
+  '    coverageHeld = parsedHeld',
+  '    coverageState = 1',
+  '  else',
+  '    coverageState = -1',
+  '  end',
+  'end',
+  'local coverageModel = redis.call("get", KEYS[4])',
+  'if (coverageRaw == false) ~= (coverageModel == false) then coverageState = -1 end',
+  'return {dayUsed, monthUsed, coverageHeld, coverageState, coverageModel or ""}',
+].join('\n');
+
+// The proxy rolls out independently from its callers. Keep the immediately
+// prior read and reserve scripts pinned until every caller runs the new model.
+const LEGACY_X_POST_BUDGET_RESERVE_SCRIPT = [
+  'local requested = tonumber(ARGV[1])',
+  'local coverageTotal = tonumber(ARGV[2]) or 0',
+  'local dailyLimit = tonumber(ARGV[3])',
+  'local monthlyLimit = tonumber(ARGV[4])',
+  'local coverageUnit = tonumber(ARGV[9]) or 0',
+  'local hasCoverageUnit = ARGV[10] == "1"',
+  'local hasReceipt = ARGV[11] == "1"',
+  'local coverageModel = ARGV[12] or ""',
+  'local deadlineMs = tonumber(ARGV[13]) or 0',
+  'local dayUsed = tonumber(redis.call("get", KEYS[1]) or "0")',
+  'local monthUsed = tonumber(redis.call("get", KEYS[2]) or "0")',
+  'local coverageRaw = redis.call("get", KEYS[5])',
+  'local coverageHeld = tonumber(coverageRaw or "0") or 0',
+  'local coverageModelRaw = redis.call("get", KEYS[9])',
+  'if hasReceipt then',
+  '  local pendingReceipt = redis.call("get", KEYS[7])',
+  '  if pendingReceipt ~= false then return {0, dayUsed, monthUsed, 4, coverageHeld, pendingReceipt} end',
+  '  if redis.call("exists", KEYS[8]) == 1 then return {0, dayUsed, monthUsed, 5, coverageHeld, ""} end',
+  'end',
+  'if deadlineMs > 0 then',
+  '  local serverTime = redis.call("time")',
+  '  local serverNowMs = (tonumber(serverTime[1]) * 1000) + math.floor(tonumber(serverTime[2]) / 1000)',
+  '  if serverNowMs >= deadlineMs then return {0, dayUsed, monthUsed, 7, coverageHeld, ""} end',
+  'end',
+  'if coverageRaw == false and coverageTotal > 0 then',
+  '  coverageHeld = coverageTotal',
+  '  redis.call("set", KEYS[5], coverageHeld, "EXAT", tonumber(ARGV[5]))',
+  '  redis.call("set", KEYS[9], coverageModel, "EXAT", tonumber(ARGV[5]))',
+  'end',
+  'if hasCoverageUnit and coverageModelRaw ~= false and coverageModelRaw ~= coverageModel then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  'if hasCoverageUnit and coverageRaw ~= false and coverageModelRaw == false then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  'local coverageAccounted = hasCoverageUnit and redis.call("exists", KEYS[6]) == 1',
+  'if coverageAccounted then return {0, dayUsed, monthUsed, 3, coverageHeld, ""} end',
+  'local coverageAfter = coverageHeld',
+  'if hasCoverageUnit then coverageAfter = math.max(0, coverageHeld - coverageUnit) end',
+  'local oncePerDay = ARGV[8] == "1"',
+  'if oncePerDay and redis.call("exists", KEYS[4]) == 1 then return {0, dayUsed, monthUsed, 3, coverageHeld} end',
+  'if dayUsed + requested + coverageAfter > dailyLimit then return {0, dayUsed, monthUsed, 1, coverageHeld} end',
+  'if monthUsed + requested + coverageAfter > monthlyLimit then return {0, dayUsed, monthUsed, 2, coverageHeld} end',
+  'dayUsed = redis.call("incrby", KEYS[1], requested)',
+  'monthUsed = redis.call("incrby", KEYS[2], requested)',
+  'redis.call("expireat", KEYS[1], tonumber(ARGV[5]))',
+  'redis.call("expireat", KEYS[2], tonumber(ARGV[6]))',
+  'if hasCoverageUnit then',
+  '  redis.call("set", KEYS[5], coverageAfter, "EXAT", tonumber(ARGV[5]))',
+  '  redis.call("set", KEYS[6], "1", "EXAT", tonumber(ARGV[5]))',
+  'end',
+  'redis.call("set", KEYS[3], requested, "EX", tonumber(ARGV[7]))',
+  'if hasReceipt then redis.call("set", KEYS[8], KEYS[3], "EX", tonumber(ARGV[7])) end',
+  'if oncePerDay then redis.call("set", KEYS[4], "done", "EXAT", tonumber(ARGV[5])) end',
+  'return {1, dayUsed, monthUsed, 0, coverageAfter, ""}',
+].join('\n');
+
+const LEGACY_X_POST_BUDGET_STATUS_SCRIPT = [
+  'local dayUsed = tonumber(redis.call("get", KEYS[1]) or "0")',
+  'local monthUsed = tonumber(redis.call("get", KEYS[2]) or "0")',
+  'local coverageRaw = redis.call("get", KEYS[3])',
   'local coverageHeld = tonumber(coverageRaw or "0") or 0',
   'local coverageModel = redis.call("get", KEYS[4])',
   'return {dayUsed, monthUsed, coverageHeld, coverageRaw == false and 0 or 1, coverageModel or ""}',
@@ -422,9 +524,15 @@ const ALLOWED_EVAL_SCRIPTS = new Set([
   X_POST_BUDGET_SETTLE_SCRIPT,
   X_POST_BUDGET_ACK_RECEIPTS_SCRIPT,
   X_POST_BUDGET_STATUS_SCRIPT,
+  LEGACY_X_POST_BUDGET_RESERVE_SCRIPT,
+  LEGACY_X_POST_BUDGET_STATUS_SCRIPT,
   PHYSICAL_PREMIUM_HISTORY_APPEND_SCRIPT,
   PHYSICAL_PREMIUM_PUBLISH_SCRIPT,
   PHYSICAL_DIVERGENCE_PUBLISH_SCRIPT,
+]);
+const LEGACY_EVAL_REPLACEMENTS = new Map([
+  [LEGACY_X_POST_BUDGET_RESERVE_SCRIPT, X_POST_BUDGET_RESERVE_SCRIPT],
+  [LEGACY_X_POST_BUDGET_STATUS_SCRIPT, X_POST_BUDGET_STATUS_SCRIPT],
 ]);
 
 // Exact-text pin, not a pattern: any change to the script — including
@@ -459,10 +567,17 @@ function assertCommandAllowed(args) {
   return cmd;
 }
 
-async function runCommand(args) {
+function commandForExecution(args) {
   const cmd = assertCommandAllowed(args);
-  const cmdArgs = args.slice(1);
-  return client.sendCommand([cmd, ...cmdArgs.map(String)]);
+  const command = [cmd, ...args.slice(1).map(String)];
+  if (cmd === 'EVAL') {
+    command[1] = LEGACY_EVAL_REPLACEMENTS.get(command[1]) || command[1];
+  }
+  return command;
+}
+
+async function runCommand(args) {
+  return client.sendCommand(commandForExecution(args));
 }
 
 // Every seeder that publishes through atomicPublish (scripts/_seed-utils.mjs) is
@@ -676,13 +791,12 @@ const server = http.createServer(async (req, res) => {
       const multi = client.multi();
       for (const cmd of commands) {
         try {
-          assertCommandAllowed(cmd);
+          multi.sendCommand(commandForExecution(cmd));
         } catch (err) {
           res.writeHead(403);
           res.end(JSON.stringify({ error: err.message }));
           return;
         }
-        multi.sendCommand(cmd.map(String));
       }
       const results = await multi.exec();
       res.writeHead(200);

--- a/scripts/lib/x-post-budget.cjs
+++ b/scripts/lib/x-post-budget.cjs
@@ -81,27 +81,52 @@ const RESERVE_LUA = [
   '  local serverNowMs = (tonumber(serverTime[1]) * 1000) + math.floor(tonumber(serverTime[2]) / 1000)',
   '  if serverNowMs >= deadlineMs then return {0, dayUsed, monthUsed, 7, coverageHeld, ""} end',
   'end',
-  'if coverageRaw == false and coverageTotal > 0 then',
-  '  coverageHeld = coverageTotal',
-  '  redis.call("set", KEYS[5], coverageHeld, "EXAT", tonumber(ARGV[5]))',
-  '  redis.call("set", KEYS[9], coverageModel, "EXAT", tonumber(ARGV[5]))',
+  'local coverageEffectiveHeld = coverageHeld',
+  'local coverageShouldWrite = false',
+  'local hasCoverageState = coverageRaw ~= false or coverageModelRaw ~= false',
+  'if hasCoverageState then',
+  '  if (coverageRaw == false) ~= (coverageModelRaw == false) then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '  local canonicalHeld = coverageRaw == "0" or string.match(coverageRaw, "^[1-9]%d*$") ~= nil',
+  '  local storedTotalRaw = string.match(coverageModelRaw, "^fixed%-slots%-v1:([1-9]%d*)$")',
+  '  local storedTotal = tonumber(storedTotalRaw)',
+  '  if not canonicalHeld or storedTotal == nil or storedTotal > dailyLimit then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '  if coverageHeld > storedTotal then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '  if coverageTotal > 0 then',
+  '    local requestedTotalRaw = string.match(coverageModel, "^fixed%-slots%-v1:([1-9]%d*)$")',
+  '    local requestedTotal = tonumber(requestedTotalRaw)',
+  '    if requestedTotal == nil or requestedTotal ~= coverageTotal or requestedTotal > dailyLimit or storedTotal < coverageTotal then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '    local spent = storedTotal - coverageHeld',
+  '    if spent > coverageTotal then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '    coverageEffectiveHeld = coverageTotal - spent',
+  '    coverageShouldWrite = storedTotal > coverageTotal',
+  '  end',
+  'elseif coverageTotal > 0 then',
+  '  local requestedTotalRaw = string.match(coverageModel, "^fixed%-slots%-v1:([1-9]%d*)$")',
+  '  local requestedTotal = tonumber(requestedTotalRaw)',
+  '  if requestedTotal == nil or requestedTotal ~= coverageTotal or requestedTotal > dailyLimit then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  '  coverageEffectiveHeld = coverageTotal',
+  '  coverageShouldWrite = true',
   'end',
-  'if hasCoverageUnit and coverageModelRaw ~= false and coverageModelRaw ~= coverageModel then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
-  'if hasCoverageUnit and coverageRaw ~= false and coverageModelRaw == false then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
   'local coverageAccounted = hasCoverageUnit and redis.call("exists", KEYS[6]) == 1',
   'if coverageAccounted then return {0, dayUsed, monthUsed, 3, coverageHeld, ""} end',
-  'local coverageAfter = coverageHeld',
-  'if hasCoverageUnit then coverageAfter = math.max(0, coverageHeld - coverageUnit) end',
+  'if hasCoverageUnit and coverageEffectiveHeld < coverageUnit then return {0, dayUsed, monthUsed, 6, coverageHeld, ""} end',
+  'local coverageAfter = coverageEffectiveHeld',
+  'if hasCoverageUnit then coverageAfter = coverageEffectiveHeld - coverageUnit end',
   'local oncePerDay = ARGV[8] == "1"',
   'if oncePerDay and redis.call("exists", KEYS[4]) == 1 then return {0, dayUsed, monthUsed, 3, coverageHeld} end',
-  'if dayUsed + requested + coverageAfter > dailyLimit then return {0, dayUsed, monthUsed, 1, coverageHeld} end',
-  'if monthUsed + requested + coverageAfter > monthlyLimit then return {0, dayUsed, monthUsed, 2, coverageHeld} end',
+  'if dayUsed + requested + coverageAfter > dailyLimit then return {0, dayUsed, monthUsed, 1, coverageEffectiveHeld} end',
+  'if monthUsed + requested + coverageAfter > monthlyLimit then return {0, dayUsed, monthUsed, 2, coverageEffectiveHeld} end',
   'dayUsed = redis.call("incrby", KEYS[1], requested)',
   'monthUsed = redis.call("incrby", KEYS[2], requested)',
   'redis.call("expireat", KEYS[1], tonumber(ARGV[5]))',
   'redis.call("expireat", KEYS[2], tonumber(ARGV[6]))',
-  'if hasCoverageUnit then',
+  'if coverageShouldWrite or hasCoverageUnit then',
   '  redis.call("set", KEYS[5], coverageAfter, "EXAT", tonumber(ARGV[5]))',
+  'end',
+  'if coverageShouldWrite then',
+  '  redis.call("set", KEYS[9], coverageModel, "EXAT", tonumber(ARGV[5]))',
+  'end',
+  'if hasCoverageUnit then',
   '  redis.call("set", KEYS[6], "1", "EXAT", tonumber(ARGV[5]))',
   'end',
   'redis.call("set", KEYS[3], requested, "EX", tonumber(ARGV[7]))',
@@ -166,9 +191,21 @@ const STATUS_LUA = [
   'local dayUsed = tonumber(redis.call("get", KEYS[1]) or "0")',
   'local monthUsed = tonumber(redis.call("get", KEYS[2]) or "0")',
   'local coverageRaw = redis.call("get", KEYS[3])',
-  'local coverageHeld = tonumber(coverageRaw or "0") or 0',
+  'local coverageHeld = 0',
+  'local coverageState = 0',
+  'if coverageRaw ~= false then',
+  '  local canonicalHeld = coverageRaw == "0" or string.match(coverageRaw, "^[1-9]%d*$") ~= nil',
+  '  local parsedHeld = tonumber(coverageRaw)',
+  '  if canonicalHeld and parsedHeld ~= nil and parsedHeld <= 9007199254740991 then',
+  '    coverageHeld = parsedHeld',
+  '    coverageState = 1',
+  '  else',
+  '    coverageState = -1',
+  '  end',
+  'end',
   'local coverageModel = redis.call("get", KEYS[4])',
-  'return {dayUsed, monthUsed, coverageHeld, coverageRaw == false and 0 or 1, coverageModel or ""}',
+  'if (coverageRaw == false) ~= (coverageModel == false) then coverageState = -1 end',
+  'return {dayUsed, monthUsed, coverageHeld, coverageState, coverageModel or ""}',
 ].join('\n');
 
 function positiveInteger(value, fallback, name) {
@@ -269,6 +306,34 @@ function budgetStatus({
       ...(nextRequestBlockedReason ? { nextRequestBlockedReason } : {}),
     } : {}),
   };
+}
+
+function projectCoverageHold({
+  coverageHeld,
+  coverageState,
+  coverageModel,
+  expectedTotal,
+  coverageUnitPosts,
+  dailyLimit,
+}) {
+  const blocked = () => ({ coverageHeld, blockedReason: 'coverage_model_mismatch' });
+  if (coverageState === 0 && coverageModel === '') {
+    if (expectedTotal === 0) return { coverageHeld: 0, blockedReason: null };
+    return expectedTotal <= dailyLimit
+      ? { coverageHeld: expectedTotal, blockedReason: null }
+      : blocked();
+  }
+  if (coverageState !== 1 || coverageModel === '') return blocked();
+  const modelMatch = /^fixed-slots-v1:([1-9]\d*)$/.exec(coverageModel);
+  const storedTotal = Number(modelMatch?.[1]);
+  if (!Number.isSafeInteger(storedTotal) || storedTotal > dailyLimit
+    || coverageHeld > storedTotal || storedTotal < expectedTotal) return blocked();
+  const spent = storedTotal - coverageHeld;
+  if (spent > expectedTotal) return blocked();
+  const effectiveHeld = expectedTotal - spent;
+  return effectiveHeld >= coverageUnitPosts
+    ? { coverageHeld: effectiveHeld, blockedReason: null }
+    : blocked();
 }
 
 function xPostBudgetServiceStatus(value) {
@@ -404,7 +469,15 @@ function createXPostBudget(options = {}) {
     const admitted = nonNegativeAt(result, 0);
     const dailyUsed = nonNegativeAt(result, 1);
     const monthlyUsed = nonNegativeAt(result, 2);
+    const reasonCode = nonNegativeAt(result, 3);
     const dailyCoverageHeld = nonNegativeAt(result, 4);
+    if (admitted === 0 && reasonCode === 6 && dailyUsed !== null && monthlyUsed !== null) {
+      return {
+        allowed: false,
+        reason: 'coverage_model_mismatch',
+        status: unavailableStatus(period, { dailyLimit, monthlyLimit, costUsdMicrosPerPost }),
+      };
+    }
     if (admitted === null || dailyUsed === null || monthlyUsed === null || dailyCoverageHeld === null) {
       return {
         allowed: false,
@@ -414,7 +487,6 @@ function createXPostBudget(options = {}) {
     }
     const status = toStatus(period, dailyUsed, monthlyUsed, dailyCoverageHeld);
     if (admitted !== 1) {
-      const reasonCode = nonNegativeAt(result, 3);
       if (reasonCode === 4) {
         const receiptRaw = Array.isArray(result) ? result[5] : null;
         if (typeof receiptRaw !== 'string' || !receiptRaw) {
@@ -691,29 +763,31 @@ function createXPostBudget(options = {}) {
     const dailyUsed = nonNegativeAt(result, 0);
     const monthlyUsed = nonNegativeAt(result, 1);
     const dailyCoverageHeld = nonNegativeAt(result, 2);
-    const hasCoverageHold = nonNegativeAt(result, 3);
+    const coverageState = integerAt(result, 3);
     const coverageModel = stringAt(result, 4);
     if (
       dailyUsed === null
       || monthlyUsed === null
       || dailyCoverageHeld === null
-      || (hasCoverageHold !== 0 && hasCoverageHold !== 1)
+      || ![-1, 0, 1].includes(coverageState)
       || coverageModel === null
     ) {
       return unavailableStatus(period, { dailyLimit, monthlyLimit, costUsdMicrosPerPost });
     }
-    const expectedCoverageModel = `fixed-slots-v1:${dailyCoveragePosts}`;
-    const coverageModelMismatch = coverageUnitPosts > 0 && (
-      (hasCoverageHold === 1 && coverageModel === '')
-      || (coverageModel !== '' && coverageModel !== expectedCoverageModel)
-    );
-    const projectedCoverageHeld = coverageUnitPosts > 0 && hasCoverageHold === 0
-      ? dailyCoveragePosts
-      : dailyCoverageHeld;
-    return toStatus(period, dailyUsed, monthlyUsed, projectedCoverageHeld, true, {
+    const projection = requestedPosts > 0
+      ? projectCoverageHold({
+        coverageHeld: dailyCoverageHeld,
+        coverageState,
+        coverageModel,
+        expectedTotal: dailyCoveragePosts,
+        coverageUnitPosts,
+        dailyLimit,
+      })
+      : { coverageHeld: dailyCoverageHeld, blockedReason: null };
+    return toStatus(period, dailyUsed, monthlyUsed, projection.coverageHeld, true, {
       requestedPosts,
       coverageUnitPosts,
-      blockedReason: coverageModelMismatch ? 'coverage_model_mismatch' : null,
+      blockedReason: projection.blockedReason,
     });
   }
 

--- a/tests/redis-rest-proxy-command-parity.test.mjs
+++ b/tests/redis-rest-proxy-command-parity.test.mjs
@@ -18,6 +18,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -51,8 +52,10 @@ function extract(pattern, label) {
 const allowedCommandsSrc = extract(/const ALLOWED_COMMANDS = new Set\(\[[\s\S]*?\]\);/, 'ALLOWED_COMMANDS');
 const scriptConstsSrc = [...proxySrc.matchAll(/const [A-Z_]+_SCRIPT = \[[\s\S]*?\]\.join\('\\n'\);/g)].map((m) => m[0]);
 const allowedEvalSrc = extract(/const ALLOWED_EVAL_SCRIPTS = new Set\(\[[\s\S]*?\]\);/, 'ALLOWED_EVAL_SCRIPTS');
+const legacyReplacementsSrc = extract(/const LEGACY_EVAL_REPLACEMENTS = new Map\(\[[\s\S]*?\]\);/, 'LEGACY_EVAL_REPLACEMENTS');
 const isAllowedEvalSrc = extract(/function isAllowedEval\([\s\S]*?\n\}/, 'isAllowedEval');
 const assertAllowedSrc = extract(/function assertCommandAllowed\([\s\S]*?\n\}/, 'assertCommandAllowed');
+const commandForExecutionSrc = extract(/function commandForExecution\([\s\S]*?\n\}/, 'commandForExecution');
 
 function buildGate() {
   // eslint-disable-next-line no-new-func
@@ -61,9 +64,20 @@ function buildGate() {
     ${allowedCommandsSrc}
     ${scriptConstsSrc.join('\n')}
     ${allowedEvalSrc}
+    ${legacyReplacementsSrc}
     ${isAllowedEvalSrc}
     ${assertAllowedSrc}
-    return { assertCommandAllowed, ALLOWED_COMMANDS, ALLOWED_EVAL_SCRIPTS };
+    ${commandForExecutionSrc}
+    return {
+      assertCommandAllowed,
+      commandForExecution,
+      ALLOWED_COMMANDS,
+      ALLOWED_EVAL_SCRIPTS,
+      X_POST_BUDGET_RESERVE_SCRIPT,
+      X_POST_BUDGET_STATUS_SCRIPT,
+      LEGACY_X_POST_BUDGET_RESERVE_SCRIPT,
+      LEGACY_X_POST_BUDGET_STATUS_SCRIPT,
+    };
   `)();
 }
 
@@ -126,10 +140,10 @@ describe('redis-rest-proxy command gate', () => {
     // The divergence this replaced: /multi-exec had its own bare
     // ALLOWED_COMMANDS.has() check, so a command added to the Set ran there
     // without the pinned-script branch runCommand enforces.
-    assert.match(proxySrc, /const cmd = assertCommandAllowed\(args\);/,
-      'runCommand must delegate to assertCommandAllowed');
-    assert.match(proxySrc, /assertCommandAllowed\(cmd\);/,
-      'the /multi-exec handler must delegate to assertCommandAllowed');
+    assert.match(proxySrc, /client\.sendCommand\(commandForExecution\(args\)\)/,
+      'runCommand must delegate to the shared command gate');
+    assert.match(proxySrc, /multi\.sendCommand\(commandForExecution\(cmd\)\)/,
+      'the /multi-exec handler must delegate to the shared command gate');
     assert.doesNotMatch(proxySrc, /if \(!ALLOWED_COMMANDS\.has\(cmdName\)\)/,
       '/multi-exec must not re-implement the allowlist check');
   });
@@ -233,5 +247,30 @@ describe('redis-rest-proxy command gate', () => {
         'a one-character script variant must stay blocked',
       );
     }
+  });
+
+  it('accepts current and immediately prior X budget callers during rollout', () => {
+    const gate = buildGate();
+    const legacyScripts = [
+      [
+        gate.LEGACY_X_POST_BUDGET_RESERVE_SCRIPT,
+        gate.X_POST_BUDGET_RESERVE_SCRIPT,
+        '16673cafd28e2c29b645f1fd6c5a98465f9d4d6e4aa2af4b8e1d9ffb67de03ce',
+      ],
+      [
+        gate.LEGACY_X_POST_BUDGET_STATUS_SCRIPT,
+        gate.X_POST_BUDGET_STATUS_SCRIPT,
+        'dd44c93034f8fdfb89b1460e651e158e213c92a37f532d58954e537367fcd99e',
+      ],
+    ];
+    for (const [script, currentScript, expectedHash] of legacyScripts) {
+      assert.equal(createHash('sha256').update(script).digest('hex'), expectedHash);
+      assert.equal(gate.ALLOWED_EVAL_SCRIPTS.has(script), true);
+      assert.equal(accepts(gate, ['EVAL', script, '1', 'budget-key']), true);
+      assert.equal(gate.commandForExecution(['EVAL', script, '1', 'budget-key'])[1], currentScript);
+      assert.equal(accepts(gate, ['EVAL', `${script} `, '1', 'budget-key']), false);
+    }
+    assert.notEqual(gate.LEGACY_X_POST_BUDGET_RESERVE_SCRIPT, RESERVE_LUA);
+    assert.notEqual(gate.LEGACY_X_POST_BUDGET_STATUS_SCRIPT, STATUS_LUA);
   });
 });

--- a/tests/x-post-budget-lua.test.mjs
+++ b/tests/x-post-budget-lua.test.mjs
@@ -358,6 +358,42 @@ describe('X Post budget Lua, executed', () => {
     assert.equal(redis.store.get(COVERAGE_HOLD_KEY), '500');
   });
 
+  it('migrates a lower same-day fixed-slots model without reclaiming spent Posts', () => {
+    const redis = makeRedis({
+      [DAY_KEY]: 5,
+      [MONTH_KEY]: 105,
+      [COVERAGE_HOLD_KEY]: 592,
+      [COVERAGE_MODEL_KEY]: 'fixed-slots-v1:597',
+    });
+    const returned = runScript(
+      RESERVE_LUA,
+      budgetKeys('reservation:new-model', 'coverage:new-model'),
+      reserveArgs(5, 505, 5, false, true),
+      redis,
+      6,
+    );
+    assert.deepEqual(returned, [1, 10, 110, 0, 495, '']);
+    assert.equal(redis.store.get(DAY_KEY), '10');
+    assert.equal(redis.store.get(MONTH_KEY), '110');
+    assert.equal(redis.store.get(COVERAGE_HOLD_KEY), '495');
+    assert.equal(redis.store.get(COVERAGE_MODEL_KEY), 'fixed-slots-v1:505');
+
+    const second = runScript(
+      RESERVE_LUA,
+      budgetKeys(
+        'reservation:second-poller',
+        'coverage:second-poller',
+        'receipt:second-poller',
+        'inflight:second-poller',
+      ),
+      reserveArgs(5, 505, 5, false, true),
+      redis,
+      6,
+    );
+    assert.deepEqual(second, [1, 15, 115, 0, 490, '']);
+    assert.equal(redis.store.get(COVERAGE_HOLD_KEY), '490');
+  });
+
   it('reads day and month counters without changing them', () => {
     const redis = makeRedis({ [DAY_KEY]: 25, [MONTH_KEY]: 425 });
     assert.deepEqual(

--- a/tests/x-post-budget-lua.test.mjs
+++ b/tests/x-post-budget-lua.test.mjs
@@ -392,6 +392,43 @@ describe('X Post budget Lua, executed', () => {
     );
     assert.deepEqual(second, [1, 15, 115, 0, 490, '']);
     assert.equal(redis.store.get(COVERAGE_HOLD_KEY), '490');
+    assert.equal(redis.store.get(COVERAGE_MODEL_KEY), 'fixed-slots-v1:505');
+  });
+
+  it('rejects unsafe coverage states without changing Redis', () => {
+    const cases = [
+      ['upward model', 495, 'fixed-slots-v1:500'],
+      ['cross-version model', 592, 'fixed-slots-v2:597'],
+      ['malformed model', 592, 'not-a-model'],
+      ['hold without model', 592, undefined],
+      ['model without hold', undefined, 'fixed-slots-v1:597'],
+      ['noncanonical model', 592, 'fixed-slots-v1:0597'],
+      ['noncanonical hold', '0592', 'fixed-slots-v1:597'],
+      ['negative hold', -1, 'fixed-slots-v1:597'],
+      ['fractional hold', 592.5, 'fixed-slots-v1:597'],
+      ['hold over stored total', 598, 'fixed-slots-v1:597'],
+      ['spent Posts over new total', 91, 'fixed-slots-v1:597'],
+      ['effective hold below the unit', 96, 'fixed-slots-v1:597'],
+    ];
+
+    for (const [label, hold, model] of cases) {
+      const initial = { [DAY_KEY]: 5, [MONTH_KEY]: 105 };
+      if (hold !== undefined) initial[COVERAGE_HOLD_KEY] = hold;
+      if (model !== undefined) initial[COVERAGE_MODEL_KEY] = model;
+      const redis = makeRedis(initial);
+      const before = [...redis.store];
+      const returned = runScript(
+        RESERVE_LUA,
+        budgetKeys(`reservation:unsafe:${label}`, `coverage:unsafe:${label}`),
+        reserveArgs(5, 505, 5),
+        redis,
+        6,
+      );
+      assert.equal(returned[0], 0, label);
+      assert.equal(returned[3], 6, label);
+      assert.deepEqual([...redis.store], before, label);
+      assert.equal(redis.expirations.size, 0, label);
+    }
   });
 
   it('reads day and month counters without changing them', () => {
@@ -408,7 +445,7 @@ describe('X Post budget Lua, executed', () => {
     ]);
   });
 
-  it('reports an unversioned legacy coverage hold to the status caller', () => {
+  it('reports partial coverage state as invalid to current and prior callers', () => {
     const redis = makeRedis({
       [DAY_KEY]: 3,
       [MONTH_KEY]: 103,
@@ -416,7 +453,30 @@ describe('X Post budget Lua, executed', () => {
     });
     assert.deepEqual(
       runScript(STATUS_LUA, [DAY_KEY, MONTH_KEY, COVERAGE_HOLD_KEY, COVERAGE_MODEL_KEY], [], redis, 5),
-      [3, 103, 500, 1, ''],
+      [3, 103, 500, -1, ''],
+    );
+
+    const modelOnlyRedis = makeRedis({
+      [DAY_KEY]: 3,
+      [MONTH_KEY]: 103,
+      [COVERAGE_MODEL_KEY]: 'fixed-slots-v1:505',
+    });
+    assert.deepEqual(
+      runScript(STATUS_LUA, [DAY_KEY, MONTH_KEY, COVERAGE_HOLD_KEY, COVERAGE_MODEL_KEY], [], modelOnlyRedis, 5),
+      [3, 103, 0, -1, 'fixed-slots-v1:505'],
+    );
+  });
+
+  it('reports a malformed coverage hold through the existing status state field', () => {
+    const redis = makeRedis({
+      [DAY_KEY]: 5,
+      [MONTH_KEY]: 105,
+      [COVERAGE_HOLD_KEY]: '592.5',
+      [COVERAGE_MODEL_KEY]: 'fixed-slots-v1:597',
+    });
+    assert.deepEqual(
+      runScript(STATUS_LUA, [DAY_KEY, MONTH_KEY, COVERAGE_HOLD_KEY, COVERAGE_MODEL_KEY], [], redis, 5),
+      [5, 105, 0, -1, 'fixed-slots-v1:597'],
     );
   });
 
@@ -482,6 +542,8 @@ describe('X Post budget Lua, executed', () => {
       [0, 0, 0, 1, 505, ''],
     );
     assert.equal(deniedRedis.store.has('reservation:denied'), false);
+    assert.equal(deniedRedis.store.has(COVERAGE_HOLD_KEY), false);
+    assert.equal(deniedRedis.store.has(COVERAGE_MODEL_KEY), false);
 
     const curated = runScript(
       RESERVE_LUA,

--- a/tests/x-post-budget.test.mjs
+++ b/tests/x-post-budget.test.mjs
@@ -469,6 +469,54 @@ describe('shared X returned-Post budget', () => {
     assert.equal(xPostBudgetServiceStatus(status), 'degraded');
   });
 
+  it('blocks the same unsafe coverage states as reserve', async () => {
+    const cases = [
+      ['upward model', [5, 105, 495, 1, 'fixed-slots-v1:500']],
+      ['cross-version model', [5, 105, 592, 1, 'fixed-slots-v2:597']],
+      ['malformed model', [5, 105, 592, 1, 'not-a-model']],
+      ['hold without model', [5, 105, 592, -1, '']],
+      ['model without hold', [5, 105, 0, -1, 'fixed-slots-v1:597']],
+      ['noncanonical model', [5, 105, 592, 1, 'fixed-slots-v1:0597']],
+      ['noncanonical hold', [5, 105, 0, -1, 'fixed-slots-v1:597']],
+      ['negative hold', [5, 105, 0, -1, 'fixed-slots-v1:597']],
+      ['fractional hold', [5, 105, 0, -1, 'fixed-slots-v1:597']],
+      ['hold over stored total', [5, 105, 598, 1, 'fixed-slots-v1:597']],
+      ['spent Posts over new total', [5, 105, 91, 1, 'fixed-slots-v1:597']],
+      ['effective hold below the unit', [5, 105, 96, 1, 'fixed-slots-v1:597']],
+    ];
+
+    for (const [label, redisStatus] of cases) {
+      const budget = createXPostBudget({
+        evalCommand: async () => redisStatus,
+        dailyCoveragePosts: DEFAULT_X_CURATED_DAILY_COVERAGE_POSTS,
+        now: () => NOW,
+      });
+      const status = await budget.status({ requestedPosts: 5, coverageUnitPosts: 5 });
+      assert.equal(status.nextRequestAdmissible, false, label);
+      assert.equal(status.nextRequestBlockedReason, 'coverage_model_mismatch', label);
+      assert.equal(xPostBudgetServiceStatus(status), 'degraded', label);
+    }
+  });
+
+  it('keeps malformed reserve states classified as coverage model mismatches', async () => {
+    for (const invalidHold of [-1, 592.5]) {
+      const budget = createXPostBudget({
+        evalCommand: async () => [0, 5, 105, 6, invalidHold, ''],
+        dailyCoveragePosts: DEFAULT_X_CURATED_DAILY_COVERAGE_POSTS,
+        now: () => NOW,
+      });
+      const outcome = await budget.reserve({
+        requestedPosts: 5,
+        coverageTotal: DEFAULT_X_CURATED_DAILY_COVERAGE_POSTS,
+        coverageUnitPosts: 5,
+        coverageId: `malformed-${invalidHold}`,
+      });
+      assert.equal(outcome.allowed, false);
+      assert.equal(outcome.reason, 'coverage_model_mismatch');
+      assert.equal(xPostBudgetServiceStatus(outcome.status), 'degraded');
+    }
+  });
+
   it('reports the binding limit without creating a reservation', async () => {
     const calls = [];
     const budget = createXPostBudget({

--- a/tests/x-post-budget.test.mjs
+++ b/tests/x-post-budget.test.mjs
@@ -440,6 +440,35 @@ describe('shared X returned-Post budget', () => {
     assert.equal(xPostBudgetServiceStatus(status), 'degraded');
   });
 
+  it('reports a lower same-day fixed-slots model as admissible', async () => {
+    const budget = createXPostBudget({
+      evalCommand: async () => [5, 105, 592, 1, 'fixed-slots-v1:597'],
+      dailyCoveragePosts: DEFAULT_X_CURATED_DAILY_COVERAGE_POSTS,
+      now: () => NOW,
+    });
+
+    const status = await budget.status({ requestedPosts: 5, coverageUnitPosts: 5 });
+    assert.equal(status.dailyCoverageHeld, 500);
+    assert.equal(status.nextRequestAdmissible, true);
+    assert.equal(status.nextRequestDailyProjected, 505);
+    assert.equal(status.nextRequestMonthlyProjected, 605);
+    assert.equal(status.nextRequestBlockedReason, undefined);
+    assert.equal(xPostBudgetServiceStatus(status), 'ok');
+  });
+
+  it('keeps an upward same-day fixed-slots change blocked', async () => {
+    const budget = createXPostBudget({
+      evalCommand: async () => [5, 105, 495, 1, 'fixed-slots-v1:500'],
+      dailyCoveragePosts: DEFAULT_X_CURATED_DAILY_COVERAGE_POSTS,
+      now: () => NOW,
+    });
+
+    const status = await budget.status({ requestedPosts: 5, coverageUnitPosts: 5 });
+    assert.equal(status.nextRequestAdmissible, false);
+    assert.equal(status.nextRequestBlockedReason, 'coverage_model_mismatch');
+    assert.equal(xPostBudgetServiceStatus(status), 'degraded');
+  });
+
   it('reports the binding limit without creating a reservation', async () => {
     const calls = [];
     const budget = createXPostBudget({


### PR DESCRIPTION
## Summary

The X feed no longer waits for the next UTC day when its fixed-slot coverage target decreases during the day. The shared Redis reservation now transfers only the unspent hold to the lower model in the same atomic operation as the next paid request; it never reclaims Posts that were already spent.

Unsafe changes still fail closed. Upward, cross-version, partial, malformed, and over-spent states cannot reserve Posts. The existing 600-Post daily limit, 20,000-Post monthly limit, and cost projection stay unchanged.

## Rollout

Deploy and verify the Redis REST proxy before the relay. During the rolling update, the proxy accepts the exact prior caller scripts but executes their hardened current equivalents. After the relay deploys, its next natural 15-minute slot can migrate the hold and poll X without a key deletion or a manual seed run.

Remove the two prior-script pins in a later change only after all prior caller instances have exited.

## Verification

- 305 focused X budget, relay, Company Monitoring, proxy, and health tests pass.
- Browser and API TypeScript checks pass.
- Import-boundary, changed-file Biome, full lint, Unicode, generated-code, and pre-push gates pass.
- Full multi-review found three P2 rollout and malformed-state issues; all three were fixed, and the final review has no open P0, P1, or P2 findings.

## Post-Deploy Monitoring & Validation

Confirm that `coverage_model_mismatch` stops after the proxy-first rollout, the next natural relay slot records an X attempt, and xFeed freshness recovers within its 45-minute budget. Treat a rejected EVAL or a continuing model mismatch as a failed rollout. Do not delete budget keys, run a manual seeder, or change the hard limits.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-Codex-000000)
