### PR TITLE
fix(market-breadth): compute S&P 500 breadth from the TradingView constituent scan

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -666,7 +666,10 @@ instead of publishing, and lost nothing.
 It must not crash the bundle: one rate-limited source firing a deploy-crash
 alert is the alert fatigue that makes the alarm worthless. Real staleness is
 caught by freshness monitoring on the published data, never by the tick's exit
-status.
+status. A seeder running as its own cron handles the same failure the same way
+but exits non-zero on purpose, so the platform's crash badge is what surfaces a
+source that has stopped answering; a bundle member's tick absorbs that exit,
+which is the difference between the two.
 
 ### Starved Tick
 

--- a/api/_product-catalog.generated.js
+++ b/api/_product-catalog.generated.js
@@ -167,7 +167,7 @@ export const PUBLIC_PRODUCT_FACTS = {
   "heroProofStats": {
     "mapLayers": 57,
     "feeds": 461,
-    "providers": 747,
+    "providers": 748,
     "alertOrigins": 5
   }
 };

--- a/docs/fear-greed-index-2.0-brief.md
+++ b/docs/fear-greed-index-2.0-brief.md
@@ -50,7 +50,7 @@ Each category scores **0–100** (0 = Extreme Fear, 100 = Extreme Greed). The we
 | VIX | Yahoo / FRED | % change |
 | HY Spread | FRED | vs long-term average |
 | F&G Header FSI | Yahoo + FRED | bespoke HYG/TLT/VIX/HY OAS stress ratio |
-| % > 200 DMA | Barchart `$S5TH` scrape | exact S&P 500 share above 200 DMA |
+| % > 200 DMA | TradingView S&P 500 constituent scan | exact S&P 500 share above 200 DMA |
 | 10Y Yield | FRED | level |
 | Fed Rate | FRED | current range |
 
@@ -88,7 +88,7 @@ All sources are free with no paid API keys required.
 | **CNN Fear & Greed** | `production.dataviz.cnn.io/index/fearandgreed/current` | JSON | User-Agent header | MEDIUM |
 | **AAII Sentiment** | `aaii.com/sentimentsurvey` (HTML scrape) | HTML | User-Agent header | LOW (blocks bots) |
 | **Barchart Total P/C** | `barchart.com/stocks/quotes/%24CPC` | HTML / Next data | User-Agent header | MEDIUM |
-| **Barchart S&P 500 > 200 DMA** | `barchart.com/stocks/quotes/%24S5TH` | HTML / Next data | User-Agent header | MEDIUM |
+| **TradingView S&P 500 > 200 DMA** | `scanner.tradingview.com/america/scan` (S&P 500 symbol set, close vs SMA200) | JSON | User-Agent header | MEDIUM |
 
 ### Yahoo Finance Symbols (22 total)
 
@@ -121,7 +121,7 @@ Uses `query1.finance.yahoo.com/v8/finance/chart` — no API key, User-Agent head
 
 **Notes:**
 
-- `$S5TH` from Barchart is the implemented % above **200-day** MA input; `^MMTH` is not fetched by the current seeder.
+- The implemented % above **200-day** MA input is computed from the TradingView S&P 500 constituent scan (close above SMA200); `^MMTH` is not fetched by the current seeder.
 - Advance/decline ratio is currently `null`. Breadth drops `ad_score` and reweights to `breadth_score * 0.57 + rsp_score * 0.43`.
 - Fallback: VIX can fall back to FRED `VIXCLS`; Yahoo failures for ETF symbols leave their derived categories neutral or degraded.
 
@@ -192,7 +192,7 @@ score = (above_count / 3) * 50 + clamp(distance_200 * 500 + 50, 0, 100) * 0.5
 ### 5. Breadth (10%)
 
 ```
-inputs: Pct_Above_200DMA from Barchart $S5TH, Advance_Decline, RSP_SPY_Divergence
+inputs: Pct_Above_200DMA from the TradingView S&P 500 scan, Advance_Decline, RSP_SPY_Divergence
 breadth_score = Pct_Above_200DMA  // already 0-100
 ad_score = clamp((AD_Ratio - 0.5) / 1.5 * 100, 0, 100)
 rsp_score = clamp(RSP_SPY_30d_diff * 10 + 50, 0, 100)
@@ -314,13 +314,14 @@ not treat it as a live key.
 | Source | Calls | Rate Limited? | Auth |
 |--------|-------|--------------|------|
 | Yahoo Finance | 22 symbols | 150ms gaps | User-Agent only |
-| Barchart | 2 HTML quote pages (`$CPC`, `$S5TH`) | No | User-Agent only |
+| Barchart | 1 HTML quote page (`$CPC`) | No | User-Agent only |
+| TradingView | 1 screener scan (S&P 500 symbol set) | No | User-Agent only |
 | CNN dataviz | 1 | No | User-Agent only |
 | AAII | 1 | Blocks bots | User-Agent + scrape |
 | Redis reads | ~10 FRED series | No | Bearer token |
 | **Total** | **~34** | — | — |
 
-**Estimated runtime**: ~3.3s (Yahoo sequential) + ~2s (Barchart/CNN/AAII parallel) + ~1s (Redis) = **~6-7s per run**
+**Estimated runtime**: ~3.3s (Yahoo sequential) + ~2s (Barchart/TradingView/CNN/AAII parallel) + ~1s (Redis) = **~6-7s per run**
 
 **Timeouts**: Set `AbortSignal.timeout(8000)` on AAII scrape (frequently stalls). AAII failure must not block the entire seed run — wrap in `try/catch`, log warn, continue with degraded Sentiment scoring.
 
@@ -420,6 +421,6 @@ Build the initial version using only data we already have + easy additions:
 7. **Momentum** — Sector ETF returns from Yahoo
 8. **Cross-Asset** — GLD/TLT/SPY/DXY returns from Yahoo
 9. **Positioning** — Barchart `$CPC` put/call + SKEW from Yahoo
-10. **Breadth** — Barchart `$S5TH` + RSP/SPY divergence, with advance/decline currently null
+10. **Breadth** — TradingView S&P 500 scan (% above 200 DMA) + RSP/SPY divergence, with advance/decline currently null
 
 All 10 categories covered from day one. No paid sources needed.

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -1487,7 +1487,7 @@ fetch('https://backboard.railway.com/graphql/v2',{method:'POST',
 | seed-market-quotes | `node scripts/seed-market-quotes.mjs` | **planned — not provisioned** | Equity index / stock bootstrap quotes (Yahoo + Finnhub + Alpha Vantage) |
 | seed-commodity-quotes | `node scripts/seed-commodity-quotes.mjs` | ~30 min (30m TTL) | Commodity + extended-gold bootstrap quotes |
 | seed-crypto-sectors | `node scripts/seed-crypto-sectors.mjs` | **planned — not provisioned** | CoinGecko crypto sector performance |
-| seed-market-breadth | `node scripts/seed-market-breadth.mjs` | daily (30d history window) | S&P 500 breadth (% above 20/50/200-day, Barchart) |
+| seed-market-breadth | `node scripts/seed-market-breadth.mjs` | daily (30d history window) | S&P 500 breadth (% above 20/50/200-day, computed from the TradingView constituent scan) |
 | seed-weather-alerts | `node scripts/seed-weather-alerts.mjs` | **planned — not provisioned** | NWS active weather alerts |
 | seed-fx-yoy | `node scripts/seed-fx-yoy.mjs` | daily (25h TTL) | Wide-coverage FX YoY + 24m drawdown (resilience FX-stress inputs) |
 | seed-comtrade-bilateral-hs4 | `node scripts/seed-comtrade-bilateral-hs4.mjs` | **`0 6 1 * *` (monthly, verified 2026-07-27)** | UN Comtrade bilateral HS4 trade flows — only scheduled consumer of the keyed 500/mo Comtrade quota |

--- a/docs/solutions/integration-issues/barchart-waf-challenge-answers-202-and-passes-resp-ok.md
+++ b/docs/solutions/integration-issues/barchart-waf-challenge-answers-202-and-passes-resp-ok.md
@@ -1,0 +1,75 @@
+---
+title: Barchart WAF challenge answers HTTP 202 and passes resp.ok, silently blanking S&P 500 breadth
+date: 2026-09-05
+category: integration-issues
+module: seed-market-breadth
+problem_type: integration_issue
+component: background_job
+symptoms:
+  - "seed-market-breadth exits 75 on every Railway tick with 'All Barchart breadth fetches failed'"
+  - "Log shows 'Barchart: 0/3 readings' and '20d=null | 50d=null | 200d=null' with no HTTP status warning before the retries"
+  - "market:breadth-history:v1 stops advancing (last publish 2026-09-02) and seed-fear-greed shows N/A for % above 200 DMA"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+related_components:
+  - seed-fear-greed
+tags: [barchart, aws-waf, http-202, resp-ok, market-breadth, tradingview-scanner, railway-seeder, scraper]
+---
+
+# Barchart WAF challenge answers HTTP 202 and passes resp.ok, silently blanking S&P 500 breadth
+
+## Problem
+
+`seed-market-breadth` scraped three Barchart quote pages (`$S5TW`, `$S5FI`, `$S5TH`) for the share of S&P 500 stocks above their 20, 50, and 200-day averages. From 2026-09-02 every page came back as an AWS WAF challenge shell, the scraper read it as a page with no price, and the seeder failed on every tick. The breadth chart froze on the 9/1 session and the Fear & Greed header lost its breadth reading.
+
+## Symptoms
+
+- Railway log per tick: `Barchart: 0/3 readings`, three retries, `FETCH FAILED: All Barchart breadth fetches failed`, `Failed gracefully`, exit 75.
+- No `Barchart <label>: HTTP <status>` warning, which the scraper only printed for non-ok statuses.
+- Production payload (`/api/bootstrap?tier=slow&public=1`, key `breadthHistory`) last updated 2026-09-02T02:04Z with a 2026-09-01 entry.
+
+## What Didn't Work
+
+- **Header spoofing.** The seeder's Chrome User-Agent plus a full set of browser client hints (`sec-ch-ua`, `Sec-Fetch-*`, `Accept-Language`) still receive the same 202 shell. It is a JavaScript challenge, not a User-Agent rule.
+- **Barchart's JSON endpoint.** `/proxies/core-api/v1/quotes/get` answers 403 without the session and XSRF cookies that only a solved challenge grants.
+- **TradingView's index copies of the series.** Symbol search lists `INDEX:S5TH`, `S5FI`, and `S5TW` (provider barchart, end-of-day only), but the scanner answers `symbol_not_exists` for them, so the index series cannot be read directly.
+- **StockCharts** `j-sum` answers a 22-byte body, not a payload.
+
+## Solution
+
+Compute the three series from constituents instead of reading an index of them. One POST to TradingView's screener scan returns every S&P 500 member with its close and the three SMAs; the share of members closing above each average is the breadth reading. The module is `scripts/_sp500-breadth.mjs`; both `scripts/seed-market-breadth.mjs` and `scripts/seed-fear-greed.mjs` import it.
+
+```js
+const resp = await fetchImpl('https://scanner.tradingview.com/america/scan', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': CHROME_UA },
+  body: JSON.stringify({ symbols: { symbolset: ['SYML:SP;SPX'] }, columns: ['name', 'close', 'SMA20', 'SMA50', 'SMA200'] }),
+  signal: AbortSignal.timeout(timeoutMs),
+});
+// Strict 200: a bot-challenge interstitial arrives as 202 and passes resp.ok.
+if (resp.status !== 200) throw new Error(`TradingView scan HTTP ${resp.status}`);
+```
+
+Two guards carry the lesson. The status must be exactly 200 and the body must parse as scan rows, so an interstitial throws instead of passing as three nulls. A window with fewer than 450 valid rows (the index has about 503) reads as `null`, because a percentage of a partial universe is not S&P 500 breadth.
+
+Verification before merge: nine unit tests in `tests/sp500-breadth.test.mjs`, a live scan (503 constituents, 20d 35.39, 50d 46.92, 200d 64.07 against Barchart's 9/1 values of 31.8, 45.52, 62.62), and an end-to-end run of the seeder through the real `runSeed` against a local Upstash REST fake that answered GET with null, SET with OK, and EVAL with 1. That run walked lock, scan, validate, staging SET, canonical SET, seed-meta, lock release, exit 0.
+
+## Why This Works
+
+The old scraper's success gate was `resp.ok`, which is true for any 2xx. AWS WAF serves its challenge as HTTP 202 with a 2 KB HTML body (`window.awsWafCookieDomainList`, `window.gokuProps`), so the gate passed, the `__NEXT_DATA__` regex found nothing, and the function returned `null` as if the page had simply lacked a price. Three silent nulls per run looked like a layout change rather than a block, and the only log line was the count.
+
+The replacement removes the dependence on a rendered page entirely. The scanner is a JSON API that returns the inputs to the metric, so the seeder owns the computation and the status gate is exact.
+
+## Prevention
+
+- **A scraper's success gate is `status === 200` plus a parse of the payload you expect.** `resp.ok` admits 202, 204, and 206. `tests/sp500-breadth.test.mjs` pins the 202-challenge, non-JSON, and non-2xx rejections; copy that trio for any new upstream fetcher.
+- **Log the status on every non-200**, not only on non-ok, so a challenge shows up in the log as a number rather than as a missing value.
+- **First diagnostic for "0/N readings" with no HTTP warning:** curl the URL with the seeder's exact `User-Agent` and `Accept` headers and print status, size, and the first 400 bytes. A 202 with a tiny HTML body naming `awsWafCookieDomainList` is a WAF interstitial, and no header change will get past it.
+- **Prove a seeder end to end without touching production:** point `UPSTASH_REDIS_REST_URL` at a local HTTP fake (GET returns null, SET returns OK, EVAL returns 1, `/pipeline` maps the array) and run the script. `startFakeUpstash` in `tests/bundle-runner.test.mjs` is the reference shape. The seeder's `loadEnvFile` only reads the checkout's own `.env.local`, so a worktree without one cannot pick up production credentials.
+
+## Related Issues
+
+- PR #7723 (the fix).
+- `docs/solutions/integration-issues/upstash-max-request-size-counts-one-command-and-answers-http-200.md`: another upstream that reports success on the status line while the body says otherwise.
+- `seed-fear-greed.mjs` still scrapes `$CPC` (total put/call) from Barchart the same way; it degrades to null and needs its own source. TradingView lists `USI:PCC` but the scanner does not serve it.

--- a/docs/solutions/integration-issues/barchart-waf-challenge-answers-202-and-passes-resp-ok.md
+++ b/docs/solutions/integration-issues/barchart-waf-challenge-answers-202-and-passes-resp-ok.md
@@ -48,10 +48,14 @@ const resp = await fetchImpl('https://scanner.tradingview.com/america/scan', {
   signal: AbortSignal.timeout(timeoutMs),
 });
 // Strict 200: a bot-challenge interstitial arrives as 202 and passes resp.ok.
-if (resp.status !== 200) throw new Error(`TradingView scan HTTP ${resp.status}`);
+if (resp.status !== 200) {
+  const err = httpRetryError(resp);
+  err.message = `TradingView scan HTTP ${resp.status}`;
+  throw err;
+}
 ```
 
-Two guards carry the lesson. The status must be exactly 200 and the body must parse as scan rows, so an interstitial throws instead of passing as three nulls. A window with fewer than 450 valid rows (the index has about 503) reads as `null`, because a percentage of a partial universe is not S&P 500 breadth.
+Two guards carry the lesson. The status must be exactly 200 and the body must parse as scan rows, so an interstitial throws instead of passing as three nulls. A 202/4xx throw is `nonRetryable` so `runSeed`'s `withRetry` does not sleep through a challenge. A window with fewer than 450 valid rows (the index has about 503) reads as `null`, because a percentage of a partial universe is not S&P 500 breadth. Incomplete three-window readings fail the tick so last-good stays published. `seed-fear-greed` reads `current.pctAbove200d` from `market:breadth-history:v1` instead of posting a second scan.
 
 Verification before merge: nine unit tests in `tests/sp500-breadth.test.mjs`, a live scan (503 constituents, 20d 35.39, 50d 46.92, 200d 64.07 against Barchart's 9/1 values of 31.8, 45.52, 62.62), and an end-to-end run of the seeder through the real `runSeed` against a local Upstash REST fake that answered GET with null, SET with OK, and EVAL with 1. That run walked lock, scan, validate, staging SET, canonical SET, seed-meta, lock release, exit 0.
 
@@ -72,4 +76,4 @@ The replacement removes the dependence on a rendered page entirely. The scanner 
 
 - PR #7723 (the fix).
 - `docs/solutions/integration-issues/upstash-max-request-size-counts-one-command-and-answers-http-200.md`: another upstream that reports success on the status line while the body says otherwise.
-- `seed-fear-greed.mjs` still scrapes `$CPC` (total put/call) from Barchart the same way; it degrades to null and needs its own source. TradingView lists `USI:PCC` but the scanner does not serve it.
+- `seed-fear-greed.mjs` still scrapes `$CPC` (total put/call) from Barchart; the status gate is now `status !== 200` so a 202 logs as HTTP 202 instead of "price not found". It still degrades to null and needs its own source. TradingView lists `USI:PCC` but the scanner does not serve it.

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -2,7 +2,7 @@
 ## Observed Source Inventory
 
 {/* BEGIN GENERATED SOURCE ATTRIBUTION */}
-This generated inventory covers **760 active source hosts** representing **747 active providers** (**331 structured/API**, **461 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced. Syndication transports such as FeedBurner and Google News remain listed as hosts and are not counted as publishers.
+This generated inventory covers **761 active source hosts** representing **748 active providers** (**332 structured/API**, **461 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced. Syndication transports such as FeedBurner and Google News remain listed as hosts and are not counted as publishers.
 
 | Provider | Observed surface |
 | --- | --- |
@@ -93,7 +93,7 @@ This generated inventory covers **760 active source hosts** representing **747 a
 | balkaninsight.com (balkaninsight.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | bangkokpost.com (bangkokpost.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | Bank of Canada (www.bankofcanada.ca) | structured — scripts/lib/boc-valet.mjs |
-| Barchart (www.barchart.com) | structured — scripts/seed-fear-greed.mjs, scripts/seed-market-breadth.mjs |
+| Barchart (www.barchart.com) | structured — scripts/seed-fear-greed.mjs |
 | basemaps.cartocdn.com (basemaps.cartocdn.com) | structured — src/config/basemap-styles.ts |
 | BBC (feeds.bbci.co.uk) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | BBC (www.bbc.com) | feed — src/config/feeds.ts |
@@ -610,6 +610,7 @@ This generated inventory covers **760 active source hosts** representing **747 a
 | Toronto Police Service Open Data (data.tps.ca) | structured — scripts/lib/tps-open-data.mjs |
 | Toronto Police Service Open Data (www.tps.ca) | structured — scripts/lib/tps-open-data.mjs |
 | Toronto Transit Commission (TTC) GTFS-RT (gtfsrt.ttc.ca) | structured — scripts/seed-ttc-alerts.mjs |
+| TradingView (scanner.tradingview.com) | structured — scripts/_sp500-breadth.mjs |
 | travel.state.gov (travel.state.gov) | structured — scripts/seed-security-advisories.mjs |
 | Travelpayouts flight-price data (api.travelpayouts.com) | structured — server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts |
 | treasury.gov (treasury.gov) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |

--- a/pro-test/src/generated/hero-stats.json
+++ b/pro-test/src/generated/hero-stats.json
@@ -1,6 +1,6 @@
 {
   "mapLayers": 57,
   "feeds": 461,
-  "providers": 747,
+  "providers": 748,
   "alertOrigins": 5
 }

--- a/public/ai-search.md
+++ b/public/ai-search.md
@@ -51,7 +51,7 @@ World Monitor is useful for investors, portfolio managers, energy and commodity 
 
 Coverage reconciled: 2026-09-05. Every figure below is generated from this repository's authoritative registries by `npm run build:ai-search` — the same registries that produce https://www.worldmonitor.app/sources/.
 
-- 747 active data providers across 760 observed source hosts (331 structured/API, 461 news & OSINT feed, 30 operational-status; a host can be more than one), grouped into 10 signal domains — full catalog at https://www.worldmonitor.app/sources/
+- 748 active data providers across 761 observed source hosts (332 structured/API, 461 news & OSINT feed, 30 operational-status; a host can be more than one), grouped into 10 signal domains — full catalog at https://www.worldmonitor.app/sources/
 - 724 feed definitions in the shared feed registry — distinct from the 461 feed-publishing hosts above, since one host can back several feed definitions
 - 40 named live data streams whose staleness is tracked and surfaced individually — a different axis from the 10 signal domains above, which group the source catalog by subject
 - 58 map layer types in the shared registry, 57 of them reachable in the full variant — the homepage publishes the full-variant figure; the remaining 1 is sunset or build-flag gated

--- a/scripts/_sp500-breadth.mjs
+++ b/scripts/_sp500-breadth.mjs
@@ -1,0 +1,66 @@
+import { CHROME_UA } from './_seed-utils.mjs';
+
+// S&P 500 breadth (% of constituents closing above their 20/50/200-day SMA),
+// computed from one TradingView screener scan of the index symbol set.
+// Barchart's $S5TW/$S5FI/$S5TH pages carried the same three series until
+// 2026-09-02, when the site put an AWS WAF challenge (HTTP 202, no body data)
+// in front of every quote page.
+
+const SCANNER_URL = 'https://scanner.tradingview.com/america/scan';
+const SP500_SYMBOLSET = 'SYML:SP;SPX';
+const WINDOWS = [
+  { field: 'pctAbove20d', column: 'SMA20' },
+  { field: 'pctAbove50d', column: 'SMA50' },
+  { field: 'pctAbove200d', column: 'SMA200' },
+];
+const COLUMNS = ['name', 'close', ...WINDOWS.map((w) => w.column)];
+const CLOSE_INDEX = 1;
+const FIRST_SMA_INDEX = 2;
+
+// The index holds ~503 tickers (dual share classes included). A window with
+// fewer valid rows than this is a partial scan, and a percentage of a partial
+// universe is not S&P 500 breadth.
+export const MIN_VALID_CONSTITUENTS = 450;
+
+/**
+ * @param {Array<{ s: string, d: Array<string|number|null> }>} rows scanner rows, d = [name, close, SMA20, SMA50, SMA200]
+ * @returns {{ readings: Record<string, number|null>, constituents: number, valid: Record<string, number> }}
+ */
+export function computeBreadth(rows, minValid = MIN_VALID_CONSTITUENTS) {
+  const readings = {};
+  const valid = {};
+  WINDOWS.forEach(({ field }, i) => {
+    let counted = 0;
+    let above = 0;
+    for (const row of rows) {
+      const close = row?.d?.[CLOSE_INDEX];
+      const sma = row?.d?.[FIRST_SMA_INDEX + i];
+      if (!Number.isFinite(close) || !Number.isFinite(sma)) continue;
+      counted++;
+      if (close > sma) above++;
+    }
+    valid[field] = counted;
+    readings[field] = counted >= minValid ? Math.round((above / counted) * 10000) / 100 : null;
+  });
+  return { readings, constituents: rows.length, valid };
+}
+
+export async function fetchSp500Breadth({ fetchImpl = fetch, timeoutMs = 15_000 } = {}) {
+  const resp = await fetchImpl(SCANNER_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': CHROME_UA },
+    body: JSON.stringify({ symbols: { symbolset: [SP500_SYMBOLSET] }, columns: COLUMNS }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  // Strict 200: a bot-challenge interstitial arrives as 202 and passes resp.ok.
+  if (resp.status !== 200) throw new Error(`TradingView scan HTTP ${resp.status}`);
+  const text = await resp.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error(`TradingView scan returned not a scan payload: ${text.slice(0, 80)}`);
+  }
+  if (!Array.isArray(body?.data)) throw new Error('TradingView scan returned not a scan payload: missing data rows');
+  return computeBreadth(body.data);
+}

--- a/scripts/_sp500-breadth.mjs
+++ b/scripts/_sp500-breadth.mjs
@@ -1,4 +1,5 @@
-import { CHROME_UA } from './_seed-utils.mjs';
+import { CHROME_UA, httpRetryError } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 // S&P 500 breadth (% of constituents closing above their 20/50/200-day SMA),
 // computed from one TradingView screener scan of the index symbol set.
@@ -16,11 +17,25 @@ const WINDOWS = [
 const COLUMNS = ['name', 'close', ...WINDOWS.map((w) => w.column)];
 const CLOSE_INDEX = 1;
 const FIRST_SMA_INDEX = 2;
+// Pin the page so a library-default [0, 50] cannot pass the 450-row floor as
+// if it were the full index. The live set is ~503 names.
+const SCAN_RANGE = [0, 1000];
+
+export const BREADTH_HISTORY_KEY = 'market:breadth-history:v1';
+export const HISTORY_LENGTH = 252;
 
 // The index holds ~503 tickers (dual share classes included). A window with
 // fewer valid rows than this is a partial scan, and a percentage of a partial
 // universe is not S&P 500 breadth.
 export const MIN_VALID_CONSTITUENTS = 450;
+
+function scanError(message, { status, nonRetryable = true, retryAfterMs } = {}) {
+  const err = new Error(message);
+  if (status != null) err.status = status;
+  err.nonRetryable = nonRetryable;
+  if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+  return err;
+}
 
 /**
  * @param {Array<{ s: string, d: Array<string|number|null> }>} rows scanner rows, d = [name, close, SMA20, SMA50, SMA200]
@@ -45,22 +60,111 @@ export function computeBreadth(rows, minValid = MIN_VALID_CONSTITUENTS) {
   return { readings, constituents: rows.length, valid };
 }
 
+export function requireCompleteReadings(readings) {
+  if (WINDOWS.some(({ field }) => readings?.[field] == null)) {
+    throw scanError('S&P 500 breadth scan produced incomplete readings');
+  }
+}
+
+export function mergeBreadthHistory(history, readings, today, maxLength = HISTORY_LENGTH) {
+  const next = Array.isArray(history) ? history.map((entry) => ({ ...entry })) : [];
+  const last = next.at(-1);
+  const updatedExisting = last?.date === today;
+  if (updatedExisting) {
+    last.pctAbove20d = readings.pctAbove20d;
+    last.pctAbove50d = readings.pctAbove50d;
+    last.pctAbove200d = readings.pctAbove200d;
+  } else {
+    next.push({
+      date: today,
+      pctAbove20d: readings.pctAbove20d,
+      pctAbove50d: readings.pctAbove50d,
+      pctAbove200d: readings.pctAbove200d,
+    });
+  }
+  while (next.length > maxLength) next.shift();
+  const currentRow = next.at(-1);
+  return {
+    history: next,
+    current: {
+      pctAbove20d: currentRow.pctAbove20d,
+      pctAbove50d: currentRow.pctAbove50d,
+      pctAbove200d: currentRow.pctAbove200d,
+    },
+    updatedExisting,
+  };
+}
+
+export async function readBreadthHistory({
+  fetchImpl = fetch,
+  url,
+  token,
+  timeoutMs = 5_000,
+} = {}) {
+  if (!url || !token) {
+    throw scanError('Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN');
+  }
+  const resp = await fetchImpl(`${url}/get/${encodeURIComponent(BREADTH_HISTORY_KEY)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (resp.status !== 200) {
+    const err = httpRetryError(resp);
+    err.message = `Breadth history GET HTTP ${resp.status}`;
+    throw err;
+  }
+  let parsed;
+  try {
+    parsed = await resp.json();
+  } catch {
+    throw scanError('Breadth history GET returned not JSON');
+  }
+  const result = parsed?.result;
+  if (!result) return null;
+  try {
+    return unwrapEnvelope(typeof result === 'string' ? JSON.parse(result) : result).data;
+  } catch {
+    throw scanError('Breadth history GET returned not an envelope');
+  }
+}
+
+export async function readPublishedPctAbove200d(opts) {
+  const data = await readBreadthHistory(opts);
+  const value = data?.current?.pctAbove200d;
+  return Number.isFinite(value) ? value : null;
+}
+
 export async function fetchSp500Breadth({ fetchImpl = fetch, timeoutMs = 15_000 } = {}) {
   const resp = await fetchImpl(SCANNER_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': CHROME_UA },
-    body: JSON.stringify({ symbols: { symbolset: [SP500_SYMBOLSET] }, columns: COLUMNS }),
+    body: JSON.stringify({
+      symbols: { symbolset: [SP500_SYMBOLSET] },
+      columns: COLUMNS,
+      range: SCAN_RANGE,
+    }),
     signal: AbortSignal.timeout(timeoutMs),
   });
   // Strict 200: a bot-challenge interstitial arrives as 202 and passes resp.ok.
-  if (resp.status !== 200) throw new Error(`TradingView scan HTTP ${resp.status}`);
+  if (resp.status !== 200) {
+    const err = httpRetryError(resp);
+    err.message = `TradingView scan HTTP ${resp.status}`;
+    throw err;
+  }
   const text = await resp.text();
   let body;
   try {
     body = JSON.parse(text);
   } catch {
-    throw new Error(`TradingView scan returned not a scan payload: ${text.slice(0, 80)}`);
+    throw scanError(`TradingView scan returned not a scan payload: ${text.slice(0, 80)}`);
   }
-  if (!Array.isArray(body?.data)) throw new Error('TradingView scan returned not a scan payload: missing data rows');
+  if (!Array.isArray(body?.data)) {
+    throw scanError('TradingView scan returned not a scan payload: missing data rows');
+  }
+  if (Number.isFinite(body.totalCount) && body.totalCount !== body.data.length) {
+    throw scanError(
+      `TradingView scan truncated: totalCount=${body.totalCount} data=${body.data.length}`,
+    );
+  }
   return computeBreadth(body.data);
 }

--- a/scripts/crawlable-sources-page.mjs
+++ b/scripts/crawlable-sources-page.mjs
@@ -111,6 +111,8 @@ const SOURCE_DOMAIN_OVERRIDES = new Map([
   ['B.C. Evacuation Orders and Alerts', 'environment'],
   ['SaskAlert', 'environment'],
   ['Hyperliquid', 'finance'],
+  ['Barchart', 'finance'],
+  ['TradingView', 'finance'],
   ['api.rainviewer.com', 'environment'],
   ['api.scrapecreators.com', 'news'],
   ['api.telegram.org', 'news'],

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1488,6 +1488,7 @@
       "scripts/_seed-contract.mjs",
       "scripts/_seed-envelope-source.mjs",
       "scripts/_seed-utils.mjs",
+      "scripts/_sp500-breadth.mjs",
       "scripts/lib/llm-telemetry.cjs",
       "scripts/nixpacks.toml",
       "scripts/package-lock.json",

--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -2,7 +2,7 @@
 
 import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, sleep, resolveProxyForConnect } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
-import { fetchSp500Breadth } from './_sp500-breadth.mjs';
+import { readPublishedPctAbove200d } from './_sp500-breadth.mjs';
 loadEnvFile(import.meta.url);
 
 const _proxyAuth = resolveProxyForConnect();
@@ -53,7 +53,7 @@ async function fetchCBOE() {
       headers: { 'User-Agent': CHROME_UA, Accept: 'text/html,application/xhtml+xml' },
       signal: AbortSignal.timeout(10_000),
     });
-    if (!resp.ok) { console.warn(`  Barchart $CPC: HTTP ${resp.status}`); return {}; }
+    if (resp.status !== 200) { console.warn(`  Barchart $CPC: HTTP ${resp.status}`); return {}; }
     const html = await resp.text();
     const block = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? html;
     const m = block.match(/"lastPrice"\s*:\s*"?([\d.]+)"?/);
@@ -64,11 +64,22 @@ async function fetchCBOE() {
   } catch (e) { console.warn(`  Barchart $CPC: ${e.message}`); return {}; }
 }
 
-// --- % of S&P 500 above 200d MA, from the TradingView constituent scan ---
+// --- % of S&P 500 above 200d MA, from the published breadth-history series ---
+// One TradingView scan lives in seed-market-breadth. Reading that key keeps
+// Fear & Greed on last-good 200d when the scanner is down, instead of scoring
+// a quiet 50 while the dedicated seeder crash-loops.
 async function fetchPctAbove200d() {
   try {
-    return (await fetchSp500Breadth()).readings.pctAbove200d;
-  } catch (e) { console.warn('  S&P 500 breadth scan failed:', e.message); return null; }
+    const value = await readPublishedPctAbove200d({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    });
+    if (value == null) console.warn('  S&P 500 % above 200d: unpublished (using RSP/SPY proxy if possible)');
+    return value;
+  } catch (e) {
+    console.warn('  S&P 500 % above 200d: unread:', e.message);
+    return null;
+  }
 }
 
 // --- CNN Fear & Greed ---

--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -2,6 +2,7 @@
 
 import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, sleep, resolveProxyForConnect } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
+import { fetchSp500Breadth } from './_sp500-breadth.mjs';
 loadEnvFile(import.meta.url);
 
 const _proxyAuth = resolveProxyForConnect();
@@ -63,20 +64,11 @@ async function fetchCBOE() {
   } catch (e) { console.warn(`  Barchart $CPC: ${e.message}`); return {}; }
 }
 
-// --- Barchart $S5TH: % of S&P 500 above 200d MA ---
-async function fetchBarchartS5TH() {
+// --- % of S&P 500 above 200d MA, from the TradingView constituent scan ---
+async function fetchPctAbove200d() {
   try {
-    const resp = await fetch('https://www.barchart.com/stocks/quotes/%24S5TH', {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'text/html,application/xhtml+xml' },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!resp.ok) { console.warn(`  Barchart $S5TH: HTTP ${resp.status}`); return null; }
-    const html = await resp.text();
-    const block = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? html;
-    const m = block.match(/"lastPrice"\s*:\s*"?([\d.]+)"?/);
-    const val = m ? parseFloat(m[1]) : NaN;
-    return Number.isFinite(val) ? val : null;
-  } catch (e) { console.warn('  Barchart $S5TH fetch failed:', e.message); return null; }
+    return (await fetchSp500Breadth()).readings.pctAbove200d;
+  } catch (e) { console.warn('  S&P 500 breadth scan failed:', e.message); return null; }
 }
 
 // --- CNN Fear & Greed ---
@@ -345,13 +337,13 @@ async function fetchAll() {
   const prevSnapshot = await readSeedSnapshot(FEAR_GREED_KEY).catch(() => null);
   const previousScore = prevSnapshot?.composite?.score ?? null;
 
-  const [yahooResults, cboeResult, cnnResult, aaiiResult, macroSignals, barchartResult] = await Promise.allSettled([
+  const [yahooResults, cboeResult, cnnResult, aaiiResult, macroSignals, breadthResult] = await Promise.allSettled([
     fetchAllYahoo(),
     fetchCBOE(),
     fetchCNN(),
     fetchAAII(),
     readMacroSignals(),
-    fetchBarchartS5TH(),
+    fetchPctAbove200d(),
   ]);
 
   const yahoo = yahooResults.status === 'fulfilled' ? yahooResults.value : {};
@@ -362,13 +354,13 @@ async function fetchAll() {
 
   // Source status summary — visible in Railway container logs
   const yahooCount = Object.values(yahoo).filter(Boolean).length;
-  console.log(`  Sources: Yahoo=${yahooCount}/${YAHOO_SYMBOLS.length} | putCall=${cboe.totalPc ?? 'null'} | CNN=${cnn ? cnn.score : 'null'} | AAII bull=${aaii ? aaii.bull : 'null'} | Barchart=$S5TH=${barchartResult.status === 'fulfilled' ? (barchartResult.value ?? 'null') : 'err'} | proxy=${_proxyAuth ? 'yes' : 'no'}`);
+  console.log(`  Sources: Yahoo=${yahooCount}/${YAHOO_SYMBOLS.length} | putCall=${cboe.totalPc ?? 'null'} | CNN=${cnn ? cnn.score : 'null'} | AAII bull=${aaii ? aaii.bull : 'null'} | S5>200d=${breadthResult.status === 'fulfilled' ? (breadthResult.value ?? 'null') : 'err'} | proxy=${_proxyAuth ? 'yes' : 'no'}`);
 
   if (yahooResults.status === 'rejected') console.warn('  Yahoo batch failed:', yahooResults.reason?.message);
   if (cboeResult.status === 'rejected') console.warn('  CBOE failed:', cboeResult.reason?.message);
   if (cnnResult.status === 'rejected') console.warn('  CNN failed:', cnnResult.reason?.message);
   if (aaiiResult.status === 'rejected') console.warn('  AAII failed:', aaiiResult.reason?.message);
-  if (barchartResult.status === 'fulfilled' && barchartResult.value == null) console.warn('  Barchart $S5TH: unavailable (using RSP/SPY proxy if possible)');
+  if (breadthResult.status === 'fulfilled' && breadthResult.value == null) console.warn('  S&P 500 % above 200d: unavailable (using RSP/SPY proxy if possible)');
 
   const [hyObs, igObs, m2Obs, walclObs, sofrObs, fedObs, curveObs, unrateObs, vixObs, dgs10Obs] = await Promise.all([
     readFred('BAMLH0A0HYM2'), readFred('BAMLC0A0CM'), readFred('M2SL'), readFred('WALCL'),
@@ -392,10 +384,10 @@ async function fetchAll() {
   const skewPrice = skew?.price ?? null;
   const sofrRate = fredLatest(sofrObs);
 
-  // Barchart $S5TH: exact % of S&P 500 above 200d MA.
+  // Exact % of S&P 500 constituents above their 200d MA.
   // Used for both breadth scoring and header display. Null → header shows N/A, breadth
   // defaults to neutral 50 (rspScore still captures RSP/SPY signal independently).
-  const pctAbove200d = barchartResult.status === 'fulfilled' ? barchartResult.value : null;
+  const pctAbove200d = breadthResult.status === 'fulfilled' ? breadthResult.value : null;
   const cryptoFg = macro?.fearGreed?.score ?? macro?.signals?.fearGreed?.value ?? null;
 
   const cats = {

--- a/scripts/seed-market-breadth.mjs
+++ b/scripts/seed-market-breadth.mjs
@@ -1,43 +1,13 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
+import { fetchSp500Breadth } from './_sp500-breadth.mjs';
 loadEnvFile(import.meta.url);
 
 const BREADTH_KEY = 'market:breadth-history:v1';
 const BREADTH_TTL = 2592000; // 30 days
 const HISTORY_LENGTH = 252; // trading days (~1 year)
-
-// Barchart breadth symbols:
-//   $S5TH = % of S&P 500 above 200-day SMA
-//   $S5FI = % of S&P 500 above 50-day SMA
-//   $S5TW = % of S&P 500 above 20-day SMA
-const BARCHART_SYMBOLS = [
-  { symbol: '%24S5TW', label: '20d', field: 'pctAbove20d' },
-  { symbol: '%24S5FI', label: '50d', field: 'pctAbove50d' },
-  { symbol: '%24S5TH', label: '200d', field: 'pctAbove200d' },
-];
-
-async function fetchBarchartPrice(encodedSymbol, label) {
-  try {
-    const resp = await fetch(`https://www.barchart.com/stocks/quotes/${encodedSymbol}`, {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'text/html,application/xhtml+xml' },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!resp.ok) {
-      console.warn(`  Barchart ${label}: HTTP ${resp.status}`);
-      return null;
-    }
-    const html = await resp.text();
-    const block = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? html;
-    const m = block.match(/"lastPrice"\s*:\s*"?([\d.]+)"?/);
-    const val = m ? parseFloat(m[1]) : NaN;
-    return Number.isFinite(val) ? val : null;
-  } catch (e) {
-    console.warn(`  Barchart ${label}: ${e.message}`);
-    return null;
-  }
-}
 
 async function readExistingHistory() {
   const url = process.env.UPSTASH_REDIS_REST_URL;
@@ -57,21 +27,13 @@ async function readExistingHistory() {
 }
 
 async function fetchAll() {
-  const readings = {};
-  let successCount = 0;
+  const { readings, constituents, valid } = await fetchSp500Breadth();
 
-  for (const { symbol, label, field } of BARCHART_SYMBOLS) {
-    const val = await fetchBarchartPrice(symbol, label);
-    readings[field] = val;
-    if (val != null) successCount++;
-    await sleep(500);
-  }
-
-  console.log(`  Barchart: ${successCount}/${BARCHART_SYMBOLS.length} readings`);
+  console.log(`  TradingView: ${constituents} S&P 500 constituents (valid 20d=${valid.pctAbove20d} | 50d=${valid.pctAbove50d} | 200d=${valid.pctAbove200d})`);
   console.log(`    20d=${readings.pctAbove20d ?? 'null'} | 50d=${readings.pctAbove50d ?? 'null'} | 200d=${readings.pctAbove200d ?? 'null'}`);
 
-  if (successCount === 0) {
-    throw new Error('All Barchart breadth fetches failed');
+  if (Object.values(readings).every((v) => v == null)) {
+    throw new Error('S&P 500 breadth scan produced no usable readings');
   }
 
   const existing = await readExistingHistory();

--- a/scripts/seed-market-breadth.mjs
+++ b/scripts/seed-market-breadth.mjs
@@ -1,30 +1,16 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed } from './_seed-utils.mjs';
-import { unwrapEnvelope } from './_seed-envelope-source.mjs';
-import { fetchSp500Breadth } from './_sp500-breadth.mjs';
+import {
+  BREADTH_HISTORY_KEY,
+  fetchSp500Breadth,
+  mergeBreadthHistory,
+  readBreadthHistory,
+  requireCompleteReadings,
+} from './_sp500-breadth.mjs';
 loadEnvFile(import.meta.url);
 
-const BREADTH_KEY = 'market:breadth-history:v1';
 const BREADTH_TTL = 2592000; // 30 days
-const HISTORY_LENGTH = 252; // trading days (~1 year)
-
-async function readExistingHistory() {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-  try {
-    const resp = await fetch(`${url}/get/${encodeURIComponent(BREADTH_KEY)}`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (!resp.ok) return null;
-    const { result } = await resp.json();
-    return result ? unwrapEnvelope(JSON.parse(result)).data : null;
-  } catch {
-    return null;
-  }
-}
 
 async function fetchAll() {
   const { readings, constituents, valid } = await fetchSp500Breadth();
@@ -32,43 +18,31 @@ async function fetchAll() {
   console.log(`  TradingView: ${constituents} S&P 500 constituents (valid 20d=${valid.pctAbove20d} | 50d=${valid.pctAbove50d} | 200d=${valid.pctAbove200d})`);
   console.log(`    20d=${readings.pctAbove20d ?? 'null'} | 50d=${readings.pctAbove50d ?? 'null'} | 200d=${readings.pctAbove200d ?? 'null'}`);
 
-  if (Object.values(readings).every((v) => v == null)) {
-    throw new Error('S&P 500 breadth scan produced no usable readings');
-  }
+  requireCompleteReadings(readings);
 
-  const existing = await readExistingHistory();
-  const history = existing?.history ?? [];
+  const existing = await readBreadthHistory({
+    url: process.env.UPSTASH_REDIS_REST_URL,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN,
+  });
   // ET trading day: Railway cron fires at 9 PM ET which is 01:00-02:00 UTC on
   // the NEXT calendar day, so UTC date would stamp today's session with
   // tomorrow's date. en-CA locale returns ISO YYYY-MM-DD; America/New_York
   // handles DST automatically.
   const today = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date());
-
-  const lastEntry = history.at(-1);
-  if (lastEntry?.date === today) {
-    lastEntry.pctAbove20d = readings.pctAbove20d ?? lastEntry.pctAbove20d;
-    lastEntry.pctAbove50d = readings.pctAbove50d ?? lastEntry.pctAbove50d;
-    lastEntry.pctAbove200d = readings.pctAbove200d ?? lastEntry.pctAbove200d;
+  const { history, current, updatedExisting } = mergeBreadthHistory(
+    existing?.history ?? [],
+    readings,
+    today,
+  );
+  if (updatedExisting) {
     console.log(`  Updated existing entry for ${today}`);
   } else {
-    history.push({
-      date: today,
-      pctAbove20d: readings.pctAbove20d,
-      pctAbove50d: readings.pctAbove50d,
-      pctAbove200d: readings.pctAbove200d,
-    });
     console.log(`  Appended new entry for ${today} (history: ${history.length} days)`);
   }
 
-  while (history.length > HISTORY_LENGTH) history.shift();
-
   return {
     updatedAt: new Date().toISOString(),
-    current: {
-      pctAbove20d: readings.pctAbove20d,
-      pctAbove50d: readings.pctAbove50d,
-      pctAbove200d: readings.pctAbove200d,
-    },
+    current,
     history,
   };
 }
@@ -76,6 +50,9 @@ async function fetchAll() {
 function validate(data) {
   return (
     data?.current != null &&
+    Number.isFinite(data.current.pctAbove20d) &&
+    Number.isFinite(data.current.pctAbove50d) &&
+    Number.isFinite(data.current.pctAbove200d) &&
     Array.isArray(data?.history) &&
     data.history.length > 0
   );
@@ -85,7 +62,7 @@ export function declareRecords(data) {
   return Array.isArray(data?.history) ? data.history.length : 0;
 }
 
-runSeed('market', 'breadth-history', BREADTH_KEY, fetchAll, {
+runSeed('market', 'breadth-history', BREADTH_HISTORY_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: BREADTH_TTL,
 

--- a/scripts/shared/product-catalog.generated.json
+++ b/scripts/shared/product-catalog.generated.json
@@ -165,7 +165,7 @@
     "heroProofStats": {
       "mapLayers": 57,
       "feeds": 461,
-      "providers": 747,
+      "providers": 748,
       "alertOrigins": 5
     }
   },

--- a/scripts/shared/product-facts.generated.json
+++ b/scripts/shared/product-facts.generated.json
@@ -163,7 +163,7 @@
   "heroProofStats": {
     "mapLayers": 57,
     "feeds": 461,
-    "providers": 747,
+    "providers": 748,
     "alertOrigins": 5
   }
 }

--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -689,6 +689,12 @@ const PROVIDER_OVERRIDES = {
     attribution: 'Barchart; link to the source quote or page.',
     status: 'terms-review',
   },
+  'scanner.tradingview.com': {
+    provider: 'TradingView',
+    license: 'TradingView terms; the screener scan endpoint is undocumented and redistribution requires review',
+    attribution: 'TradingView; link to the S&P 500 stock screener.',
+    status: 'terms-review',
+  },
   'www.bankofcanada.ca': {
     provider: 'Bank of Canada',
     license: 'Bank of Canada Terms of Use — permission to freely use, copy, distribute and transmit website content with attribution (https://www.bankofcanada.ca/terms/)',
@@ -932,13 +938,13 @@ const PROVIDER_OVERRIDES = {
 // a provider-bearing override a separate, explicit lifecycle event instead of
 // something `--write` can silently normalize into the manifest.
 export const PROVIDER_IDENTITY_REVIEW = Object.freeze({
-  sha256: 'b95aa14699deb45fe8ece9e9806dc03038b4fb378024c824afc32b6ef2a4b159',
-  reason: 'Preserve reviewed provider identities and register the two official NASA FIRMS Area API hosts as one provider identity.',
+  sha256: 'cd71e5c18ce0b2048c57e8f825b4b82838aafcd59f8e5086a116d84fd79cd358',
+  reason: 'Preserve reviewed provider identities, register the two official NASA FIRMS Area API hosts as one provider identity, and name TradingView as the provider behind the S&P 500 breadth screener scan that replaced the WAF-blocked Barchart quote pages.',
   // A URL cited here is scanned like any other: this file sits inside
   // SOURCE_ROOTS, so citing a host that is not already a registered source
   // invents a provider row for it. The B.C. catalogue URLs above are safe
   // because that host is itself an observed source; parallel.ai is not.
-  reviewReference: 'Issue #6449 BGS provenance review; plus Issue #7371 country corpus identity review; plus Issue #7005 IMD cyclone/marine source-rights probe; plus Issues #7012, #7036, and #6682 Toronto safety sources; plus PR #7576 source migration review; plus Issue #7000 publisher-centric source catalog; plus Issue #7001, Issue #6437, Issue #6622, Issue #6659, PR #6447, the 2026-09-01 FAOSTAT transport identity review, and the 2026-09-04 FIRMS partial-coverage incident.',
+  reviewReference: 'Issue #6449 BGS provenance review; plus Issue #7371 country corpus identity review; plus Issue #7005 IMD cyclone/marine source-rights probe; plus Issues #7012, #7036, and #6682 Toronto safety sources; plus PR #7576 source migration review; plus Issue #7000 publisher-centric source catalog; plus Issue #7001, Issue #6437, Issue #6622, Issue #6659, PR #6447, the 2026-09-01 FAOSTAT transport identity review, the 2026-09-04 FIRMS partial-coverage incident, and the 2026-09-05 Barchart WAF outage that moved S&P 500 breadth to the TradingView screener scan.',
 });
 
 export function providerIdentityDigest(providerOverrides = PROVIDER_OVERRIDES) {

--- a/scripts/source-origin.mjs
+++ b/scripts/source-origin.mjs
@@ -349,6 +349,7 @@ const HOST_ORIGINS = Object.freeze({
   'rss.libsyn.com': 'US',
   'rss.politico.com': 'US',
   'rsf.org': 'FR',
+  'scanner.tradingview.com': 'US',
   'schema.org': 'US',
   'seekingalpha.com': 'US',
   'serpapi.com': 'US',

--- a/shared/product-catalog.generated.json
+++ b/shared/product-catalog.generated.json
@@ -165,7 +165,7 @@
     "heroProofStats": {
       "mapLayers": 57,
       "feeds": 461,
-      "providers": 747,
+      "providers": 748,
       "alertOrigins": 5
     }
   },

--- a/shared/product-facts.generated.json
+++ b/shared/product-facts.generated.json
@@ -163,7 +163,7 @@
   "heroProofStats": {
     "mapLayers": 57,
     "feeds": 461,
-    "providers": 747,
+    "providers": 748,
     "alertOrigins": 5
   }
 }

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -7963,6 +7963,20 @@
       ]
     },
     {
+      "host": "scanner.tradingview.com",
+      "provider": "TradingView",
+      "kind": "structured",
+      "observed": true,
+      "license": "TradingView terms; the screener scan endpoint is undocumented and redistribution requires review",
+      "attribution": "TradingView; link to the S&P 500 stock screener.",
+      "status": "terms-review",
+      "references": [
+        {
+          "path": "scripts/_sp500-breadth.mjs"
+        }
+      ]
+    },
+    {
       "host": "schema.org",
       "provider": "schema.org",
       "kind": "structured",
@@ -10676,9 +10690,6 @@
       "references": [
         {
           "path": "scripts/seed-fear-greed.mjs"
-        },
-        {
-          "path": "scripts/seed-market-breadth.mjs"
         }
       ]
     },

--- a/tests/sp500-breadth.test.mjs
+++ b/tests/sp500-breadth.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeBreadth,
+  fetchSp500Breadth,
+  MIN_VALID_CONSTITUENTS,
+} from '../scripts/_sp500-breadth.mjs';
+
+// Scanner row shape: d = [name, close, SMA20, SMA50, SMA200].
+function row(name, close, sma20, sma50, sma200) {
+  return { s: `NYSE:${name}`, d: [name, close, sma20, sma50, sma200] };
+}
+
+function universe(size, build) {
+  return Array.from({ length: size }, (_, i) => build(i));
+}
+
+// Barchart started answering its quote pages with an HTTP 202 AWS WAF
+// challenge shell on 2026-09-02. The old scraper treated 202 as success and
+// returned null three times per run, so the seeder failed on every tick with
+// nothing in the log but "0/3 readings".
+const WAF_CHALLENGE_HTML = '<!DOCTYPE html><html><head><title></title><script>window.awsWafCookieDomainList = [];</script></head></html>';
+
+describe('computeBreadth', () => {
+  it('reports the share of constituents closing above each moving average', () => {
+    const rows = universe(500, (i) => row(`T${i}`, 100, i < 100 ? 90 : 110, i < 250 ? 90 : 110, i < 400 ? 90 : 110));
+    const { readings, constituents, valid } = computeBreadth(rows);
+    assert.deepEqual(readings, { pctAbove20d: 20, pctAbove50d: 50, pctAbove200d: 80 });
+    assert.equal(constituents, 500);
+    assert.deepEqual(valid, { pctAbove20d: 500, pctAbove50d: 500, pctAbove200d: 500 });
+  });
+
+  it('rounds to two decimals and counts a close on the average as not above it', () => {
+    const rows = universe(503, (i) => row(`T${i}`, 100, i === 0 ? 100 : i < 179 ? 90 : 110, 90, 90));
+    assert.equal(computeBreadth(rows).readings.pctAbove20d, 35.39);
+  });
+
+  it('excludes rows whose close or average is missing from that window only', () => {
+    const rows = universe(500, (i) => row(`T${i}`, 100, 90, 90, i < 40 ? null : 90));
+    const { readings, valid } = computeBreadth(rows);
+    assert.equal(valid.pctAbove200d, 460);
+    assert.equal(readings.pctAbove200d, 100);
+    assert.equal(readings.pctAbove20d, 100);
+  });
+
+  it('returns null for a window with fewer valid rows than the S&P 500 floor', () => {
+    const rows = universe(MIN_VALID_CONSTITUENTS - 1, (i) => row(`T${i}`, 100, 90, 90, 90));
+    assert.deepEqual(computeBreadth(rows).readings, { pctAbove20d: null, pctAbove50d: null, pctAbove200d: null });
+  });
+
+  it('returns null readings for an empty scan', () => {
+    const { readings, constituents } = computeBreadth([]);
+    assert.equal(constituents, 0);
+    assert.deepEqual(readings, { pctAbove20d: null, pctAbove50d: null, pctAbove200d: null });
+  });
+});
+
+describe('fetchSp500Breadth', () => {
+  it('scans the S&P 500 symbol set with close and the three averages', async () => {
+    let captured;
+    const fetchImpl = async (url, init) => {
+      captured = { url, init };
+      const rows = universe(503, (i) => row(`T${i}`, 100, 90, 90, 90));
+      return new Response(JSON.stringify({ totalCount: rows.length, data: rows }), { status: 200 });
+    };
+    const { readings, constituents } = await fetchSp500Breadth({ fetchImpl });
+    assert.equal(captured.url, 'https://scanner.tradingview.com/america/scan');
+    assert.equal(captured.init.method, 'POST');
+    const body = JSON.parse(captured.init.body);
+    assert.deepEqual(body.symbols, { symbolset: ['SYML:SP;SPX'] });
+    assert.deepEqual(body.columns, ['name', 'close', 'SMA20', 'SMA50', 'SMA200']);
+    assert.equal(constituents, 503);
+    assert.deepEqual(readings, { pctAbove20d: 100, pctAbove50d: 100, pctAbove200d: 100 });
+  });
+
+  it('rejects a bot-challenge page instead of reading it as three missing values', async () => {
+    const fetchImpl = async () => new Response(WAF_CHALLENGE_HTML, { status: 202, headers: { 'content-type': 'text/html' } });
+    await assert.rejects(fetchSp500Breadth({ fetchImpl }), /HTTP 202/);
+  });
+
+  it('rejects a 200 whose body is not a scan payload', async () => {
+    const fetchImpl = async () => new Response(WAF_CHALLENGE_HTML, { status: 200, headers: { 'content-type': 'text/html' } });
+    await assert.rejects(fetchSp500Breadth({ fetchImpl }), /not a scan payload/);
+  });
+
+  it('rejects a non-2xx status', async () => {
+    const fetchImpl = async () => new Response('{"error":"rate limited"}', { status: 429 });
+    await assert.rejects(fetchSp500Breadth({ fetchImpl }), /HTTP 429/);
+  });
+});

--- a/tests/sp500-breadth.test.mjs
+++ b/tests/sp500-breadth.test.mjs
@@ -1,10 +1,16 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import { CHROME_UA } from '../scripts/_seed-utils.mjs';
 import {
+  BREADTH_HISTORY_KEY,
   computeBreadth,
   fetchSp500Breadth,
+  mergeBreadthHistory,
   MIN_VALID_CONSTITUENTS,
+  readBreadthHistory,
+  readPublishedPctAbove200d,
+  requireCompleteReadings,
 } from '../scripts/_sp500-breadth.mjs';
 
 // Scanner row shape: d = [name, close, SMA20, SMA50, SMA200].
@@ -14,6 +20,10 @@ function row(name, close, sma20, sma50, sma200) {
 
 function universe(size, build) {
   return Array.from({ length: size }, (_, i) => build(i));
+}
+
+function completeReadings() {
+  return { pctAbove20d: 20, pctAbove50d: 50, pctAbove200d: 80 };
 }
 
 // Barchart started answering its quote pages with an HTTP 202 AWS WAF
@@ -49,10 +59,102 @@ describe('computeBreadth', () => {
     assert.deepEqual(computeBreadth(rows).readings, { pctAbove20d: null, pctAbove50d: null, pctAbove200d: null });
   });
 
+  it('returns null for only the window that falls under the floor', () => {
+    const rows = universe(500, (i) => row(`T${i}`, 100, 90, 90, i < 60 ? null : 90));
+    const { readings, valid } = computeBreadth(rows);
+    assert.equal(valid.pctAbove200d, 440);
+    assert.equal(readings.pctAbove200d, null);
+    assert.equal(readings.pctAbove20d, 100);
+    assert.equal(readings.pctAbove50d, 100);
+  });
+
   it('returns null readings for an empty scan', () => {
     const { readings, constituents } = computeBreadth([]);
     assert.equal(constituents, 0);
     assert.deepEqual(readings, { pctAbove20d: null, pctAbove50d: null, pctAbove200d: null });
+  });
+});
+
+describe('requireCompleteReadings', () => {
+  it('accepts a full three-window reading', () => {
+    requireCompleteReadings(completeReadings());
+  });
+
+  it('rejects a mixed-null reading so last-good is preserved', () => {
+    let err;
+    try {
+      requireCompleteReadings({ pctAbove20d: 20, pctAbove50d: 50, pctAbove200d: null });
+    } catch (caught) {
+      err = caught;
+    }
+    assert.match(err?.message ?? '', /incomplete readings/);
+    assert.equal(err.nonRetryable, true);
+  });
+});
+
+describe('mergeBreadthHistory', () => {
+  it('appends a new day and sets current from the last history row', () => {
+    const prior = [{ date: '2026-09-01', ...completeReadings() }];
+    const nextReadings = { pctAbove20d: 30, pctAbove50d: 40, pctAbove200d: 70 };
+    const { history, current, updatedExisting } = mergeBreadthHistory(prior, nextReadings, '2026-09-05');
+    assert.equal(updatedExisting, false);
+    assert.equal(history.length, 2);
+    assert.deepEqual(history.at(-1), { date: '2026-09-05', ...nextReadings });
+    assert.deepEqual(current, nextReadings);
+    assert.deepEqual(prior[0], { date: '2026-09-01', ...completeReadings() });
+  });
+
+  it('overwrites the same-day row and keeps current aligned with history[-1]', () => {
+    const prior = [{ date: '2026-09-05', ...completeReadings() }];
+    const nextReadings = { pctAbove20d: 21, pctAbove50d: 51, pctAbove200d: 81 };
+    const { history, current, updatedExisting } = mergeBreadthHistory(prior, nextReadings, '2026-09-05');
+    assert.equal(updatedExisting, true);
+    assert.equal(history.length, 1);
+    assert.deepEqual(history[0], { date: '2026-09-05', ...nextReadings });
+    assert.deepEqual(current, nextReadings);
+  });
+});
+
+describe('readBreadthHistory', () => {
+  it('returns null for an HTTP 200 empty key', async () => {
+    const fetchImpl = async () => new Response(JSON.stringify({ result: null }), { status: 200 });
+    assert.equal(await readBreadthHistory({ fetchImpl, url: 'https://upstash.example', token: 't' }), null);
+  });
+
+  it('throws on a failed GET instead of treating it as empty history', async () => {
+    const fetchImpl = async () => new Response('timeout', { status: 503 });
+    const err = await readBreadthHistory({ fetchImpl, url: 'https://upstash.example', token: 't' }).then(
+      () => null,
+      (caught) => caught,
+    );
+    assert.match(err?.message ?? '', /Breadth history GET HTTP 503/);
+    assert.equal(err.nonRetryable, false);
+  });
+
+  it('throws when Redis credentials are missing', async () => {
+    const err = await readBreadthHistory({ fetchImpl: async () => { throw new Error('should not fetch'); } }).then(
+      () => null,
+      (caught) => caught,
+    );
+    assert.match(err?.message ?? '', /Missing UPSTASH/);
+    assert.equal(err.nonRetryable, true);
+  });
+});
+
+describe('readPublishedPctAbove200d', () => {
+  it('returns the published current 200d reading', async () => {
+    const payload = { current: { pctAbove20d: 20, pctAbove50d: 50, pctAbove200d: 64.07 }, history: [] };
+    const fetchImpl = async (url) => {
+      assert.match(url, new RegExp(`/get/${encodeURIComponent(BREADTH_HISTORY_KEY)}$`));
+      return new Response(JSON.stringify({ result: JSON.stringify(payload) }), { status: 200 });
+    };
+    assert.equal(await readPublishedPctAbove200d({ fetchImpl, url: 'https://upstash.example', token: 't' }), 64.07);
+  });
+
+  it('returns null when the published current 200d is missing', async () => {
+    const payload = { current: { pctAbove20d: 20, pctAbove50d: 50, pctAbove200d: null }, history: [] };
+    const fetchImpl = async () => new Response(JSON.stringify({ result: JSON.stringify(payload) }), { status: 200 });
+    assert.equal(await readPublishedPctAbove200d({ fetchImpl, url: 'https://upstash.example', token: 't' }), null);
   });
 });
 
@@ -67,25 +169,48 @@ describe('fetchSp500Breadth', () => {
     const { readings, constituents } = await fetchSp500Breadth({ fetchImpl });
     assert.equal(captured.url, 'https://scanner.tradingview.com/america/scan');
     assert.equal(captured.init.method, 'POST');
+    assert.equal(captured.init.headers['User-Agent'], CHROME_UA);
     const body = JSON.parse(captured.init.body);
     assert.deepEqual(body.symbols, { symbolset: ['SYML:SP;SPX'] });
     assert.deepEqual(body.columns, ['name', 'close', 'SMA20', 'SMA50', 'SMA200']);
+    assert.deepEqual(body.range, [0, 1000]);
     assert.equal(constituents, 503);
     assert.deepEqual(readings, { pctAbove20d: 100, pctAbove50d: 100, pctAbove200d: 100 });
   });
 
+  async function rejected(run) {
+    return run().then(
+      () => null,
+      (caught) => caught,
+    );
+  }
+
   it('rejects a bot-challenge page instead of reading it as three missing values', async () => {
     const fetchImpl = async () => new Response(WAF_CHALLENGE_HTML, { status: 202, headers: { 'content-type': 'text/html' } });
-    await assert.rejects(fetchSp500Breadth({ fetchImpl }), /HTTP 202/);
+    const err = await rejected(() => fetchSp500Breadth({ fetchImpl }));
+    assert.match(err?.message ?? '', /HTTP 202/);
+    assert.equal(err.nonRetryable, true);
   });
 
   it('rejects a 200 whose body is not a scan payload', async () => {
     const fetchImpl = async () => new Response(WAF_CHALLENGE_HTML, { status: 200, headers: { 'content-type': 'text/html' } });
-    await assert.rejects(fetchSp500Breadth({ fetchImpl }), /not a scan payload/);
+    const err = await rejected(() => fetchSp500Breadth({ fetchImpl }));
+    assert.match(err?.message ?? '', /not a scan payload/);
+    assert.equal(err.nonRetryable, true);
   });
 
-  it('rejects a non-2xx status', async () => {
+  it('rejects a retryable non-2xx without marking it permanent', async () => {
     const fetchImpl = async () => new Response('{"error":"rate limited"}', { status: 429 });
-    await assert.rejects(fetchSp500Breadth({ fetchImpl }), /HTTP 429/);
+    const err = await rejected(() => fetchSp500Breadth({ fetchImpl }));
+    assert.match(err?.message ?? '', /HTTP 429/);
+    assert.equal(err.nonRetryable, false);
+  });
+
+  it('rejects a truncated page whose totalCount disagrees with data.length', async () => {
+    const rows = universe(460, (i) => row(`T${i}`, 100, 90, 90, 90));
+    const fetchImpl = async () => new Response(JSON.stringify({ totalCount: 503, data: rows }), { status: 200 });
+    const err = await rejected(() => fetchSp500Breadth({ fetchImpl }));
+    assert.match(err?.message ?? '', /truncated/);
+    assert.equal(err.nonRetryable, true);
   });
 });


### PR DESCRIPTION
## What broke

`seed-market-breadth` has failed on every Railway tick since 2026-09-03 (exit 75, `All Barchart breadth fetches failed`). Production `market:breadth-history:v1` last published at 2026-09-02T02:04Z with the 2026-09-01 session. The 9/2, 9/3, and 9/4 sessions are missing from the chart.

## Root cause

Barchart put an AWS WAF challenge in front of every `/stocks/quotes/*` page. The challenge shell comes back as **HTTP 202** with a 2 KB body that has no `__NEXT_DATA__` and no `lastPrice`. The scraper checked `resp.ok`, which is true for 202, so each of the three symbols silently returned `null` and the seeder logged only `Barchart: 0/3 readings` before retrying. Reproduced with curl using the seeder's exact User-Agent and Accept headers. Full browser client-hint headers get the same 202, and the core-api JSON endpoint returns 403 without the session cookie the challenge withholds.

`seed-fear-greed` scraped `$S5TH` the same way and has been showing N/A for "% above 200 DMA" since the same day.

## Fix

- New `scripts/_sp500-breadth.mjs`: one POST to TradingView's screener scan for the `SYML:SP;SPX` symbol set with `close`, `SMA20`, `SMA50`, `SMA200`, then the share of constituents closing above each average. A window with fewer than 450 valid rows (of ~503) reads as `null` rather than a percentage of a partial universe. The status must be exactly 200 and the body must parse as scan rows, so a challenge interstitial throws instead of being read as three missing values.
- `seed-market-breadth.mjs` uses the module. The history merge and publish path are unchanged.
- `seed-fear-greed.mjs` takes `pctAbove200d` from the same scan (display and breadth score). Its `$CPC` put/call scrape is still on Barchart and still dead. It degrades to null and needs its own source; TradingView lists `USI:PCC` but the scanner does not serve it. Left for a follow-up.
- Registry watch pattern, attribution manifest (TradingView provider identity, reviewed epoch bumped), runbook, and the fear-greed brief follow the source.

## Verification

- `tests/sp500-breadth.test.mjs` (9 tests): breadth math, per-window coverage floor, request shape, and the 202-challenge, non-JSON, and non-2xx rejections. Lands red in the first commit and green in the second.
- Live scan through the module: 503 constituents, 20d=35.39, 50d=46.92, 200d=64.07. Barchart's last published values on 9/1 were 31.8 / 45.52 / 62.62.
- End to end: ran `scripts/seed-market-breadth.mjs` through the real `runSeed` against a local Upstash REST fake. Lock, scan, validate, staging SET, canonical SET, seed-meta, lock release, exit 0.
- Gates run locally: source-attribution (47), railway-watch-path-audit (99), nixpacks no-escape-import (191), fear-greed-doc-parity, market-methodology-doc-contracts, documentation-alignment-guardrails, market-breadth, seed-utils. Biome clean.

## Continuity note

The values are now computed from constituents with TradingView's SMAs rather than read from Barchart's index series, so expect sub-point differences at the 9/1 to 9/8 seam in the chart, not a level shift. The next scheduled tick is Tuesday 2026-09-08 02:00 UTC; a manual redeploy of the `seed-market-breadth` service after merge would backfill sooner.

https://claude.ai/code/session_01JtaPo4CJeQJsev3fSkwZhq
