### PR TITLE
fix(cross-strait): accept nested MND publication dates

### DIFF
--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -1446,7 +1446,7 @@ function extractMndPublicationDay(html) {
     ?? extractHtmlElementBodies(html, ['div', 'section'], 'newsinfo')[0];
   if (container == null) throw new Error('MND_PUBLICATION_METADATA_MISSING');
   const dateBodies = extractHtmlElementBodies(container, ['span'], 'body-2', 2);
-  const publicationDay = dateBodies[0]?.includes('<') ? null : dottedDate(dateBodies[0]);
+  const publicationDay = dottedDate(decodeHtml(dateBodies[0]));
   if (!publicationDay || dateBodies.length !== 1) throw new Error('MND_PUBLICATION_DATE_MISSING');
   return publicationDay;
 }

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -38,6 +38,7 @@ import {
   CROSS_STRAIT_ACTIVITY_TTL_SECONDS,
   crossStraitActivityContentMeta,
   fetchCrossStraitActivitySeedSnapshot,
+  writeSourceHealth,
 } from '../scripts/seed-cross-strait-activity.mjs';
 import { isCrossStraitActivitySnapshot } from '../src/components/cross-strait-activity-summary';
 
@@ -1417,7 +1418,9 @@ describe('quantified cross-Strait activity (#5575)', () => {
       const url = String(input);
       calls.push({ url, init });
       if (url.includes('mnd.gov.tw') && /plaactlist/i.test(url)) {
-        return new Response(fixture('mnd-list.html'), { headers: { 'Content-Type': 'text/html' } });
+        return new Response(mndListWithCount(1, 87_151), {
+          headers: { 'Content-Type': 'text/html' },
+        });
       }
       if (url.includes('mnd.gov.tw')) {
         return new Response(fixture('mnd-detail.html'), { headers: { 'Content-Type': 'text/html' } });
@@ -1435,7 +1438,27 @@ describe('quantified cross-Strait activity (#5575)', () => {
       previousSnapshot: null,
       sleepFn: async (ms) => { delays.push(ms); },
     });
+    const mnd = snapshot.sources.find((source: { id: string }) => source.id === 'taiwan-mnd');
+    const healthWrites = new Map<string, unknown>();
+    await writeSourceHealth(snapshot, async (key: string, value: unknown) => {
+      healthWrites.set(key, value);
+    });
+
     assert.ok(snapshot.observations.length >= 3);
+    assert.equal(validateCrossStraitActivitySnapshot(snapshot), true);
+    assert.equal(mnd?.transportStatus, 'fresh');
+    assert.deepEqual(mnd?.errorCodes, []);
+    assert.deepEqual(
+      healthWrites.get('seed-meta:military:cross-strait-activity:taiwan-mnd'),
+      {
+        fetchedAt: Date.parse(retrievedAt),
+        recordCount: snapshot.observations.filter(
+          (row: { sourceId: string }) => row.sourceId === 'taiwan-mnd',
+        ).length,
+        sourceState: 'ok',
+        stale: false,
+      },
+    );
     assert.ok(
       calls.length
         <= MND_MAX_LIST_PAGES_PER_BACKFILL_RUN + MND_MAX_DETAIL_REQUESTS_PER_RUN + 1,

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -238,6 +238,24 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(validateDecisionSignalProvenance(observation.provenance).ok, true);
   });
 
+  it('accepts the official nested MND publication date inside scoped metadata', () => {
+    const html = fixture('mnd-detail.html');
+    assert.match(
+      html,
+      /<span class="body-2"><span class="en">2026\.07\.25<\/span><\/span>/,
+    );
+
+    const observation = parseTaiwanMndDetail(html, {
+      sourceUrl: 'https://www.mnd.gov.tw/en/News/PLAAct/87151',
+      retrievedAt,
+      expectedPublicationDay: '2026-07-25',
+    });
+
+    assert.equal(observation.publicationTime, '2026-07-25');
+    assert.equal(observation.reportingDay, '2026-07-25');
+    assert.equal(validateDecisionSignalProvenance(observation.provenance).ok, true);
+  });
+
   it('decodes malformed numeric HTML entities without crashing the source parser', () => {
     const rows = parseJapanModIndex(`
       <a href="/js/pdf/2026/p20260730_01.pdf">

--- a/tests/fixtures/cross-strait-activity/mnd-detail.html
+++ b/tests/fixtures/cross-strait-activity/mnd-detail.html
@@ -1,6 +1,6 @@
 <meta property="og:url" content="https://www.mnd.gov.tw/en/News/PLAAct/87151" />
 <div class="newsInfo">
-  <span class="body-2">2026.07.25</span>
+  <span class="body-2"><span class="en">2026.07.25</span></span>
 </div>
 <div class="maincontent">
   <p>1.Date:<br />


### PR DESCRIPTION
## Why

Taiwan MND detail pages can wrap the publication date in a nested `span.en` element. The parser rejected any markup in the scoped `span.body-2` field. A valid official report then produced `MND_PUBLICATION_DATE_MISSING` and marked the Taiwan MND source as errored.

## Scope

- Decode the content of the already-scoped `span.body-2` field before `dottedDate()` validates it.
- Update the MND detail fixture with the official nested date shape.
- Prove the parser result, provenance, full snapshot validation, fresh source state, and written source-health metadata.
- Keep the MND list parser, request limits, retention, and health classification unchanged.

## Tradeoffs

The parser still fails closed if the selected metadata has more than one `span.body-2` field or if its visible text is not one valid dotted date. The shared MND health contract has no identical-failure signature state, so this change does not add a first-failure pending period. Missing or unusable source data still reports an immediate error.

## Blast Radius

The runtime change affects only Taiwan MND detail-page publication dates. It reuses the existing bounded HTML decoder after the existing metadata scope. The URL allowlist, response-size limit, calendar check, future-date check, reporting-window check, provenance, and last-good retention remain in place.

## Verification

- The regression test failed before the fix with `MND_PUBLICATION_DATE_MISSING`.
- `./node_modules/.bin/tsx --test --test-timeout=120000 tests/cross-strait-activity.test.mts` passed 95 tests.
- `npm run typecheck` passed.
- `node --check scripts/cross-strait-activity/adapters.mjs` passed.
- `npm run test:data` passed.
- A live request to the current official MND detail page returned HTTP 200 and parsed publication day `2026-09-04` with the production request and response bounds. The current live response used the flat date shape. The committed fixture gives deterministic coverage for the observed nested variant.
