### PR TITLE
test(seo): stop pinning the llms.txt version to package.json (#6038)

### DIFF
--- a/tests/ai-search-product-facts.test.mjs
+++ b/tests/ai-search-product-facts.test.mjs
@@ -320,13 +320,16 @@ describe('#6038 ai-search.md is generated, not hand-maintained', () => {
 });
 
 describe('#6038 AI briefing version headers', () => {
-  it('pins the llms.txt version to the published package version', () => {
-    const header = read('public/llms.txt').match(VERSION_HEADER_RE)?.[0];
-    assert.ok(header, 'public/llms.txt must carry a machine-readable version line');
-    assert.equal(
-      header.match(/\d+\.\d+\.\d+/)[0],
-      JSON.parse(read('package.json')).version,
-      'the briefing version must track the published package version',
+  it('declares a machine-readable version header llms-full can copy', () => {
+    // Deliberately NOT pinned to package.json. Deriving this line from the
+    // package version would make an unrelated release commit red until both
+    // briefings were regenerated — a release chore for a field that is not
+    // among the stale-claim classes #6038 exists to close. The line is
+    // hand-maintained; what is enforced is that it is well-formed, so
+    // readVersionHeader cannot fail silently, and that llms-full matches it.
+    assert.ok(
+      VERSION_HEADER_RE.test(read('public/llms.txt')),
+      'public/llms.txt must carry a "> Version: X.Y.Z · Last updated: YYYY-MM-DD" line',
     );
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #7676. That PR gave `llms-full.txt` the version header `llms.txt` already carried — the round-5 audit's actual ask, since a consumer had no way to date a 240 KB corpus. It also pinned `llms.txt`'s version to `package.json`, which was **my addition, not the audit's**, and it created a release chore: an unrelated version bump went red until someone hand-edited `llms.txt` and regenerated `llms-full.txt`.

This removes the pin. A semver string is not among the stale-claim classes #6038 exists to close (language, feed, provider, tool, layer, variant, price, waitlist), and gating releases on it buys nothing that issue asked for.

## What is still enforced

- **The header is well-formed** — `readVersionHeader` throws on a malformed line, so without this check a bad edit would surface as a confusing generator failure rather than a clear test failure.
- **`llms-full.txt` matches `llms.txt` byte for byte** — the two briefings still cannot disagree with each other. `build-llms-full.mjs` copies the line verbatim rather than restating it, so that parity is structural.

Only the coupling to `package.json` is gone.

## Test plan

Simulated the release that motivated this: bumped `package.json` to `2.11.0` against an unchanged `llms.txt`.

| Check | Before | After |
|-------|--------|-------|
| `tests/ai-search-product-facts.test.mjs` | 1 failure | 18 pass |
| `npm run build:llms-full:check` | unchanged | unchanged |
| `tests/seo-geo-residue.test.mjs` | 18 pass | 18 pass |

Then restored `package.json` and confirmed the retained check still has teeth: rewriting the header to `> Version: 2.10 · Updated 2026-09-01` turns it red.

## Why not the alternatives

- **Auto-rewrite the version via the `product:facts` transform** (the pattern already used for `pricing.md`, `docs.json`, `agent-card.json`) does not remove the CI step — `product:facts:check` still fails until someone runs the generator and commits. It converts hand-editing two files into running one command, which was not the problem.
- **Dropping the version and keeping only the date** would answer the audit equally well, but removes a field `llms.txt` already publishes — a change to a live surface beyond what #6038 asked for.

https://claude.ai/code/session_012etYjVsNxuah9Rkbba91P5
