### PR TITLE
Recover wildfire coverage from intermittent NASA FIRMS failures

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -606,7 +606,14 @@ const SEED_META = {
   // churn while still detecting a stopped worker well before leases age out.
   companyMonitoringWorker: { key: 'seed-meta:company-monitoring:worker', maxStaleMin: 5, workerControl: true },
   earthquakes:      { key: 'seed-meta:seismology:earthquakes',  maxStaleMin: 30 },
-  wildfires:        { key: 'seed-meta:wildfire:fires',          maxStaleMin: 360 }, // FIRMS NRT resets at midnight UTC; new-day data takes 3-6h to accumulate
+  wildfires:        {
+    key: 'seed-meta:wildfire:fires',
+    maxStaleMin: 360,
+    sourceFailure: {
+      warnAfterConsecutive: 2,
+      failureCodePattern: /^FIRMS_PARTIAL_COVERAGE$/,
+    },
+  }, // FIRMS NRT resets at midnight UTC; new-day data takes 3-6h to accumulate
   wildfiresBootstrap: { key: 'seed-meta:wildfire:fires-bootstrap', maxStaleMin: 360 }, // Compact CDN payload is a distinct publish target; monitor it so canonical fallback cannot hide transform/write failures.
   outages:          { key: 'seed-meta:infra:outages',           maxStaleMin: 30 },
   climateAnomalies: { key: 'seed-meta:climate:anomalies',       maxStaleMin: 540 }, // bundled into seed-bundle-climate (cron `0 */3 * * *`, every 3h); 540 = 3× cron cadence per project convention. Prior 240 (1.33× cron) flipped to silent-EMPTY between minute 180 (TTL_DATA expiry) and 240 (alarm trigger) on every routine cron-jitter cycle — see scripts/seed-climate-anomalies.mjs CACHE_TTL comment.
@@ -2167,14 +2174,40 @@ function parseFiniteRecordCount(raw) {
   return null;
 }
 
+function projectSourceFailure(meta, policy) {
+  if (!policy || meta?.sourceState !== 'degraded') return null;
+  const errorCode = typeof meta?.errorCode === 'string'
+    && policy.failureCodePattern.test(meta.errorCode)
+    ? meta.errorCode
+    : null;
+  if (!errorCode) return null;
+  const lastSourceFailureCode = typeof meta?.lastSourceFailureCode === 'string'
+    && policy.failureCodePattern.test(meta.lastSourceFailureCode)
+    ? meta.lastSourceFailureCode
+    : null;
+  const consecutiveSourceFailures = Number.isInteger(meta?.consecutiveSourceFailures)
+    && meta.consecutiveSourceFailures >= 1
+    ? Math.min(meta.consecutiveSourceFailures, 100)
+    : null;
+  const pending = lastSourceFailureCode === errorCode
+    && consecutiveSourceFailures !== null
+    && consecutiveSourceFailures < policy.warnAfterConsecutive;
+  return {
+    errorCode,
+    consecutiveSourceFailures,
+    lastSourceFailureCode,
+    pending,
+  };
+}
+
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null, chinaRow: null, workerControl: null, resilienceCacheState: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null, coverage: null, sourceFailure: null, synthesisFailure: null, dominantFailureMode: null, chinaRow: null, workerControl: null, resilienceCacheState: null };
   }
   // Per-command Redis errors on the GET seed-meta half of the pipeline must
   // not silently fall through to STALE_SEED — promote to REDIS_PARTIAL.
   if (keyMetaErrors.get(seedCfg.key)) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null, chinaRow: null, workerControl: null, resilienceCacheState: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null, coverage: null, sourceFailure: null, synthesisFailure: null, dominantFailureMode: null, chinaRow: null, workerControl: null, resilienceCacheState: null };
   }
   // Unwrap through the envelope helper. Legacy seed-meta is a bare
   // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
@@ -2231,6 +2264,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       decisionGroups: null,
       coverage: null,
       errorCode,
+      sourceFailure: null,
       synthesisFailure: null,
       dominantFailureMode: null,
       // A producer that reported `status: 'error'` never got far enough to
@@ -2260,6 +2294,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   // transport path is externally blocked. Keep that state visible without
   // treating it as a broken producer that can be repaired by another retry.
   const sourceBlocked = meta?.sourceState === 'blocked';
+  const sourceFailure = projectSourceFailure(meta, seedCfg.sourceFailure);
   // Source-specific producers can preserve usable last-good records while a
   // current upstream attempt is degraded. Surface that state immediately as a
   // warning without discarding the retained record count from health output.
@@ -2270,7 +2305,8 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   const sourceDegraded = inputFreshnessExpired || (typeof meta?.sourceState === 'string'
     && meta.sourceState !== 'ok'
     && !sourceUnavailable
-    && !sourceBlocked);
+    && !sourceBlocked
+    && sourceFailure?.pending !== true);
   // Content-age trio (2026-05-04 health-readiness plan). Presence of
   // maxContentAgeMin is the opt-in signal — legacy seeders without it
   // get contentAge: null and skip the STALE_CONTENT branch in classifyKey.
@@ -2420,6 +2456,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     decisionGroups,
     coverage,
     errorCode,
+    sourceFailure,
     synthesisFailure,
     dominantFailureMode,
     chinaRow,
@@ -2525,6 +2562,7 @@ function classifyKey(name, redisKey, opts, ctx) {
     decisionGroups,
     coverage,
     errorCode,
+    sourceFailure,
     synthesisFailure,
     dominantFailureMode,
     chinaRow,
@@ -2816,7 +2854,16 @@ function classifyKey(name, redisKey, opts, ctx) {
   // becomes EMPTY, and gating the code on SEED_ERROR would trade the operator's
   // "why" for the severity bump — leaving a bare crit whose explanation is
   // sitting unread in seed-meta.
-  if (fault === 'SEED_ERROR' && errorCode) entry.errorCode = errorCode;
+  if ((fault === 'SEED_ERROR' || sourceFailure) && errorCode) entry.errorCode = errorCode;
+  if (sourceFailure) {
+    if (sourceFailure.consecutiveSourceFailures !== null) {
+      entry.consecutiveSourceFailures = sourceFailure.consecutiveSourceFailures;
+    }
+    if (sourceFailure.lastSourceFailureCode) {
+      entry.lastSourceFailureCode = sourceFailure.lastSourceFailureCode;
+    }
+    if (sourceFailure.pending) entry.sourceFailurePending = true;
+  }
   // Coarse producer-run diagnostic, relayed whenever the producer recorded it —
   // the whole point of #6323 is that a coverage shortfall's dominant cause is
   // visible on /api/health without Railway logs or a raw index read, so gating

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -2,7 +2,7 @@
 ## Observed Source Inventory
 
 {/* BEGIN GENERATED SOURCE ATTRIBUTION */}
-This generated inventory covers **760 active source hosts** representing **747 active providers** (**331 structured/API**, **461 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced. Syndication transports such as FeedBurner and Google News remain listed as hosts and are not counted as publishers.
+This generated inventory covers **761 active source hosts** representing **747 active providers** (**332 structured/API**, **461 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced. Syndication transports such as FeedBurner and Google News remain listed as hosts and are not counted as publishers.
 
 | Provider | Observed surface |
 | --- | --- |
@@ -264,7 +264,6 @@ This generated inventory covers **760 active source hosts** representing **747 a
 | FINRA (feeds.finra.org) | structured — scripts/seed-regulatory-actions.mjs |
 | Fintraffic Digitraffic (not-currently-wired) | Excluded / candidate — No current fetch observed |
 | Firecrawl (api.firecrawl.dev) | structured — scripts/seed-grocery-basket.mjs |
-| firms.modaps.eosdis.nasa.gov (firms.modaps.eosdis.nasa.gov) | structured — scripts/seed-fire-detections.mjs |
 | focustaiwan.tw (focustaiwan.tw) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | fonts.googleapis.com (fonts.googleapis.com) | structured — server/_shared/brief-render.js |
 | foreignpolicy.com (foreignpolicy.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
@@ -401,6 +400,8 @@ This generated inventory covers **760 active source hosts** representing **747 a
 | mx.usembassy.gov (mx.usembassy.gov) | structured — scripts/seed-security-advisories.mjs |
 | n1info.hr (n1info.hr) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | Naharnet Lebanon (www.naharnet.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
+| NASA FIRMS (firms.modaps.eosdis.nasa.gov) | structured — scripts/wildfire/firms-area.mjs |
+| NASA FIRMS (firms2.modaps.eosdis.nasa.gov) | structured — scripts/wildfire/firms-area.mjs |
 | nasstatus.faa.gov (nasstatus.faa.gov) | structured — scripts/seed-aviation.mjs, server/worldmonitor/aviation/v1/_shared.ts |
 | nationalpost.com (nationalpost.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | ndtvindiaelemarchana.akamaized.net (ndtvindiaelemarchana.akamaized.net) | feed — src/components/LiveNewsPanel.ts |

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1289,7 +1289,8 @@
       "scripts/package.json",
       "scripts/seed-fire-detections.mjs",
       "scripts/wildfire/bc-fire-points.mjs",
-      "scripts/wildfire/cwfis-wfs.mjs"
+      "scripts/wildfire/cwfis-wfs.mjs",
+      "scripts/wildfire/firms-area.mjs"
     ],
     "cronSchedule": "*/10 * * * *",
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-43-not-bundled"

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -7,7 +7,7 @@
 //   - startCommand: node seed-fire-detections.mjs
 //   - Cron schedule: "*/10 * * * *" (every 10min UTC)
 
-import { loadEnvFile, runSeed, CHROME_UA, sleep, MAX_PAYLOAD_BYTES } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, MAX_PAYLOAD_BYTES } from './_seed-utils.mjs';
 import { buildEnvelope } from './_seed-envelope-source.mjs';
 import { compactWildfireDashboardPayload, WILDFIRE_CANONICAL_DETECTION_LIMIT } from './_wildfire-dashboard.mjs';
 import {
@@ -16,133 +16,18 @@ import {
 import {
   canadianWildfireAfterPublish,
   fetchBcFirePoints,
+  hasCompleteWorldwideWildfireCoverage,
   mergeWildfireSourcesWithBc,
 } from './wildfire/bc-fire-points.mjs';
+import {
+  fetchAllFirmsRegions,
+  FIRMS_SOURCES,
+} from './wildfire/firms-area.mjs';
 
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'wildfire:fires:v1';
 const BOOTSTRAP_KEY = 'wildfire:fires-bootstrap:v1';
-const FIRMS_SOURCES = ['VIIRS_SNPP_NRT', 'VIIRS_NOAA20_NRT', 'VIIRS_NOAA21_NRT'];
-
-const MONITORED_REGIONS = {
-  'Ukraine': '22,44,40,53',
-  'Russia': '20,50,180,82',
-  'Iran': '44,25,63,40',
-  'Israel/Gaza': '34,29,36,34',
-  'Syria': '35,32,42,37',
-  'Taiwan': '119,21,123,26',
-  'North Korea': '124,37,131,43',
-  'Saudi Arabia': '34,16,56,32',
-  'Turkey': '26,36,45,42',
-};
-
-function mapConfidence(c) {
-  switch ((c || '').toLowerCase()) {
-    case 'h': return 'FIRE_CONFIDENCE_HIGH';
-    case 'n': return 'FIRE_CONFIDENCE_NOMINAL';
-    case 'l': return 'FIRE_CONFIDENCE_LOW';
-    default: return 'FIRE_CONFIDENCE_UNSPECIFIED';
-  }
-}
-
-function parseCSV(csv) {
-  const lines = csv.trim().split('\n');
-  if (lines.length < 2) return [];
-  const headers = lines[0].split(',').map(h => h.trim());
-  const results = [];
-  for (let i = 1; i < lines.length; i++) {
-    const vals = lines[i].split(',').map(v => v.trim());
-    if (vals.length < headers.length) continue;
-    const row = {};
-    headers.forEach((h, idx) => { row[h] = vals[idx]; });
-    results.push(row);
-  }
-  return results;
-}
-
-function parseDetectedAt(acqDate, acqTime) {
-  const padded = (acqTime || '').padStart(4, '0');
-  const hours = padded.slice(0, 2);
-  const minutes = padded.slice(2);
-  return new Date(`${acqDate}T${hours}:${minutes}:00Z`).getTime();
-}
-
-async function fetchRegionSource(apiKey, regionName, bbox, source) {
-  const url = `https://firms.modaps.eosdis.nasa.gov/api/area/csv/${apiKey}/${source}/${bbox}/1`;
-  let lastErr;
-  for (let attempt = 1; attempt <= 2; attempt++) {
-    try {
-      const res = await fetch(url, {
-        headers: { Accept: 'text/csv', 'User-Agent': CHROME_UA },
-        signal: AbortSignal.timeout(30_000),
-      });
-      if (!res.ok) throw new Error(`FIRMS ${res.status} for ${regionName}/${source}`);
-      return parseCSV(await res.text());
-    } catch (err) {
-      lastErr = err;
-      if (attempt < 2) await sleep(6_000); // match inter-call pacing so retry stays within FIRMS 10 req/min budget
-    }
-  }
-  throw lastErr;
-}
-
-async function fetchAllRegions(apiKey) {
-  const entries = Object.entries(MONITORED_REGIONS);
-  const seen = new Set();
-  const fireDetections = [];
-  let fulfilled = 0;
-  let failed = 0;
-
-  for (const source of FIRMS_SOURCES) {
-    for (const [regionName, bbox] of entries) {
-      try {
-        const rows = await fetchRegionSource(apiKey, regionName, bbox, source);
-        fulfilled++;
-        for (const row of rows) {
-          const id = `${row.latitude ?? ''}-${row.longitude ?? ''}-${row.acq_date ?? ''}-${row.acq_time ?? ''}`;
-          if (seen.has(id)) continue;
-          seen.add(id);
-          const detectedAt = parseDetectedAt(row.acq_date || '', row.acq_time || '');
-          const brightness = parseFloat(row.bright_ti4 ?? '0') || 0;
-          const frp = parseFloat(row.frp ?? '0') || 0;
-          fireDetections.push({
-            id,
-            location: {
-              latitude: parseFloat(row.latitude ?? '0') || 0,
-              longitude: parseFloat(row.longitude ?? '0') || 0,
-            },
-            brightness,
-            frp,
-            confidence: mapConfidence(row.confidence || ''),
-            satellite: row.satellite || '',
-            detectedAt,
-            region: regionName,
-            dayNight: row.daynight || '',
-            possibleExplosion: frp > 80 && brightness > 380,
-            source: 'firms',
-            kind: 'active',
-            emergency: true,
-          });
-        }
-      } catch (err) {
-        failed++;
-        console.error(`  [FIRMS] ${source}/${regionName}: ${err.message || err}`);
-      }
-      await sleep(6_000); // FIRMS free tier: 10 req/min — 6s between calls stays safely under limit
-    }
-    console.log(`  ${source}: ${fireDetections.length} total (${fulfilled} ok, ${failed} failed)`);
-  }
-
-  // Surface the per-call outcome, don't just log it. Every throw above is
-  // caught inside the loop, so this function has NO rejection path: a total
-  // FIRMS outage (expired key, NASA 5xx, rate-limit block) returns exactly
-  // like a genuinely empty window. Without these counters the merge grades
-  // FIRMS 'ok' on promise settlement alone and republishes the canonical
-  // WORLDWIDE key as Canada-only, which every downstream content clock then
-  // reads as healthy. See #7141 follow-up.
-  return { fireDetections, pagination: undefined, _firmsFulfilledCalls: fulfilled, _firmsFailedCalls: failed };
-}
 
 export function declareRecords(data) {
   return Array.isArray(data?.fireDetections) ? data.fireDetections.length : 0;
@@ -157,7 +42,7 @@ export function declareRecords(data) {
 // Ranking is the dashboard comparator (possibleExplosion -> confidence -> brightness -> frp ->
 // detectedAt), so what gets dropped is always the lowest-signal tail, and the real FIRMS count
 // survives in `pagination.totalCount`.
-const CANONICAL_SOURCE_VERSION = `${FIRMS_SOURCES.join('+')}+cwfis-wfs-v1+bc-wildfire-kml-v1`;
+const CANONICAL_SOURCE_VERSION = `${FIRMS_SOURCES.join('+')}+firms-area-v2+cwfis-wfs-v1+bc-wildfire-kml-v1`;
 
 function measureCanonicalPublishBytes(data) {
   return Buffer.byteLength(JSON.stringify(buildEnvelope({
@@ -198,7 +83,7 @@ async function fetchMergedWildfires() {
   }
   console.log('  FIRMS key configured');
   return mergeWildfireSourcesWithBc({
-    fetchFirms: async () => fetchAllRegions(apiKey),
+    fetchFirms: () => fetchAllFirmsRegions(apiKey),
     fetchCwfis: () => fetchCwfisFires({ fetchFn: globalThis.fetch, cache }),
     fetchBcWildfire: () => fetchBcFirePoints({ fetchFn: globalThis.fetch, cache }),
   });
@@ -206,7 +91,10 @@ async function fetchMergedWildfires() {
 
 async function main() {
   await runSeed('wildfire', 'fires', CANONICAL_KEY, fetchMergedWildfires, {
-    validateFn: (data) => Array.isArray(data?.fireDetections) && data.fireDetections.length > 0,
+    // A partial response cannot replace a key whose contract is worldwide.
+    // runSeed preserves both canonical and bootstrap last-good keys when this
+    // returns false, then afterValidationSkip records the current diagnosis.
+    validateFn: hasCompleteWorldwideWildfireCoverage,
     // 2h — deliberately BELOW the 6h health gate (maxStaleMin 360). Do NOT "fix" this
     // by raising it to satisfy tests/seed-ttl-outlives-staleness-fleet: doing so DOWNGRADES
     // a safety alarm. Verified against classifyKey with the seeder dead for 3h:
@@ -235,6 +123,9 @@ async function main() {
     schemaVersion: 1,
     maxStaleMin: 360,
     afterPublish: canadianWildfireAfterPublish,
+    afterValidationSkip: (data, { existingSeedMeta }) => canadianWildfireAfterPublish(data, {
+      previousMeta: existingSeedMeta,
+    }),
   });
 }
 

--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -128,6 +128,15 @@ export const PROVIDER_IDENTITY_GROUPS = Object.freeze({
     reason: 'The English publisher host and the direct feed host belong to one Interfax provider identity.',
     reviewReference: 'PR #6840 follow-up',
   }),
+  'nasa-firms': Object.freeze({
+    provider: 'NASA FIRMS',
+    memberHosts: Object.freeze([
+      'firms.modaps.eosdis.nasa.gov',
+      'firms2.modaps.eosdis.nasa.gov',
+    ]),
+    reason: 'The primary and official secondary Area API hosts serve one NASA FIRMS dataset identity.',
+    reviewReference: 'Review #20260904 FIRMS partial-coverage incident',
+  }),
   'opensky-network': Object.freeze({
     provider: 'opensky-network.org',
     memberHosts: Object.freeze(['auth.opensky-network.org', 'opensky-network.org']),
@@ -169,6 +178,20 @@ export const PROVIDER_IDENTITY_GROUPS = Object.freeze({
 const PROVIDER_OVERRIDES = {
   'api.adsb.lol': { provider: 'adsb.lol' },
   'api.airplanes.live': { provider: 'airplanes.live' },
+  'firms.modaps.eosdis.nasa.gov': {
+    provider: 'NASA FIRMS',
+    identityGroup: 'nasa-firms',
+    license: 'NASA FIRMS provider terms apply; redistribution terms require review',
+    attribution: 'Credit NASA FIRMS and link to the original upstream API or dataset.',
+    status: 'terms-review',
+  },
+  'firms2.modaps.eosdis.nasa.gov': {
+    provider: 'NASA FIRMS',
+    identityGroup: 'nasa-firms',
+    license: 'NASA FIRMS provider terms apply; redistribution terms require review',
+    attribution: 'Credit NASA FIRMS and link to the original upstream API or dataset.',
+    status: 'terms-review',
+  },
   'api.imd.gov.in': {
     provider: 'India Meteorological Department',
     identityGroup: 'imd',
@@ -909,13 +932,13 @@ const PROVIDER_OVERRIDES = {
 // a provider-bearing override a separate, explicit lifecycle event instead of
 // something `--write` can silently normalize into the manifest.
 export const PROVIDER_IDENTITY_REVIEW = Object.freeze({
-  sha256: '2ce115029a352d9faa4625b542bbd88eb149148821712779c7842bd5df1f1a59',
-  reason: 'Preserve reviewed provider identities and register the current two-host City of Toronto Calls package identity.',
+  sha256: 'b95aa14699deb45fe8ece9e9806dc03038b4fb378024c824afc32b6ef2a4b159',
+  reason: 'Preserve reviewed provider identities and register the two official NASA FIRMS Area API hosts as one provider identity.',
   // A URL cited here is scanned like any other: this file sits inside
   // SOURCE_ROOTS, so citing a host that is not already a registered source
   // invents a provider row for it. The B.C. catalogue URLs above are safe
   // because that host is itself an observed source; parallel.ai is not.
-  reviewReference: 'Issue #6449 BGS provenance review; plus Issue #7371 country corpus identity review; plus Issue #7005 IMD cyclone/marine source-rights probe; plus Issues #7012, #7036, and #6682 Toronto safety sources; plus PR #7576 source migration review; plus Issue #7000 publisher-centric source catalog; plus Issue #7001, Issue #6437, Issue #6622, Issue #6659, PR #6447, and the 2026-09-01 FAOSTAT transport identity review.',
+  reviewReference: 'Issue #6449 BGS provenance review; plus Issue #7371 country corpus identity review; plus Issue #7005 IMD cyclone/marine source-rights probe; plus Issues #7012, #7036, and #6682 Toronto safety sources; plus PR #7576 source migration review; plus Issue #7000 publisher-centric source catalog; plus Issue #7001, Issue #6437, Issue #6622, Issue #6659, PR #6447, the 2026-09-01 FAOSTAT transport identity review, and the 2026-09-04 FIRMS partial-coverage incident.',
 });
 
 export function providerIdentityDigest(providerOverrides = PROVIDER_OVERRIDES) {

--- a/scripts/wildfire/bc-fire-points.mjs
+++ b/scripts/wildfire/bc-fire-points.mjs
@@ -678,7 +678,32 @@ export async function mergeWildfireSourcesWithBc({ fetchFirms, fetchCwfis, fetch
   };
 }
 
-export function canadianWildfireAfterPublish(data) {
+export function hasCompleteWorldwideWildfireCoverage(data) {
+  return Array.isArray(data?.fireDetections)
+    && data.fireDetections.length > 0
+    && data?._firmsState === 'ok'
+    && data?._firmsPartial !== true;
+}
+
+function nextIdenticalSourceFailureCount(previousMeta, errorCode) {
+  // A missing or unreadable predecessor cannot prove this is the first failure.
+  // Fail closed so a transient seed-meta read error cannot restart the grace
+  // window while the same partial-coverage incident continues.
+  if (!previousMeta || typeof previousMeta !== 'object') return 2;
+  const previousCode = previousMeta?.lastSourceFailureCode ?? previousMeta?.errorCode;
+  if (previousCode !== errorCode) return 1;
+  if (Number.isInteger(previousMeta?.consecutiveSourceFailures)
+    && previousMeta.consecutiveSourceFailures >= 1) {
+    return Math.min(previousMeta.consecutiveSourceFailures + 1, 100);
+  }
+  // Metadata written before the streak fields shipped already represents one
+  // observed failure. Count the next identical run as the second failure so a
+  // rollout cannot turn an active production warning green.
+  if (previousMeta?.sourceState === 'degraded' && previousMeta?.errorCode === errorCode) return 2;
+  return 1;
+}
+
+export function canadianWildfireAfterPublish(data, { previousMeta = null } = {}) {
   const cwfisFailed = data?._cwfisState !== 'ok';
   const bcFailed = data?._bcState !== 'ok';
   // FIRMS is the GLOBAL source for this key. Losing it drops the canonical
@@ -696,11 +721,14 @@ export function canadianWildfireAfterPublish(data) {
   // outage and above healthy: report it rather than let the surviving regions
   // stand in for the globe unremarked.
   if (firmsPartial && !firmsFailed && failureCount === 0) {
+    const errorCode = 'FIRMS_PARTIAL_COVERAGE';
     return {
       freshnessMetaPatch: {
         sourceState: 'degraded',
-        errorCode: 'FIRMS_PARTIAL_COVERAGE',
+        errorCode,
         canadaSourceFailureCount: 0,
+        consecutiveSourceFailures: nextIdenticalSourceFailureCount(previousMeta, errorCode),
+        lastSourceFailureCode: errorCode,
       },
     };
   }

--- a/scripts/wildfire/firms-area.mjs
+++ b/scripts/wildfire/firms-area.mjs
@@ -1,0 +1,163 @@
+import { CHROME_UA, sleep } from '../_seed-utils.mjs';
+
+export const FIRMS_API_BASE_URLS = Object.freeze([
+  'https://firms.modaps.eosdis.nasa.gov',
+  'https://firms2.modaps.eosdis.nasa.gov',
+]);
+
+export const FIRMS_SOURCES = Object.freeze([
+  'VIIRS_SNPP_NRT',
+  'VIIRS_NOAA20_NRT',
+  'VIIRS_NOAA21_NRT',
+]);
+
+export const MONITORED_REGIONS = Object.freeze({
+  Ukraine: '22,44,40,53',
+  Russia: '20,50,180,82',
+  Iran: '44,25,63,40',
+  'Israel/Gaza': '34,29,36,34',
+  Syria: '35,32,42,37',
+  Taiwan: '119,21,123,26',
+  'North Korea': '124,37,131,43',
+  'Saudi Arabia': '34,16,56,32',
+  Turkey: '26,36,45,42',
+});
+
+const REQUEST_PACE_MS = 6_000;
+
+function mapConfidence(value) {
+  switch ((value || '').toLowerCase()) {
+    case 'h': return 'FIRE_CONFIDENCE_HIGH';
+    case 'n': return 'FIRE_CONFIDENCE_NOMINAL';
+    case 'l': return 'FIRE_CONFIDENCE_LOW';
+    default: return 'FIRE_CONFIDENCE_UNSPECIFIED';
+  }
+}
+
+function parseCsv(csv) {
+  const lines = csv.trim().split('\n');
+  if (lines.length < 2) return [];
+  const headers = lines[0].split(',').map((header) => header.trim());
+  const results = [];
+  for (let index = 1; index < lines.length; index++) {
+    const values = lines[index].split(',').map((value) => value.trim());
+    if (values.length < headers.length) continue;
+    const row = {};
+    headers.forEach((header, column) => { row[header] = values[column]; });
+    results.push(row);
+  }
+  return results;
+}
+
+function parseDetectedAt(acqDate, acqTime) {
+  const padded = (acqTime || '').padStart(4, '0');
+  const hours = padded.slice(0, 2);
+  const minutes = padded.slice(2);
+  return new Date(`${acqDate}T${hours}:${minutes}:00Z`).getTime();
+}
+
+function safeFailureReason(error) {
+  if (Number.isInteger(error?.status)) return `HTTP ${error.status}`;
+  if (error?.name === 'TimeoutError' || error?.name === 'AbortError') return 'timeout';
+  return 'request error';
+}
+
+function buildAreaUrl(baseUrl, apiKey, source, bbox) {
+  return `${baseUrl}/api/area/csv/${apiKey}/${source}/${bbox}/1`;
+}
+
+export async function fetchFirmsRegionSource(apiKey, regionName, bbox, source, {
+  fetchFn = globalThis.fetch,
+  sleepFn = sleep,
+  logger = console,
+} = {}) {
+  const failures = [];
+  for (let index = 0; index < FIRMS_API_BASE_URLS.length; index++) {
+    const baseUrl = FIRMS_API_BASE_URLS[index];
+    try {
+      const response = await fetchFn(buildAreaUrl(baseUrl, apiKey, source, bbox), {
+        headers: { Accept: 'text/csv', 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!response.ok) {
+        const error = new Error('FIRMS request failed');
+        error.status = response.status;
+        throw error;
+      }
+      return parseCsv(await response.text());
+    } catch (error) {
+      const endpoint = index === 0 ? 'primary' : 'secondary';
+      failures.push(`${endpoint} ${safeFailureReason(error)}`);
+      if (index + 1 < FIRMS_API_BASE_URLS.length) {
+        logger.warn(`  [FIRMS] ${source}/${regionName}: ${failures.at(-1)}; trying secondary`);
+        await sleepFn(REQUEST_PACE_MS);
+      }
+    }
+  }
+  throw new Error(`FIRMS ${source}/${regionName} failed (${failures.join(', ')})`);
+}
+
+export async function fetchAllFirmsRegions(apiKey, {
+  fetchFn = globalThis.fetch,
+  sleepFn = sleep,
+  logger = console,
+} = {}) {
+  const seen = new Set();
+  const fireDetections = [];
+  let fulfilled = 0;
+  let failed = 0;
+
+  for (const source of FIRMS_SOURCES) {
+    for (const [regionName, bbox] of Object.entries(MONITORED_REGIONS)) {
+      try {
+        const rows = await fetchFirmsRegionSource(apiKey, regionName, bbox, source, {
+          fetchFn,
+          sleepFn,
+          logger,
+        });
+        fulfilled++;
+        for (const row of rows) {
+          const id = `${row.latitude ?? ''}-${row.longitude ?? ''}-${row.acq_date ?? ''}-${row.acq_time ?? ''}`;
+          if (seen.has(id)) continue;
+          seen.add(id);
+          const detectedAt = parseDetectedAt(row.acq_date || '', row.acq_time || '');
+          const brightness = parseFloat(row.bright_ti4 ?? '0') || 0;
+          const frp = parseFloat(row.frp ?? '0') || 0;
+          fireDetections.push({
+            id,
+            location: {
+              latitude: parseFloat(row.latitude ?? '0') || 0,
+              longitude: parseFloat(row.longitude ?? '0') || 0,
+            },
+            brightness,
+            frp,
+            confidence: mapConfidence(row.confidence || ''),
+            satellite: row.satellite || '',
+            detectedAt,
+            region: regionName,
+            dayNight: row.daynight || '',
+            possibleExplosion: frp > 80 && brightness > 380,
+            source: 'firms',
+            kind: 'active',
+            emergency: true,
+          });
+        }
+      } catch (error) {
+        failed++;
+        logger.error(`  [FIRMS] ${source}/${regionName}: ${error.message || error}`);
+      }
+      // Keep the existing bounded cadence. NASA accounts in transactions, not
+      // raw requests, so this pace limits traffic without claiming a per-minute
+      // request quota.
+      await sleepFn(REQUEST_PACE_MS);
+    }
+    logger.log(`  ${source}: ${fireDetections.length} total (${fulfilled} ok, ${failed} failed)`);
+  }
+
+  return {
+    fireDetections,
+    pagination: undefined,
+    _firmsFulfilledCalls: fulfilled,
+    _firmsFailedCalls: failed,
+  };
+}

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -4287,15 +4287,29 @@
     },
     {
       "host": "firms.modaps.eosdis.nasa.gov",
-      "provider": "firms.modaps.eosdis.nasa.gov",
+      "provider": "NASA FIRMS",
       "kind": "structured",
       "observed": true,
-      "license": "Provider terms for this upstream API/dataset; verify before redistribution",
-      "attribution": "Credit firms.modaps.eosdis.nasa.gov and link to the original upstream API/dataset.",
+      "license": "NASA FIRMS provider terms apply; redistribution terms require review",
+      "attribution": "Credit NASA FIRMS and link to the original upstream API or dataset.",
       "status": "terms-review",
       "references": [
         {
-          "path": "scripts/seed-fire-detections.mjs"
+          "path": "scripts/wildfire/firms-area.mjs"
+        }
+      ]
+    },
+    {
+      "host": "firms2.modaps.eosdis.nasa.gov",
+      "provider": "NASA FIRMS",
+      "kind": "structured",
+      "observed": true,
+      "license": "NASA FIRMS provider terms apply; redistribution terms require review",
+      "attribution": "Credit NASA FIRMS and link to the original upstream API or dataset.",
+      "status": "terms-review",
+      "references": [
+        {
+          "path": "scripts/wildfire/firms-area.mjs"
         }
       ]
     },

--- a/tests/bc-fire-points.test.mjs
+++ b/tests/bc-fire-points.test.mjs
@@ -341,8 +341,79 @@ describe('independent FIRMS + CWFIS + BC merge', () => {
         sourceState: 'degraded',
         errorCode: 'FIRMS_PARTIAL_COVERAGE',
         canadaSourceFailureCount: 0,
+        consecutiveSourceFailures: 1,
+        lastSourceFailureCode: 'FIRMS_PARTIAL_COVERAGE',
       },
       'partial worldwide coverage must be visible, not silent',
+    );
+  });
+
+  it('debounces only the first identical partial FIRMS failure while usable data survives', () => {
+    const now = Date.parse('2026-09-04T20:40:00Z');
+    const dataKey = healthTesting.BOOTSTRAP_KEYS.wildfires;
+    const metaKey = healthTesting.SEED_META.wildfires.key;
+    const partial = {
+      _firmsState: 'ok',
+      _firmsPartial: true,
+      _cwfisState: 'ok',
+      _bcState: 'ok',
+    };
+    const firstPatch = canadianWildfireAfterPublish(partial, {
+      previousMeta: { sourceState: 'ok' },
+    }).freshnessMetaPatch;
+    const classify = (patch, { hasData = true, fetchedAt = now - 60_000 } = {}) => (
+      healthTesting.classifyKey('wildfires', dataKey, { allowOnDemand: false }, {
+        keyStrens: new Map(hasData ? [[dataKey, 256]] : []),
+        keyErrors: new Map(),
+        keyMetaValues: new Map([[metaKey, JSON.stringify({
+          fetchedAt,
+          recordCount: hasData ? 100 : 0,
+          ...patch,
+        })]]),
+        keyMetaErrors: new Map(),
+        now,
+      })
+    );
+
+    assert.equal(firstPatch.consecutiveSourceFailures, 1);
+    assert.equal(firstPatch.lastSourceFailureCode, 'FIRMS_PARTIAL_COVERAGE');
+    assert.deepEqual(classify(firstPatch), {
+      status: 'OK',
+      records: 100,
+      errorCode: 'FIRMS_PARTIAL_COVERAGE',
+      consecutiveSourceFailures: 1,
+      lastSourceFailureCode: 'FIRMS_PARTIAL_COVERAGE',
+      sourceFailurePending: true,
+    });
+
+    const secondPatch = canadianWildfireAfterPublish(partial, {
+      previousMeta: { fetchedAt: now - 60_000, recordCount: 100, ...firstPatch },
+    }).freshnessMetaPatch;
+    assert.equal(secondPatch.consecutiveSourceFailures, 2);
+    assert.equal(classify(secondPatch).status, 'SEED_ERROR');
+
+    const legacyProductionPatch = canadianWildfireAfterPublish(partial, {
+      previousMeta: {
+        sourceState: 'degraded',
+        errorCode: 'FIRMS_PARTIAL_COVERAGE',
+      },
+    }).freshnessMetaPatch;
+    assert.equal(
+      legacyProductionPatch.consecutiveSourceFailures,
+      2,
+      'the first repaired run must preserve the existing production warning',
+    );
+    assert.equal(classify(legacyProductionPatch).status, 'SEED_ERROR');
+
+    assert.equal(
+      classify(firstPatch, { fetchedAt: now - 5 * 60_000 }).status,
+      'OK',
+      'a usable last-good snapshot receives the same single-run grace',
+    );
+    assert.notEqual(
+      classify(firstPatch, { hasData: false }).status,
+      'OK',
+      'missing global data fails immediately even on the first partial failure',
     );
   });
 
@@ -680,6 +751,7 @@ describe('module import contract', () => {
     assert.match(seederSrc, /wildfire:fires:v1/);
     assert.doesNotMatch(seederSrc, /wildfire:canada/);
     assert.doesNotMatch(seederSrc, /fetch\.bind/);
+    assert.match(seederSrc, /firms2\.modaps\.eosdis\.nasa\.gov/);
     assert.match(railwaySrc, /scripts\/wildfire\/bc-fire-points\.mjs/);
     assert.match(railwaySrc, /scripts\/wildfire\/cwfis-wfs\.mjs/);
   });

--- a/tests/bc-fire-points.test.mjs
+++ b/tests/bc-fire-points.test.mjs
@@ -22,6 +22,7 @@ import {
   enrichOrAppendBc,
   fetchApprovedBcUrl,
   fetchBcFirePoints,
+  hasCompleteWorldwideWildfireCoverage,
   latLonTimeKey,
   mergeWildfireSourcesWithBc,
   parseBcFireGeoJson,
@@ -36,6 +37,7 @@ const geojson = readFileSync(resolve(here, 'fixtures/wildfire/bc-current-fire-po
 const cwfisActiveJson = readFileSync(resolve(here, 'fixtures/wildfire/cwfis-national-activefires.json'), 'utf8');
 const parseModuleSrc = readFileSync(resolve(here, '../scripts/wildfire/bc-fire-points.mjs'), 'utf8');
 const cwfisModuleSrc = readFileSync(resolve(here, '../scripts/wildfire/cwfis-wfs.mjs'), 'utf8');
+const firmsModuleSrc = readFileSync(resolve(here, '../scripts/wildfire/firms-area.mjs'), 'utf8');
 const testSrc = readFileSync(fileURLToPath(import.meta.url), 'utf8');
 const seederSrc = readFileSync(resolve(here, '../scripts/seed-fire-detections.mjs'), 'utf8');
 const aisRelaySrc = readFileSync(resolve(here, '../scripts/ais-relay.cjs'), 'utf8');
@@ -335,8 +337,15 @@ describe('independent FIRMS + CWFIS + BC merge', () => {
     assert.equal(mostlyDark._firmsState, 'ok', 'some coverage survived, so not a full outage');
     assert.equal(mostlyDark._firmsPartial, true);
     assert.equal(mostlyDark._firmsFailedCalls, 26);
+    assert.equal(
+      hasCompleteWorldwideWildfireCoverage(mostlyDark),
+      false,
+      'an incomplete worldwide snapshot must preserve the last-good keys',
+    );
     assert.deepEqual(
-      canadianWildfireAfterPublish(mostlyDark).freshnessMetaPatch,
+      canadianWildfireAfterPublish(mostlyDark, {
+        previousMeta: { sourceState: 'ok' },
+      }).freshnessMetaPatch,
       {
         sourceState: 'degraded',
         errorCode: 'FIRMS_PARTIAL_COVERAGE',
@@ -384,6 +393,8 @@ describe('independent FIRMS + CWFIS + BC merge', () => {
       consecutiveSourceFailures: 1,
       lastSourceFailureCode: 'FIRMS_PARTIAL_COVERAGE',
       sourceFailurePending: true,
+      seedAgeMin: 1,
+      maxStaleMin: 360,
     });
 
     const secondPatch = canadianWildfireAfterPublish(partial, {
@@ -404,16 +415,57 @@ describe('independent FIRMS + CWFIS + BC merge', () => {
       'the first repaired run must preserve the existing production warning',
     );
     assert.equal(classify(legacyProductionPatch).status, 'SEED_ERROR');
+    assert.equal(classify({
+      sourceState: 'degraded',
+      errorCode: 'FIRMS_PARTIAL_COVERAGE',
+    }).status, 'SEED_ERROR', 'legacy production metadata fails closed during rollout');
+
+    const unknownHistoryPatch = canadianWildfireAfterPublish(partial).freshnessMetaPatch;
+    assert.equal(
+      unknownHistoryPatch.consecutiveSourceFailures,
+      2,
+      'an unreadable predecessor cannot restart the one-run grace window',
+    );
+    assert.equal(classify(unknownHistoryPatch).status, 'SEED_ERROR');
+
+    const changedIdentityPatch = canadianWildfireAfterPublish(partial, {
+      previousMeta: {
+        sourceState: 'degraded',
+        errorCode: 'FIRMS_SOURCE_FAILED',
+        consecutiveSourceFailures: 7,
+        lastSourceFailureCode: 'FIRMS_SOURCE_FAILED',
+      },
+    }).freshnessMetaPatch;
+    assert.equal(
+      changedIdentityPatch.consecutiveSourceFailures,
+      1,
+      'a different source failure cannot advance this failure identity',
+    );
 
     assert.equal(
       classify(firstPatch, { fetchedAt: now - 5 * 60_000 }).status,
       'OK',
       'a usable last-good snapshot receives the same single-run grace',
     );
+    assert.equal(
+      classify(firstPatch, { fetchedAt: now - 361 * 60_000 }).status,
+      'STALE_SEED',
+      'the first-failure grace cannot hide a last-good snapshot past its freshness budget',
+    );
     assert.notEqual(
       classify(firstPatch, { hasData: false }).status,
       'OK',
       'missing global data fails immediately even on the first partial failure',
+    );
+    assert.deepEqual(
+      canadianWildfireAfterPublish({
+        _firmsState: 'ok',
+        _firmsPartial: false,
+        _cwfisState: 'ok',
+        _bcState: 'ok',
+      }, { previousMeta: secondPatch }).freshnessMetaPatch,
+      { sourceState: 'ok' },
+      'a successful natural run clears the streak fields from the replacement metadata',
     );
   });
 
@@ -434,6 +486,7 @@ describe('independent FIRMS + CWFIS + BC merge', () => {
     assert.equal(emptyButLive._firmsState, 'ok');
     assert.equal(emptyButLive._firmsErrorCode, null);
     assert.equal(emptyButLive._firmsPartial, false, 'full coverage is not partial');
+    assert.equal(hasCompleteWorldwideWildfireCoverage(emptyButLive), true);
     assert.equal(
       canadianWildfireAfterPublish(emptyButLive).freshnessMetaPatch.sourceState,
       'ok',
@@ -451,6 +504,7 @@ describe('independent FIRMS + CWFIS + BC merge', () => {
     assert.equal(canadaOnly._firmsErrorCode, 'FIRMS_SOURCE_FAILED');
     assert.equal(canadaOnly._cwfisState, 'ok');
     assert.equal(canadaOnly._bcState, 'ok');
+    assert.equal(hasCompleteWorldwideWildfireCoverage(canadaOnly), false);
 
     // Both Canadian sources are healthy, so canadaSourceFailureCount stays 0 —
     // but the canonical key just lost its worldwide coverage. Never report 'ok'.
@@ -747,12 +801,15 @@ describe('module import contract', () => {
     assert.match(seederSrc, /mergeWildfireSourcesWithBc/);
     assert.match(seederSrc, /fetchBcFirePoints/);
     assert.match(seederSrc, /fetchCwfisFires/);
-    assert.match(seederSrc, /afterPublish:\s*canadianWildfireAfterPublish/);
+    assert.match(seederSrc, /afterPublish:[\s\S]{0,160}canadianWildfireAfterPublish/);
+    assert.match(seederSrc, /afterValidationSkip:[\s\S]{0,160}canadianWildfireAfterPublish/);
+    assert.match(seederSrc, /validateFn:\s*hasCompleteWorldwideWildfireCoverage/);
     assert.match(seederSrc, /wildfire:fires:v1/);
     assert.doesNotMatch(seederSrc, /wildfire:canada/);
     assert.doesNotMatch(seederSrc, /fetch\.bind/);
-    assert.match(seederSrc, /firms2\.modaps\.eosdis\.nasa\.gov/);
+    assert.match(firmsModuleSrc, /firms2\.modaps\.eosdis\.nasa\.gov/);
     assert.match(railwaySrc, /scripts\/wildfire\/bc-fire-points\.mjs/);
     assert.match(railwaySrc, /scripts\/wildfire\/cwfis-wfs\.mjs/);
+    assert.match(railwaySrc, /scripts\/wildfire\/firms-area\.mjs/);
   });
 });

--- a/tests/firms-area.test.mjs
+++ b/tests/firms-area.test.mjs
@@ -1,0 +1,128 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  fetchAllFirmsRegions,
+  fetchFirmsRegionSource,
+  FIRMS_API_BASE_URLS,
+  FIRMS_SOURCES,
+  MONITORED_REGIONS,
+} from '../scripts/wildfire/firms-area.mjs';
+
+const EMPTY_CSV = 'latitude,longitude,acq_date,acq_time,bright_ti4,frp,confidence,satellite,daynight\n';
+const DETECTION_CSV = `${EMPTY_CSV}34.1,36.2,2026-09-04,0425,391.2,91.5,h,N,D\n`;
+
+function response(status, body = EMPTY_CSV) {
+  return new Response(body, { status });
+}
+
+function captureLogger() {
+  const messages = { log: [], warn: [], error: [] };
+  return {
+    messages,
+    logger: {
+      log: (message) => messages.log.push(message),
+      warn: (message) => messages.warn.push(message),
+      error: (message) => messages.error.push(message),
+    },
+  };
+}
+
+describe('NASA FIRMS Area API sequence', () => {
+  it('tries the official secondary host after a primary HTTP failure', async () => {
+    const urls = [];
+    const sleeps = [];
+    const { logger, messages } = captureLogger();
+    const rows = await fetchFirmsRegionSource(
+      'test-map-key',
+      'Ukraine',
+      MONITORED_REGIONS.Ukraine,
+      FIRMS_SOURCES[0],
+      {
+        fetchFn: async (url) => {
+          urls.push(url);
+          return response(urls.length === 1 ? 500 : 200);
+        },
+        sleepFn: async (milliseconds) => sleeps.push(milliseconds),
+        logger,
+      },
+    );
+
+    assert.deepEqual(rows, []);
+    assert.deepEqual(
+      urls.map((url) => new URL(url).origin),
+      FIRMS_API_BASE_URLS,
+    );
+    assert.equal(new URL(urls[0]).pathname, new URL(urls[1]).pathname);
+    assert.deepEqual(sleeps, [6_000]);
+    assert.match(messages.warn[0], /VIIRS_SNPP_NRT\/Ukraine: primary HTTP 500; trying secondary/);
+    assert.doesNotMatch(messages.warn[0], /test-map-key/);
+  });
+
+  it('keeps the source-major 27-call worldwide sequence and six-second cadence', async () => {
+    const urls = [];
+    const sleeps = [];
+    const { logger } = captureLogger();
+    const result = await fetchAllFirmsRegions('test-map-key', {
+      fetchFn: async (url) => {
+        urls.push(url);
+        return response(200, urls.length === 1 ? DETECTION_CSV : EMPTY_CSV);
+      },
+      sleepFn: async (milliseconds) => sleeps.push(milliseconds),
+      logger,
+    });
+
+    assert.equal(result._firmsFulfilledCalls, 27);
+    assert.equal(result._firmsFailedCalls, 0);
+    assert.deepEqual(result.fireDetections, [{
+      id: '34.1-36.2-2026-09-04-0425',
+      location: { latitude: 34.1, longitude: 36.2 },
+      brightness: 391.2,
+      frp: 91.5,
+      confidence: 'FIRE_CONFIDENCE_HIGH',
+      satellite: 'N',
+      detectedAt: Date.parse('2026-09-04T04:25:00Z'),
+      region: 'Ukraine',
+      dayNight: 'D',
+      possibleExplosion: true,
+      source: 'firms',
+      kind: 'active',
+      emergency: true,
+    }]);
+    assert.equal(urls.length, FIRMS_SOURCES.length * Object.keys(MONITORED_REGIONS).length);
+    assert.equal(sleeps.length, 27);
+    assert.ok(sleeps.every((milliseconds) => milliseconds === 6_000));
+    const requestPaths = urls.map((url) => new URL(url).pathname);
+    assert.deepEqual(
+      requestPaths.slice(0, 9),
+      Object.values(MONITORED_REGIONS).map(
+        (bbox) => `/api/area/csv/test-map-key/${FIRMS_SOURCES[0]}/${bbox}/1`,
+      ),
+    );
+    assert.match(requestPaths[9], new RegExp(`/${FIRMS_SOURCES[1]}/`));
+    assert.match(requestPaths[18], new RegExp(`/${FIRMS_SOURCES[2]}/`));
+  });
+
+  it('keeps region and satellite diagnostics when both hosts fail', async () => {
+    const urls = [];
+    const { logger, messages } = captureLogger();
+    const failedPath = `/${FIRMS_SOURCES[0]}/${MONITORED_REGIONS.Ukraine}/`;
+    const result = await fetchAllFirmsRegions('test-map-key', {
+      fetchFn: async (url) => {
+        urls.push(url);
+        return response(new URL(url).pathname.includes(failedPath) ? 500 : 200);
+      },
+      sleepFn: async () => {},
+      logger,
+    });
+
+    assert.equal(result._firmsFulfilledCalls, 26);
+    assert.equal(result._firmsFailedCalls, 1);
+    assert.equal(urls.length, 28);
+    assert.match(
+      messages.error[0],
+      /VIIRS_SNPP_NRT\/Ukraine failed \(primary HTTP 500, secondary HTTP 500\)/,
+    );
+    assert.doesNotMatch(messages.error[0], /test-map-key/);
+  });
+});


### PR DESCRIPTION
## Summary

- Try the official `firms2.modaps.eosdis.nasa.gov` Area API host after a failed primary request. This keeps the existing limit of two attempts per region and satellite.
- Reject incomplete FIRMS coverage at the seed publish boundary. Preserve both the canonical and bootstrap last-good keys.
- Keep the first identical partial failure pending only while fresh last-good data exists. Warn on the second failure. Missing, stale, legacy, and unknown-history states fail closed.
- Add the new source module to the Railway dependency closure and register both NASA FIRMS hosts as one reviewed source identity.

## Root cause

Production run `1788553803500-mers8e` completed 19 of 27 FIRMS calls. The next run completed 2 of 27. Later runs failed different regions and all three satellites with HTTP 500 responses, while successful requests continued after failures.

The old retry path sent both attempts to the primary host. The moving failure set rules out a fixed region partition. The cross-satellite failures rule out one satellite feed. NASA documents the same Area API on a secondary host and tells users to try it when the primary site has problems:

- https://firms.modaps.eosdis.nasa.gov/content/notifications/firms/update.html
- https://firms.modaps.eosdis.nasa.gov/api/area/
- https://firms.modaps.eosdis.nasa.gov/api/map_key/

The repository changes do not claim that NASA confirmed a provider incident. Primary-host instability is an inference from the production request pattern and NASA's published failover contract.

## Verification

- `npm run test:data`: 30,084 passed, 0 failed, 40 skipped.
- Focused wildfire and health tests: 155 passed, 0 failed.
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint:boundaries`
- `npm run --silent sources:check`
- `npm run --silent inventory:facts:check`
- `npm run --silent product:facts:check`
- Source-attribution tests: 47 passed, 0 failed.
- Deployment and Railway contract tests: 355 passed, 0 failed, 6 skipped.
- Biome check on the seven changed executable and test files.
- Full-depth `ce-code-review`: two moderate findings found and fixed, no remaining findings.

## Production state

No seeder, redeploy, Railway setting, or other production mutation ran during this work. Deployment and natural production acceptance remain separate follow-up states after merge. A successful scheduled run must prove live recovery.
