### PR TITLE
feat(mcp): get_fred_series — bounded on-demand FRED macro series for agents

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -9,7 +9,7 @@ import {
 // @ts-expect-error — generated JS module, no declaration file
 import MINING_SITES_RAW from '../../../shared/mining-sites.js';
 import { readJsonFromUpstash } from '../../_upstash-json.js';
-import { argStr } from '../filters';
+import { argNum, argStr, argStrList } from '../filters';
 import { buildAuthHeaders } from '../auth';
 import { assertToolFetchOk, BillingDenialError, RpcValidationError, throwIfBillingDenial } from '../billing-denial';
 import { SUPPORTED_CONSUMER_PRICES_COUNTRIES } from '../constants';
@@ -2359,6 +2359,76 @@ export const RPC_TOOLS: ToolDef[] = [
       'GET /api/consumer-prices/v1/list-consumer-price-categories',
       'GET /api/consumer-prices/v1/list-consumer-price-movers',
       'GET /api/consumer-prices/v1/list-retailer-price-spreads',
+    ],
+  },
+  {
+    name: 'get_fred_series',
+    _outputBudgetBytes: 131072,
+    description:
+      'On-demand FRED macro series from the seeded cache: rates, yields, inflation, labor, money supply, and stress indices. ' +
+      'Answers through the canonical get-fred-series-batch RPC — the same bounded allowlist and Railway-seeded data the ' +
+      'dashboard reads, so no external FRED call ever happens at request time and unlisted series cannot be pulled. Up to 20 ' +
+      'series per call; observations return newest-last. A requested id missing from `results` is either outside the ' +
+      'allowlist or not yet seeded — compare `fetched` with `requested`.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        series_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'FRED series ids (case-insensitive), bounded to the seeded allowlist: WALCL, FEDFUNDS, T10Y2Y, UNRATE, ' +
+            'CPIAUCSL, DGS10, VIXCLS, GDP, M2SL, DCOILWTICO, BAMLH0A0HYM2, ICSA, MORTGAGE30US, GSCPI, T10Y3M, STLFSI4, ' +
+            'DGS1MO, DGS3MO, DGS6MO, DGS1, DGS2, DGS5, DGS30, BAMLC0A0CM, SOFR, ESTR, EURIBOR3M, EURIBOR6M, EURIBOR1Y.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Observations per series, newest-last (default 24, max 1000). Keep small — 20 series at full history is large.',
+        },
+      },
+      required: ['series_ids'],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        results: { type: 'object', additionalProperties: { type: 'object', properties: {
+          seriesId: { type: 'string' }, title: { type: 'string' },
+          units: { type: 'string' }, frequency: { type: 'string' },
+          observations: { type: 'array', items: { type: 'object', properties: {
+            date: { type: 'string' }, value: { type: 'number' },
+          } } },
+        } } },
+        fetched: { type: 'number' },
+        requested: { type: 'number', description: 'Allowlisted ids actually looked up; below the ids sent when some were unlisted.' },
+      },
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    _execute: async (params, base, context) => {
+      const seriesIds = argStrList(params.series_ids)
+        .map((id) => id.trim().toUpperCase())
+        .filter(Boolean)
+        .slice(0, 20);
+      const requestedLimit = argNum(params.limit);
+      // Bounded by default: the RPC's own default is 120 observations, which
+      // at 20 series would dwarf the output budget for an agent that only
+      // wanted the latest readings.
+      const limit = requestedLimit !== null && requestedLimit > 0
+        ? Math.min(requestedLimit, 1000)
+        : 24;
+      const url = `${base}/api/economic/v1/get-fred-series-batch`;
+      const body = JSON.stringify({ seriesIds, limit });
+      const auth = await buildAuthHeaders(context, 'POST', url, body);
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
+        body,
+        signal: AbortSignal.timeout(8_000),
+      });
+      await assertToolFetchOk(res, 'get-fred-series-batch');
+      return res.json();
+    },
+    _apiPaths: [
+      "POST /api/economic/v1/get-fred-series-batch",
     ],
   },
   {

--- a/tests/mcp-fred-series-tool.test.mjs
+++ b/tests/mcp-fred-series-tool.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * #5707 (item: on-demand FRED series) — the dashboard exposes curated
+ * FRED-derived series, and the seeded universe is already servable through
+ * the get-fred-series-batch RPC's allowlist, but agents had no way to pull
+ * a common macro series (UNRATE, CPIAUCSL, FEDFUNDS…) on demand.
+ *
+ * get_fred_series is the bounded parameterized surface: the tool answers
+ * through the canonical RPC (same allowlist, same seeded cache, zero new
+ * seeders and zero external calls), and its description names the exact
+ * allowlist so agents can discover what is servable — with a parity test
+ * pinning that list to the server's own ALLOWED_SERIES set.
+ */
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  HMAC_SECRET,
+  callBody,
+  makeProDeps,
+  PRO_USER_ID,
+  proReq,
+} from './helpers/mcp-pro-deps.mjs';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+const FRED_RPC_PATH = '/api/economic/v1/get-fred-series-batch';
+
+const canonicalResponse = {
+  results: {
+    UNRATE: {
+      seriesId: 'UNRATE',
+      title: 'Unemployment Rate',
+      units: 'Percent',
+      frequency: 'Monthly',
+      observations: [
+        { date: '2026-07-01', value: 4.2 },
+        { date: '2026-08-01', value: 4.3 },
+      ],
+    },
+  },
+  fetched: 1,
+  requested: 1,
+};
+
+describe('get_fred_series MCP tool (#5707)', () => {
+  let mcpHandler;
+  let requests;
+
+  beforeEach(async () => {
+    process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+    process.env.MCP_TELEMETRY = 'false';
+    requests = [];
+    globalThis.fetch = async (input, init = {}) => {
+      requests.push({ url: String(input), init });
+      return new Response(JSON.stringify(canonicalResponse), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const mod = await import(`../api/mcp.ts?fred-series=${Date.now()}-${Math.random()}`);
+    mcpHandler = mod.mcpHandler;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in originalEnv)) delete process.env[key];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('lists the tool and answers through the canonical FRED batch RPC', async () => {
+    const listed = await mcpHandler(new Request('https://worldmonitor.app/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }));
+    const tool = (await listed.json()).result.tools.find((entry) => entry.name === 'get_fred_series');
+    assert.ok(tool, 'tool must be discoverable through tools/list');
+    assert.deepEqual(tool.inputSchema.required, ['series_ids']);
+
+    requests = [];
+    const { deps } = makeProDeps();
+    const response = await mcpHandler(
+      proReq('POST', callBody('get_fred_series', { series_ids: ['unrate'] })),
+      deps,
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    const downstream = requests.find((entry) => {
+      try { return new URL(entry.url).pathname === FRED_RPC_PATH; } catch { return false; }
+    });
+    assert.ok(downstream, 'tool must answer through the canonical RPC, not a second FRED implementation');
+    const sent = JSON.parse(downstream.init.body);
+    assert.deepEqual(sent.seriesIds, ['UNRATE'], 'ids are normalized to the allowlist casing');
+    assert.match(downstream.init.headers['X-WM-MCP-Internal'] ?? '', /^\d+\.[A-Za-z0-9_-]+$/);
+    assert.equal(downstream.init.headers['X-WM-MCP-User-Id'], PRO_USER_ID);
+
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.fetched, 1);
+    assert.equal(payload.results.UNRATE.observations.length, 2);
+  });
+
+  it('caps the observation window by default so a 20-series pull cannot blow the output budget', async () => {
+    requests = [];
+    const { deps } = makeProDeps();
+    await mcpHandler(proReq('POST', callBody('get_fred_series', { series_ids: ['UNRATE'] })), deps);
+
+    const downstream = requests.find((entry) => String(entry.url).includes(FRED_RPC_PATH));
+    const sent = JSON.parse(downstream.init.body);
+    assert.ok(
+      Number.isFinite(sent.limit) && sent.limit > 0 && sent.limit <= 60,
+      `the tool must send a bounded default observation limit, got ${sent.limit}`,
+    );
+  });
+
+  it("the description's advertised allowlist is the server's ALLOWED_SERIES, verbatim", async () => {
+    const listed = await mcpHandler(new Request('https://worldmonitor.app/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }));
+    const tool = (await listed.json()).result.tools.find((entry) => entry.name === 'get_fred_series');
+
+    const serverSource = readFileSync('server/worldmonitor/economic/v1/get-fred-series-batch.ts', 'utf8');
+    const setBlock = serverSource.match(/const ALLOWED_SERIES = new Set<string>\(\[([\s\S]*?)\]\);/);
+    assert.ok(setBlock, 'server allowlist must stay a literal Set');
+    const serverIds = [...setBlock[1].matchAll(/'([A-Z0-9]+)'/g)].map((m) => m[1]);
+    assert.ok(serverIds.length > 10);
+
+    for (const id of serverIds) {
+      assert.ok(
+        tool.inputSchema.properties.series_ids.description.includes(id),
+        `series_ids description must advertise ${id} — the allowlist an agent cannot discover is a guessing game`,
+      );
+    }
+  });
+});

--- a/tests/mcp-output-schema-coverage.test.mjs
+++ b/tests/mcp-output-schema-coverage.test.mjs
@@ -626,6 +626,7 @@ describe('api/mcp.ts — per-tool outputSchema coverage (v1.7.0)', () => {
     'get_chokepoint_dependencies',
     'get_country_risk',
     'get_defense_industrial_base',
+    'get_fred_series',
     'get_demographics_capability',
     'get_food_stocks',
     'get_intel_timeline',


### PR DESCRIPTION
Promotes one item from the #5707 small-surface triage checklist: **on-demand FRED series parameter** ('a bounded series_id allowlist parameter would let agents pull common macro series without new seeders').

## What it is

`get_fred_series` in the RPC-tool wave: POSTs to the canonical `/api/economic/v1/get-fred-series-batch` with the signed internal-MCP headers — the same bounded allowlist and Railway-seeded cache the dashboard reads, zero external FRED calls at request time, no new seeders, no second implementation.

## Bounded on both axes

- **Series**: normalized to the allowlist casing, capped at the RPC's 20-per-call; the `series_ids` description advertises the full allowlist (UNRATE, CPIAUCSL, FEDFUNDS, the yield-curve tenors, stress indices, …) so agents don't guess — and a parity test greps the server's `ALLOWED_SERIES` literal and asserts every id appears in the advertisement, so the two cannot drift.
- **Observations**: default 24 per series, newest-last (the RPC's own 120 default × 20 series would dwarf the output budget), caller-raisable to the RPC's 1000 cap.

## Contract & drift protection

Enrolled in `VERBATIM_PASSTHROUGH_TOOLS`, so the declared `outputSchema` is checked against the OpenAPI response schema by the existing coverage suite. `_apiPaths` declares the POST route; annotations are read-only/idempotent/closed-world.

## Tests

`tests/mcp-fred-series-tool.test.mjs` (3, the `get_defense_industrial_base` harness pattern): discoverable via `tools/list` and answers through the canonical RPC with normalized ids + signed headers; the bounded default observation limit is actually sent; the allowlist-advertisement parity check. Mutation check: dropping the id normalization reds the canonical-RPC test. Output-schema coverage suite green with the new enrollment (42/42 combined); typecheck + biome clean. Only `api/mcp/` + `tests/` touched — no codegen inputs, fork-artifact gate unaffected.