### PR TITLE
docs(imd): document complete Railway credential setup

### DIFF
--- a/docs/natural-disasters.mdx
+++ b/docs/natural-disasters.mdx
@@ -8,6 +8,49 @@ The Natural layer combines two authoritative sources for comprehensive disaster 
 
 North Indian Ocean cyclone tracks, forecast wind radii, and cones of uncertainty come from the official IMD API (`weather:imd-cyclone-marine:v1`). Observed positions stay distinct from forecast positions. Wind radii and the cone of uncertainty are forecast/uncertainty geometry, never an observed storm footprint. The seeder does not flatten these products into `weather:alerts:v1`. Live fetch requires `IMD_API_KEY`, `IMD_API_EMAIL`, and `IMD_API_PASSWORD`; the seeder mints a short-lived JWT for each run. A disabled or empty snapshot is not an all-clear.
 
+## Configure the IMD Railway seeder
+
+IMD authenticates each API request with both an API key and a JWT. The API key
+identifies the approved server and static public IP. Railway calls this address
+a static outbound IP. The JWT authenticates the IMD account and expires after
+3,600 seconds. WorldMonitor mints a new JWT at the start of each seed run. Do
+not store the JWT in Railway.
+
+1. Create an account in the [IMD API portal](https://api.imd.gov.in/public/index.php).
+   Use the same account to create the API key and mint JWTs. Follow the
+   [IMD API Portal User Guide](https://api.imd.gov.in/public/IMD_API_Portal_User_Guide.pdf).
+2. Enable [Railway Static Outbound IPs](https://docs.railway.com/networking/static-outbound-ips)
+   for the service. Run the following command to list the addresses Railway can
+   use:
+
+   ```bash
+   railway outbound-network static-ip status \
+     --service seed-imd-cyclone-marine \
+     --environment production \
+     --json
+   ```
+
+   Register the outbound address with IMD when you create the production API
+   key. Railway can assign several addresses to a high-availability service. If
+   the command lists more than one address, confirm with IMD how to authorize
+   each address. A key that is bound to one address can fail when Railway uses
+   another one.
+3. Add these service variables in Railway. Store each value as a secret.
+
+   | Variable | Value |
+   |---|---|
+   | `IMD_API_KEY` | The active production key for the Railway outbound IP |
+   | `IMD_API_EMAIL` | The registered IMD account email that owns the key |
+   | `IMD_API_PASSWORD` | The password for the same IMD account |
+
+   Do not set `IMD_API_TOKEN`. The seeder sends the account credentials to
+   `POST https://api.imd.gov.in/api/oauth/token.php` and keeps the returned JWT
+   only for the current run.
+4. Deploy from `main`. Wait for the next `*/15 * * * *` cron run. Confirm that
+   the published IMD snapshot has `coverageState: ok`. A successful Railway
+   deployment or an `OK_ZERO` process result does not prove that IMD accepted
+   the credentials.
+
 ## GDACS (Global Disaster Alert and Coordination System)
 
 UN-backed disaster alert system providing official severity assessments:

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -1495,6 +1495,9 @@ fetch('https://backboard.railway.com/graphql/v2',{method:'POST',
 | seed-service-statuses | `node scripts/seed-service-statuses.mjs` | **planned — not provisioned** | Service-status warm-ping; primary seeder is the AIS relay loop |
 | seed-imd-cyclone-marine | `node seed-imd-cyclone-marine.mjs` | **`*/15 * * * *` (verified 2026-09-05)** | Official IMD cyclone, port, coastal, and marine products; scripts-root Nixpacks service `5f943d96-5f89-4817-941b-fdc36b71722e` |
 
+Configure the IMD account credentials and the IP-bound production key before
+you activate this service. See [Configure the IMD Railway seeder](natural-disasters.mdx#configure-the-imd-railway-seeder).
+
 The bilateral HS4 cron uses `COMTRADE_API_KEYS` and a 480-request hard budget
 under the provider's 500-call monthly quota. The authenticated route requests
 one four-year window (`Y-2` through `Y-5`) in each of two HS4 batches and keeps

--- a/tests/imd-cyclone-marine.test.mjs
+++ b/tests/imd-cyclone-marine.test.mjs
@@ -389,6 +389,24 @@ test('requires valid IMD API key and account credentials', async () => {
   assert.deepEqual(requested, []);
 });
 
+test('documents the complete IMD Railway credential setup', () => {
+  const docs = readFileSync(join(root, 'docs/natural-disasters.mdx'), 'utf8');
+  const heading = '## Configure the IMD Railway seeder';
+  const start = docs.indexOf(heading);
+  assert.notEqual(start, -1, `missing ${heading}`);
+  const nextHeading = docs.indexOf('\n## ', start + heading.length);
+  const setup = docs.slice(start, nextHeading === -1 ? docs.length : nextHeading);
+
+  assert.match(setup, /IMD_API_KEY/);
+  assert.match(setup, /IMD_API_EMAIL/);
+  assert.match(setup, /IMD_API_PASSWORD/);
+  assert.match(setup, /https:\/\/api\.imd\.gov\.in\/public\/IMD_API_Portal_User_Guide\.pdf/);
+  assert.match(setup, /static public IP/i);
+  assert.match(setup, /api\/oauth\/token\.php/);
+  assert.match(setup, /Do not store the JWT/i);
+  assert.doesNotMatch(setup, /IMD_API_TOKEN=/);
+});
+
 test('mints a fresh IMD JWT before each product batch', async () => {
   let minted = 0;
   const productTokens = [];

--- a/tests/imd-cyclone-marine.test.mjs
+++ b/tests/imd-cyclone-marine.test.mjs
@@ -403,7 +403,7 @@ test('documents the complete IMD Railway credential setup', () => {
   assert.match(setup, /https:\/\/api\.imd\.gov\.in\/public\/IMD_API_Portal_User_Guide\.pdf/);
   assert.match(setup, /static public IP/i);
   assert.match(setup, /api\/oauth\/token\.php/);
-  assert.match(setup, /Do not store the JWT/i);
+  assert.match(setup, /Do\s+not store the JWT/i);
   assert.doesNotMatch(setup, /IMD_API_TOKEN=/);
 });
 


### PR DESCRIPTION
## Why

The public docs named the three IMD variables but did not explain the account, JWT, or IP-binding setup. Operators could still configure only the API key and get an unavailable source.

## Scope

- Add a Railway setup procedure to `docs/natural-disasters.mdx`.
- Link the Railway seed runbook to that procedure.
- Add a regression test that pins the complete credential and IP contract.

## Blast Radius

Documentation and one focused Node test only. The seeder runtime and Railway configuration are unchanged.

## Verification

- `node --test tests/imd-cyclone-marine.test.mjs` passed, 20 tests.
- `npm run lint:md` passed.
- `npm run docs:check` passed.
- `npm run lint:public-docs` passed.
- `npm run docs:dates:check` passed.
- The repository pre-push gate passed, including TypeScript, Markdown, MDX, Unicode, version, and changed-test checks.
