### PR TITLE
Recover wildfire coverage with a bounded primary retry

### DIFF
--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -2,7 +2,7 @@
 ## Observed Source Inventory
 
 {/* BEGIN GENERATED SOURCE ATTRIBUTION */}
-This generated inventory covers **761 active source hosts** representing **747 active providers** (**332 structured/API**, **461 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced. Syndication transports such as FeedBurner and Google News remain listed as hosts and are not counted as publishers.
+This generated inventory covers **760 active source hosts** representing **747 active providers** (**331 structured/API**, **461 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced. Syndication transports such as FeedBurner and Google News remain listed as hosts and are not counted as publishers.
 
 | Provider | Observed surface |
 | --- | --- |
@@ -401,7 +401,7 @@ This generated inventory covers **761 active source hosts** representing **747 a
 | n1info.hr (n1info.hr) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | Naharnet Lebanon (www.naharnet.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | NASA FIRMS (firms.modaps.eosdis.nasa.gov) | structured — scripts/wildfire/firms-area.mjs |
-| NASA FIRMS (firms2.modaps.eosdis.nasa.gov) | structured — scripts/wildfire/firms-area.mjs |
+| NASA FIRMS (firms2.modaps.eosdis.nasa.gov) | Excluded / candidate — No current fetch observed |
 | nasstatus.faa.gov (nasstatus.faa.gov) | structured — scripts/seed-aviation.mjs, server/worldmonitor/aviation/v1/_shared.ts |
 | nationalpost.com (nationalpost.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | ndtvindiaelemarchana.akamaized.net (ndtvindiaelemarchana.akamaized.net) | feed — src/components/LiveNewsPanel.ts |

--- a/public/ai-search.md
+++ b/public/ai-search.md
@@ -51,7 +51,7 @@ World Monitor is useful for investors, portfolio managers, energy and commodity 
 
 Coverage reconciled: 2026-09-05. Every figure below is generated from this repository's authoritative registries by `npm run build:ai-search` — the same registries that produce https://www.worldmonitor.app/sources/.
 
-- 747 active data providers across 761 observed source hosts (332 structured/API, 461 news & OSINT feed, 30 operational-status; a host can be more than one), grouped into 10 signal domains — full catalog at https://www.worldmonitor.app/sources/
+- 747 active data providers across 760 observed source hosts (331 structured/API, 461 news & OSINT feed, 30 operational-status; a host can be more than one), grouped into 10 signal domains — full catalog at https://www.worldmonitor.app/sources/
 - 724 feed definitions in the shared feed registry — distinct from the 461 feed-publishing hosts above, since one host can back several feed definitions
 - 40 named live data streams whose staleness is tracked and surfaced individually — a different axis from the 10 signal domains above, which group the source catalog by subject
 - 58 map layer types in the shared registry, 57 of them reachable in the full variant — the homepage publishes the full-variant figure; the remaining 1 is sunset or build-flag gated

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -111,7 +111,8 @@ async function main() {
     // ranks its top-500 over every detection FIRMS returned — capping here cannot change what
     // the dashboard renders. Capping inside fetchAllRegions would not have that property.
     publishTransform: capCanonicalPayload,
-    lockTtlMs: 2_400_000, // 40 min — 27 slots × ~72s worst case (30s timeout + 6s backoff + 30s retry + 6s pace) ≈ 32.4 min; pad headroom. Next cron tick sees lock held and safely skips.
+    lockTtlMs: 3_600_000, // 60 min — 27 slots × 108s (3 × 30s attempts + 3 × 6s pace) = 48.6 min; leave publication headroom. Overlapping cron ticks skip the held lock.
+    fetchPhaseTimeoutMs: 3_300_000, // 55 min — bound whole-fetch retries if all upstreams fail, before the lock expires.
     sourceVersion: CANONICAL_SOURCE_VERSION,
     extraKeys: [{
       key: BOOTSTRAP_KEY,

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -111,8 +111,8 @@ async function main() {
     // ranks its top-500 over every detection FIRMS returned — capping here cannot change what
     // the dashboard renders. Capping inside fetchAllRegions would not have that property.
     publishTransform: capCanonicalPayload,
-    lockTtlMs: 3_600_000, // 60 min — 27 slots × 108s (3 × 30s attempts + 3 × 6s pace) = 48.6 min; leave publication headroom. Overlapping cron ticks skip the held lock.
-    fetchPhaseTimeoutMs: 3_300_000, // 55 min — bound whole-fetch retries if all upstreams fail, before the lock expires.
+    lockTtlMs: 2_700_000, // 45 min — 27 slots × 72s (2 × 30s attempts + 2 × 6s pace) = 32.4 min; leave fetch and publication headroom. Overlapping cron ticks skip the held lock.
+    fetchPhaseTimeoutMs: 2_400_000, // 40 min — bound whole-fetch retries if all upstreams fail, before the lock expires.
     sourceVersion: CANONICAL_SOURCE_VERSION,
     extraKeys: [{
       key: BOOTSTRAP_KEY,

--- a/scripts/wildfire/firms-area.mjs
+++ b/scripts/wildfire/firms-area.mjs
@@ -1,9 +1,6 @@
 import { CHROME_UA, sleep } from '../_seed-utils.mjs';
 
-export const FIRMS_API_BASE_URLS = Object.freeze([
-  'https://firms.modaps.eosdis.nasa.gov',
-  'https://firms2.modaps.eosdis.nasa.gov',
-]);
+export const FIRMS_API_BASE_URL = 'https://firms.modaps.eosdis.nasa.gov';
 
 export const FIRMS_SOURCES = Object.freeze([
   'VIIRS_SNPP_NRT',
@@ -72,14 +69,10 @@ export async function fetchFirmsRegionSource(apiKey, regionName, bbox, source, {
   logger = console,
 } = {}) {
   const failures = [];
-  // A valid primary MAP_KEY can be rejected by the secondary. Give a transient
-  // primary failure one more paced attempt before declaring this slot missing.
-  const attempts = [...FIRMS_API_BASE_URLS, FIRMS_API_BASE_URLS[0]];
-  const labels = ['primary', 'secondary', 'primary retry'];
-  for (let index = 0; index < attempts.length; index++) {
-    const baseUrl = attempts[index];
+  const labels = ['primary', 'primary retry'];
+  for (let index = 0; index < labels.length; index++) {
     try {
-      const response = await fetchFn(buildAreaUrl(baseUrl, apiKey, source, bbox), {
+      const response = await fetchFn(buildAreaUrl(FIRMS_API_BASE_URL, apiKey, source, bbox), {
         headers: { Accept: 'text/csv', 'User-Agent': CHROME_UA },
         signal: AbortSignal.timeout(30_000),
       });
@@ -92,7 +85,10 @@ export async function fetchFirmsRegionSource(apiKey, regionName, bbox, source, {
     } catch (error) {
       const endpoint = labels[index];
       failures.push(`${endpoint} ${safeFailureReason(error)}`);
-      if (index + 1 < attempts.length) {
+      const retryable = !Number.isInteger(error?.status) || error.status === 408
+        || error.status === 429 || (error.status >= 500 && error.status <= 599);
+      if (!retryable) break;
+      if (index + 1 < labels.length) {
         logger.warn(`  [FIRMS] ${source}/${regionName}: ${failures.at(-1)}; trying ${labels[index + 1]}`);
         await sleepFn(REQUEST_PACE_MS);
       }

--- a/scripts/wildfire/firms-area.mjs
+++ b/scripts/wildfire/firms-area.mjs
@@ -72,8 +72,12 @@ export async function fetchFirmsRegionSource(apiKey, regionName, bbox, source, {
   logger = console,
 } = {}) {
   const failures = [];
-  for (let index = 0; index < FIRMS_API_BASE_URLS.length; index++) {
-    const baseUrl = FIRMS_API_BASE_URLS[index];
+  // A valid primary MAP_KEY can be rejected by the secondary. Give a transient
+  // primary failure one more paced attempt before declaring this slot missing.
+  const attempts = [...FIRMS_API_BASE_URLS, FIRMS_API_BASE_URLS[0]];
+  const labels = ['primary', 'secondary', 'primary retry'];
+  for (let index = 0; index < attempts.length; index++) {
+    const baseUrl = attempts[index];
     try {
       const response = await fetchFn(buildAreaUrl(baseUrl, apiKey, source, bbox), {
         headers: { Accept: 'text/csv', 'User-Agent': CHROME_UA },
@@ -86,10 +90,10 @@ export async function fetchFirmsRegionSource(apiKey, regionName, bbox, source, {
       }
       return parseCsv(await response.text());
     } catch (error) {
-      const endpoint = index === 0 ? 'primary' : 'secondary';
+      const endpoint = labels[index];
       failures.push(`${endpoint} ${safeFailureReason(error)}`);
-      if (index + 1 < FIRMS_API_BASE_URLS.length) {
-        logger.warn(`  [FIRMS] ${source}/${regionName}: ${failures.at(-1)}; trying secondary`);
+      if (index + 1 < attempts.length) {
+        logger.warn(`  [FIRMS] ${source}/${regionName}: ${failures.at(-1)}; trying ${labels[index + 1]}`);
         await sleepFn(REQUEST_PACE_MS);
       }
     }

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -4303,15 +4303,10 @@
       "host": "firms2.modaps.eosdis.nasa.gov",
       "provider": "NASA FIRMS",
       "kind": "structured",
-      "observed": true,
+      "observed": false,
       "license": "NASA FIRMS provider terms apply; redistribution terms require review",
       "attribution": "Credit NASA FIRMS and link to the original upstream API or dataset.",
-      "status": "terms-review",
-      "references": [
-        {
-          "path": "scripts/wildfire/firms-area.mjs"
-        }
-      ]
+      "status": "excluded"
     },
     {
       "host": "focustaiwan.tw",

--- a/tests/bc-fire-points.test.mjs
+++ b/tests/bc-fire-points.test.mjs
@@ -807,7 +807,8 @@ describe('module import contract', () => {
     assert.match(seederSrc, /wildfire:fires:v1/);
     assert.doesNotMatch(seederSrc, /wildfire:canada/);
     assert.doesNotMatch(seederSrc, /fetch\.bind/);
-    assert.match(firmsModuleSrc, /firms2\.modaps\.eosdis\.nasa\.gov/);
+    assert.match(firmsModuleSrc, /firms\.modaps\.eosdis\.nasa\.gov/);
+    assert.doesNotMatch(firmsModuleSrc, /firms2\.modaps\.eosdis\.nasa\.gov/);
     assert.match(railwaySrc, /scripts\/wildfire\/bc-fire-points\.mjs/);
     assert.match(railwaySrc, /scripts\/wildfire\/cwfis-wfs\.mjs/);
     assert.match(railwaySrc, /scripts\/wildfire\/firms-area\.mjs/);

--- a/tests/firms-area.test.mjs
+++ b/tests/firms-area.test.mjs
@@ -1,5 +1,10 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import {
+  hasCompleteWorldwideWildfireCoverage,
+  mergeWildfireSourcesWithBc,
+} from '../scripts/wildfire/bc-fire-points.mjs';
 
 import {
   fetchAllFirmsRegions,
@@ -29,6 +34,73 @@ function captureLogger() {
 }
 
 describe('NASA FIRMS Area API sequence', () => {
+  it('recovers complete coverage after a primary transport error and secondary MAP_KEY rejection', async () => {
+    const urls = [];
+    const sleeps = [];
+    const { logger, messages } = captureLogger();
+    const failedPath = `/${FIRMS_SOURCES[0]}/${MONITORED_REGIONS.Ukraine}/`;
+    let affectedAttempts = 0;
+    const firms = await fetchAllFirmsRegions('test-map-key', {
+      fetchFn: async (url) => {
+        urls.push(url);
+        if (new URL(url).pathname.includes(failedPath)) {
+          affectedAttempts++;
+          if (affectedAttempts === 1) throw new TypeError('fetch failed');
+          if (affectedAttempts === 2) return response(400, 'Invalid MAP_KEY.');
+          return response(200, DETECTION_CSV);
+        }
+        return response(200);
+      },
+      sleepFn: async (ms) => sleeps.push(ms),
+      logger,
+    });
+    const merged = await mergeWildfireSourcesWithBc({
+      fetchFirms: async () => firms,
+      fetchCwfis: async () => ({ fireDetections: [] }),
+      fetchBcWildfire: async () => ({ fireDetections: [] }),
+    });
+    assert.equal(hasCompleteWorldwideWildfireCoverage(merged), true);
+    assert.equal(firms._firmsFulfilledCalls, 27);
+    assert.equal(firms._firmsFailedCalls, 0);
+    assert.equal(firms.fireDetections.length, 1);
+    assert.deepEqual(urls.slice(0, 3).map((url) => new URL(url).origin), [
+      ...FIRMS_API_BASE_URLS, FIRMS_API_BASE_URLS[0],
+    ]);
+    assert.equal(new Set(urls.slice(0, 3).map((url) => new URL(url).pathname)).size, 1);
+    assert.equal(urls.length, 29);
+    assert.equal(sleeps.length, 29);
+    assert.ok(sleeps.every((ms) => ms === 6_000));
+    assert.equal(messages.error.length, 0);
+    assert.doesNotMatch(messages.warn.join('\n'), /test-map-key/);
+  });
+
+  it('bounds an exhausted run below the seed lock with publication headroom', async (t) => {
+    let attempts = 0;
+    let budgetMs = 0;
+    t.mock.method(AbortSignal, 'timeout', (ms) => {
+      budgetMs += ms;
+      return new AbortController().signal;
+    });
+    const { logger } = captureLogger();
+    const firms = await fetchAllFirmsRegions('test-map-key', {
+      fetchFn: async () => {
+        attempts++;
+        throw new DOMException('timed out', 'TimeoutError');
+      },
+      sleepFn: async (ms) => { budgetMs += ms; },
+      logger,
+    });
+    assert.equal(attempts, 81);
+    assert.equal(firms._firmsFulfilledCalls, 0);
+    assert.equal(firms._firmsFailedCalls, 27);
+    const source = readFileSync(new URL('../scripts/seed-fire-detections.mjs', import.meta.url), 'utf8');
+    const lockMs = Number(source.match(/lockTtlMs:\s*([\d_]+)/)[1].replaceAll('_', ''));
+    const deadlineMatch = source.match(/fetchPhaseTimeoutMs:\s*([\d_]+)/);
+    assert.ok(deadlineMatch, 'bound outer all-source retries before the seed lock expires');
+    const deadlineMs = Number(deadlineMatch[1].replaceAll('_', ''));
+    assert.ok(deadlineMs >= budgetMs + 5 * 60_000, `${deadlineMs} must cover ${budgetMs} plus fetch headroom`);
+    assert.ok(lockMs >= deadlineMs + 5 * 60_000, 'leave publication and cleanup headroom inside the lock');
+  });
   it('tries the official secondary host after a primary HTTP failure', async () => {
     const urls = [];
     const sleeps = [];
@@ -118,10 +190,10 @@ describe('NASA FIRMS Area API sequence', () => {
 
     assert.equal(result._firmsFulfilledCalls, 26);
     assert.equal(result._firmsFailedCalls, 1);
-    assert.equal(urls.length, 28);
+    assert.equal(urls.length, 29);
     assert.match(
       messages.error[0],
-      /VIIRS_SNPP_NRT\/Ukraine failed \(primary HTTP 500, secondary HTTP 500\)/,
+      /VIIRS_SNPP_NRT\/Ukraine failed \(primary HTTP 500, secondary HTTP 500, primary retry HTTP 500\)/,
     );
     assert.doesNotMatch(messages.error[0], /test-map-key/);
   });

--- a/tests/firms-area.test.mjs
+++ b/tests/firms-area.test.mjs
@@ -9,7 +9,7 @@ import {
 import {
   fetchAllFirmsRegions,
   fetchFirmsRegionSource,
-  FIRMS_API_BASE_URLS,
+  FIRMS_API_BASE_URL,
   FIRMS_SOURCES,
   MONITORED_REGIONS,
 } from '../scripts/wildfire/firms-area.mjs';
@@ -34,7 +34,7 @@ function captureLogger() {
 }
 
 describe('NASA FIRMS Area API sequence', () => {
-  it('recovers complete coverage after a primary transport error and secondary MAP_KEY rejection', async () => {
+  it('recovers complete coverage with one paced retry on the primary host', async () => {
     const urls = [];
     const sleeps = [];
     const { logger, messages } = captureLogger();
@@ -46,7 +46,6 @@ describe('NASA FIRMS Area API sequence', () => {
         if (new URL(url).pathname.includes(failedPath)) {
           affectedAttempts++;
           if (affectedAttempts === 1) throw new TypeError('fetch failed');
-          if (affectedAttempts === 2) return response(400, 'Invalid MAP_KEY.');
           return response(200, DETECTION_CSV);
         }
         return response(200);
@@ -63,12 +62,12 @@ describe('NASA FIRMS Area API sequence', () => {
     assert.equal(firms._firmsFulfilledCalls, 27);
     assert.equal(firms._firmsFailedCalls, 0);
     assert.equal(firms.fireDetections.length, 1);
-    assert.deepEqual(urls.slice(0, 3).map((url) => new URL(url).origin), [
-      ...FIRMS_API_BASE_URLS, FIRMS_API_BASE_URLS[0],
+    assert.deepEqual(urls.slice(0, 2).map((url) => new URL(url).origin), [
+      FIRMS_API_BASE_URL, FIRMS_API_BASE_URL,
     ]);
-    assert.equal(new Set(urls.slice(0, 3).map((url) => new URL(url).pathname)).size, 1);
-    assert.equal(urls.length, 29);
-    assert.equal(sleeps.length, 29);
+    assert.equal(new Set(urls.slice(0, 2).map((url) => new URL(url).pathname)).size, 1);
+    assert.equal(urls.length, 28);
+    assert.equal(sleeps.length, 28);
     assert.ok(sleeps.every((ms) => ms === 6_000));
     assert.equal(messages.error.length, 0);
     assert.doesNotMatch(messages.warn.join('\n'), /test-map-key/);
@@ -90,7 +89,7 @@ describe('NASA FIRMS Area API sequence', () => {
       sleepFn: async (ms) => { budgetMs += ms; },
       logger,
     });
-    assert.equal(attempts, 81);
+    assert.equal(attempts, 54);
     assert.equal(firms._firmsFulfilledCalls, 0);
     assert.equal(firms._firmsFailedCalls, 27);
     const source = readFileSync(new URL('../scripts/seed-fire-detections.mjs', import.meta.url), 'utf8');
@@ -101,7 +100,7 @@ describe('NASA FIRMS Area API sequence', () => {
     assert.ok(deadlineMs >= budgetMs + 5 * 60_000, `${deadlineMs} must cover ${budgetMs} plus fetch headroom`);
     assert.ok(lockMs >= deadlineMs + 5 * 60_000, 'leave publication and cleanup headroom inside the lock');
   });
-  it('tries the official secondary host after a primary HTTP failure', async () => {
+  it('retries the primary host after a transient HTTP failure', async () => {
     const urls = [];
     const sleeps = [];
     const { logger, messages } = captureLogger();
@@ -123,12 +122,42 @@ describe('NASA FIRMS Area API sequence', () => {
     assert.deepEqual(rows, []);
     assert.deepEqual(
       urls.map((url) => new URL(url).origin),
-      FIRMS_API_BASE_URLS,
+      [FIRMS_API_BASE_URL, FIRMS_API_BASE_URL],
     );
     assert.equal(new URL(urls[0]).pathname, new URL(urls[1]).pathname);
     assert.deepEqual(sleeps, [6_000]);
-    assert.match(messages.warn[0], /VIIRS_SNPP_NRT\/Ukraine: primary HTTP 500; trying secondary/);
+    assert.match(messages.warn[0], /VIIRS_SNPP_NRT\/Ukraine: primary HTTP 500; trying primary retry/);
     assert.doesNotMatch(messages.warn[0], /test-map-key/);
+  });
+
+
+  it('does not retry key rejection or permanent HTTP errors', async () => {
+    for (const status of [400, 401, 403, 404]) {
+      let attempts = 0;
+      const { logger } = captureLogger();
+      await assert.rejects(fetchFirmsRegionSource('test-map-key', 'Ukraine', MONITORED_REGIONS.Ukraine, FIRMS_SOURCES[0], {
+        fetchFn: async () => { attempts++; return response(status, 'Invalid MAP_KEY.'); },
+        sleepFn: async () => assert.fail('permanent errors must not schedule a retry'),
+        logger,
+      }), new RegExp(`primary HTTP ${status}`));
+      assert.equal(attempts, 1);
+    }
+  });
+
+  it('bounds transient HTTP retries to one attempt with six-second pacing', async () => {
+    for (const status of [408, 429, 500, 503]) {
+      const urls = [];
+      const sleeps = [];
+      const { logger } = captureLogger();
+      await fetchFirmsRegionSource('test-map-key', 'Ukraine', MONITORED_REGIONS.Ukraine, FIRMS_SOURCES[0], {
+        fetchFn: async (url) => { urls.push(url); return response(urls.length === 1 ? status : 200); },
+        sleepFn: async (ms) => sleeps.push(ms),
+        logger,
+      });
+      assert.equal(urls.length, 2);
+      assert.equal(urls[0], urls[1]);
+      assert.deepEqual(sleeps, [6_000]);
+    }
   });
 
   it('keeps the source-major 27-call worldwide sequence and six-second cadence', async () => {
@@ -175,7 +204,7 @@ describe('NASA FIRMS Area API sequence', () => {
     assert.match(requestPaths[18], new RegExp(`/${FIRMS_SOURCES[2]}/`));
   });
 
-  it('keeps region and satellite diagnostics when both hosts fail', async () => {
+  it('keeps region and satellite diagnostics when both primary attempts fail', async () => {
     const urls = [];
     const { logger, messages } = captureLogger();
     const failedPath = `/${FIRMS_SOURCES[0]}/${MONITORED_REGIONS.Ukraine}/`;
@@ -190,10 +219,10 @@ describe('NASA FIRMS Area API sequence', () => {
 
     assert.equal(result._firmsFulfilledCalls, 26);
     assert.equal(result._firmsFailedCalls, 1);
-    assert.equal(urls.length, 29);
+    assert.equal(urls.length, 28);
     assert.match(
       messages.error[0],
-      /VIIRS_SNPP_NRT\/Ukraine failed \(primary HTTP 500, secondary HTTP 500, primary retry HTTP 500\)/,
+      /VIIRS_SNPP_NRT\/Ukraine failed \(primary HTTP 500, primary retry HTTP 500\)/,
     );
     assert.doesNotMatch(messages.error[0], /test-map-key/);
   });


### PR DESCRIPTION
The primary FIRMS endpoint can fail transiently while the secondary rejects the configured MAP_KEY. Retry the working primary once, with the existing six-second pace, for transport errors, timeouts, HTTP 408/429, and 5xx responses. Permanent HTTP failures stop without a retry. Remove the secondary-host detour and mark that host retired in the existing attribution inventory.

The complete 27-request worldwide coverage gate and last-good behavior remain intact. Two attempts per slot bound the request-and-pace budget to 32.4 minutes; a 40-minute fetch deadline and 45-minute lock leave publication and cleanup time.

Validation: 229 focused wildfire/packaging checks, 52 contract/generated-document regression checks, 867 MDX checks, attribution/inventory validation, and pre-push gates passed. Updated the existing BC integration assertion and generated AI-search source figures to match the retired host. The deployed SSH probe could not run because Railway's SSH verification service was unavailable. Natural production acceptance remains required after merge and deployment: three distinct consecutive complete runs within the fixed observation window, including evidence that the primary retry succeeds.
