### PR TITLE
chore(auth): pin the Clerk SDK and UI to exact versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@aws-sdk/client-s3": "^3.1009.0",
-        "@clerk/clerk-js": "^6.13.0",
+        "@clerk/clerk-js": "6.25.6",
         "@deck.gl/core": "^9.2.11",
         "@deck.gl/layers": "^9.2.11",
         "@deck.gl/mapbox": "^9.2.11",

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
     "@aws-sdk/client-s3": "^3.1009.0",
-    "@clerk/clerk-js": "^6.13.0",
+    "@clerk/clerk-js": "6.25.6",
     "@deck.gl/core": "^9.2.11",
     "@deck.gl/layers": "^9.2.11",
     "@deck.gl/mapbox": "^9.2.11",

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -165,11 +165,18 @@ function getAfterSignOutUrl(): string {
 // is absent (mirrors stale-bundle-check.ts's __BUILD_HASH__ handling).
 const CLERK_JS_VERSION = typeof __CLERK_JS_VERSION__ !== 'undefined' ? __CLERK_JS_VERSION__ : '';
 
-// @clerk/ui major paired with @clerk/clerk-js v6. The UI controller ships in a
-// SEPARATE package from the (headless) SDK and is loaded from the same Frontend
-// API; its UMD bundle exposes `window.__internal_ClerkUICtor`, which we pass to
-// `clerk.load()`. Bump this alongside any @clerk/clerk-js MAJOR upgrade.
-const CLERK_UI_VERSION = '1';
+// @clerk/ui version paired with @clerk/clerk-js v6. The UI controller ships in
+// a SEPARATE package from the (headless) SDK and is loaded from the same
+// Frontend API; its UMD bundle exposes `window.__internal_ClerkUICtor`, which
+// we pass to `clerk.load()`.
+//
+// Pinned EXACTLY (#7352): a bare major resolved at request time, so Clerk
+// could change or remove parts of the prebuilt SignIn/UserProfile surfaces —
+// including passkey management — with no repo change, no PR, and no CI
+// signal. Upgrades are now deliberate: bump this constant (and the
+// @clerk/clerk-js pin in package.json) together, then re-verify the auth
+// smoke against the SERVED bundles, not node_modules.
+const CLERK_UI_VERSION = '1.32.2';
 
 // The SDK UMD bundle, loaded with a `data-clerk-publishable-key` attribute,
 // auto-creates a (not-yet-loaded) Clerk instance on `window.Clerk` — it exposes

--- a/tests/clerk-runtime-version-pin.test.mts
+++ b/tests/clerk-runtime-version-pin.test.mts
@@ -1,0 +1,80 @@
+/**
+ * #7352 — the Clerk code we ship must be the Clerk code we test against, and
+ * it must not change without a commit.
+ *
+ * Two resolution gaps existed: package.json declared `^6.13.0` while the
+ * lockfile installed 6.25.6 (vite strips the range prefix to build the
+ * Frontend API URL, so production SERVED 6.13.0 while TypeScript compiled
+ * against 6.25.6 — twelve minors of drift between the runtime and its
+ * types), and `CLERK_UI_VERSION = '1'` let the prebuilt SignIn/UserProfile
+ * surfaces float across an entire major at request time with no repo change
+ * and no CI signal.
+ *
+ * Both are pinned exactly now; this guard reds any reintroduction of a range.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+const EXACT_SEMVER = /^\d+\.\d+\.\d+$/;
+const RANGE_CHARS = /[\^~<>=*x\s]/;
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+const lock = JSON.parse(readFileSync('package-lock.json', 'utf8')) as {
+  packages: Record<string, { version?: string }>;
+};
+const clerkServiceSrc = readFileSync('src/services/clerk.ts', 'utf8');
+
+const declared = pkg.dependencies?.['@clerk/clerk-js'] ?? pkg.devDependencies?.['@clerk/clerk-js'] ?? '';
+const installed = lock.packages['node_modules/@clerk/clerk-js']?.version ?? '';
+
+describe('Clerk runtime version pin (#7352)', () => {
+  it('declares @clerk/clerk-js as an exact version, not a range', () => {
+    assert.match(
+      declared, EXACT_SEMVER,
+      `@clerk/clerk-js must be pinned exactly — a range means the SERVED bundle ` +
+      `(vite strips the prefix into __CLERK_JS_VERSION__) and the compiled-against ` +
+      `types can drift by minors with no commit; got "${declared}"`,
+    );
+  });
+
+  it('the declared version IS the installed version, so runtime and types agree', () => {
+    assert.match(installed, EXACT_SEMVER, 'lockfile must carry a concrete install');
+    assert.equal(
+      declared, installed,
+      'package.json and package-lock.json must name the same @clerk/clerk-js — ' +
+      'the declared value is what production serves, the installed one is what tsc checks',
+    );
+  });
+
+  it('the generated Frontend API SDK URL carries no range characters', () => {
+    // Mirror vite.config.ts: the injected __CLERK_JS_VERSION__ is the declared
+    // string with any range prefix stripped. With an exact pin the strip is a
+    // no-op; if a range sneaks back, the stripped value diverges from the
+    // declared one and this fails alongside the exactness guard above.
+    const stripped = declared.replace(/^[\^~>=<\s]*/, '');
+    assert.equal(stripped, declared, 'stripping must be a no-op on an exact pin');
+    const url = `https://clerk.worldmonitor.app/npm/@clerk/clerk-js@${stripped}/dist/clerk.browser.js`;
+    assert.ok(!RANGE_CHARS.test(`@${stripped}`.slice(1)), `URL version segment must be literal: ${url}`);
+  });
+
+  it('CLERK_UI_VERSION is an exact version, so the UI bundle cannot float across a major', () => {
+    const match = clerkServiceSrc.match(/const CLERK_UI_VERSION = '([^']*)';/);
+    assert.ok(match, 'CLERK_UI_VERSION must remain a plain literal in src/services/clerk.ts');
+    assert.match(
+      match![1]!, EXACT_SEMVER,
+      `@clerk/ui@${match![1]} resolves at request time — a bare major lets Clerk change ` +
+      'the prebuilt SignIn/UserProfile surfaces (including passkey management) with no ' +
+      'repo change and no CI signal',
+    );
+  });
+
+  it('the SDK pin stays on the major the UI pairing guard expects', () => {
+    // vite.config.ts hard-fails on a non-6 major and points at CLERK_UI_VERSION;
+    // mirroring it here keeps the pairing visible in the test run too.
+    assert.equal(declared.split('.')[0], '6');
+  });
+});


### PR DESCRIPTION
Fixes #7352

## Acceptance mapping

- **`@clerk/clerk-js` pinned exactly; lockfile updated** — `6.25.6`, the lockfile's installed version, per the issue's 'matching the lockfile so runtime and types agree'. The served bundle therefore moves 6.13.0 → 6.25.6 (that is the point of the issue, and why it demands the smoke below). Lockfile delta is the one-line range field.
- **`CLERK_UI_VERSION` pinned exactly** — `1.32.2` (current release on the `@clerk/ui` v1 line paired with clerk-js v6), replacing the bare `'1'` that resolved at request time. The comment now documents the deliberate-upgrade procedure: bump both pins together, re-verify against the SERVED bundles (the passkey plan's lesson).
- **Guard test fails if either reverts to a range** — `tests/clerk-runtime-version-pin.test.mts`: exact-semver on the declaration, declared === installed, the vite strip expression is a no-op so the generated Frontend API URL carries no range characters, `CLERK_UI_VERSION` exact, and the major-6 pairing mirror of vite's own guard. Verified: `^6.25.6` reds 4 tests, `'1'` reds 1.
- **Manual auth smoke** — cannot be run from a fork; the versions to record are **clerk-js 6.25.6 + @clerk/ui 1.32.2**. This box is deliberately left for a maintainer preview deploy (sign in, open account profile, confirm a Pro entitlement resolves).
- **Documented upgrade step** — in the `CLERK_UI_VERSION` comment block, per the issue's 'bump deliberately, re-verify against the served bundle'.

## Verification

`npx tsx --test tests/clerk-runtime-version-pin.test.mts` (5/5), `npm run typecheck` clean, biome clean. Own commit, own PR, no feature riding along — as the issue's landing note requires.