### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Last commit](https://img.shields.io/github/last-commit/koala73/worldmonitor)](https://github.com/koala73/worldmonitor/commits/main)
 [![Latest release](https://img.shields.io/github/v/release/koala73/worldmonitor?style=flat)](https://github.com/koala73/worldmonitor/releases/latest)
 [![npm: worldmonitor](https://img.shields.io/npm/v/worldmonitor?logo=npm&label=npm)](https://www.npmjs.com/package/worldmonitor)
-[![smithery badge](https://smithery.ai/badge/worldmonitor/wm-mcp)](https://smithery.ai/servers/worldmonitor/wm-mcp)
+[![LightNow capabilities](https://lightnow.ai/badge/app.worldmonitor/mcp)](https://lightnow.ai/servers/app.worldmonitor/mcp)
 [![skills.sh](https://skills.sh/b/koala73/worldmonitor)](https://skills.sh/koala73/worldmonitor)
 
 <p align="center">


### PR DESCRIPTION
## Summary

Replaces the broken Smithery badge with the verified LightNow capability badge (74 T · 14 R · 6 P).

Closes #7683

- [Server listing](https://lightnow.ai/servers/app.worldmonitor/mcp)
- [Badge variants](https://docs.lightnow.ai/how-to/add-capability-badge/)

## Type of change

- [x] Documentation

## Affected areas

- [x] Other: README badge

## Checklist

- [x] No API keys or secrets committed
- [x] Required preflight completed: `status: ready`
- [x] README markdownlint and `docs:check` pass in a network-isolated container
- [ ] TypeScript compiles without errors (N/A — README-only)

## Documentation Alignment Checklist

N/A — this changes only a badge and does not publish or change documentation claims.

## Screenshots

N/A