### PR TITLE
fix(docs): refresh the page-date manifest — main is red on docs-stats

### DIFF
--- a/src/config/docs-page-dates.generated.ts
+++ b/src/config/docs-page-dates.generated.ts
@@ -126,7 +126,7 @@ export const DOCS_PAGE_DATES: Record<string, string> = {
   "scenario-engine": "2026-08-15",
   "sdks": "2026-08-24",
   "signal-intelligence": "2026-08-16",
-  "source-attribution": "2026-09-04",
+  "source-attribution": "2026-09-05",
   "strategic-risk": "2026-08-16",
   "support": "2026-07-26",
   "terms": "2026-08-28",


### PR DESCRIPTION
## Summary

**main is currently red on `docs-stats`** — `src/config/docs-page-dates.generated.ts` is stale. This is the one-line refresh that restores it.

My own merge caused it, and the mechanism is worth naming because a PR cannot prevent it:

- #7676 touched `docs/source-attribution.mdx` (a single row added by `sources:generate`).
- While that PR was open, the file's last commit was dated `2026-09-04` and the committed manifest said `2026-09-04`. The gate was green.
- The **squash merge created a new commit dated `2026-09-05`**, which became that file's last commit — so the manifest went stale *at merge time*, after its own PR had already passed.

```diff
-  "source-attribution": "2026-09-04",
+  "source-attribution": "2026-09-05",
```

## This is recurring, not a one-off

#7651 was titled "refresh the docs page date manifest against merged git history" — the same fix for the same reason. The manifest has since been touched by #7650 and #7653 as drive-by churn.

The root cause is structural: `docs:dates:check` compares a committed artifact against a value **the merge itself changes**, so no PR can pre-satisfy it. Any PR touching a tracked docs page that merges on a different day than its last commit red-lines main until someone regenerates. I have not attempted the root-cause fix here — main being red should not wait on a design change — but it is worth its own issue, and the plausible directions are a floor comparison (manifest date must not be *newer* than git) rather than equality, deriving from content frontmatter instead of git, or having the merge queue regenerate.

## Verification

- `npm run docs:dates:check` — clean.
- `npm run docs:check` — OK, 2 doc claims match code.
- `tests/docs-page-dates.test.mjs` — 1 pass.
- **Timezone-checked before committing.** The generator derives dates with `--date=format-local`, so a manifest refreshed from a non-UTC machine can disagree with CI for any commit near a midnight boundary. Regenerated under both `TZ=UTC` and my local `+04:00`; output is byte-identical, so this commit matches what CI computes.

https://claude.ai/code/session_012etYjVsNxuah9Rkbba91P5
