### PR TITLE
feat(mcp): get_global_air_activity — world-level military air rollup

### DIFF
--- a/api/mcp/registry/analysis-tools.ts
+++ b/api/mcp/registry/analysis-tools.ts
@@ -539,6 +539,93 @@ export const ANALYSIS_TOOLS: ToolDef[] = [
     _apiPaths: [],
   },
   {
+    name: 'get_global_air_activity',
+    _outputBudgetBytes: 32768,
+    description:
+      'Global military air activity: how many aircraft are aloft worldwide right now, by type and theater. ' +
+      'A cheap aggregate over the seeded world flight snapshot — one total, an aircraft-type breakdown ' +
+      '(fighters, tankers, AWACS, reconnaissance, transports, bombers, drones), per-theater rollups using the ' +
+      'same theater assignment the surge engine uses, and the count outside every declared theater. Quiet ' +
+      'theaters are omitted rather than reported as zero rows. Scope is military aircraft from ' +
+      'redistribution-cleared providers — the seeded snapshot that covers the world; for civilian traffic or a ' +
+      'single country use get_airspace, and for posture/threat interpretation of the same data use ' +
+      'get_military_surge.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        cached_at: { type: ['string', 'null'], description: 'Fetch time of the flight snapshot.' },
+        stale: { type: 'boolean', description: ANALYSIS_STALE_DESCRIPTION },
+        ...ANALYSIS_CACHE_STATUS_PROPERTIES,
+        data: {
+          type: 'object',
+          properties: {
+            total_military_aircraft: { type: 'number' },
+            by_aircraft_type: { type: 'object', additionalProperties: { type: 'number' } },
+            theaters: { type: 'array', items: { type: 'object', properties: {
+              theater_id: { type: 'string' }, theater_name: { type: 'string' }, short_name: { type: 'string' },
+              total_aircraft: { type: 'number' },
+              fighters: { type: 'number' }, tankers: { type: 'number' }, awacs: { type: 'number' },
+              reconnaissance: { type: 'number' }, transport: { type: 'number' },
+              bombers: { type: 'number' }, drones: { type: 'number' },
+            } } },
+            outside_theater_count: { type: 'number', description: 'Aircraft aloft outside every declared posture theater.' },
+          },
+          required: [],
+        },
+      },
+      required: ['cached_at', 'stale', 'data'],
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    _execute: async () => {
+      const {
+        payloads: [flightsPayload],
+        freshness,
+      } = await readCachesWithFreshness(
+        ['military:flights:v1'],
+        [{ key: 'seed-meta:military:flights', maxStaleMin: 30 }],
+      );
+      requireAnyInput([flightsPayload], freshness, 'The military flight snapshot is unavailable');
+
+      // Same adapter as get_military_surge: redistribution gating and shape
+      // tolerance live in ONE place, and the theater assignment below is the
+      // surge engine's own — no second geometry implementation.
+      const flights = militaryFlightsToSurgeInputs(flightsPayload);
+      const byType: Record<string, number> = {};
+      for (const flight of flights) {
+        byType[flight.aircraftType] = (byType[flight.aircraftType] ?? 0) + 1;
+      }
+      const theaters = getTheaterPostureSummaries(flights)
+        .filter((summary) => summary.totalAircraft > 0)
+        .map((summary) => ({
+          theater_id: summary.theaterId,
+          theater_name: summary.theaterName,
+          short_name: summary.shortName,
+          total_aircraft: summary.totalAircraft,
+          fighters: summary.fighters,
+          tankers: summary.tankers,
+          awacs: summary.awacs,
+          reconnaissance: summary.reconnaissance,
+          transport: summary.transport,
+          bombers: summary.bombers,
+          drones: summary.drones,
+        }));
+      const inTheaters = theaters.reduce((sum, theater) => sum + theater.total_aircraft, 0);
+
+      return {
+        ...freshness,
+        data: {
+          total_military_aircraft: flights.length,
+          by_aircraft_type: byType,
+          theaters,
+          outside_theater_count: Math.max(0, flights.length - inTheaters),
+        },
+      };
+    },
+    _coverageKeys: ['military:flights:v1'],
+    _apiPaths: [],
+  },
+  {
     name: 'get_military_surge',
     _outputBudgetBytes: 65536,
     description:

--- a/tests/mcp-global-air-activity.test.mjs
+++ b/tests/mcp-global-air-activity.test.mjs
@@ -1,0 +1,144 @@
+/**
+ * #5707 (item: global airborne-traffic snapshot) — get_airspace answers one
+ * country at a time; nothing answered "what is aloft worldwide right now?"
+ * even though the seeded military flight snapshot IS the world dataset.
+ *
+ * get_global_air_activity is a cheap aggregate over `military:flights:v1`:
+ * one world total, an aircraft-type breakdown, per-theater rollups reusing
+ * the SAME theater assignment the surge engine uses (no second geometry
+ * implementation), and the count outside every declared theater. Military
+ * scope is deliberate and disclosed: the redistribution-gated seeded snapshot
+ * covers the world; civilian coverage remains per-country via get_airspace.
+ */
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { installRedis } from './helpers/fake-upstash-redis.mts';
+import { TOOL_REGISTRY } from '../api/mcp/registry/index.ts';
+
+const findTool = (name) => TOOL_REGISTRY.find((t) => t.name === name);
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
+const ORIGINAL_REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_REDIS_URL === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_REDIS_URL;
+  if (ORIGINAL_REDIS_TOKEN === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_REDIS_TOKEN;
+});
+
+// Persian-Gulf coordinates land inside the middle-east posture theater; the
+// mid-Pacific point sits outside every declared theater boundary.
+const IN_THEATER = { lat: 26.5, lon: 52.0 };
+const OUTSIDE_THEATERS = { lat: -40.0, lon: -140.0 };
+
+function flight(id, { lat, lon }, aircraftType, source = 'wingbits') {
+  return {
+    id,
+    callsign: id.toUpperCase(),
+    lat,
+    lon,
+    lastSeenMs: Date.now(),
+    operator: 'usaf',
+    aircraftType,
+    sourceMeta: { source },
+  };
+}
+
+function install(payload) {
+  installRedis({
+    'seed-meta:military:flights': { fetchedAt: Date.now(), recordCount: 4, sourceVersion: 'test' },
+    'military:flights:v1': payload,
+  }, { keepVercelEnv: true });
+}
+
+describe('get_global_air_activity (#5707)', () => {
+  it('aggregates the world total, type breakdown, theater rollups, and the outside-theater remainder', async () => {
+    install({
+      flights: [
+        flight('f1', IN_THEATER, 'fighter'),
+        flight('f2', IN_THEATER, 'tanker'),
+        flight('f3', OUTSIDE_THEATERS, 'transport'),
+        flight('f4', OUTSIDE_THEATERS, 'unknown'),
+      ],
+      fetchedAt: Date.now(),
+    });
+
+    const result = await findTool('get_global_air_activity')._execute({}, '', {}, {});
+
+    assert.equal(result.data.total_military_aircraft, 4);
+    assert.equal(result.data.by_aircraft_type.fighter, 1);
+    assert.equal(result.data.by_aircraft_type.tanker, 1);
+    assert.equal(result.data.by_aircraft_type.transport, 1);
+    assert.equal(result.data.by_aircraft_type.unknown, 1);
+
+    // Theater boundaries overlap; which named theater claims the Gulf point
+    // is the surge engine's call, not this test's. What must hold: some
+    // theater carries both Gulf flights, correctly typed.
+    const gulfTheater = result.data.theaters.find((t) => t.total_aircraft === 2);
+    assert.ok(gulfTheater, `a theater must carry both Gulf flights: ${JSON.stringify(result.data.theaters)}`);
+    assert.equal(gulfTheater.fighters, 1);
+    assert.equal(gulfTheater.tankers, 1);
+
+    const inTheaters = result.data.theaters.reduce((sum, t) => sum + t.total_aircraft, 0);
+    assert.equal(result.data.outside_theater_count, result.data.total_military_aircraft - inTheaters);
+    assert.equal(typeof result.stale, 'boolean');
+  });
+
+  it('quiet theaters are omitted, not reported as zero rows', async () => {
+    install({ flights: [flight('f1', IN_THEATER, 'fighter')], fetchedAt: Date.now() });
+
+    const result = await findTool('get_global_air_activity')._execute({}, '', {}, {});
+
+    assert.ok(result.data.theaters.length >= 1);
+    for (const theater of result.data.theaters) {
+      assert.ok(theater.total_aircraft > 0, `zero-count theater rows are noise: ${theater.theater_id}`);
+    }
+  });
+
+  it('non-redistributable flights never reach the aggregate', async () => {
+    install({
+      flights: [
+        flight('f1', IN_THEATER, 'fighter'),
+        flight('f2', IN_THEATER, 'fighter', 'opensky-network'),
+      ],
+      fetchedAt: Date.now(),
+    });
+
+    const result = await findTool('get_global_air_activity')._execute({}, '', {}, {});
+
+    assert.equal(
+      result.data.total_military_aircraft, 1,
+      'the OpenSky-sourced flight must be excluded by the shared redistribution gate',
+    );
+  });
+
+  it('fails loudly when the snapshot is missing rather than reporting an empty sky', async () => {
+    installRedis({
+      'seed-meta:military:flights': { fetchedAt: Date.now(), recordCount: 4, sourceVersion: 'test' },
+    }, { keepVercelEnv: true });
+
+    await assert.rejects(
+      () => findTool('get_global_air_activity')._execute({}, '', {}, {}),
+      /unavailable|no .*feed/i,
+      'an absent snapshot is an availability failure — an empty-sky answer would be a lie',
+    );
+  });
+
+  it('declares the hybrid tool contract', () => {
+    const tool = findTool('get_global_air_activity');
+    assert.ok(tool, 'tool must be registered');
+    assert.equal(tool._cacheKeys, undefined, 'hybrid _execute tool, not a cache tool');
+    assert.deepEqual(tool._coverageKeys, ['military:flights:v1']);
+    assert.deepEqual(tool.inputSchema.required, [], 'callable with no arguments');
+    assert.deepEqual(tool.annotations, {
+      readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false,
+    });
+    assert.match(tool.description, /get_airspace/, 'must point per-country/civilian askers at get_airspace');
+    const firstSentence = tool.description.match(/^[\s\S]+?[.!?](?:\s|$)/);
+    assert.ok(firstSentence && Buffer.byteLength(firstSentence[0].trim(), 'utf8') <= 120,
+      'first sentence must survive tools/list compression');
+  });
+});


### PR DESCRIPTION
Promotes one item from the #5707 small-surface triage checklist: **global airborne-traffic snapshot** ('a world-level rollup is a cheap aggregate of data we already touch').

## What it is

A hybrid `_execute` tool over `military:flights:v1` (freshness from `seed-meta:military:flights`, same 30-min budget as `get_military_surge`): world total, aircraft-type breakdown, per-theater rollups, and the outside-every-theater remainder.

## Reuse, not reimplementation

- `militaryFlightsToSurgeInputs` — the SAME shared adapter `get_military_surge` uses, so the redistribution gate (OpenSky-sourced flights never cross the agent boundary) and payload-shape tolerance live in exactly one place.
- `getTheaterPostureSummaries` — the surge engine's own theater assignment; no second geometry implementation.

## Honest scope

Military-only, by design: the seeded snapshot is the world dataset the checklist meant; there is no seeded global civilian snapshot. The description discloses this and routes civilian/per-country questions to `get_airspace` and posture interpretation to `get_military_surge`. Quiet theaters are omitted (zero rows are noise); a missing snapshot rejects loudly rather than reporting an empty sky.

## Tests

`tests/mcp-global-air-activity.test.mjs` (5) through the real registry + fake-Upstash harness: aggregation + remainder arithmetic, quiet-theater omission (mutation-checked), OpenSky exclusion, loud unavailability, and the hybrid-tool contract (coverage keys, no-arg callability, annotations, `tools/list` first-sentence byte budget — the same contract shape `mcp-analysis-rpc-tools-contract` pins for its wave).

Sibling suites green: analysis rpc tools + contract (71/71 incl. the new file), output-schema coverage. Typecheck + biome clean. Only `api/mcp/` + `tests/` are touched — no codegen inputs, so the fork-artifact gate is unaffected.