### PR TITLE
fix(imd): route Railway seeder through fixed proxy

### DIFF
--- a/docs/natural-disasters.mdx
+++ b/docs/natural-disasters.mdx
@@ -42,19 +42,35 @@ not store the JWT in Railway.
    register only one Railway address and assume that the service will keep using
    it.
 
-   Activation requires deterministic single-IP external egress, or another host
-   with one fixed outbound public IP. Register that one address with IMD when
-   you create the production API key. The seeder does not currently define an
-   application-level proxy variable. Do not cycle keys on HTTP 403: that cannot
-   create a deterministic key/IP pair. Treat HTTP 403 from every product as an
-   API key status or public-IP authorization failure.
+   Activation requires deterministic single-IP external egress. Set
+   `PROXY_URL` to a fixed-egress HTTPS CONNECT proxy, using either
+   `https://user:password@host:port` or Decodo's
+   `host:port:user:password` format. The seeder routes the JWT request and every
+   IMD product request through this proxy. It does not proxy Redis traffic and
+   does not fall back to direct Railway egress.
+
+   Verify the proxy's public egress IP from the service environment and register
+   that one address with IMD when you create the production API key. Do not
+   cycle keys on HTTP 403: that cannot create a deterministic key/IP pair. Treat
+   an IMD-origin HTTP 403 from every product as an API key status or public-IP
+   authorization failure. A proxy CONNECT HTTP 403 is a proxy-provider policy
+   failure instead.
+
+   Confirm that the proxy provider permits `api.imd.gov.in` before activation.
+   Decodo's [ISP Pay/IP restricted-target policy](https://help.decodo.com/docs/isp-pay-per-ip-proxy-restricted-targets)
+   lists government sites as restricted and states that this restriction cannot
+   be removed from that proxy product. It returns a proxy CONNECT HTTP 403 before
+   a request reaches IMD, so it cannot provide the IMD route even when its fixed
+   egress IP is correct. Use a fixed-egress proxy that explicitly permits the IMD
+   host.
 3. Add these service variables in Railway. Store each value as a secret.
 
    | Variable | Value |
    |---|---|
-   | `IMD_API_KEY` | The active production key for the Railway outbound IP |
+   | `IMD_API_KEY` | The active production key for the fixed proxy egress IP |
    | `IMD_API_EMAIL` | The registered IMD account email that owns the key |
    | `IMD_API_PASSWORD` | The password for the same IMD account |
+   | `PROXY_URL` | A secret proxy route with one fixed public egress IP registered with IMD |
 
    Do not set `IMD_API_TOKEN`. The seeder sends the account credentials to
    `POST https://api.imd.gov.in/api/oauth/token.php` and keeps the returned JWT

--- a/docs/natural-disasters.mdx
+++ b/docs/natural-disasters.mdx
@@ -30,19 +30,23 @@ not store the JWT in Railway.
      --json
    ```
 
-   Register the outbound address with IMD when you create the production API
-   key. Railway assigns three static outbound IPv4 addresses to a
-   high-availability service and balances traffic across them. The IMD portal
-   documents a maximum of 2 Development keys and 2 Production keys, and each
-   key is associated with one server public IP. The native Railway HA address
-   set therefore does not fit the documented IMD key model.
+   Railway assigns three static outbound IPv4 addresses to a high-availability
+   service and balances traffic across them. Application code cannot select the
+   Railway NAT address for an IMD request or reliably probe it in advance: an
+   IP-check request is a separate connection and can use a different address
+   from the later IMD request.
 
-   Do not register only one Railway address and assume that the service will
-   keep using it. Before activation, either get written confirmation from IMD
-   that all three Railway addresses are authorized for this account, or put the
-   service behind network infrastructure that presents one static public IP and
-   register that address with IMD. The seeder does not currently define an
-   application-level proxy variable. Treat HTTP 403 from every product as an
+   The IMD portal documents a maximum of 2 Development keys and 2 Production keys,
+   and each key is associated with one server public IP. Railway's native
+   three-IP HA egress cannot satisfy the documented IMD contract. Do not
+   register only one Railway address and assume that the service will keep using
+   it.
+
+   Activation requires deterministic single-IP external egress, or another host
+   with one fixed outbound public IP. Register that one address with IMD when
+   you create the production API key. The seeder does not currently define an
+   application-level proxy variable. Do not cycle keys on HTTP 403: that cannot
+   create a deterministic key/IP pair. Treat HTTP 403 from every product as an
    API key status or public-IP authorization failure.
 3. Add these service variables in Railway. Store each value as a secret.
 

--- a/scripts/lib/imd-cyclone-marine.mjs
+++ b/scripts/lib/imd-cyclone-marine.mjs
@@ -7,7 +7,12 @@
  * Live fetch requires an API key and IMD account credentials. Disabled is not all-clear.
  */
 
+import { createRequire } from 'node:module';
+
 import { CHROME_UA, roundGeoCoordinate } from '../_seed-utils.mjs';
+
+const require = createRequire(import.meta.url);
+const { parseProxyConfig, proxyFetch } = require('../_proxy-utils.cjs');
 
 export const IMD_HOST = 'api.imd.gov.in';
 export const IMD_API_ORIGIN = 'https://api.imd.gov.in';
@@ -764,10 +769,42 @@ export async function fetchApprovedImdJson(url, {
   return readBoundedJsonResponse(response, maxBytes);
 }
 
+export function createImdProxyFetch(rawProxyUrl, { proxyFetchFn = proxyFetch } = {}) {
+  const proxyUrl = String(rawProxyUrl || '').trim();
+  if (!proxyUrl) throw new Error('IMD_PROXY_URL_MISSING');
+  const proxyConfig = parseProxyConfig(proxyUrl);
+  if (!proxyConfig || proxyConfig.tls !== true) throw new Error('IMD_PROXY_URL_INVALID');
+  return async (url, init = {}) => {
+    if (!isAllowedImdHost(url)) throw new Error('UNTRUSTED_SOURCE_HOST');
+    const headers = init.headers || {};
+    const response = await proxyFetchFn(url, proxyConfig, {
+      accept: headers.Accept || headers.accept || '*/*',
+      headers,
+      method: init.method || 'GET',
+      body: init.body ?? null,
+      maxResponseBytes: IMD_MAX_BYTES,
+      timeoutMs: IMD_TIMEOUT_MS,
+      signal: init.signal,
+    });
+    const responseHeaders = {};
+    if (response.contentType) responseHeaders['Content-Type'] = response.contentType;
+    if (response.location) responseHeaders.Location = response.location;
+    const status = Number(response.status) || 502;
+    const body = status === 204 || status === 205 || status === 304
+      ? null
+      : (response.buffer || Buffer.alloc(0));
+    return new Response(body, { status, headers: responseHeaders });
+  };
+}
+
 function imdAuthFailureReason(err) {
   const message = String(err?.message || '');
+  if (err?.proxyConnect === true && Number.isInteger(err?.status)) {
+    return `IMD_PROXY_CONNECT_HTTP_${err.status}`;
+  }
   if (/^IMD_AUTH_HTTP_[1-5]\d{2}$/.test(message)) return message;
   if (err?.name === 'AbortError' || err?.name === 'TimeoutError') return 'IMD_AUTH_TIMEOUT';
+  if (err?.code === 'RESPONSE_TOO_LARGE') return 'IMD_AUTH_RESPONSE_TOO_LARGE';
   if (/^IMD_RESPONSE_TOO_LARGE:\d+$/.test(message)) return 'IMD_AUTH_RESPONSE_TOO_LARGE';
   if (message === 'IMD_AUTH_RESPONSE_INVALID') return message;
   return 'IMD_AUTH_FAILED';
@@ -820,6 +857,10 @@ async function mintImdApiToken({
 
 function imdFetchFailureReason(err) {
   const message = String(err?.message || '');
+  if (err?.proxyConnect === true && Number.isInteger(err?.status)) {
+    return `IMD_PROXY_CONNECT_HTTP_${err.status}`;
+  }
+  if (err?.code === 'RESPONSE_TOO_LARGE') return 'IMD_RESPONSE_TOO_LARGE';
   if (
     /^HTTP \d{3}$/.test(message)
     || message === 'UNTRUSTED_SOURCE_HOST'

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1619,6 +1619,7 @@
       "IMD_API_KEY",
       "IMD_API_EMAIL",
       "IMD_API_PASSWORD",
+      "PROXY_URL",
       "UPSTASH_REDIS_REST_URL",
       "UPSTASH_REDIS_REST_TOKEN"
     ],

--- a/scripts/seed-imd-cyclone-marine.mjs
+++ b/scripts/seed-imd-cyclone-marine.mjs
@@ -11,6 +11,7 @@ import {
   IMD_CANONICAL_KEY,
   IMD_MAX_CONTENT_AGE_MIN,
   IMD_SOURCE_VERSION,
+  createImdProxyFetch,
   declareImdRecords,
   fetchImdCycloneMarine,
   imdAfterPublish,
@@ -45,7 +46,8 @@ async function fetchSnapshot() {
   } catch (err) {
     console.warn(`imd-cyclone-marine: last-good read failed: ${err.message || err}`);
   }
-  return fetchImdCycloneMarine({ userAgent: CHROME_UA, previous });
+  const fetchFn = createImdProxyFetch(process.env.PROXY_URL);
+  return fetchImdCycloneMarine({ userAgent: CHROME_UA, previous, fetchFn });
 }
 
 runSeed('weather', 'imd-cyclone-marine', IMD_CANONICAL_KEY, fetchSnapshot, {

--- a/tests/imd-cyclone-marine.test.mjs
+++ b/tests/imd-cyclone-marine.test.mjs
@@ -52,6 +52,17 @@ function jsonResponse(body, status = 200) {
   });
 }
 
+function proxyJsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    buffer: Buffer.from(JSON.stringify(body)),
+    contentType: 'application/json',
+    headers: { 'content-type': 'application/json' },
+    location: '',
+  };
+}
+
 test('allows only https://api.imd.gov.in product URLs', () => {
   assert.equal(isAllowedImdHost(imdProductUrl(IMD_PRODUCTS.cycloneTrack)), true);
   assert.equal(isAllowedImdHost('http://api.imd.gov.in/api/v1/cyclone_track'), false);
@@ -405,6 +416,8 @@ test('documents the complete IMD Railway credential setup', () => {
   for (const name of railwayService.requiredEnv.filter((entry) => entry.startsWith('IMD_'))) {
     assert.ok(setup.includes(name), `missing documented Railway variable ${name}`);
   }
+  assert.ok(railwayService.requiredEnv.includes('PROXY_URL'));
+  assert.ok(setup.includes('PROXY_URL'), 'missing documented Railway proxy variable');
   assert.ok(setup.includes(railwayService.cronSchedule));
   assert.match(setup, /https:\/\/api\.imd\.gov\.in\/public\/IMD_API_Portal_User_Guide\.pdf/);
   assert.match(setup, /static public IP/i);
@@ -458,6 +471,43 @@ test('mints a fresh IMD JWT before each product batch', async () => {
     'Bearer fresh-token-1',
     'Bearer fresh-token-2',
   ]));
+});
+
+test('routes IMD authentication and every product through PROXY_URL', async () => {
+  const proxyUrl = 'isp.decodo.test:10001:proxy-user:proxy-secret';
+  const directRequests = [];
+  const proxyRequests = [];
+  const snapshot = await fetchImdCycloneMarine({
+    env: { ...LIVE_ENV, PROXY_URL: proxyUrl },
+    fetchFn: async (url) => {
+      directRequests.push(String(url));
+      throw new Error('direct IMD request must not run when PROXY_URL is configured');
+    },
+    proxyFetchFn: async (url, proxyConfig, options) => {
+      proxyRequests.push({ url: String(url), proxyConfig, options });
+      if (String(url) === IMD_OAUTH_TOKEN_URL) {
+        return proxyJsonResponse({ access_token: 'proxy-token', token_type: 'Bearer', expires_in: 3600 });
+      }
+      return proxyJsonResponse([]);
+    },
+    now: NOW,
+  });
+
+  assert.deepEqual(directRequests, []);
+  assert.equal(proxyRequests.length, 7);
+  assert.ok(proxyRequests.every(({ proxyConfig }) => (
+    proxyConfig.host === 'isp.decodo.test'
+    && proxyConfig.port === 10001
+    && proxyConfig.auth === 'proxy-user:proxy-secret'
+    && proxyConfig.tls === true
+  )));
+  assert.equal(proxyRequests[0].options.method, 'POST');
+  assert.deepEqual(JSON.parse(proxyRequests[0].options.body), {
+    email: 'operator@example.com',
+    password: 'railway-secret',
+  });
+  assert.ok(proxyRequests.slice(1).every(({ options }) => options.headers.Authorization === 'Bearer proxy-token'));
+  assert.equal(snapshot.coverageState, 'ok');
 });
 
 test('redacts IMD transport errors before they reach the cached public snapshot', async () => {

--- a/tests/imd-cyclone-marine.test.mjs
+++ b/tests/imd-cyclone-marine.test.mjs
@@ -399,6 +399,7 @@ test('documents the complete IMD Railway credential setup', () => {
   assert.notEqual(start, -1, `missing ${heading}`);
   const nextHeading = docs.indexOf('\n## ', start + heading.length);
   const setup = docs.slice(start, nextHeading === -1 ? docs.length : nextHeading);
+  const setupText = setup.replace(/\s+/g, ' ');
 
   assert.ok(setup.includes(railwayService.service));
   for (const name of railwayService.requiredEnv.filter((entry) => entry.startsWith('IMD_'))) {
@@ -408,8 +409,14 @@ test('documents the complete IMD Railway credential setup', () => {
   assert.match(setup, /https:\/\/api\.imd\.gov\.in\/public\/IMD_API_Portal_User_Guide\.pdf/);
   assert.match(setup, /static public IP/i);
   assert.match(setup, /three static outbound IPv4 addresses/i);
-  assert.match(setup, /maximum of 2 Development keys and 2 Production keys/i);
-  assert.match(setup, /one static public IP/i);
+  assert.match(setupText, /maximum of 2 Development keys and 2 Production keys/i);
+  assert.match(setupText, /balances traffic across them/i);
+  assert.match(setupText, /Application code cannot select the Railway NAT address.*or reliably probe it in advance/i);
+  assert.match(setupText, /native three-IP HA egress cannot satisfy the documented IMD contract/i);
+  assert.match(setupText, /requires deterministic single-IP external egress/i);
+  assert.match(setupText, /another host with one fixed outbound public IP/i);
+  assert.match(setupText, /Do not cycle keys on HTTP 403/i);
+  assert.doesNotMatch(setupText, /written confirmation from IMD.*all three Railway addresses are authorized/i);
   assert.match(setup, /HTTP 403/i);
   assert.ok(setup.includes(IMD_OAUTH_TOKEN_URL));
   assert.match(setup, /Do\s+not store the JWT/i);

--- a/tests/imd-cyclone-marine.test.mjs
+++ b/tests/imd-cyclone-marine.test.mjs
@@ -15,6 +15,7 @@ import {
   assembleImdSnapshot,
   buildDisabledSnapshot,
   cycloneEventsFromSnapshot,
+  createImdProxyFetch,
   declareImdRecords,
   dropExpiredRecords,
   fetchImdCycloneMarine,
@@ -427,7 +428,10 @@ test('documents the complete IMD Railway credential setup', () => {
   assert.match(setupText, /Application code cannot select the Railway NAT address.*or reliably probe it in advance/i);
   assert.match(setupText, /native three-IP HA egress cannot satisfy the documented IMD contract/i);
   assert.match(setupText, /requires deterministic single-IP external egress/i);
-  assert.match(setupText, /another host with one fixed outbound public IP/i);
+  assert.match(setupText, /routes the JWT request and every IMD product request through this proxy/i);
+  assert.match(setupText, /does not fall back to direct Railway egress/i);
+  assert.match(setupText, /government sites as restricted/i);
+  assert.match(setupText, /returns a proxy CONNECT HTTP 403 before a request reaches IMD/i);
   assert.match(setupText, /Do not cycle keys on HTTP 403/i);
   assert.doesNotMatch(setupText, /written confirmation from IMD.*all three Railway addresses are authorized/i);
   assert.match(setup, /HTTP 403/i);
@@ -475,25 +479,25 @@ test('mints a fresh IMD JWT before each product batch', async () => {
 
 test('routes IMD authentication and every product through PROXY_URL', async () => {
   const proxyUrl = 'isp.decodo.test:10001:proxy-user:proxy-secret';
-  const directRequests = [];
   const proxyRequests = [];
-  const snapshot = await fetchImdCycloneMarine({
-    env: { ...LIVE_ENV, PROXY_URL: proxyUrl },
-    fetchFn: async (url) => {
-      directRequests.push(String(url));
-      throw new Error('direct IMD request must not run when PROXY_URL is configured');
-    },
+  const fetchFn = createImdProxyFetch(proxyUrl, {
     proxyFetchFn: async (url, proxyConfig, options) => {
       proxyRequests.push({ url: String(url), proxyConfig, options });
       if (String(url) === IMD_OAUTH_TOKEN_URL) {
         return proxyJsonResponse({ access_token: 'proxy-token', token_type: 'Bearer', expires_in: 3600 });
       }
+      if (String(url).endsWith('/cyclone_cou')) {
+        return proxyJsonResponse(fixture('imd-cyclone-cou.json'));
+      }
       return proxyJsonResponse([]);
     },
+  });
+  const snapshot = await fetchImdCycloneMarine({
+    env: LIVE_ENV,
+    fetchFn,
     now: NOW,
   });
 
-  assert.deepEqual(directRequests, []);
   assert.equal(proxyRequests.length, 7);
   assert.ok(proxyRequests.every(({ proxyConfig }) => (
     proxyConfig.host === 'isp.decodo.test'
@@ -508,6 +512,77 @@ test('routes IMD authentication and every product through PROXY_URL', async () =
   });
   assert.ok(proxyRequests.slice(1).every(({ options }) => options.headers.Authorization === 'Bearer proxy-token'));
   assert.equal(snapshot.coverageState, 'ok');
+});
+
+test('fails closed without a required or valid IMD proxy', async () => {
+  assert.throws(() => createImdProxyFetch(''), /IMD_PROXY_URL_MISSING/);
+  assert.throws(() => createImdProxyFetch('not-a-proxy'), /IMD_PROXY_URL_INVALID/);
+  assert.throws(
+    () => createImdProxyFetch('http://proxy-user:proxy-secret@isp.decodo.test:10001'),
+    /IMD_PROXY_URL_INVALID/,
+  );
+});
+
+test('redacts proxy credentials from IMD transport failures', async () => {
+  const proxySecret = 'proxy-user:proxy-secret';
+  const fetchFn = createImdProxyFetch(`isp.decodo.test:10001:${proxySecret}`, {
+    proxyFetchFn: async () => {
+      throw new Error(`proxy authentication failed for ${proxySecret}`);
+    },
+  });
+  const snapshot = await fetchImdCycloneMarine({
+    env: LIVE_ENV,
+    fetchFn,
+    now: NOW,
+  });
+
+  assert.equal(snapshot.coverageState, 'unavailable');
+  assert.equal(snapshot.products.cycloneTrack.reason, 'IMD_AUTH_FAILED');
+  assert.doesNotMatch(JSON.stringify(snapshot), /proxy-secret/);
+});
+
+test('classifies bounded proxy responses without exposing transport details', async () => {
+  const tooLarge = Object.assign(new Error('proxy response too large'), {
+    code: 'RESPONSE_TOO_LARGE',
+  });
+  const authSnapshot = await fetchImdCycloneMarine({
+    env: LIVE_ENV,
+    fetchFn: createImdProxyFetch('proxy.test:443:user:password', {
+      proxyFetchFn: async () => { throw tooLarge; },
+    }),
+    now: NOW,
+  });
+  assert.equal(authSnapshot.products.cycloneTrack.reason, 'IMD_AUTH_RESPONSE_TOO_LARGE');
+
+  const productSnapshot = await fetchImdCycloneMarine({
+    env: LIVE_ENV,
+    fetchFn: createImdProxyFetch('proxy.test:443:user:password', {
+      proxyFetchFn: async (url) => {
+        if (String(url) === IMD_OAUTH_TOKEN_URL) {
+          return proxyJsonResponse({ access_token: 'proxy-token', token_type: 'Bearer', expires_in: 3600 });
+        }
+        throw tooLarge;
+      },
+    }),
+    now: NOW,
+  });
+  assert.equal(productSnapshot.products.cycloneTrack.reason, 'IMD_RESPONSE_TOO_LARGE');
+});
+
+test('distinguishes a proxy tunnel rejection from an IMD origin rejection', async () => {
+  const proxyRejected = Object.assign(new Error('proxy refused target'), {
+    status: 403,
+    proxyConnect: true,
+  });
+  const snapshot = await fetchImdCycloneMarine({
+    env: LIVE_ENV,
+    fetchFn: createImdProxyFetch('proxy.test:443:user:password', {
+      proxyFetchFn: async () => { throw proxyRejected; },
+    }),
+    now: NOW,
+  });
+
+  assert.equal(snapshot.products.cycloneTrack.reason, 'IMD_PROXY_CONNECT_HTTP_403');
 });
 
 test('redacts IMD transport errors before they reach the cached public snapshot', async () => {
@@ -684,6 +759,7 @@ test('seeder stays off weather:alerts:v1 and uses the dedicated canonical key', 
   assert.equal(IMD_CANONICAL_KEY, 'weather:imd-cyclone-marine:v1');
   assert.match(seeder, /#7005/);
   assert.match(seeder, /seed-activated:weather:imd-cyclone-marine/);
+  assert.match(seeder, /createImdProxyFetch\(process\.env\.PROXY_URL\)/);
   const lib = readFileSync(join(root, 'scripts/lib/imd-cyclone-marine.mjs'), 'utf8');
   assert.doesNotMatch(lib, /\/api\/v1\/districtnowcast/);
   assert.doesNotMatch(lib, /\/api\/v1\/districtwarning/);

--- a/tests/railway-watch-path-audit.test.mjs
+++ b/tests/railway-watch-path-audit.test.mjs
@@ -1015,6 +1015,7 @@ describe('planned Railway service lifecycle', () => {
       'IMD_API_KEY',
       'IMD_API_EMAIL',
       'IMD_API_PASSWORD',
+      'PROXY_URL',
       'UPSTASH_REDIS_REST_URL',
       'UPSTASH_REDIS_REST_TOKEN',
     ]);


### PR DESCRIPTION
## Summary

- route IMD JWT minting and all six documented product requests through the Railway `PROXY_URL`
- require the proxy in the Railway service registry and fail closed instead of falling back to Railway's three outbound IPs
- preserve bounded responses, safe error redaction, and distinguish proxy CONNECT failures from IMD origin failures
- document the complete IMD credential, fixed-egress, and provider-compatibility setup

## Verification

- pre-push repository gate passed, including `typecheck`, `typecheck:api`, changed tests, documentation and MDX checks, generated-code freshness, and version checks
- focused IMD/proxy tests: 33 passed
- Railway and import-graph tests: 119 passed
- Railway registry tests: 13 passed
- Railway `PROXY_URL` is present and its fixed public egress was verified without exposing infrastructure details or the secret

## Live status

A read-only request using the production Railway variables reached the configured proxy, but the proxy rejected CONNECT to `api.imd.gov.in` with HTTP 403 before the request reached IMD. Decodo documents government sites as restricted for ISP Pay/IP and says that restriction cannot be removed for that product. Production IMD acceptance therefore requires a fixed-egress proxy that permits `api.imd.gov.in`; the code and Railway variable contract are ready for that route.

This PR does not merge, deploy, or mutate the production Redis snapshot.
