### PR TITLE
docs(imd): document Railway HA authorization limit

### DIFF
--- a/docs/natural-disasters.mdx
+++ b/docs/natural-disasters.mdx
@@ -31,10 +31,18 @@ not store the JWT in Railway.
    ```
 
    Register the outbound address with IMD when you create the production API
-   key. Railway can assign several addresses to a high-availability service. If
-   the command lists more than one address, confirm with IMD how to authorize
-   each address. A key that is bound to one address can fail when Railway uses
-   another one.
+   key. Railway assigns three static outbound IPv4 addresses to a
+   high-availability service and balances traffic across them. The IMD portal
+   documents a maximum of 2 Development keys and 2 Production keys, and each
+   key is associated with one server public IP. The native Railway HA address
+   set therefore does not fit the documented IMD key model.
+
+   Do not register only one Railway address and assume that the service will
+   keep using it. Before activation, either get written confirmation from IMD
+   that all three Railway addresses are authorized for this account, or route
+   the IMD requests through an egress gateway with one static public IP and
+   register that address with IMD. Treat HTTP 403 from every product as an API
+   key status or public-IP authorization failure.
 3. Add these service variables in Railway. Store each value as a secret.
 
    | Variable | Value |

--- a/docs/natural-disasters.mdx
+++ b/docs/natural-disasters.mdx
@@ -39,10 +39,11 @@ not store the JWT in Railway.
 
    Do not register only one Railway address and assume that the service will
    keep using it. Before activation, either get written confirmation from IMD
-   that all three Railway addresses are authorized for this account, or route
-   the IMD requests through an egress gateway with one static public IP and
-   register that address with IMD. Treat HTTP 403 from every product as an API
-   key status or public-IP authorization failure.
+   that all three Railway addresses are authorized for this account, or put the
+   service behind network infrastructure that presents one static public IP and
+   register that address with IMD. The seeder does not currently define an
+   application-level proxy variable. Treat HTTP 403 from every product as an
+   API key status or public-IP authorization failure.
 3. Add these service variables in Railway. Store each value as a secret.
 
    | Variable | Value |
@@ -54,10 +55,20 @@ not store the JWT in Railway.
    Do not set `IMD_API_TOKEN`. The seeder sends the account credentials to
    `POST https://api.imd.gov.in/api/oauth/token.php` and keeps the returned JWT
    only for the current run.
-4. Deploy from `main`. Wait for the next `*/15 * * * *` cron run. Confirm that
-   the published IMD snapshot has `coverageState: ok`. A successful Railway
-   deployment or an `OK_ZERO` process result does not prove that IMD accepted
-   the credentials.
+4. Deploy from `main` and record the deployment time. Confirm that the active
+   deployment manifest uses the registry schedule, `*/15 * * * *`, then wait
+   for its next natural cron run.
+5. Call the WorldMonitor MCP tool `get_imd_cyclone_marine`. Accept the setup
+   only when the response has `stale: false`, its IMD snapshot has
+   `coverageState: ok`, and `generatedAt` is later than the deployment time.
+   Each enabled product must have `status: ok`; its record count can be zero
+   during a quiet period. Also confirm that
+   `https://api.worldmonitor.app/api/health?compact=1` does not list
+   `imdCycloneMarine` in `problems`.
+
+   A successful Railway deployment, an older green cache value, or an
+   `OK_ZERO` process result does not prove that IMD accepted the current
+   credentials and egress path.
 
 ## GDACS (Global Disaster Alert and Coordination System)
 

--- a/tests/imd-cyclone-marine.test.mjs
+++ b/tests/imd-cyclone-marine.test.mjs
@@ -402,6 +402,10 @@ test('documents the complete IMD Railway credential setup', () => {
   assert.match(setup, /IMD_API_PASSWORD/);
   assert.match(setup, /https:\/\/api\.imd\.gov\.in\/public\/IMD_API_Portal_User_Guide\.pdf/);
   assert.match(setup, /static public IP/i);
+  assert.match(setup, /three static outbound IPv4 addresses/i);
+  assert.match(setup, /maximum of 2 Development keys and 2 Production keys/i);
+  assert.match(setup, /egress gateway with one static public IP/i);
+  assert.match(setup, /HTTP 403/i);
   assert.match(setup, /api\/oauth\/token\.php/);
   assert.match(setup, /Do\s+not store the JWT/i);
   assert.doesNotMatch(setup, /IMD_API_TOKEN=/);

--- a/tests/imd-cyclone-marine.test.mjs
+++ b/tests/imd-cyclone-marine.test.mjs
@@ -391,23 +391,31 @@ test('requires valid IMD API key and account credentials', async () => {
 
 test('documents the complete IMD Railway credential setup', () => {
   const docs = readFileSync(join(root, 'docs/natural-disasters.mdx'), 'utf8');
+  const railwayServices = JSON.parse(readFileSync(join(root, 'scripts/railway-services.json'), 'utf8'));
+  const railwayService = railwayServices.find((entry) => entry.service === 'seed-imd-cyclone-marine');
+  assert.ok(railwayService, 'missing IMD Railway service registry entry');
   const heading = '## Configure the IMD Railway seeder';
   const start = docs.indexOf(heading);
   assert.notEqual(start, -1, `missing ${heading}`);
   const nextHeading = docs.indexOf('\n## ', start + heading.length);
   const setup = docs.slice(start, nextHeading === -1 ? docs.length : nextHeading);
 
-  assert.match(setup, /IMD_API_KEY/);
-  assert.match(setup, /IMD_API_EMAIL/);
-  assert.match(setup, /IMD_API_PASSWORD/);
+  assert.ok(setup.includes(railwayService.service));
+  for (const name of railwayService.requiredEnv.filter((entry) => entry.startsWith('IMD_'))) {
+    assert.ok(setup.includes(name), `missing documented Railway variable ${name}`);
+  }
+  assert.ok(setup.includes(railwayService.cronSchedule));
   assert.match(setup, /https:\/\/api\.imd\.gov\.in\/public\/IMD_API_Portal_User_Guide\.pdf/);
   assert.match(setup, /static public IP/i);
   assert.match(setup, /three static outbound IPv4 addresses/i);
   assert.match(setup, /maximum of 2 Development keys and 2 Production keys/i);
-  assert.match(setup, /egress gateway with one static public IP/i);
+  assert.match(setup, /one static public IP/i);
   assert.match(setup, /HTTP 403/i);
-  assert.match(setup, /api\/oauth\/token\.php/);
+  assert.ok(setup.includes(IMD_OAUTH_TOKEN_URL));
   assert.match(setup, /Do\s+not store the JWT/i);
+  assert.match(setup, /stale: false/);
+  assert.match(setup, /generatedAt.*later than the deployment time/is);
+  assert.match(setup, /imdCycloneMarine.*problems/is);
   assert.doesNotMatch(setup, /IMD_API_TOKEN=/);
 });
 


### PR DESCRIPTION
## Why

PR #7722 documented the three IMD credentials but was merged before production validation finished. The first current-code Railway run minted a JWT successfully, then every IMD product returned HTTP 403. Railway assigns three balanced static outbound IPs, while the IMD guide binds a key to one server IP and documents only two production keys.

## Scope

- Document the Railway HA and IMD IP-binding incompatibility.
- Require explicit authorization for all Railway IPs or infrastructure with one public egress IP.
- Require post-deployment timestamp, freshness, per-product status, and compact-health evidence before acceptance.
- Tie the documentation test to the executable Railway registry and exported IMD token endpoint.

## Blast Radius

Documentation and one focused Node test only. No Railway setting, credential, or runtime code changes in this PR.

## Verification

- `node --test tests/imd-cyclone-marine.test.mjs` passed, 20 tests.
- `npm run lint:md` passed.
- `npm run docs:check` passed.
- `npm run lint:public-docs` passed.
- `npm run docs:dates:check` passed.
- The repository pre-push gate passed, including TypeScript, Markdown, MDX, Unicode, version, and changed-test checks.

## Production Evidence

- Railway static outbound IP is enabled with three HA addresses.
- The run that started at `1788612213765` published a snapshot generated at `1788612214322`.
- The snapshot had `coverageState: unavailable`; all six enabled products returned HTTP 403.
- JWT minting therefore passed, but IMD did not authorize the API key from the production egress path.
