### PR TITLE
fix(ci): retain snapshot handoff when bot PRs are blocked

### DIFF
--- a/.github/workflows/resilience-snapshot-refresh.yml
+++ b/.github/workflows/resilience-snapshot-refresh.yml
@@ -35,15 +35,11 @@ jobs:
           existing_pr=$(gh pr list --state all --head "$branch" --json number --jq '.[0].number // empty')
           if [ -n "$existing_pr" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "existing_pr=true" >> "$GITHUB_OUTPUT"
             echo "Monthly snapshot PR #${existing_pr} already exists."
             exit 0
           fi
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            gh pr create \
-              --base main \
-              --head "$branch" \
-              --title "chore(resilience): refresh published snapshot ${period}" \
-              --body "Monthly credentialed CRI snapshot refresh. Rebuilds the crawlable corpus, root sitemap, and llms-full corpus."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -88,7 +84,7 @@ jobs:
             tests/sitemap-generation.test.mjs \
             tests/seo-geo-residue.test.mjs \
             tests/ai-search-product-facts.test.mjs
-      - name: Open the monthly snapshot PR
+      - name: Commit the monthly snapshot
         if: steps.reconcile.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -102,8 +98,43 @@ jobs:
           git add "$snapshot_path" public/sitemap.xml public/sitemap-main.xml public/llms-full.txt public/ai-search.md
           git commit -m "chore(resilience): refresh published snapshot ${snapshot_date}"
           git push --set-upstream origin "$BRANCH_NAME"
-          gh pr create \
-            --base main \
-            --head "$BRANCH_NAME" \
-            --title "chore(resilience): refresh published snapshot ${snapshot_date}" \
-            --body "Monthly credentialed CRI snapshot refresh. Rebuilds the crawlable corpus, root sitemap, and llms-full corpus."
+      - name: Open the monthly snapshot PR
+        id: delivery
+        if: steps.reconcile.outputs.existing_pr != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ steps.reconcile.outputs.branch }}
+        run: |
+          git fetch --no-tags origin "$BRANCH_NAME"
+          git diff --binary origin/main...FETCH_HEAD > "$RUNNER_TEMP/resilience-snapshot.patch"
+          if gh pr create \
+              --base main \
+              --head "$BRANCH_NAME" \
+              --title "chore(resilience): refresh published snapshot ${BRANCH_NAME##*-snapshot-}" \
+              --body "Monthly credentialed CRI snapshot refresh. Rebuilds the crawlable corpus, root sitemap, and llms-full corpus." \
+              > "$RUNNER_TEMP/snapshot-pr.out" 2> "$RUNNER_TEMP/snapshot-pr.err"; then
+            cat "$RUNNER_TEMP/snapshot-pr.out" >> "$GITHUB_STEP_SUMMARY"
+          elif grep -Fq 'GitHub Actions is not permitted to create or approve pull requests' "$RUNNER_TEMP/snapshot-pr.err"; then
+            echo "manual=true" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Snapshot needs maintainer review::Repository policy blocks bot PR creation; use the retained patch or compare link."
+            {
+              echo '### Maintainer action required'
+              echo
+              echo 'The snapshot is generated and the monthly branch is pushed. No PR was created because repository policy blocks it.'
+              echo
+              echo "[Review and open the monthly PR](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/main...${BRANCH_NAME})"
+              echo
+              echo 'The resilience-snapshot-handoff artifact contains the binary patch. Publication remains pending review and merge.'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat "$RUNNER_TEMP/snapshot-pr.err" >&2
+            exit 1
+          fi
+      - name: Retain the monthly snapshot handoff
+        if: steps.delivery.outputs.manual == 'true'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: resilience-snapshot-handoff
+          path: ${{ runner.temp }}/resilience-snapshot.patch
+          retention-days: 30
+          if-no-files-found: error

--- a/tests/resilience-snapshot-workflow.test.mjs
+++ b/tests/resilience-snapshot-workflow.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { it } from 'node:test';
+import { parse } from 'yaml';
+
+const workflow = parse(readFileSync(new URL('../.github/workflows/resilience-snapshot-refresh.yml', import.meta.url), 'utf8'));
+const step = (name) => workflow.jobs.refresh.steps.find((entry) => entry.name === name);
+
+function execute(name, { policy = '', existingPr = '', existingBranch = false } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'wm-snapshot-workflow-'));
+  try {
+    const gh = join(root, 'gh');
+    const git = join(root, 'git');
+    writeFileSync(gh, `#!/bin/bash
+printf '%s\\n' "$*" >> "$CALLS"
+if [[ "$*" == 'pr list '* ]]; then printf '%s' "$EXISTING_PR"; exit 0; fi
+if [[ "$*" == 'pr create '* ]]; then
+  if [[ -n "$POLICY_ERROR" ]]; then printf '%s\\n' "$POLICY_ERROR" >&2; exit 1; fi
+  printf '%s\\n' 'https://github.com/fixture/repo/pull/1'; exit 0
+fi
+exit 2
+`);
+    writeFileSync(git, `#!/bin/bash
+printf '%s\\n' "$*" >> "$CALLS"
+case "$1" in
+  ls-remote) [[ "$EXISTING_BRANCH" == true ]]; exit $? ;;
+  fetch) exit 0 ;;
+  diff) printf '%s\\n' 'diff --git a/snapshot.json b/snapshot.json'; exit 0 ;;
+  *) exit 2 ;;
+esac
+`);
+    chmodSync(gh, 0o755);
+    chmodSync(git, 0o755);
+    for (const name of ['output', 'summary', 'calls']) writeFileSync(join(root, name), '');
+    const result = spawnSync('bash', ['-e', '-o', 'pipefail', '-c', step(name).run], {
+      cwd: root, encoding: 'utf8', timeout: 10_000,
+      env: {
+        PATH: `${root}:${process.env.PATH}`, RUNNER_TEMP: root,
+        GITHUB_OUTPUT: join(root, 'output'), GITHUB_STEP_SUMMARY: join(root, 'summary'),
+        GITHUB_SERVER_URL: 'https://github.com', GITHUB_REPOSITORY: 'fixture/repo',
+        BRANCH_NAME: 'automation/resilience-snapshot-2026-09', CALLS: join(root, 'calls'),
+        POLICY_ERROR: policy, EXISTING_PR: existingPr, EXISTING_BRANCH: String(existingBranch),
+      },
+    });
+    return {
+      ...result,
+      output: readFileSync(join(root, 'output'), 'utf8'),
+      summary: readFileSync(join(root, 'summary'), 'utf8'),
+      calls: readFileSync(join(root, 'calls'), 'utf8'),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+it('hands off a reviewable patch when repository policy blocks bot PR creation', () => {
+  const result = execute('Open the monthly snapshot PR', { policy: 'GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.output, /manual=true/);
+  assert.match(result.summary, /Maintainer action required/);
+  assert.match(result.summary, /compare\/main\.\.\.automation\/resilience-snapshot-2026-09/);
+  assert.match(result.calls, /diff --binary/);
+  const upload = step('Retain the monthly snapshot handoff');
+  assert.match(upload.if, /steps\.delivery\.outputs\.manual == 'true'/);
+  assert.match(upload.with.path, /resilience-snapshot\.patch/);
+  assert.equal(upload.with['if-no-files-found'], 'error');
+});
+
+it('records normal PR delivery and keeps unexpected failures fatal', () => {
+  const success = execute('Open the monthly snapshot PR');
+  assert.equal(success.status, 0, success.stderr);
+  assert.match(success.summary, /https:\/\/github.com\/fixture\/repo\/pull\/1/);
+  assert.doesNotMatch(success.output, /manual=true/);
+  const failed = execute('Open the monthly snapshot PR', { policy: 'Bad credentials' });
+  assert.notEqual(failed.status, 0);
+  assert.doesNotMatch(failed.output, /manual=true/);
+});
+
+it('reuses a branch without recapturing, and skips a month already represented by a PR', () => {
+  const branch = execute('Reconcile the monthly review branch', { existingBranch: true });
+  assert.equal(branch.status, 0, branch.stderr);
+  assert.match(branch.output, /skip=true/);
+  assert.doesNotMatch(branch.calls, /pr create/);
+  assert.doesNotMatch(branch.output, /existing_pr=true/);
+  const pr = execute('Reconcile the monthly review branch', { existingPr: '42' });
+  assert.equal(pr.status, 0, pr.stderr);
+  assert.match(pr.output, /existing_pr=true/);
+  assert.match(step('Open the monthly snapshot PR').if, /steps\.reconcile\.outputs\.existing_pr != 'true'/);
+});


### PR DESCRIPTION
## Summary

The monthly resilience snapshot workflow pushes its branch but fails when repository policy rejects GitHub Actions PR creation. Retain a binary patch artifact and a compare link as an explicit maintainer handoff for that exact rejection. A month with an existing branch uses the same delivery step; a month with an existing PR still skips capture.

Normal PR creation remains automatic where allowed. Authentication, API, and other unexpected failures remain fatal. Repository settings and trust permissions are unchanged. A successful handoff explicitly leaves publication pending review and merge.

## Validation

- Reproduced policy-rejected delivery and existing-branch failure against the original workflow shell.
- Execute the actual workflow shell with stubbed GitHub/Git commands for normal delivery, exact policy rejection, unexpected failure, existing branch, and existing PR.
- All 43 focused and related snapshot/publication tests pass; Biome and diff checks pass.
- Live policy acceptance remains pending a natural or separately authorized workflow run after merge.
