### PR TITLE
fix(cross-strait): retry transient MND metadata loss

### DIFF
--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2321,8 +2321,15 @@ function rotatingRefreshCandidates(previousMnd, excludedUrls, now) {
     (_, index) => eligible[(offset + index) % eligible.length]);
 }
 
-function hasMndOutboundBudget({ runStartedAt, nowFn, cadenceMs }) {
-  return nowFn() - runStartedAt + cadenceMs + REQUEST_TIMEOUT_MS <= MND_OUTBOUND_BUDGET_MS;
+function hasMndOutboundBudget({
+  runStartedAt,
+  nowFn,
+  cadenceMs,
+  reservedRequestCount = 0,
+}) {
+  const reservedMs = reservedRequestCount * (REQUEST_CADENCE_MS + REQUEST_TIMEOUT_MS);
+  return nowFn() - runStartedAt + cadenceMs + REQUEST_TIMEOUT_MS + reservedMs
+    <= MND_OUTBOUND_BUDGET_MS;
 }
 
 /**
@@ -2659,20 +2666,38 @@ export async function fetchCrossStraitActivitySnapshot({
   );
   const candidates = [...primaryCandidates, ...refreshCandidates]
     .slice(0, MND_MAX_DETAIL_REQUESTS_PER_RUN);
+  const candidateSchedule = [
+    ...primaryCandidates.map((candidate) => ({
+      candidate,
+      isRefresh: false,
+      reservedRefreshAttempts: refreshCandidates.length,
+    })),
+    ...refreshCandidates.map((candidate, index) => ({
+      candidate,
+      isRefresh: true,
+      reservedRefreshAttempts: refreshCandidates.length - index - 1,
+    })),
+  ];
   const parsedMnd = [];
   let detailRequestCount = 0;
+  let primaryBudgetExhausted = false;
   candidateLoop:
-  for (const candidate of candidates) {
+  for (const { candidate, isRefresh, reservedRefreshAttempts } of candidateSchedule) {
+    if (primaryBudgetExhausted && !isRefresh) continue;
+    const detailAttemptLimit = MND_MAX_DETAIL_REQUESTS_PER_RUN - reservedRefreshAttempts;
     let retryingMissingMetadata = false;
-    while (detailRequestCount < MND_MAX_DETAIL_REQUESTS_PER_RUN) {
+    while (detailRequestCount < detailAttemptLimit) {
       if (!hasMndOutboundBudget({
         runStartedAt,
         nowFn,
         cadenceMs: REQUEST_CADENCE_MS,
+        reservedRequestCount: reservedRefreshAttempts,
       })) {
         if (retryingMissingMetadata) mndErrors.push('MND_PUBLICATION_METADATA_MISSING');
         mndErrors.push('OUTBOUND_BUDGET_EXHAUSTED');
-        break candidateLoop;
+        if (isRefresh && !retryingMissingMetadata) break candidateLoop;
+        if (!isRefresh) primaryBudgetExhausted = true;
+        break;
       }
       try {
         await sleepFn(REQUEST_CADENCE_MS);
@@ -2692,7 +2717,7 @@ export async function fetchCrossStraitActivitySnapshot({
         if (
           code === 'MND_PUBLICATION_METADATA_MISSING'
           && !retryingMissingMetadata
-          && detailRequestCount < MND_MAX_DETAIL_REQUESTS_PER_RUN
+          && detailRequestCount < detailAttemptLimit
         ) {
           retryingMissingMetadata = true;
           continue;

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2691,7 +2691,7 @@ export async function fetchCrossStraitActivitySnapshot({
         runStartedAt,
         nowFn,
         cadenceMs: REQUEST_CADENCE_MS,
-        reservedRequestCount: reservedRefreshAttempts,
+        reservedRequestCount: isRefresh && !retryingMissingMetadata ? 0 : reservedRefreshAttempts,
       })) {
         if (retryingMissingMetadata) mndErrors.push('MND_PUBLICATION_METADATA_MISSING');
         mndErrors.push('OUTBOUND_BUDGET_EXHAUSTED');

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2609,8 +2609,8 @@ export async function fetchCrossStraitActivitySnapshot({
     }
     try {
       if (cadenceMs) await sleepFn(cadenceMs);
-      const html = await fetchBoundedText(fetchFn, url, mndContract);
       requestCount += 1;
+      const html = await fetchBoundedText(fetchFn, url, mndContract);
       const rows = parseTaiwanMndList(html).map((row) => {
         const previous = previousMndByUrl.get(row.sourceUrl);
         return {
@@ -2639,7 +2639,6 @@ export async function fetchCrossStraitActivitySnapshot({
         break;
       }
     } catch (error) {
-      requestCount += 1;
       mndErrors.push(errorCode(error));
       if (page === 1) break;
     }
@@ -2661,29 +2660,46 @@ export async function fetchCrossStraitActivitySnapshot({
   const candidates = [...primaryCandidates, ...refreshCandidates]
     .slice(0, MND_MAX_DETAIL_REQUESTS_PER_RUN);
   const parsedMnd = [];
+  let detailRequestCount = 0;
+  candidateLoop:
   for (const candidate of candidates) {
-    if (!hasMndOutboundBudget({
-      runStartedAt,
-      nowFn,
-      cadenceMs: REQUEST_CADENCE_MS,
-    })) {
-      mndErrors.push('OUTBOUND_BUDGET_EXHAUSTED');
-      break;
-    }
-    try {
-      await sleepFn(REQUEST_CADENCE_MS);
-      const html = await fetchBoundedText(fetchFn, candidate.sourceUrl, mndContract);
-      requestCount += 1;
-      parsedMnd.push(parseTaiwanMndDetail(html, {
-        sourceUrl: candidate.sourceUrl,
-        retrievedAt: generatedAt,
-        expectedPublicationDay: candidate.publicationDay,
-        allowPublicationAdvance: candidate.allowPublicationAdvance === true,
-        expectedReportingDay: candidate.expectedReportingDay ?? null,
-      }));
-    } catch (error) {
-      requestCount += 1;
-      mndErrors.push(errorCode(error));
+    let retryingMissingMetadata = false;
+    while (detailRequestCount < MND_MAX_DETAIL_REQUESTS_PER_RUN) {
+      if (!hasMndOutboundBudget({
+        runStartedAt,
+        nowFn,
+        cadenceMs: REQUEST_CADENCE_MS,
+      })) {
+        if (retryingMissingMetadata) mndErrors.push('MND_PUBLICATION_METADATA_MISSING');
+        mndErrors.push('OUTBOUND_BUDGET_EXHAUSTED');
+        break candidateLoop;
+      }
+      try {
+        await sleepFn(REQUEST_CADENCE_MS);
+        detailRequestCount += 1;
+        requestCount += 1;
+        const html = await fetchBoundedText(fetchFn, candidate.sourceUrl, mndContract);
+        parsedMnd.push(parseTaiwanMndDetail(html, {
+          sourceUrl: candidate.sourceUrl,
+          retrievedAt: generatedAt,
+          expectedPublicationDay: candidate.publicationDay,
+          allowPublicationAdvance: candidate.allowPublicationAdvance === true,
+          expectedReportingDay: candidate.expectedReportingDay ?? null,
+        }));
+        break;
+      } catch (error) {
+        const code = errorCode(error);
+        if (
+          code === 'MND_PUBLICATION_METADATA_MISSING'
+          && !retryingMissingMetadata
+          && detailRequestCount < MND_MAX_DETAIL_REQUESTS_PER_RUN
+        ) {
+          retryingMissingMetadata = true;
+          continue;
+        }
+        mndErrors.push(code);
+        break;
+      }
     }
   }
 

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -94,6 +94,13 @@ function mndListWithCount(count: number, firstId = 90_000): string {
   </div>`;
 }
 
+function mndDetailWithoutPublicationMetadata(): string {
+  return fixture('mnd-detail.html').replace(
+    /<div class="newsInfo">[\s\S]*?<\/div>/,
+    '',
+  );
+}
+
 function mndObservationForDay(day: number, aircraft = day) {
   const date = new Date(Date.UTC(2026, 3, day, 22));
   const reportingDay = date.toISOString().slice(0, 10);
@@ -2615,8 +2622,10 @@ describe('quantified cross-Strait activity (#5575)', () => {
 
     assert.equal(mnd?.transportStatus, 'error');
     assert.ok(mnd?.errorCodes.includes('MND_LIST_ROWS_MISSING'));
+    assert.ok(mnd?.errorCodes.includes('MND_PUBLICATION_METADATA_MISSING'));
     assert.match(mndRequests[0] ?? '', /plaactlist/i);
-    assert.equal(mndRequests.length, 1 + MND_REFRESH_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(mndRequests.length, 1 + MND_REFRESH_DETAIL_REQUESTS_PER_RUN * 2);
+    assert.equal(mnd?.requestCount, mndRequests.length);
     assert.equal(
       snapshot.observations.filter((row: { sourceId: string }) => row.sourceId === 'taiwan-mnd').length,
       MND_REQUIRED_REPORTING_DAYS,
@@ -2871,6 +2880,114 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(
       snapshot.observations.filter((row: { sourceId: string }) => row.sourceId === 'taiwan-mnd').length,
       1,
+    );
+  });
+
+  it('retries transient missing MND publication metadata within the detail request cap', async () => {
+    const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    const detailCalls: string[] = [];
+    const firstUrl = 'https://www.mnd.gov.tw/en/News/PLAAct/90000';
+    let firstUrlAttempts = 0;
+    const missingMetadata = mndDetailWithoutPublicationMetadata();
+    const fetchFn = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+      if (url.includes('plaactlist')) return new Response(list);
+      detailCalls.push(url);
+      if (url === firstUrl) {
+        firstUrlAttempts += 1;
+        if (firstUrlAttempts === 1) return new Response(missingMetadata);
+      }
+      return new Response(fixture('mnd-detail.html'));
+    };
+
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn,
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+    });
+    const mnd = snapshot.sources.find((source: { id: string }) => source.id === 'taiwan-mnd');
+
+    assert.equal(firstUrlAttempts, 2);
+    assert.ok(detailCalls.length <= MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(mnd?.requestCount, detailCalls.length + 1);
+    assert.equal(mnd?.transportStatus, 'fresh');
+    assert.deepEqual(mnd?.errorCodes, []);
+  });
+
+  it('keeps missing metadata hard when the detail request cap blocks its retry', async () => {
+    const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    const detailCalls: string[] = [];
+    const lastUrl = `https://www.mnd.gov.tw/en/News/PLAAct/${90_000 + MND_MAX_DETAIL_REQUESTS_PER_RUN - 1}`;
+    const fetchFn = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+      if (url.includes('plaactlist')) return new Response(list);
+      detailCalls.push(url);
+      return new Response(
+        url === lastUrl ? mndDetailWithoutPublicationMetadata() : fixture('mnd-detail.html'),
+      );
+    };
+
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn,
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+    });
+    const mnd = snapshot.sources.find((source: { id: string }) => source.id === 'taiwan-mnd');
+
+    assert.equal(detailCalls.length, MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(detailCalls.filter((url) => url === lastUrl).length, 1);
+    assert.equal(mnd?.requestCount, MND_MAX_DETAIL_REQUESTS_PER_RUN + 1);
+    assert.equal(mnd?.transportStatus, 'error');
+    assert.ok(mnd?.errorCodes.includes('MND_PUBLICATION_METADATA_MISSING'));
+  });
+
+  it('retains metadata failure when the outbound budget expires before retry', async () => {
+    const retained = Array.from(
+      { length: MND_REQUIRED_REPORTING_DAYS },
+      (_, index) => mndObservationForDay(index + 1),
+    );
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt,
+      previousSnapshot: null,
+      mndOutcome: { ok: true, requestCount: 0, observations: retained },
+      japanOutcome: { ok: true, requestCount: 0, availableDocumentUrls: [] },
+    });
+    const previousMnd = previousSnapshot.sources.find(
+      (source: { id: string }) => source.id === 'taiwan-mnd',
+    );
+    let clock = 0;
+    const mndRequests: string[] = [];
+    const fetchFn = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+      mndRequests.push(url);
+      if (url.includes('plaactlist')) return new Response(mndListWithCount(1));
+      clock = MND_OUTBOUND_BUDGET_MS;
+      return new Response(mndDetailWithoutPublicationMetadata());
+    };
+
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn,
+      now: Date.parse(retrievedAt),
+      previousSnapshot,
+      nowFn: () => clock,
+      sleepFn: async () => {},
+    });
+    const mnd = snapshot.sources.find((source: { id: string }) => source.id === 'taiwan-mnd');
+
+    assert.equal(mndRequests.length, 2);
+    assert.equal(mnd?.requestCount, mndRequests.length);
+    assert.equal(mnd?.transportStatus, 'error');
+    assert.ok(mnd?.errorCodes.includes('MND_PUBLICATION_METADATA_MISSING'));
+    assert.ok(mnd?.errorCodes.includes('OUTBOUND_BUDGET_EXHAUSTED'));
+    assert.equal(mnd?.lastSuccessAt, previousMnd?.lastSuccessAt);
+    assert.equal(
+      snapshot.observations.filter((row: { sourceId: string }) => row.sourceId === 'taiwan-mnd').length,
+      retained.length,
     );
   });
 

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -2916,6 +2916,138 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.deepEqual(mnd?.errorCodes, []);
   });
 
+  it('preserves reserved correction refreshes when a primary detail needs a retry', async () => {
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt,
+      previousSnapshot: null,
+      mndOutcome: {
+        ok: true,
+        requestCount: 0,
+        observations: Array.from({ length: 28 }, (_, index) => mndObservationForDay(index + 1)),
+      },
+      japanOutcome: { ok: true, requestCount: 0, availableDocumentUrls: [] },
+    });
+    const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    const firstPrimaryUrl = 'https://www.mnd.gov.tw/en/News/PLAAct/90000';
+    const detailCalls: string[] = [];
+    let firstPrimaryAttempts = 0;
+    const fetchFn = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+      if (url.includes('plaactlist')) return new Response(list);
+      detailCalls.push(url);
+      if (url === firstPrimaryUrl) {
+        firstPrimaryAttempts += 1;
+        if (firstPrimaryAttempts === 1) return new Response(mndDetailWithoutPublicationMetadata());
+      }
+      return new Response(fixture('mnd-detail.html'));
+    };
+
+    await fetchCrossStraitActivitySnapshot({
+      fetchFn,
+      now: Date.parse(retrievedAt),
+      previousSnapshot,
+      sleepFn: async () => {},
+    });
+
+    const correctionRefreshes = detailCalls.filter((url) => /\/PLAAct\/860\d{2}$/.test(url));
+    assert.equal(firstPrimaryAttempts, 2);
+    assert.equal(correctionRefreshes.length, MND_REFRESH_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(detailCalls.length, MND_MAX_DETAIL_REQUESTS_PER_RUN);
+  });
+
+  it('preserves correction refresh wall-clock headroom when a primary detail needs a retry', async () => {
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt,
+      previousSnapshot: null,
+      mndOutcome: {
+        ok: true,
+        requestCount: 0,
+        observations: Array.from({ length: 28 }, (_, index) => mndObservationForDay(index + 1)),
+      },
+      japanOutcome: { ok: true, requestCount: 0, availableDocumentUrls: [] },
+    });
+    const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    const firstPrimaryUrl = 'https://www.mnd.gov.tw/en/News/PLAAct/90000';
+    const detailCalls: string[] = [];
+    let firstPrimaryAttempts = 0;
+    let clock = 0;
+    const fetchFn = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+      clock += 9_000;
+      if (url.includes('plaactlist')) return new Response(list);
+      detailCalls.push(url);
+      if (url === firstPrimaryUrl) {
+        firstPrimaryAttempts += 1;
+        if (firstPrimaryAttempts === 1) return new Response(mndDetailWithoutPublicationMetadata());
+      }
+      return new Response(fixture('mnd-detail.html'));
+    };
+
+    await fetchCrossStraitActivitySnapshot({
+      fetchFn,
+      now: Date.parse(retrievedAt),
+      nowFn: () => clock,
+      previousSnapshot,
+      sleepFn: async (ms) => { clock += ms; },
+    });
+
+    const correctionRefreshes = detailCalls.filter((url) => /\/PLAAct\/860\d{2}$/.test(url));
+    assert.equal(firstPrimaryAttempts, 2);
+    assert.equal(correctionRefreshes.length, MND_REFRESH_DETAIL_REQUESTS_PER_RUN);
+    assert.ok(clock <= MND_OUTBOUND_BUDGET_MS);
+  });
+
+  it('continues reserved corrections when one correction cannot fit its metadata retry', async () => {
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt,
+      previousSnapshot: null,
+      mndOutcome: {
+        ok: true,
+        requestCount: 0,
+        observations: Array.from({ length: 28 }, (_, index) => mndObservationForDay(index + 1)),
+      },
+      japanOutcome: { ok: true, requestCount: 0, availableDocumentUrls: [] },
+    });
+    const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    const detailCalls: string[] = [];
+    let firstCorrectionUrl = '';
+    let clock = 0;
+    const fetchFn = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+      if (url.includes('plaactlist')) return new Response(list);
+      detailCalls.push(url);
+      const isCorrection = /\/PLAAct\/860\d{2}$/.test(url);
+      if (isCorrection && firstCorrectionUrl === '') firstCorrectionUrl = url;
+      clock += url === firstCorrectionUrl ? 15_000 : 13_000;
+      return new Response(
+        url === firstCorrectionUrl
+          ? mndDetailWithoutPublicationMetadata()
+          : fixture('mnd-detail.html'),
+      );
+    };
+
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn,
+      now: Date.parse(retrievedAt),
+      nowFn: () => clock,
+      previousSnapshot,
+      sleepFn: async (ms) => { clock += ms; },
+    });
+    const mnd = snapshot.sources.find((source: { id: string }) => source.id === 'taiwan-mnd');
+    const correctionRefreshes = detailCalls.filter((url) => /\/PLAAct\/860\d{2}$/.test(url));
+
+    assert.equal(new Set(correctionRefreshes).size, MND_REFRESH_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(correctionRefreshes.filter((url) => url === firstCorrectionUrl).length, 1);
+    assert.ok(detailCalls.length <= MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    assert.ok(clock <= MND_OUTBOUND_BUDGET_MS);
+    assert.equal(mnd?.transportStatus, 'error');
+    assert.ok(mnd?.errorCodes.includes('MND_PUBLICATION_METADATA_MISSING'));
+    assert.ok(mnd?.errorCodes.includes('OUTBOUND_BUDGET_EXHAUSTED'));
+  });
+
   it('keeps missing metadata hard when the detail request cap blocks its retry', async () => {
     const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
     const detailCalls: string[] = [];

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -2854,6 +2854,67 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(snapshot.sources[0].requestCount, mndCalls.length);
   });
 
+  it('uses remaining time for correction first attempts after slow list discovery', async () => {
+    const correctionDetails = new Map([21, 22, 23].map((day) => [
+      `https://www.mnd.gov.tw/en/News/PLAAct/${99_000 + day}`,
+      fixture('mnd-detail.html')
+        .replace('2026.07.25', `2026.07.${day}`)
+        .replace(
+          '6 a.m. Jul. 24 (Fri.) to 6 a.m. Jul. 25 (Sat.) (UTC+8)',
+          `6 a.m. Jul. ${day - 1} to 6 a.m. Jul. ${day} (UTC+8)`,
+        ),
+    ]));
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: '2026-07-25T05:30:00.000Z',
+      previousSnapshot: null,
+      mndOutcome: {
+        ok: true,
+        requestCount: 0,
+        observations: [...correctionDetails].map(([sourceUrl, html]) => parseTaiwanMndDetail(html, {
+          sourceUrl,
+          retrievedAt,
+          expectedPublicationDay: `2026-07-${sourceUrl.slice(-2)}`,
+        })),
+      },
+      japanOutcome: { ok: true, requestCount: 0, availableDocumentUrls: [] },
+    });
+
+    for (const [listDelayMs, expectedDetails] of [[14_000, 2], [16_000, 1]]) {
+      let clock = 0;
+      let listCalls = 0;
+      const detailCalls: string[] = [];
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        now: Date.parse(retrievedAt),
+        nowFn: () => clock,
+        previousSnapshot,
+        proxyUrl: '',
+        sleepFn: async (ms) => { clock += ms; },
+        fetchFn: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+          if (url.includes('plaactlist')) {
+            listCalls += 1;
+            clock += listDelayMs;
+            return new Response(fixture('mnd-list.html'));
+          }
+          detailCalls.push(url);
+          clock += 20_000;
+          return new Response(correctionDetails.get(url) ?? fixture('mnd-detail.html'));
+        },
+      });
+      const mnd = snapshot.sources.find((source: { id: string }) => source.id === 'taiwan-mnd');
+
+      assert.equal(listCalls, MND_MAX_LIST_PAGES_PER_BACKFILL_RUN);
+      assert.equal(detailCalls.length, expectedDetails);
+      assert.ok(detailCalls.every((url) => correctionDetails.has(url)));
+      assert.ok(clock <= MND_OUTBOUND_BUDGET_MS);
+      assert.equal(mnd?.requestCount, listCalls + detailCalls.length);
+      assert.equal(mnd?.transportStatus, 'fresh');
+      assert.equal(mnd?.lastSuccessAt, retrievedAt);
+      assert.deepEqual(mnd?.errorCodes, ['OUTBOUND_BUDGET_EXHAUSTED']);
+    }
+  });
+
   it('keeps a partial MND collection fresh when only the outbound budget stops more work', async () => {
     let budgetCheck = 0;
     const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);


### PR DESCRIPTION
## Summary

The Taiwan MND source now recovers when an otherwise successful detail request returns a transient page without its publication metadata container. Production recorded `MND_PUBLICATION_METADATA_MISSING` while the bundle still published retained data; the deployed request accounting showed 15 requests because two parser failures were each counted twice on a 13-request run.

The adapter retries only this metadata-missing signature once. The retry consumes the existing 20-detail-request limit and the existing monotonic wall-clock budget. It displaces optional primary backfill work so all three reserved correction refreshes keep their first attempt. A repeated malformed response remains a hard source error, keeps the prior `lastSuccessAt`, and preserves last-good observations.

Related: #7684

## Validation

- `./node_modules/.bin/tsx --test --test-timeout=120000 tests/cross-strait-activity.test.mts` - 101 passed, 0 failed
- `npm run test:data` - 30,240 passed, 0 failed, 40 skipped
- `npm run typecheck` - passed
- `npm run lint` - passed with existing warnings outside this diff
- Full code review - 9 reviewer lenses, 0 findings, 0 remaining test gaps

The regression tests cover transient recovery, persistent malformed responses, the request-20 boundary, wall-clock expiry before retry, reserved correction attempts under the request and time budgets, exact request accounting, and last-good retention.

## Post-Deploy Monitoring & Validation

- Watch the next natural three-hour `Cross-Strait-Activity` bundle run and one following run. Do not invoke the seeder manually.
- Search logs for `MND_PUBLICATION_METADATA_MISSING`, `OUTBOUND_BUDGET_EXHAUSTED`, and the Taiwan MND source result.
- Healthy signal: `crossStraitActivityTaiwanMnd` advances `lastSuccessAt`, reports fresh transport, and has no metadata-missing error.
- Failure trigger: metadata remains missing after the bounded retry, `lastSuccessAt` does not advance, or health remains `SEED_ERROR`.
- Owner: WorldMonitor production operator.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-6](https://img.shields.io/badge/GPT--6-000000)
