### PR TITLE
fix(health): show production acceptance in monitor summaries

### DIFF
--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -106,9 +106,13 @@ jobs:
         # same durable incident already attached to the operational anchor.
         continue-on-error: true
         run: |
+          summary_args=()
+          if grep -q -- "'markdown-output':" scripts/check-seed-freshness.mjs; then
+            summary_args=(--markdown-output "$RUNNER_TEMP/seed-freshness-summary.md")
+          fi
           node scripts/check-seed-freshness.mjs \
             --json-output "$RUNNER_TEMP/seed-freshness-observation.json" \
-            --markdown-output "$RUNNER_TEMP/seed-freshness-summary.md"
+            "${summary_args[@]}"
 
       - name: Publish ingestion operational transitions
         if: ${{ !cancelled() && steps.gate.conclusion != 'failure' }}
@@ -149,6 +153,8 @@ jobs:
         run: |
           if [ -s "$RUNNER_TEMP/seed-freshness-summary.md" ]; then
             cat "$RUNNER_TEMP/seed-freshness-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          elif [ -s "$RUNNER_TEMP/seed-freshness-observation.json" ]; then
+            printf '## Production ingestion acceptance\n\n**Summary unavailable for this gated revision.** An observation was produced; inspect the retained JSON artifact for its acceptance verdict.\n' >> "$GITHUB_STEP_SUMMARY"
           else
             printf '## Production ingestion acceptance\n\n**Unverified.** No current observation was produced. Inspect the [gate and probe logs](%s/%s/actions/runs/%s).\n' \
               "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -105,7 +105,10 @@ jobs:
         # The next step decides whether that problem is a new transition or the
         # same durable incident already attached to the operational anchor.
         continue-on-error: true
-        run: node scripts/check-seed-freshness.mjs --json-output "$RUNNER_TEMP/seed-freshness-observation.json"
+        run: |
+          node scripts/check-seed-freshness.mjs \
+            --json-output "$RUNNER_TEMP/seed-freshness-observation.json" \
+            --markdown-output "$RUNNER_TEMP/seed-freshness-summary.md"
 
       - name: Publish ingestion operational transitions
         if: ${{ !cancelled() && steps.gate.conclusion != 'failure' }}
@@ -140,3 +143,22 @@ jobs:
             --sha "$SEED_ACCEPTANCE_SHA" \
             "${status_args[@]}" \
             --report "$RUNNER_TEMP/seed-freshness-observation.json"
+
+      - name: Show production acceptance
+        if: ${{ always() }}
+        run: |
+          if [ -s "$RUNNER_TEMP/seed-freshness-summary.md" ]; then
+            cat "$RUNNER_TEMP/seed-freshness-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '## Production ingestion acceptance\n\n**Unverified.** No current observation was produced. Inspect the [gate and probe logs](%s/%s/actions/runs/%s).\n' \
+              "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Retain acceptance observation
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: seed-freshness-observation
+          path: ${{ runner.temp }}/seed-freshness-observation.json
+          retention-days: 7
+          if-no-files-found: ignore

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -518,6 +518,29 @@ Selected thresholds from `SEED_META`:
 
 > These are illustrative; `SEED_META` in `api/health.js` is the source of truth and each entry documents its own cadence rationale.
 
+### Scheduled monitor results
+
+The Seed Freshness Monitor publishes a production acceptance summary on each
+workflow run and retains its JSON observation for seven days. The summary lists
+active incidents, acknowledged degradation, stale-content grace deadlines, and
+baseline entries that no longer appear in health.
+
+A successful workflow run can still have active source incidents. The workflow
+alerts on new or changed incidents and suppresses repeat alerts for unchanged
+failures. Read the production acceptance summary to determine whether the data
+passed. An unavailable observation is **Unverified**, never healthy.
+
+Generate the same report locally without publishing GitHub statuses:
+
+```bash
+node scripts/check-seed-freshness.mjs \
+  --json-output /tmp/seed-freshness.json \
+  --markdown-output /tmp/seed-freshness.md
+```
+
+The command still exits nonzero when operational acceptance fails. It writes
+both reports from the same health observation before returning that verdict.
+
 ### Example Requests
 
 ```bash

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -131,6 +131,9 @@ export function findOperationalProblems(payload, now = Date.now()) {
       name,
       status: problem?.status ?? 'UNKNOWN',
       records: problem?.records,
+      ...(typeof problem?.errorCode === 'string' && /^[A-Z0-9_:-]{1,100}$/.test(problem.errorCode)
+        ? { errorCode: problem.errorCode }
+        : {}),
       ...(Number.isFinite(problem?.seedAgeMin)
         ? { seedAgeMin: problem.seedAgeMin }
         : {}),
@@ -455,14 +458,55 @@ export function buildAcceptanceObservation(payload, baseline, now = Date.now()) 
     version: 1,
     checkedAt,
     acceptance,
+    graced: findGracedStaleContent(payload, now),
     report: formatAcceptanceReport(acceptance, checkedAt),
   };
+}
+
+function markdownCell(value) {
+  return String(value ?? 'unknown').slice(0, 500)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/[\r\n]/g, ' ').replace(/\|/g, '&#124;')
+    .replace(/[\\`*_[\]()]/g, '\\$&');
+}
+
+export function formatAcceptanceMarkdown({ checkedAt, acceptance, report, graced = [] }) {
+  const { blocking, acknowledged, cleared, expired, expiresAt } = acceptance;
+  const verdict = report.failed ? 'Failed' : acknowledged.length || graced.length
+    ? 'Passed with acknowledged degradation or active grace' : 'Passed';
+  const lines = [
+    '## Production ingestion acceptance', '',
+    `**${verdict}.** Observed ${markdownCell(checkedAt)}.`, '',
+    'Workflow success can mean the observation completed without a new incident alert. It does not prove source recovery.', '',
+    '| Source | State | Detail |', '| --- | --- | --- |',
+  ];
+  for (const [state, problems] of [['Active', blocking], ['Acknowledged', acknowledged]]) {
+    for (const problem of problems) {
+      const code = problem.errorCode ? `; ${problem.errorCode}` : '';
+      const owner = problem.issue ? `; tracking issue #${problem.issue}` : '';
+      lines.push(`| ${markdownCell(problem.name)} | ${state} | ${markdownCell(describeProblem(problem) + code + owner)} |`);
+    }
+  }
+  for (const problem of graced) {
+    lines.push(`| ${markdownCell(problem.name)} | In grace | Alerts at ${markdownCell(problem.graceUntil)} |`);
+  }
+  for (const problem of cleared) {
+    lines.push(`| ${markdownCell(problem.name)} | Baseline entry cleared | No longer reported; review tracking issue #${markdownCell(problem.issue)} |`);
+  }
+  if (!blocking.length && !acknowledged.length && !graced.length && !cleared.length) {
+    lines.push('| None | No active source incidents | Current observation |');
+  }
+  if (expired) lines.push('', `Accepted-problem baseline expired at ${markdownCell(expiresAt)}. Acceptance remains failed.`);
+  return `${lines.join('\n')}\n`;
 }
 
 async function main() {
   const { values } = parseArgs({
     args: process.argv.slice(2),
-    options: { 'json-output': { type: 'string' } },
+    options: {
+      'json-output': { type: 'string' },
+      'markdown-output': { type: 'string' },
+    },
     strict: true,
   });
   const healthUrl = process.env.HEALTH_URL || DEFAULT_HEALTH_URL;
@@ -478,11 +522,12 @@ async function main() {
   const observation = buildAcceptanceObservation(payload, readAcceptanceBaseline());
   const outputPath = values['json-output'];
   if (outputPath) writeFileSync(outputPath, `${JSON.stringify(observation, null, 2)}\n`);
+  if (values['markdown-output']) writeFileSync(values['markdown-output'], formatAcceptanceMarkdown(observation));
   const { report } = observation;
   for (const line of report.info) console.log(line);
   // Non-blocking, but never silent: a green run should still say which feeds
   // are mid-grace and when they start counting as warnings.
-  for (const graced of findGracedStaleContent(payload)) {
+  for (const graced of observation.graced) {
     console.log(`in grace: ${graced.name} (${graced.status}, alerting at ${graced.graceUntil})`);
   }
   for (const line of report.errors) console.error(line);

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 
 import YAML from 'yaml';
@@ -10,6 +14,7 @@ import {
   buildAcceptanceObservation,
   findOperationalProblems,
   formatAcceptanceReport,
+  formatAcceptanceMarkdown,
   isOnDemandProblem,
   findGracedStaleContent,
   isStaleContentGraceProblem,
@@ -32,6 +37,86 @@ const TEST_WORKFLOW_URL = new URL('../.github/workflows/test.yml', import.meta.u
 const PRE_PUSH_HOOK_URL = new URL('../.husky/pre-push', import.meta.url);
 const readCommittedBaseline = () => JSON.parse(readFileSync(COMMITTED_BASELINE_URL, 'utf8'));
 const readRailwayServices = () => JSON.parse(readFileSync(RAILWAY_SERVICES_URL, 'utf8'));
+
+describe('production acceptance summary', () => {
+  const now = Date.parse('2026-09-05T07:00:00.000Z');
+  const baseline = { expiresAt: '2026-09-06', acknowledged: [] };
+  const observation = (problems, accepted = baseline) => buildAcceptanceObservation({
+    status: Object.keys(problems).length ? 'WARNING' : 'HEALTHY',
+    checkedAt: new Date(now).toISOString(),
+    problems,
+  }, accepted, now);
+
+  it('shows every continuing incident independently of the workflow verdict', () => {
+    const report = observation({
+      wildfires: { status: 'SEED_ERROR', records: 1932, errorCode: 'FIRMS_PARTIAL_COVERAGE' },
+      physicalDivergence: { status: 'SEED_ERROR', records: 2 },
+      crossStraitActivityTaiwanMnd: { status: 'SEED_ERROR', records: 133 },
+    });
+    const markdown = formatAcceptanceMarkdown(report);
+    assert.match(markdown, /\*\*Failed\.\*\* Observed 2026-09-05T07:00:00.000Z/);
+    for (const source of report.acceptance.blocking) assert.ok(markdown.includes(`| ${source.name} | Active |`));
+    assert.ok(markdown.includes('FIRMS\\_PARTIAL\\_COVERAGE'));
+    assert.match(markdown, /without a new incident alert/);
+  });
+
+  it('keeps acknowledgements, grace deadlines, and cleared baseline entries distinct', () => {
+    const report = observation({
+      known: { status: 'EMPTY' },
+      frozen: { status: 'STALE_CONTENT', staleContentGraceUntil: '2026-09-05T08:00:00.000Z' },
+    }, { ...baseline, acknowledged: [
+      { name: 'known', status: 'EMPTY', issue: 1, reason: 'Known source problem' },
+      { name: 'recovered', status: 'EMPTY', issue: 2, reason: 'Old problem' },
+    ] });
+    const markdown = formatAcceptanceMarkdown(report);
+    assert.match(markdown, /Passed with acknowledged degradation or active grace/);
+    assert.match(markdown, /known \| Acknowledged/);
+    assert.match(markdown, /frozen \| In grace \| Alerts at 2026-09-05T08:00:00.000Z/);
+    assert.match(markdown, /recovered \| Baseline entry cleared/);
+  });
+
+  it('escapes source text and keeps an expired baseline failed even with no incidents', () => {
+    const hostile = formatAcceptanceMarkdown(observation({
+      '<img>\n[link](https://example.com)|extra': { status: 'UNKNOWN', errorCode: '<secret>' },
+    }));
+    assert.doesNotMatch(hostile, /<img>|<secret>|\[link\]\(/);
+    assert.match(hostile, /&lt;img&gt;/);
+    assert.match(hostile, /&#124;/);
+    assert.match(formatAcceptanceMarkdown(observation({})), /\*\*Passed\.\*\*/);
+    const expired = formatAcceptanceMarkdown(observation({}, {
+      expiresAt: '2026-09-04',
+      acknowledged: [{ name: 'old', status: 'EMPTY', issue: 1, reason: 'Old baseline' }],
+    }));
+    assert.match(expired, /\*\*Failed\.\*\*/);
+    assert.match(expired, /baseline expired/);
+  });
+
+  it('writes JSON and Markdown from one CLI request before returning a failed verdict', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'seed-summary-'));
+    try {
+      const preload = join(dir, 'fetch.mjs');
+      const calls = join(dir, 'calls');
+      writeFileSync(preload, `import { appendFileSync } from 'node:fs';
+globalThis.fetch = async () => {
+  appendFileSync(${JSON.stringify(calls)}, 'request\\n');
+  return Response.json({ status: 'WARNING', checkedAt: new Date().toISOString(), problems: { wildfires: { status: 'SEED_ERROR', records: 2 } } });
+};\n`);
+      const json = join(dir, 'observation.json');
+      const markdown = join(dir, 'summary.md');
+      const result = spawnSync(process.execPath, [
+        '--import', preload, fileURLToPath(new URL('../scripts/check-seed-freshness.mjs', import.meta.url)),
+        '--json-output', json, '--markdown-output', markdown,
+      ], { encoding: 'utf8', timeout: 10_000 });
+      assert.equal(result.status, 1, result.stderr);
+      const report = JSON.parse(readFileSync(json, 'utf8'));
+      assert.equal(report.report.failed, true);
+      assert.equal(readFileSync(markdown, 'utf8'), formatAcceptanceMarkdown(report));
+      assert.equal(readFileSync(calls, 'utf8'), 'request\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('scheduled seed freshness monitor', () => {
   it('projects stable per-source statuses without putting changing ages in the incident identity', () => {

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -92,6 +92,35 @@ function runPublisherFromLegacyRevision() {
   }
 }
 
+it('captures JSON when the gated ancestor predates Markdown output support', () => {
+  const tempDir = mkdtempSync(join(repoRoot, '.tmp-seed-freshness-legacy-probe-'));
+  try {
+    mkdirSync(join(tempDir, 'scripts'));
+    writeFileSync(join(tempDir, 'scripts/check-seed-freshness.mjs'), [
+      "import { parseArgs } from 'node:util';",
+      "import { writeFileSync } from 'node:fs';",
+      "const { values } = parseArgs({ options: { 'json-output': { type: 'string' } } });",
+      "writeFileSync(values['json-output'], JSON.stringify({ version: 1, report: { failed: true } }));",
+      'process.exitCode = 1;',
+    ].join('\n'));
+    const result = spawnSync('bash', ['-e', '-c', stepNamed('Check ingestion operational acceptance').run], {
+      cwd: tempDir, encoding: 'utf8', env: { ...process.env, RUNNER_TEMP: tempDir },
+    });
+    assert.equal(result.status, 1, 'the legacy probe must retain its strict failure');
+    assert.doesNotMatch(result.stderr, /Unknown option/);
+    assert.deepEqual(JSON.parse(readFileSync(join(tempDir, 'seed-freshness-observation.json'), 'utf8')), {
+      version: 1, report: { failed: true },
+    });
+    const summary = join(tempDir, 'summary.md');
+    const shown = spawnSync('bash', ['-e', '-c', stepNamed('Show production acceptance').run], {
+      cwd: tempDir, encoding: 'utf8', env: { ...process.env, RUNNER_TEMP: tempDir, GITHUB_STEP_SUMMARY: summary },
+    });
+    assert.equal(shown.status, 0, shown.stderr);
+    assert.match(readFileSync(summary, 'utf8'), /observation was produced/);
+    assert.doesNotMatch(readFileSync(summary, 'utf8'), /No current observation/);
+  } finally { rmSync(tempDir, { recursive: true, force: true }); }
+});
+
 const HEAD_SHA = '0123456789abcdef';
 // Frozen so the age bound is a boundary, not a race against the wall clock:
 // `date` is faked below and every ancestor age is expressed against this.

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -239,6 +239,34 @@ function runScheduledGate(head, ancestors = []) {
 }
 
 describe('seed freshness workflow control plane', () => {
+  it('shows failed acceptance even after a successful publisher and marks a missing observation unverified', () => {
+    const step = stepNamed('Show production acceptance');
+    assert.equal(step.if, '${{ always() }}');
+    assertBashSyntax(step.run);
+    const artifact = stepNamed('Retain acceptance observation');
+    assert.equal(artifact.if, '${{ always() }}');
+    assert.equal(artifact.with['retention-days'], 7);
+    assert.equal(artifact.with.path, '${{ runner.temp }}/seed-freshness-observation.json');
+    const dir = mkdtempSync(join(repoRoot, '.tmp-seed-summary-'));
+    try {
+      const output = join(dir, 'summary.md');
+      const run = () => spawnSync('bash', ['-e', '-c', step.run], {
+        encoding: 'utf8',
+        env: { ...process.env, RUNNER_TEMP: dir, GITHUB_STEP_SUMMARY: output,
+          GITHUB_SERVER_URL: 'https://github.com', GITHUB_REPOSITORY: 'koala73/worldmonitor', GITHUB_RUN_ID: '123' },
+      });
+      assert.equal(run().status, 0);
+      assert.match(readFileSync(output, 'utf8'), /Unverified.*No current observation/);
+      assert.match(readFileSync(output, 'utf8'), /https:\/\/github.com\/koala73\/worldmonitor\/actions\/runs\/123/);
+      writeFileSync(output, '');
+      writeFileSync(join(dir, 'seed-freshness-summary.md'), '**Failed.** wildfires remains active.\n');
+      assert.equal(run().status, 0);
+      assert.equal(readFileSync(output, 'utf8'), '**Failed.** wildfires remains active.\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('monitors the checked-out main SHA when its gate passed', () => {
     const success = runScheduledGate('success', [
       { sha: 'aaaaaaaaaaaaaaaa', state: 'success', ageSeconds: 900 },


### PR DESCRIPTION
## Why

A Seed Freshness Monitor run can succeed while source incidents remain active because the workflow suppresses repeat alerts. The job summary now shows the production acceptance verdict and every active source from the same validated observation used by the existing checker.

The report also distinguishes acknowledged degradation, grace deadlines, and cleared baseline entries. A gate or probe failure shows an unverified result. The workflow retains the sanitized JSON observation for seven days. Existing alert transitions and health thresholds are unchanged.

## Verification

- 941 focused monitor, workflow, status-publisher, and MDX checks passed.
- The real CLI read production health and wrote matching JSON and Markdown with failed acceptance and the two active source rows.
- Public documentation checks, JavaScript syntax, diff checks, and all repository pre-push gates passed.

## Post-deploy monitoring and validation

Observe the next natural Seed Freshness Monitor run. Confirm that the summary and retained JSON agree, that an unchanged active incident remains visible, and that no duplicate source status is published. A missing observation must show Unverified. This PR does not claim recovery of any upstream source.
