### PR TITLE
test(slop-audit): give six weak guards teeth

### DIFF
--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -654,6 +654,11 @@ function coverageWeightedMean(dimensions: ResilienceDimension[]): number {
   return weightedSum / totalWeight;
 }
 
+export const __testing__ = {
+  coverageWeightedMean,
+  IMPUTED_DIM_WEIGHT_FACTOR,
+};
+
 export const PENALTY_ALPHA = 0.50;
 
 export function penalizedPillarScore(pillars: { score: number; weight: number }[]): number {

--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -1025,3 +1025,8 @@ export async function fetchLngVulnerability(): Promise<LngVulnerabilityData | nu
 
   return null;
 }
+
+export const __testing__ = {
+  getWbBreaker,
+  wbBreakerPoolSize: () => wbBreakers.size,
+};

--- a/tests/helpers/vite-glob-stub.mjs
+++ b/tests/helpers/vite-glob-stub.mjs
@@ -1,0 +1,4 @@
+// Stands in for Vite's `import.meta.glob` when a browser module is bundled
+// for node with esbuild. Callers only enumerate the result, so an empty map
+// is enough; anything that actually needs a locale must load it explicitly.
+export const __wmNoGlob = () => ({});

--- a/tests/insights-loader.test.mjs
+++ b/tests/insights-loader.test.mjs
@@ -8,6 +8,7 @@ import {
   __resetServerInsightsCacheForTests,
 } from '../src/services/insights-loader';
 import { __testing__ as bootstrapTesting } from '../src/services/bootstrap';
+import { insightsSnapshotRejection } from '../shared/insights-snapshot.js';
 
 describe('insights-loader', () => {
   describe('MAX_AGE_MS — server-cadence-aligned freshness window', () => {
@@ -24,63 +25,88 @@ describe('insights-loader', () => {
     });
   });
 
-  describe('getServerInsights (logic validation)', () => {
-    function isFresh(generatedAt) {
-      const age = Date.now() - new Date(generatedAt).getTime();
-      return age < MAX_AGE_MS;
-    }
-
-    it('rejects data older than the freshness window', () => {
-      const old = new Date(Date.now() - MAX_AGE_MS - 60_000).toISOString();
-      assert.equal(isFresh(old), false);
+  // These asserted against a local isFresh copy and against object literals
+  // the test had just written ("assert.equal(degraded.worldBrief, '')" on a
+  // literal ''), so neither block could fail. Both gates live in the shared
+  // validator, which names the reason it rejects.
+  describe('insightsSnapshotRejection — freshness gate', () => {
+    const now = Date.parse('2026-09-05T12:00:00.000Z');
+    const snapshotAt = (ageMs) => ({
+      topStories: [{ primaryTitle: 'Test', sourceCount: 2 }],
+      generatedAt: new Date(now - ageMs).toISOString(),
     });
 
-    it('accepts data younger than the freshness window', () => {
-      const fresh = new Date(Date.now() - 5 * 60 * 1000).toISOString();
-      assert.equal(isFresh(fresh), true);
+    it('accepts a snapshot generated now', () => {
+      assert.equal(insightsSnapshotRejection(snapshotAt(0), now), null);
     });
 
-    it('accepts data from now', () => {
-      assert.equal(isFresh(new Date().toISOString()), true);
+    it('accepts a snapshot inside the window', () => {
+      assert.equal(insightsSnapshotRejection(snapshotAt(5 * 60 * 1000), now), null);
     });
 
-    it('rejects exactly window-aged data', () => {
-      const exact = new Date(Date.now() - MAX_AGE_MS).toISOString();
-      assert.equal(isFresh(exact), false);
+    it('rejects a snapshot exactly the window old', () => {
+      assert.equal(insightsSnapshotRejection(snapshotAt(MAX_AGE_MS), now), 'stale-snapshot');
+    });
+
+    it('rejects a snapshot past the window', () => {
+      assert.equal(insightsSnapshotRejection(snapshotAt(MAX_AGE_MS + 60_000), now), 'stale-snapshot');
+    });
+
+    it('rejects a snapshot generated in the future', () => {
+      assert.equal(insightsSnapshotRejection(snapshotAt(-60_000), now), 'future-generated-at');
     });
   });
 
-  describe('ServerInsights payload shape', () => {
-    it('validates required fields', () => {
-      const valid = {
+  describe('insightsSnapshotRejection — payload shape gate', () => {
+    const now = Date.parse('2026-09-05T12:00:00.000Z');
+    const generatedAt = new Date(now).toISOString();
+
+    it('accepts a full payload', () => {
+      assert.equal(insightsSnapshotRejection({
         worldBrief: 'Test brief',
         worldBriefSources: [{ title: 'Test', source: 's', url: 'https://example.com/test' }],
         briefProvider: 'groq',
         status: 'ok',
         topStories: [{ primaryTitle: 'Test', sourceCount: 2 }],
-        generatedAt: new Date().toISOString(),
+        generatedAt,
         clusterCount: 10,
         multiSourceCount: 5,
         fastMovingCount: 3,
-      };
-      assert.ok(valid.topStories.length >= 1);
-      assert.ok(['ok', 'degraded'].includes(valid.status));
+      }, now), null);
     });
 
-    it('allows degraded status with empty brief', () => {
-      const degraded = {
+    it('accepts a degraded payload with an empty brief', () => {
+      assert.equal(insightsSnapshotRejection({
         worldBrief: '',
         status: 'degraded',
         topStories: [{ primaryTitle: 'Test' }],
-        generatedAt: new Date().toISOString(),
-      };
-      assert.equal(degraded.worldBrief, '');
-      assert.equal(degraded.status, 'degraded');
+        generatedAt,
+      }, now), null);
     });
 
     it('rejects empty topStories', () => {
-      const empty = { topStories: [] };
-      assert.equal(empty.topStories.length >= 1, false);
+      assert.equal(insightsSnapshotRejection({ topStories: [], generatedAt }, now), 'malformed-snapshot');
+    });
+
+    it('rejects a payload with no topStories array', () => {
+      assert.equal(insightsSnapshotRejection({ generatedAt }, now), 'malformed-snapshot');
+    });
+
+    it('rejects a non-object payload', () => {
+      assert.equal(insightsSnapshotRejection(null, now), 'malformed-snapshot');
+    });
+
+    it('rejects a payload with no generatedAt', () => {
+      assert.equal(insightsSnapshotRejection({
+        topStories: [{ primaryTitle: 'Test' }],
+      }, now), 'missing-generated-at');
+    });
+
+    it('rejects an unparseable generatedAt', () => {
+      assert.equal(insightsSnapshotRejection({
+        topStories: [{ primaryTitle: 'Test' }],
+        generatedAt: 'not-a-date',
+      }, now), 'missing-generated-at');
     });
   });
 

--- a/tests/oil-inventories.test.mjs
+++ b/tests/oil-inventories.test.mjs
@@ -1,199 +1,115 @@
-import { describe, it } from 'node:test';
+// Contract tests for the GetOilInventories RPC.
+//
+// These called a local copy of the handler's mapping logic until the copy
+// drifted: it emitted `changeWoW` and `changeWoW4` and used `null` for absent
+// sections, while the handler emits `changeWow`, drops `changeWoW4`, and uses
+// `undefined`. The copy asserted the seeder's payload shape, not the response
+// the panel reads. They now drive the real handler over a fake Upstash.
+
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { createRedisFetch } from './helpers/fake-upstash-redis.mts';
+import { getOilInventories } from '../server/worldmonitor/economic/v1/get-oil-inventories.ts';
+import { escapeHtml } from '../src/utils/sanitize.ts';
 
-// ─── Inline helpers mirroring handler mapping logic ───
+const CRUDE_KEY = 'economic:crude-inventories:v1';
+const SPR_KEY = 'economic:spr:v1';
+const NAT_GAS_KEY = 'economic:nat-gas-storage:v1';
 
-/** Maps raw SPR seed payload to handler response shape. Value is ALREADY in Mb. */
-function mapSprResponse(raw) {
-  if (!raw) return null;
-  return {
-    latestPeriod: raw.latestPeriod,
-    latestStocksMb: raw.barrels,
-    changeWoW: raw.changeWoW,
-    changeWoW4: raw.changeWoW4,
-    weeks: (raw.weeks ?? []).map(w => ({ period: w.period, stocksMb: w.barrels })),
-  };
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+before(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  process.env.UPSTASH_REDIS_REST_URL = originalEnv.url;
+  process.env.UPSTASH_REDIS_REST_TOKEN = originalEnv.token;
+});
+
+/** Seeds the fake Upstash with the given keys and runs the real handler. */
+async function callHandler(fixtures) {
+  const { fetchImpl } = createRedisFetch(fixtures);
+  globalThis.fetch = fetchImpl;
+  return getOilInventories({}, {});
 }
 
-/** Simulates handler assembling partial response from 6 Redis keys */
-function assembleOilInventories({ crude, spr, natGas, euGas, iea, refinery }) {
-  return {
-    crudeWeeks: crude ?? null,
-    spr: spr ? mapSprResponse(spr) : null,
-    natGasWeeks: natGas ?? null,
-    euGas: euGas ?? null,
-    ieaStocks: iea ?? null,
-    refinery: refinery ?? null,
-  };
-}
-
-// ─── Pure utility helpers ───
-
-function reverseForChart(weeks) {
-  return weeks.slice().reverse();
-}
-
-function sortIeaForChart(members) {
-  return members.slice().sort((a, b) => {
-    const aNet = a.netExporter === true;
-    const bNet = b.netExporter === true;
-    if (aNet !== bNet) return aNet ? 1 : -1;
-    const aVal = a.daysOfCover ?? Infinity;
-    const bVal = b.daysOfCover ?? Infinity;
-    return aVal - bVal;
-  });
-}
-
-function escapeHtml(str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function mergeByPeriod(crudeWeeks, sprWeeks) {
-  const crudeMap = new Map(crudeWeeks.map(w => [w.period, w.stocksMb]));
-  const sprMap = new Map(sprWeeks.map(w => [w.period, w.stocksMb]));
-  const allPeriods = [...new Set([...crudeMap.keys(), ...sprMap.keys()])].sort();
-  return allPeriods.map(p => ({
-    period: p,
-    crudeMb: crudeMap.get(p) ?? null,
-    sprMb: sprMap.get(p) ?? null,
-  }));
-}
-
-// ─── Tests ───
-
-describe('Oil Inventories', () => {
-
-  // Test 1: SPR double-conversion guard
-  it('SPR values are already in Mb — handler must NOT divide by 1,000,000', () => {
-    const mockSpr = {
-      latestPeriod: '2026-04-04',
-      barrels: 395.2,
-      changeWoW: -0.3,
-      changeWoW4: -1.2,
-      weeks: [
-        { period: '2026-04-04', barrels: 395.2 },
-        { period: '2026-03-28', barrels: 395.5 },
-      ],
-    };
-
-    const sprResponse = mapSprResponse(mockSpr);
-
-    assert.equal(sprResponse.latestStocksMb, 395.2, 'latestStocksMb must equal raw barrels (already Mb)');
-    assert.ok(sprResponse.latestStocksMb > 100, `SPR sanity guard failed: ${sprResponse.latestStocksMb} <= 100 (real SPR is ~350-400 Mb)`);
-    assert.equal(sprResponse.weeks[0].stocksMb, 395.2, 'weeks[0].stocksMb must equal raw barrels');
-    assert.equal(sprResponse.weeks[1].stocksMb, 395.5);
-    assert.equal(sprResponse.changeWoW, -0.3);
-    assert.equal(sprResponse.changeWoW4, -1.2);
-  });
-
-  // Test 2: Handler partial-key availability
-  it('degrades independently when some Redis keys return null', () => {
-    const response = assembleOilInventories({
-      crude: [{ period: '2026-04-04', stocksMb: 440 }],
-      spr: null,
-      natGas: [{ period: '2026-04-04', storageBcf: 1800 }],
-      euGas: null,
-      iea: null,
-      refinery: null,
+describe('GetOilInventories — SPR unit contract', () => {
+  it('passes SPR barrels through as Mb without dividing by 1,000,000', async () => {
+    const response = await callHandler({
+      [SPR_KEY]: {
+        latestPeriod: '2026-04-04',
+        barrels: 395.2,
+        changeWoW: -0.3,
+        changeWoW4: -1.2,
+        weeks: [
+          { period: '2026-04-04', barrels: 395.2 },
+          { period: '2026-03-28', barrels: 395.5 },
+        ],
+      },
     });
 
-    assert.ok(Array.isArray(response.crudeWeeks), 'crudeWeeks should be an array');
-    assert.ok(response.crudeWeeks.length > 0, 'crudeWeeks should have entries');
-    assert.equal(response.spr, null, 'spr should be null when Redis key missing');
-    assert.ok(Array.isArray(response.natGasWeeks), 'natGasWeeks should be an array');
-    assert.ok(response.natGasWeeks.length > 0, 'natGasWeeks should have entries');
-    assert.equal(response.euGas, null, 'euGas should be null when Redis key missing');
-    assert.equal(response.ieaStocks, null, 'ieaStocks should be null when Redis key missing');
-    assert.equal(response.refinery, null, 'refinery should be null when Redis key missing');
-  });
-
-  // Test 3: Chart sort order verification
-  it('reverses EIA data to oldest-first for charting and sorts IEA by daysOfCover', () => {
-    const crudeNewestFirst = [
-      { period: '2026-04-04', stocksMb: 440 },
-      { period: '2026-03-28', stocksMb: 442 },
-      { period: '2026-03-21', stocksMb: 444 },
-    ];
-
-    const reversed = reverseForChart(crudeNewestFirst);
-    assert.equal(reversed[0].period, '2026-03-21', 'reversed[0] should be oldest');
-    assert.equal(reversed[2].period, '2026-04-04', 'reversed[last] should be newest');
-    assert.equal(crudeNewestFirst[0].period, '2026-04-04', 'original array must not be mutated');
-
-    const ieaMembers = [
-      { country: 'US', daysOfCover: 120, netExporter: false },
-      { country: 'JP', daysOfCover: 85, netExporter: false },
-      { country: 'NO', daysOfCover: 150, netExporter: true },
-      { country: 'XX', daysOfCover: null, netExporter: false },
-    ];
-
-    const sorted = sortIeaForChart(ieaMembers);
-    assert.equal(sorted[0].daysOfCover, 85, 'lowest daysOfCover first');
-    assert.equal(sorted[1].daysOfCover, 120, 'second lowest next');
-    // netExporter and null daysOfCover go to bottom
-    assert.equal(sorted[2].country, 'XX', 'null daysOfCover should be near bottom');
-    assert.equal(sorted[3].country, 'NO', 'netExporter should be last');
-  });
-
-  // Test 4: SVG label escaping
-  it('escapes HTML/SVG-unsafe characters in upstream strings', () => {
-    assert.equal(
-      escapeHtml('<script>alert(1)</script>'),
-      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    assert.equal(response.spr.latestStocksMb, 395.2, 'latestStocksMb must equal raw barrels (already Mb)');
+    assert.ok(
+      response.spr.latestStocksMb > 100,
+      `SPR sanity guard failed: ${response.spr.latestStocksMb} <= 100 (real SPR is ~350-400 Mb)`,
     );
+    assert.equal(response.spr.weeks[0].stocksMb, 395.2);
+    assert.equal(response.spr.weeks[1].stocksMb, 395.5);
+  });
+
+  it('emits changeWow and does not surface the seeder-only changeWoW4', async () => {
+    const response = await callHandler({
+      [SPR_KEY]: { latestPeriod: '2026-04-04', barrels: 395.2, changeWoW: -0.3, changeWoW4: -1.2, weeks: [] },
+    });
+
+    assert.equal(response.spr.changeWow, -0.3, 'the proto field is changeWow, sourced from the seeder changeWoW');
+    assert.ok(!('changeWoW' in response.spr), 'the seeder spelling must not leak into the response');
+    assert.ok(!('changeWoW4' in response.spr), 'changeWoW4 is seeder-only and the handler drops it');
+  });
+
+  it('defaults changeWow to 0 when the seeder omits it', async () => {
+    const response = await callHandler({ [SPR_KEY]: { barrels: 395.2, weeks: [] } });
+    assert.equal(response.spr.changeWow, 0);
+  });
+});
+
+describe('GetOilInventories — partial Redis availability', () => {
+  it('degrades section by section, leaving absent sections undefined', async () => {
+    const response = await callHandler({
+      [CRUDE_KEY]: { weeks: [{ period: '2026-04-04', stocksMb: 440, weeklyChangeMb: -2 }] },
+      [NAT_GAS_KEY]: { weeks: [{ period: '2026-04-04', storBcf: 1800, weeklyChangeBcf: 12 }] },
+    });
+
+    assert.ok(Array.isArray(response.crudeWeeks));
+    assert.equal(response.crudeWeeks.length, 1);
+    assert.ok(Array.isArray(response.natGasWeeks));
+    assert.equal(response.natGasWeeks.length, 1);
+    assert.equal(response.spr, undefined, 'absent sections are undefined, not null');
+    assert.equal(response.euGas, undefined);
+    assert.equal(response.ieaStocks, undefined);
+    assert.equal(response.refinery, undefined);
+  });
+
+  it('returns empty week arrays when every key is missing', async () => {
+    const response = await callHandler({});
+
+    assert.deepEqual(response.crudeWeeks, []);
+    assert.deepEqual(response.natGasWeeks, []);
+    assert.equal(response.spr, undefined);
+  });
+});
+
+describe('SVG label escaping', () => {
+  it('escapes HTML-unsafe characters in upstream strings', () => {
+    assert.equal(escapeHtml('<script>alert(1)</script>'), '&lt;script&gt;alert(1)&lt;/script&gt;');
     assert.equal(escapeHtml('US'), 'US', 'safe strings must not be mutated');
     assert.equal(escapeHtml('R&D'), 'R&amp;D');
-    assert.equal(escapeHtml('"quoted"'), '&quot;quoted&quot;');
-    assert.equal(escapeHtml("it's"), "it&#39;s");
-  });
-
-  // Test 5: Crude/SPR merge-by-period with mismatched weeks
-  it('merges crude and SPR by period with nulls for missing sides', () => {
-    const crudeWeeks = [
-      { period: 'A', stocksMb: 440 },
-      { period: 'B', stocksMb: 442 },
-      { period: 'C', stocksMb: 444 },
-    ];
-    const sprWeeks = [
-      { period: 'B', stocksMb: 395 },
-      { period: 'C', stocksMb: 396 },
-      { period: 'D', stocksMb: 397 },
-    ];
-
-    const result = mergeByPeriod(crudeWeeks, sprWeeks);
-
-    assert.equal(result.length, 4, 'union of periods A,B,C,D = 4 entries');
-    assert.deepEqual(result[0], { period: 'A', crudeMb: 440, sprMb: null });
-    assert.deepEqual(result[1], { period: 'B', crudeMb: 442, sprMb: 395 });
-    assert.deepEqual(result[2], { period: 'C', crudeMb: 444, sprMb: 396 });
-    assert.deepEqual(result[3], { period: 'D', crudeMb: null, sprMb: 397 });
-  });
-
-  // Test 6: Stacked chart skips weeks where one series is null (no fake zero-collapse)
-  it('stacked chart filters to complete weeks only, falls back to crude-only when SPR absent', () => {
-    const merged = mergeByPeriod(
-      [{ period: 'A', stocksMb: 440 }, { period: 'B', stocksMb: 442 }, { period: 'C', stocksMb: 444 }],
-      [{ period: 'B', stocksMb: 395 }, { period: 'C', stocksMb: 396 }],
-    );
-    // Week A has crude but no SPR => should NOT appear in complete set
-    const complete = merged.filter(w => w.crudeMb != null && w.sprMb != null);
-    assert.equal(complete.length, 2, 'only B and C have both series');
-    assert.equal(complete[0].period, 'B');
-    assert.equal(complete[1].period, 'C');
-
-    // When SPR is entirely absent, fall back to crude-only
-    const noSpr = mergeByPeriod(
-      [{ period: 'X', stocksMb: 100 }, { period: 'Y', stocksMb: 200 }],
-      [],
-    );
-    const completeNoSpr = noSpr.filter(w => w.crudeMb != null && w.sprMb != null);
-    assert.equal(completeNoSpr.length, 0, 'no complete weeks when SPR absent');
-    const crudeOnly = noSpr.filter(w => w.crudeMb != null);
-    assert.equal(crudeOnly.length, 2, 'crude-only fallback should have 2 weeks');
   });
 });

--- a/tests/resilience-cohort-anti-inversion.test.mts
+++ b/tests/resilience-cohort-anti-inversion.test.mts
@@ -299,17 +299,17 @@ describe('cohort anti-inversion deterministic fixture (Plan 2026-04-26-002 §U1)
 });
 
 describe('cohort anti-inversion against live ranking (Plan 2026-04-26-002 §U1)', () => {
-  // SKIP guard: if Upstash creds are missing, all tests in this describe block
-  // log + pass without running the live invariants. Required for CI-without-prod-creds.
+  // Skips without Upstash creds so CI and dev machines still pass. The same
+  // four invariants run unconditionally against the committed fixture above,
+  // so skipping here loses the production reading, not the invariant.
   const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
   const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
   const credsPresent = Boolean(upstashUrl && upstashToken);
 
   if (!credsPresent) {
-    it('[skip] live invariants — UPSTASH_REDIS_REST_URL/TOKEN not set in env', () => {
-      console.log('[cohort-anti-inversion] Skipping live invariants — no Upstash credentials in env. Set UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN to run.');
-      assert.ok(true);
-    });
+    // A real skip, not a passing no-op. Reporting this as a pass inflated the
+    // count with a case that asserted nothing.
+    it.skip('live invariants — UPSTASH_REDIS_REST_URL/TOKEN not set in env', () => {});
     return;
   }
 
@@ -394,12 +394,12 @@ describe('cohort anti-inversion against live ranking (Plan 2026-04-26-002 §U1)'
       'Plan 002 §U6 per-capita normalization should keep microstate-territories out of the top 20.');
   });
 
-  it('REPORT-ONLY: per-cohort coverage in the live ranking [diagnostic]', () => {
-    if (!ranking) return;
+  it('every cohort has live-ranking coverage', () => {
+    assert.ok(ranking, 'live ranking must be loaded');
     for (const [key, cohort] of Object.entries(cohorts)) {
       const present = cohort.iso2.filter((iso) => ranking!.has(iso)).length;
       console.log(`[cohort-anti-inversion] ${key}: ${present}/${cohort.iso2.length} present in ranking`);
+      assert.ok(present > 0, `${key} has no members in the live ranking, so its invariants read nothing`);
     }
-    assert.ok(true);
   });
 });

--- a/tests/resilience-coverage-penalty.test.mts
+++ b/tests/resilience-coverage-penalty.test.mts
@@ -3,119 +3,104 @@
 //
 // The penalty halves the effective weight of any dim with a non-empty
 // `imputationClass` (i.e., the scorer set the class because the dim has
-// no observed data). These tests pin the math directly using synthetic
-// dim arrays so future contributors can't silently change the factor.
+// no observed data).
+//
+// These asserted against a local mirror of the formula whose stated
+// detection mechanism was a reviewer noticing the mirror and the real
+// function disagree. It had already drifted: the mirror read a per-dim
+// `weight` field, while the real function looks the weight up in
+// RESILIENCE_DIMENSION_WEIGHTS by dimension id. They now call the real
+// function through the module's testing export.
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { __testing__ } from '../server/worldmonitor/resilience/v1/_shared.ts';
 
-// We can't import the private `coverageWeightedMean` directly, but we
-// can drive it end-to-end by constructing fixture dimensions and calling
-// `buildPillarList` / domain aggregation. Simpler approach: replicate
-// the contract here with the EXACT same formula — if the production
-// formula drifts, the §U4 doc-comment in _shared.ts will visibly
-// disagree with this mirror, surfacing the divergence in code review.
+const { coverageWeightedMean, IMPUTED_DIM_WEIGHT_FACTOR } = __testing__;
 
-const IMPUTED_DIM_WEIGHT_FACTOR = 0.5;
-
-function coverageWeightedMeanMirror(
-  dims: Array<{ score: number; coverage: number; weight?: number; imputationClass: string }>,
-): number {
-  let totalWeight = 0;
-  let weightedSum = 0;
-  for (const d of dims) {
-    const w = d.weight ?? 1.0;
-    const imputationFactor = d.imputationClass ? IMPUTED_DIM_WEIGHT_FACTOR : 1.0;
-    const effective = d.coverage * w * imputationFactor;
-    totalWeight += effective;
-    weightedSum += d.score * effective;
-  }
-  if (!totalWeight) return 0;
-  return weightedSum / totalWeight;
+/** A dimension carrying only the fields coverageWeightedMean reads. */
+function dim(id: string, score: number, coverage: number, imputationClass = '') {
+  return { id, score, coverage, imputationClass } as never;
 }
 
 describe('coverage penalty for imputed dims (Plan 2026-04-26-002 §U4)', () => {
+  it('halves the weight of an imputed dim', () => {
+    assert.equal(IMPUTED_DIM_WEIGHT_FACTOR, 0.5);
+  });
+
   it('observed-only dims behave like the v15 coverage-weighted mean (no penalty)', () => {
-    const dims = [
-      { score: 80, coverage: 1.0, imputationClass: '' },
-      { score: 60, coverage: 1.0, imputationClass: '' },
-    ];
-    // (80 + 60) / 2 = 70 — no penalty applied.
-    assert.equal(coverageWeightedMeanMirror(dims), 70);
+    const dims = [dim('macroFiscal', 80, 1.0), dim('cyberDigital', 60, 1.0)];
+    // both weight 1.0, both fully covered: (80 + 60) / 2 = 70.
+    assert.equal(coverageWeightedMean(dims), 70);
   });
 
   it('half-imputed dim contributes half-weight, lifting the mean toward observed dims', () => {
-    // High-scoring imputed dim (85, stable-absence) at half weight, paired
-    // with an observed dim at 60. Pre-§U4: mean = (85 + 60) / 2 = 72.5.
-    // Post-§U4: mean = (85*0.5 + 60*1.0) / (0.5 + 1.0) = (42.5 + 60) / 1.5 = 68.33.
+    // Pre-§U4: mean = (85 + 60) / 2 = 72.5.
+    // Post-§U4: mean = (85*0.5 + 60*1.0) / (0.5 + 1.0) = 68.33.
     const dims = [
-      { score: 85, coverage: 1.0, imputationClass: 'stable-absence' },
-      { score: 60, coverage: 1.0, imputationClass: '' },
+      dim('macroFiscal', 85, 1.0, 'stable-absence'),
+      dim('cyberDigital', 60, 1.0),
     ];
-    const result = coverageWeightedMeanMirror(dims);
-    assert.ok(Math.abs(result - 68.333) < 0.01,
-      `expected ~68.33 (imputed at 0.5 weight), got ${result}`);
+    const result = coverageWeightedMean(dims);
+    assert.ok(Math.abs(result - 68.333) < 0.01, `expected ~68.33 (imputed at 0.5 weight), got ${result}`);
   });
 
   it('low-scoring imputed dim at half weight lifts the mean (less drag)', () => {
-    // unmonitored impute (50/0.3) at half weight; observed dim at 80.
-    // Pre-§U4: weighted = (50*0.3 + 80*1.0) / (0.3 + 1.0) = (15 + 80) / 1.3 ≈ 73.08
-    // Post-§U4: weighted = (50*0.15 + 80*1.0) / (0.15 + 1.0) = (7.5 + 80) / 1.15 ≈ 76.09
+    // Pre-§U4: (50*0.3 + 80*1.0) / (0.3 + 1.0) ≈ 73.08
+    // Post-§U4: (50*0.15 + 80*1.0) / (0.15 + 1.0) ≈ 76.09
     const dims = [
-      { score: 50, coverage: 0.3, imputationClass: 'unmonitored' },
-      { score: 80, coverage: 1.0, imputationClass: '' },
+      dim('macroFiscal', 50, 0.3, 'unmonitored'),
+      dim('cyberDigital', 80, 1.0),
     ];
-    const result = coverageWeightedMeanMirror(dims);
-    assert.ok(result > 75 && result < 77,
-      `expected ~76.09 (imputed drag halved → mean lifted), got ${result}`);
+    const result = coverageWeightedMean(dims);
+    assert.ok(result > 75 && result < 77, `expected ~76.09 (imputed drag halved → mean lifted), got ${result}`);
   });
 
   it('all-imputed dim list: penalty cancels in the ratio (mean unchanged from v15)', () => {
-    // When every dim is imputed, halving every weight cancels in the ratio:
-    // (s1*c1*0.5 + s2*c2*0.5) / (c1*0.5 + c2*0.5) = (s1*c1 + s2*c2) / (c1 + c2).
-    // The penalty ONLY shifts the mean when there's a mix of observed +
-    // imputed dims — pure-imputed countries see no change.
-    const dimsAllImputed = [
-      { score: 85, coverage: 0.7, imputationClass: 'stable-absence' },
-      { score: 50, coverage: 0.3, imputationClass: 'unmonitored' },
+    // Halving every weight cancels in the ratio, so the penalty only shifts
+    // the mean when observed and imputed dims are mixed.
+    const imputed = [
+      dim('macroFiscal', 85, 0.7, 'stable-absence'),
+      dim('cyberDigital', 50, 0.3, 'unmonitored'),
     ];
-    const dimsAllImputedV15 = [
-      { score: 85, coverage: 0.7, imputationClass: '' },  // simulated v15: no penalty
-      { score: 50, coverage: 0.3, imputationClass: '' },
-    ];
-    const v16 = coverageWeightedMeanMirror(dimsAllImputed);
-    const v15 = coverageWeightedMeanMirror(dimsAllImputedV15);
-    assert.ok(Math.abs(v16 - v15) < 0.001,
-      `pure-imputed dim list should be invariant under §U4 (v15=${v15}, v16=${v16})`);
+    const asV15 = [dim('macroFiscal', 85, 0.7), dim('cyberDigital', 50, 0.3)];
+    const v16 = coverageWeightedMean(imputed);
+    const v15 = coverageWeightedMean(asV15);
+    assert.ok(Math.abs(v16 - v15) < 0.001, `pure-imputed dim list should be invariant under §U4 (v15=${v15}, v16=${v16})`);
   });
 
   it('zero-coverage dims contribute zero regardless of imputation factor', () => {
-    // Retired dims have coverage=0; they should be neutralized whether
-    // imputed or not. Verifies §U4 doesn't double-count them.
+    // Retired dims carry coverage=0 and must be neutralized either way.
     const dims = [
-      { score: 0, coverage: 0, imputationClass: '' },               // retired observed
-      { score: 0, coverage: 0, imputationClass: 'unmonitored' },    // retired imputed
-      { score: 70, coverage: 1.0, imputationClass: '' },
+      dim('reserveAdequacy', 0, 0),
+      dim('fuelStockDays', 0, 0, 'unmonitored'),
+      dim('cyberDigital', 70, 1.0),
     ];
-    assert.equal(coverageWeightedMeanMirror(dims), 70);
+    assert.equal(coverageWeightedMean(dims), 70);
   });
 
   it('empty dim list returns 0 (no division-by-zero)', () => {
-    assert.equal(coverageWeightedMeanMirror([]), 0);
+    assert.equal(coverageWeightedMean([]), 0);
   });
 
-  it('per-dim weight is multiplicative with the imputation factor', () => {
-    // Recovery dims dial down to weight=0.5; if also imputed, effective
-    // weight = coverage * 0.5 * 0.5 = 0.25 of nominal.
+  it('reads the per-dim weight from the canonical table, not from the dim', () => {
+    // liquidReserveAdequacy is 0.5 in RESILIENCE_DIMENSION_WEIGHTS and also
+    // imputed here, so its effective weight is coverage * 0.5 * 0.5.
+    // weighted = 90*1*1*1 + 50*0.3*0.5*0.5 = 93.75
+    // totalW   = 1*1*1 + 0.3*0.5*0.5 = 1.075  →  ≈ 87.21
     const dims = [
-      { score: 90, coverage: 1.0, weight: 1.0, imputationClass: '' },
-      { score: 50, coverage: 0.3, weight: 0.5, imputationClass: 'unmonitored' },  // recovery imputed
+      dim('macroFiscal', 90, 1.0),
+      dim('liquidReserveAdequacy', 50, 0.3, 'unmonitored'),
     ];
-    // weighted = 90*1*1*1 + 50*0.3*0.5*0.5 = 90 + 3.75 = 93.75
-    // totalW = 1*1*1 + 0.3*0.5*0.5 = 1 + 0.075 = 1.075
-    // mean = 93.75 / 1.075 ≈ 87.21
-    const result = coverageWeightedMeanMirror(dims);
-    assert.ok(Math.abs(result - 87.21) < 0.01,
-      `expected ~87.21 (per-dim weight × imputation factor compose), got ${result}`);
+    const result = coverageWeightedMean(dims);
+    assert.ok(Math.abs(result - 87.21) < 0.01, `expected ~87.21 (table weight × imputation factor compose), got ${result}`);
+
+    // A weight field on the dim itself is ignored, so the same ids give the
+    // same answer whatever the caller attaches.
+    const withStrayWeight = [
+      { ...dim('macroFiscal', 90, 1.0), weight: 0.1 },
+      { ...dim('liquidReserveAdequacy', 50, 0.3, 'unmonitored'), weight: 9 },
+    ] as never[];
+    assert.equal(coverageWeightedMean(withStrayWeight), result);
   });
 });

--- a/tests/route-explorer-keyboard.test.mts
+++ b/tests/route-explorer-keyboard.test.mts
@@ -7,19 +7,19 @@
  * import of RouteExplorer.ts crashes in node:test.
  *
  * Pure formatting/filtering/url-state logic is covered by the sibling test files
- * (route-explorer-pickers, route-explorer-url-state). The actual modal lifecycle,
- * keyboard bindings, and focus trap need a real browser environment and are
- * covered by the Sprint 6 Playwright E2E suite (e2e/route-explorer.spec.ts).
+ * (route-explorer-pickers, route-explorer-url-state). This file covers the
+ * route-utils formatters only.
+ *
+ * The modal lifecycle, keyboard bindings, and focus trap are NOT covered. This
+ * file used to name e2e/route-explorer.spec.ts as their home; no such spec
+ * exists and nothing under e2e/ references RouteExplorer, so the claim read as
+ * coverage that was never written.
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-describe('RouteExplorer keyboard + modal surface (deferred to E2E)', () => {
-  it('pure url-state and picker utilities are covered by sibling tests', () => {
-    assert.ok(true);
-  });
-
+describe('RouteExplorer route-utils formatters', () => {
   it('route-utils formatters import cleanly in node', async () => {
     const mod = await import('../src/components/RouteExplorer/tabs/route-utils.ts');
     assert.equal(typeof mod.formatTransitRange, 'function');

--- a/tests/route-explorer-lane.test.mts
+++ b/tests/route-explorer-lane.test.mts
@@ -11,7 +11,7 @@
  * empty-state work.
  */
 
-import { describe, it } from 'node:test';
+import { after, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { computeLane } from '../server/worldmonitor/supply-chain/v1/get-route-explorer-lane.ts';
@@ -173,13 +173,11 @@ describe('get-route-explorer-lane smoke matrix (30 queries)', () => {
     }
   }
 
-  it('gap report summary (informational, never fails)', () => {
-    // Print a compact gap report so plan reviewers can see which pairs
-    // returned synthetic / empty data.
-    if (gapRows.length === 0) {
-      // No-op when run before the matrix above (test ordering is preserved)
-      return;
-    }
+  // A diagnostic, not a test. It used to be declared as an `it` that ended
+  // in assert.ok(true), so it reported as a passing case while asserting
+  // nothing. An after() hook prints the same report without inflating the count.
+  after(() => {
+    if (gapRows.length === 0) return;
     const noLane = gapRows.filter((r) => r.noModeledLane);
     const emptyExposures = gapRows.filter((r) => r.exposures === 0);
     const emptyBypasses = gapRows.filter((r) => r.bypasses === 0);
@@ -202,8 +200,6 @@ describe('get-route-explorer-lane smoke matrix (30 queries)', () => {
         '\nbypass guidance only for the primary one. Sprint 3 should decide: expand to top-N chokepoints,' +
         '\nor show a "see also" hint in the UI.',
     );
-    // Always passes; informational only.
-    assert.ok(true);
   });
 
   it('cargo-aware route selection: CN->JP tanker picks energy route over container', async () => {

--- a/tests/tech-readiness-circuit-breakers.test.mjs
+++ b/tests/tech-readiness-circuit-breakers.test.mjs
@@ -19,11 +19,12 @@
  * identical to the existing getFredBreaker(seriesId) pattern.
  */
 
-import { describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
 import * as ts from 'typescript'; // TypeScript compiler API — available via the typescript devDep used by tsc
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -76,15 +77,6 @@ function collectCallExpressions(node) {
   return calls;
 }
 
-function findPropertyAssignment(node, name) {
-  if (!ts.isObjectLiteralExpression(node)) return undefined;
-  return node.properties.find(
-    (prop) => ts.isPropertyAssignment(prop)
-      && ((ts.isIdentifier(prop.name) && prop.name.text === name)
-        || (ts.isStringLiteral(prop.name) && prop.name.text === name)),
-  );
-}
-
 function isIdentifierNamed(node, name) {
   return ts.isIdentifier(node) && node.text === name;
 }
@@ -107,48 +99,111 @@ function getTechIndicatorKeys(sourceFile) {
   return keys;
 }
 
-function getCreateCircuitBreakerNameInitializer(fn) {
-  const createCall = collectCallExpressions(fn).find((call) => isIdentifierNamed(call.expression, 'createCircuitBreaker'));
-  assert.ok(createCall, 'getWbBreaker must call createCircuitBreaker');
-
-  const optionsArg = createCall.arguments[0];
-  assert.ok(optionsArg && ts.isObjectLiteralExpression(optionsArg), 'createCircuitBreaker must receive an options object');
-
-  const nameProp = findPropertyAssignment(optionsArg, 'name');
-  assert.ok(nameProp, 'createCircuitBreaker options must include a name');
-  return nameProp.initializer;
-}
-
 // ============================================================
-// 1. Static analysis: source structure guarantees
+// 1. Behavioral: the pool hands out one breaker per indicator
 // ============================================================
 
+// The structural assertions this section replaced pinned the shape of
+// getWbBreaker (a Map exists, a factory exists, the name is a template
+// string) without ever calling it. Keying the pool on a constant instead
+// of `indicatorCode` — the exact bug in this file's header — left every
+// one of them green, because the mutation preserves the shape they read.
+// These drive the real factory instead.
 describe('economic/index.ts — per-indicator World Bank circuit breakers', () => {
+  let getWbBreaker;
+  let wbBreakerPoolSize;
+
+  before(async () => {
+    const result = await build({
+      stdin: {
+        contents: "export { __testing__ } from './src/services/economic/index.ts';",
+        loader: 'ts',
+        resolveDir: root,
+        sourcefile: 'wb-breaker-test-entry.ts',
+      },
+      bundle: true,
+      // `import.meta.env` and `import.meta.glob` are Vite-only. The economic
+      // service reaches i18n's locale glob transitively, so both need a value
+      // before the bundle will evaluate under node.
+      define: { 'import.meta.env': '{"DEV":false}', 'import.meta.glob': '__wmNoGlob' },
+      inject: [resolve(__dirname, 'helpers/vite-glob-stub.mjs')],
+      format: 'esm',
+      logLevel: 'silent',
+      platform: 'node',
+      target: 'node20',
+      write: false,
+    });
+    const source = result.outputFiles[0]?.text;
+    assert.ok(source, 'esbuild must emit the economic service harness');
+    const mod = await import(`data:text/javascript;base64,${Buffer.from(source).toString('base64')}`);
+    ({ getWbBreaker, wbBreakerPoolSize } = mod.__testing__);
+  });
+
+  // Declared first so it reads a clean pool. A shared breaker would answer
+  // the second indicator from the first one's warm cache without calling
+  // through at all, which is failure mode 1 in this file's header.
+  it('never serves one indicator’s cached rows to another', async () => {
+    const fallback = { data: [], pagination: undefined };
+    const rowsA = {
+      data: [{ countryCode: 'USA', indicatorCode: 'WB.CACHE.A', year: 2023, value: 120 }],
+      pagination: undefined,
+    };
+    const rowsB = {
+      data: [{ countryCode: 'FRA', indicatorCode: 'WB.CACHE.B', year: 2023, value: 42 }],
+      pagination: undefined,
+    };
+
+    const servedA = await getWbBreaker('WB.CACHE.A').execute(async () => rowsA, fallback);
+    const servedB = await getWbBreaker('WB.CACHE.B').execute(async () => rowsB, fallback);
+
+    assert.deepEqual(servedA, rowsA);
+    assert.deepEqual(servedB, rowsB, 'the second indicator must call through, not read the first one’s cache');
+  });
+
+  it('hands out a distinct breaker per indicator code', () => {
+    assert.notEqual(
+      getWbBreaker('IT.NET.USER.ZS'),
+      getWbBreaker('IT.CEL.SETS.P2'),
+      'two indicators must not share one breaker instance',
+    );
+  });
+
+  it('hands out the same breaker for a repeated indicator code', () => {
+    assert.equal(getWbBreaker('IT.NET.BBND.P2'), getWbBreaker('IT.NET.BBND.P2'));
+  });
+
+  it('grows the pool once per distinct indicator', () => {
+    const startSize = wbBreakerPoolSize();
+    getWbBreaker('GB.XPD.RSDV.GD.ZS');
+    getWbBreaker('GB.XPD.RSDV.GD.ZS');
+    assert.equal(wbBreakerPoolSize(), startSize + 1);
+  });
+
+  it('names each breaker for its own indicator', () => {
+    assert.equal(getWbBreaker('WB.NAME.CHECK').name, 'WB:WB.NAME.CHECK');
+  });
+
+  it('confines a tripped indicator to itself', async () => {
+    const tripped = getWbBreaker('WB.TRIP.A');
+    const healthy = getWbBreaker('WB.TRIP.B');
+    const fallback = { data: [], pagination: undefined };
+    const alwaysFail = () => { throw new Error('World Bank unavailable'); };
+
+    await tripped.execute(alwaysFail, fallback);
+    await tripped.execute(alwaysFail, fallback);
+
+    assert.equal(tripped.isOnCooldown(), true, 'two failures must trip the indicator that failed');
+    assert.equal(healthy.isOnCooldown(), false, 'a second indicator must stay closed');
+  });
+
+});
+
+// ============================================================
+// 2. Static analysis: the call site the pool tests cannot reach
+// ============================================================
+
+describe('economic/index.ts — getIndicatorData wiring', () => {
   const sourceFile = loadEconomicSourceFile();
-
-  it('does NOT have a single shared wbBreaker', () => {
-    assert.equal(
-      findVariableDeclaration(sourceFile, 'wbBreaker'),
-      undefined,
-      'Single shared wbBreaker must not exist — use getWbBreaker(indicatorCode) instead',
-    );
-  });
-
-  it('has a wbBreakers Map for per-indicator instances', () => {
-    const decl = findVariableDeclaration(sourceFile, 'wbBreakers');
-    assert.ok(decl?.initializer && ts.isNewExpression(decl.initializer), 'wbBreakers declaration must exist');
-    assert.ok(isIdentifierNamed(decl.initializer.expression, 'Map'), 'wbBreakers must be initialized with new Map(...)');
-  });
-
-  it('has a getWbBreaker(indicatorCode) factory function', () => {
-    const fn = findFunctionDeclaration(sourceFile, 'getWbBreaker');
-    assert.ok(fn, 'getWbBreaker function must exist');
-    assert.equal(fn.parameters[0]?.name.getText(sourceFile), 'indicatorCode');
-    assert.ok(
-      collectCallExpressions(fn).some((call) => isIdentifierNamed(call.expression, 'createCircuitBreaker')),
-      'getWbBreaker must create circuit breakers lazily',
-    );
-  });
 
   it('getIndicatorData calls getWbBreaker(indicator).execute, not a shared breaker', () => {
     const fn = findFunctionDeclaration(sourceFile, 'getIndicatorData');
@@ -166,27 +221,6 @@ describe('economic/index.ts — per-indicator World Bank circuit breakers', () =
       executeCall,
       'getIndicatorData must use getWbBreaker(indicator).execute, not a shared wbBreaker',
     );
-  });
-
-  it('per-indicator breaker names include the indicator code', () => {
-    const fn = findFunctionDeclaration(sourceFile, 'getWbBreaker');
-    assert.ok(fn, 'getWbBreaker function must exist');
-
-    const nameInitializer = getCreateCircuitBreakerNameInitializer(fn);
-    assert.ok(
-      ts.isTemplateExpression(nameInitializer),
-      'Breaker name should be a template string scoped to the indicator code',
-    );
-    assert.equal(nameInitializer.head.text, 'WB:');
-    assert.equal(nameInitializer.templateSpans.length, 1);
-    assert.ok(isIdentifierNamed(nameInitializer.templateSpans[0]?.expression, 'indicatorCode'));
-  });
-
-  it('mirrors fredBatchBreaker pattern (consistency check)', () => {
-    const fredDecl = findVariableDeclaration(sourceFile, 'fredBatchBreaker');
-    assert.ok(fredDecl?.initializer && ts.isCallExpression(fredDecl.initializer), 'fredBatchBreaker must exist');
-    assert.ok(isIdentifierNamed(fredDecl.initializer.expression, 'createCircuitBreaker'));
-    assert.ok(findFunctionDeclaration(sourceFile, 'getWbBreaker'), 'getWbBreaker implementation should be present');
   });
 });
 


### PR DESCRIPTION
## Why

A slop audit of `fb3a774af` found tests that pass without exercising the code they name. I verified all eight findings independently and reproduced the strongest one: the World Bank circuit-breaker suite permits the exact bug its header describes.

This PR is the first of two. It gives the weak guards teeth. The dead-code deletions follow in a stacked PR.

## Scope

`tests/tech-readiness-circuit-breakers.test.mjs` asserted the AST shape of `getWbBreaker` without calling it. Keying `wbBreakers` on the constant `shared` instead of `indicatorCode` left all 13 tests green, because the mutation preserves the Map, the factory, and the `WB:${indicatorCode}` template they read. Five structural assertions are replaced by six that bundle the real module and call the factory, covering pool keying, per-indicator naming, cooldown confinement, and the cross-indicator cache read. The `getIndicatorData` call-site pin stays; no unit test reaches it.

`tests/oil-inventories.test.mjs` mirrored the handler's mapping locally and the mirror had drifted. It emitted `changeWoW` and `changeWoW4` and used `null` for absent sections, while `get-oil-inventories.ts` emits `changeWow`, drops the seeder-only `changeWoW4`, and uses `undefined`. It now drives the real handler over the existing fake Upstash. The chart-order and merge-by-period copies are dropped: neither mirrors a function that exists under that name, and `OilInventoriesPanel` owns the real merge. Escaping imports the real `escapeHtml`.

`tests/resilience-coverage-penalty.test.mts` asserted against a local mirror of `coverageWeightedMean` whose stated detection mechanism was a reviewer noticing the mirror and the real function disagree. It had drifted too: the mirror read a per-dim `weight` field, while the real function looks the weight up in `RESILIENCE_DIMENSION_WEIGHTS` by dimension id, so its last case pinned a contract production never had.

`tests/insights-loader.test.mjs` had two blocks that could not fail. One defined a local `isFresh` and tested that. The other wrote object literals and read its own fields back, including `assert.equal(degraded.worldBrief, '')` on a literal `''`. Both gates live in `insightsSnapshotRejection`, which names the reason it rejects, so the twelve replacements assert on the reason.

`tests/resilience-cohort-anti-inversion.test.mts` emitted a passing test that asserted nothing when Upstash credentials were absent. It now uses `it.skip`. The four anti-inversion invariants are unaffected: they already run unconditionally against the committed fixture through the same assertion helpers, and only the production reading is skipped. The per-cohort coverage case gained a real assertion in place of `assert.ok(true)`.

`tests/route-explorer-keyboard.test.mts` opened with an `assert.ok(true)` placeholder under a docblock naming `e2e/route-explorer.spec.ts` as the home for modal, keyboard, and focus-trap coverage. That spec does not exist and nothing under `e2e/` references RouteExplorer. The docblock now says the surface is uncovered. The lane gap report moved from an `it` ending in `assert.ok(true)` to an `after` hook; it prints the same report without reporting itself as a pass.

Production changes are three additions and nothing else: a `__testing__` export in `src/services/economic/index.ts` and in `server/worldmonitor/resilience/v1/_shared.ts`, following the existing `__testing__` convention, plus `tests/helpers/vite-glob-stub.mjs` to stand in for Vite's `import.meta.glob` when a browser module is bundled for node.

## Tradeoffs

The keyboard and focus-trap surface stays uncovered. Writing the missing Playwright spec needs a running app and belongs in its own change; this PR stops the file from claiming coverage it does not have.

The economic service reaches i18n's locale glob transitively, so its test bundle needs both `import.meta.env` and `import.meta.glob` defined. That is two Vite shims in a node test rather than one, and it follows the seam `tests/aviation-hydration-path.test.mts` already established.

## Blast Radius

No runtime behavior changes. The two production diffs add exports and touch no existing code path. `tsc --noEmit` is clean.

Test counts shift down where cases that asserted nothing were removed, and one case now reports as skipped rather than passed. A CI run without Upstash credentials reports 21 passed and 1 skipped for the cohort suite instead of 22 passed.

## Verification

Every rewritten guard was proven against a mutation of the code it claims to protect, each applied and reverted locally.

- `getWbBreaker` keyed on a constant instead of `indicatorCode`: 13/13 passed before, 5 of 6 new cases fail now.
- `changeWow` renamed to `changeWoW` in the oil handler: 2 of 6 cases fail.
- `IMPUTED_DIM_WEIGHT_FACTOR` from 0.5 to 1.0: 4 of 8 cases fail. Dropping the `RESILIENCE_DIMENSION_WEIGHTS` lookup: 1 of 8 fails. The old mirror caught neither.
- Staleness comparison loosened from `>=` to `>`: the boundary case fails.

Full suites for every area that imports the touched files, run with `tsx --test`: 1351 tests, 0 failures, 1 skipped. `npx tsc --noEmit` exits 0.

https://claude.ai/code/session_01GeUm7Ebws6WjH8Mz9D1faX
