### PR TITLE
fix(railway): isolate runtime readiness from registry sync

### DIFF
--- a/.github/workflows/railway-registry-sync.yml
+++ b/.github/workflows/railway-registry-sync.yml
@@ -102,7 +102,8 @@ jobs:
             echo
             echo '- **Stale revision:** run the workflow from the current `main`; never re-run an older workflow attempt.'
             echo '- **Registry-managed drift:** fix the registry or the reconciler, then run the current `main` workflow.'
-            echo '- **Source branch, check-suite, or required-variable drift:** repair the named Railway service setting; the registry patch cannot write these fields.'
+            echo '- **Source branch or check-suite drift:** repair the named Railway service setting; the registry patch cannot write these fields.'
+            echo '- **Runtime prerequisites:** missing source credentials are listed separately and do not fail registry sync. The ingestion monitor reports source health.'
             echo '- **CLI or observation failure:** restore Railway access, then run the current `main` workflow.'
             echo
             echo 'Do not run a local production `--apply` from a stale checkout.'

--- a/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
+++ b/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
@@ -392,13 +392,27 @@ ref before evaluating ancestry. An `AHEAD` deployment is healthy only when its
 running commit is proven reachable from the authorized current `main` ref;
 otherwise it reports `AHEAD_LINEAGE_UNPROVEN`.
 
-### Still true, and unchanged
+### Runtime prerequisites and source health
 
 Routing variables that a source resolves as `SOURCE_SPECIFIC || PROXY_URL`
 are declared as a nested any-of group in `requiredEnv`, matching the shape
 `scripts/_bundle-runner.mjs` accepts. Declared flat, the gate demands *both* and
 reports drift for a service routing perfectly well on its source-specific exit —
 stricter than the runtime it guards.
+
+Registry sync separates these runtime prerequisites from deployment configuration.
+Removing an IMD API key can disable the source, but it must not prevent a watch-path
+or cron repair for another service. Apply mode lists missing variable names in its
+log and GitHub step summary, then applies and verifies configuration changes
+without treating those missing credentials as configuration drift. It never
+writes variables. A run with only missing credentials performs no apply.
+
+The standalone audit remains strict about required variables. Invalid service
+identity, missing services, unsafe root changes, failed Railway calls, and
+configuration that does not converge still fail registry sync. A successful sync
+proves configuration convergence only. The ingestion monitor retains source-health
+verdicts and suppresses duplicate incident transitions; a disabled source does not
+become healthy because registry sync passed.
 
 The separate `scripts/check-seed-freshness.mjs` probe accepts the healthy compact
 response shape where `problems` is absent and fails for every actionable

--- a/scripts/audit-railway-watch-paths.mjs
+++ b/scripts/audit-railway-watch-paths.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 
@@ -530,6 +530,7 @@ export async function waitForRailwayServiceConfigConvergence(
     attempts = 5,
     delayMs = 1_000,
     sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    evaluateRequiredEnv = true,
   } = {},
 ) {
   let remaining = [];
@@ -538,6 +539,7 @@ export async function waitForRailwayServiceConfigConvergence(
       await readConfig(),
       serviceIdsByName,
       registry,
+      { evaluateRequiredEnv },
     );
     if (remaining.length === 0 || attempt === attempts) return remaining;
     await sleep(delayMs);
@@ -657,20 +659,42 @@ async function main() {
         deadlineAt: deploymentDeadlineAt,
       })
     : () => readEnvironmentConfig(environment);
+  const config = await readConfig();
   const drift = auditRailwayServiceConfig(
-    await readConfig(),
+    config,
     serviceIdsByName,
     registry,
     {
-      evaluateRequiredEnv: !deploymentOnly,
+      evaluateRequiredEnv: !apply && !deploymentOnly,
       requireMainTrigger: deploymentOnly,
     },
   );
+  const runtimePrerequisites = apply
+    ? auditRailwayServiceConfig(config, serviceIdsByName, registry)
+      .filter((entry) => entry.missingRequiredEnv?.length > 0)
+      .map(({ service, missingRequiredEnv }) => ({ service, missingRequiredEnv }))
+    : [];
   // Always name the target. --apply mutates live infrastructure and the
   // environment is resolved from argv, so it must never be implicit.
   console.log(`Railway operational-config audit: environment=${environment} mode=${deploymentOnly ? 'deployment-only' : apply ? 'apply' : 'audit'}`);
   if (deploymentOnly) {
     console.log('Required environment variables were not evaluated: the Viewer projection cannot request their values.');
+  }
+  if (runtimePrerequisites.length > 0) {
+    const lines = [
+      '### Unavailable runtime prerequisites',
+      '',
+      'Registry sync verifies deployment configuration, not source health. Missing runtime credentials do not block configuration repairs. Source health remains visible in the ingestion monitor.',
+      '',
+      ...runtimePrerequisites.map(({ service, missingRequiredEnv }) => (
+        `- ${service}: missing ${missingRequiredEnv.join(', ')}`
+      )),
+      '',
+    ];
+    console.log(lines.join('\n'));
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+    }
   }
   if (asJson) {
     console.log(JSON.stringify({
@@ -679,6 +703,7 @@ async function main() {
       deploymentOnly,
       requiredEnvironmentEvaluated: !deploymentOnly,
       drift,
+      ...(apply ? { runtimePrerequisites } : {}),
     }, null, 2));
   }
   else printAudit(drift);
@@ -700,6 +725,7 @@ async function main() {
     readConfig,
     serviceIdsByName,
     registry,
+    { evaluateRequiredEnv: false },
   );
   if (remaining.length > 0) {
     printAudit(remaining);

--- a/scripts/run-railway-registry-sync.mjs
+++ b/scripts/run-railway-registry-sync.mjs
@@ -90,6 +90,9 @@ function registrySyncChildEnv(env) {
   if (hasValue(env, 'RAILWAY_CONFIG_AUDIT_JOB_STARTED_AT_MS')) {
     childEnv.RAILWAY_CONFIG_AUDIT_JOB_STARTED_AT_MS = env.RAILWAY_CONFIG_AUDIT_JOB_STARTED_AT_MS;
   }
+  if (hasValue(env, 'GITHUB_STEP_SUMMARY')) {
+    childEnv.GITHUB_STEP_SUMMARY = env.GITHUB_STEP_SUMMARY;
+  }
   return childEnv;
 }
 

--- a/tests/railway-registry-sync-cli.test.mjs
+++ b/tests/railway-registry-sync-cli.test.mjs
@@ -138,6 +138,32 @@ describe('Railway registry sync CLI with unavailable source credentials', () => 
     assert.deepEqual(fixture.read().edits, []);
   });
 
+  it('separates runtime prerequisites from configuration drift in JSON output', (t) => {
+    const fixture = createFixture(t);
+    delete fixture.state.config.services[imdId].variables.IMD_API_KEY;
+    fixture.save();
+    const result = fixture.run(['--apply', '--json']);
+    assertSucceeded(result);
+    const report = JSON.parse(result.stdout.slice(result.stdout.indexOf('{\n')));
+    assert.deepEqual(report.drift, []);
+    assert.equal(report.requiredEnvironmentEvaluated, true);
+    assert.deepEqual(report.runtimePrerequisites, [{
+      service: 'seed-imd-cyclone-marine',
+      missingRequiredEnv: ['IMD_API_KEY'],
+    }]);
+  });
+
+  it('still refuses a missing managed service when another source is unavailable', (t) => {
+    const fixture = createFixture(t);
+    delete fixture.state.config.services[imdId].variables.IMD_API_KEY;
+    delete fixture.state.config.services[otherId];
+    fixture.save();
+    const result = fixture.run();
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /seed-insights not present in Railway production/);
+    assert.deepEqual(fixture.read().edits, []);
+  });
+
   it('still refuses an unsafe root change when a source is unavailable', (t) => {
     const fixture = createFixture(t);
     delete fixture.state.config.services[imdId].variables.IMD_API_KEY;

--- a/tests/railway-registry-sync-cli.test.mjs
+++ b/tests/railway-registry-sync-cli.test.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const runnerPath = fileURLToPath(new URL('../scripts/run-railway-registry-sync.mjs', import.meta.url));
+const auditPath = fileURLToPath(new URL('../scripts/audit-railway-watch-paths.mjs', import.meta.url));
+const registry = JSON.parse(readFileSync(new URL('../scripts/railway-services.json', import.meta.url)));
+const fleet = JSON.parse(readFileSync(new URL('../scripts/railway-native-autodeploy-fleet.json', import.meta.url))).services;
+const imdId = fleet.find(({ name }) => name === 'seed-imd-cyclone-marine').id;
+const otherId = fleet.find(({ name }) => name === 'seed-insights').id;
+const secret = 'fixture-secret-must-not-appear-in-output';
+
+function createFixture(t) {
+  const directory = mkdtempSync(join(tmpdir(), 'railway-registry-cli-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const statePath = join(directory, 'state.json');
+  const summaryPath = join(directory, 'summary.md');
+  const config = { services: {} };
+  for (const { id, name } of fleet) {
+    const entry = registry.find((candidate) => candidate.service === name);
+    config.services[id] = {
+      source: {
+        repo: 'koala73/worldmonitor',
+        rootDirectory: entry?.deployMode === 'nixpacks-root-scripts' ? 'scripts' : '',
+      },
+      build: { watchPatterns: entry?.watchPatterns ?? ['scripts/**', 'shared/**'], dockerfilePath: entry?.dockerfile },
+      deploy: { startCommand: entry?.startCommand, cronSchedule: entry?.cronSchedule },
+      variables: Object.fromEntries((entry?.requiredEnv ?? []).flat().map((name) => [name, secret])),
+    };
+  }
+  const state = {
+    inventory: fleet.map((service) => ({ ...service, source: { repo: 'koala73/worldmonitor' } })),
+    config,
+    edits: [],
+  };
+  const save = () => writeFileSync(statePath, JSON.stringify(state));
+  save();
+  const cliPath = join(directory, 'railway');
+  writeFileSync(cliPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+const statePath = ${JSON.stringify(statePath)};
+const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+const command = process.argv.slice(2, 4).join(' ');
+if (command === 'service list') {
+  console.log(JSON.stringify(state.inventory));
+} else if (command === 'environment config') {
+  if (state.failRead) { console.error('fixture observation failed'); process.exit(1); }
+  console.log(JSON.stringify(state.config));
+} else if (command === 'environment edit') {
+  if (state.failWrite) { console.error('fixture write failed'); process.exit(1); }
+  const patch = JSON.parse(fs.readFileSync(0, 'utf8'));
+  state.edits.push(patch);
+  if (!state.ignoreWrite) {
+    for (const [id, changes] of Object.entries(patch.services)) {
+      for (const [section, values] of Object.entries(changes)) {
+        Object.assign(state.config.services[id][section], values);
+      }
+    }
+  }
+  fs.writeFileSync(statePath, JSON.stringify(state));
+  console.log('{}');
+} else {
+  console.error('unexpected fixture command: ' + command);
+  process.exit(1);
+}
+`);
+  chmodSync(cliPath, 0o755);
+  const run = (auditArgs) => spawnSync(process.execPath, auditArgs ? [auditPath, ...auditArgs] : [runnerPath, '--mode', 'apply'], {
+    encoding: 'utf8',
+    timeout: 15_000,
+    env: {
+      PATH: `${directory}:${process.env.PATH}`,
+      RAILWAY_PROJECT_ID: 'fixture-project',
+      RAILWAY_TOKEN: 'fixture-token',
+      GITHUB_STEP_SUMMARY: summaryPath,
+    },
+  });
+  return {
+    state, save, run, summaryPath,
+    read: () => JSON.parse(readFileSync(statePath, 'utf8')),
+  };
+}
+
+function assertSucceeded(result) {
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, new RegExp(secret));
+}
+
+describe('Railway registry sync CLI with unavailable source credentials', () => {
+  it('does no work for matching configuration and complete credentials', (t) => {
+    const fixture = createFixture(t);
+    assertSucceeded(fixture.run());
+    assert.deepEqual(fixture.read().edits, []);
+  });
+
+  it('reports a removed IMD key without failing or applying an empty patch', (t) => {
+    const fixture = createFixture(t);
+    delete fixture.state.config.services[imdId].variables.IMD_API_KEY;
+    fixture.save();
+    const result = fixture.run();
+    assertSucceeded(result);
+    assert.match(result.stdout, /seed-imd-cyclone-marine.*IMD_API_KEY/);
+    assert.match(result.stdout, /runtime prerequisites/i);
+    assert.deepEqual(fixture.read().edits, []);
+    const summary = readFileSync(fixture.summaryPath, 'utf8');
+    assert.match(summary, /seed-imd-cyclone-marine.*IMD_API_KEY/);
+    assert.match(summary, /not source health/i);
+    assert.doesNotMatch(summary, new RegExp(secret));
+  });
+
+  it('repairs and verifies other services with the IMD key absent, then becomes a no-op', (t) => {
+    const fixture = createFixture(t);
+    delete fixture.state.config.services[imdId].variables.IMD_API_KEY;
+    const expected = [...fixture.state.config.services[otherId].build.watchPatterns];
+    fixture.state.config.services[otherId].build.watchPatterns = ['wrong-path'];
+    fixture.save();
+    assertSucceeded(fixture.run());
+    const updated = fixture.read();
+    assert.deepEqual(updated.edits, [{ services: { [otherId]: { build: { watchPatterns: expected } } } }]);
+    assert.equal(updated.config.services[imdId].variables.IMD_API_KEY, undefined);
+    assert.deepEqual(updated.config.services[otherId].variables, fixture.state.config.services[otherId].variables);
+    assertSucceeded(fixture.run());
+    assert.equal(fixture.read().edits.length, 1);
+  });
+
+  it('retains the strict standalone readiness audit', (t) => {
+    const fixture = createFixture(t);
+    delete fixture.state.config.services[imdId].variables.IMD_API_KEY;
+    fixture.save();
+    const result = fixture.run(['--environment', 'production']);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /missing required environment IMD_API_KEY/);
+    assert.deepEqual(fixture.read().edits, []);
+  });
+
+  it('still refuses an unsafe root change when a source is unavailable', (t) => {
+    const fixture = createFixture(t);
+    delete fixture.state.config.services[imdId].variables.IMD_API_KEY;
+    fixture.state.config.services[otherId].source.rootDirectory = 'wrong-root';
+    fixture.save();
+    const result = fixture.run();
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /rootDirectory is.*wrong-root/);
+    assert.deepEqual(fixture.read().edits, []);
+  });
+
+  for (const failure of ['failRead', 'failWrite', 'ignoreWrite']) {
+    it(`does not hide ${failure} behind an unavailable source`, (t) => {
+      const fixture = createFixture(t);
+      delete fixture.state.config.services[imdId].variables.IMD_API_KEY;
+      fixture.state.config.services[otherId].build.watchPatterns = ['wrong-path'];
+      fixture.state[failure] = true;
+      fixture.save();
+      const result = fixture.run(['--apply', '--environment', 'production']);
+      assert.equal(result.error, undefined);
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, failure === 'ignoreWrite' ? /operational-config drift remains/ : /fixture (observation|write) failed/);
+    });
+  }
+});

--- a/tests/railway-registry-sync-runner.test.mjs
+++ b/tests/railway-registry-sync-runner.test.mjs
@@ -65,6 +65,7 @@ describe('Railway registry sync runner', () => {
       env: {
         ...baseEnv,
         RAILWAY_TOKEN: 'mutation',
+        GITHUB_STEP_SUMMARY: '/tmp/registry-summary.md',
         UNRELATED_SECRET: 'must-not-cross',
       },
       spawnImpl,
@@ -90,6 +91,7 @@ describe('Railway registry sync runner', () => {
       '2',
     ]);
     assert.equal(calls[0][2].env.RAILWAY_TOKEN, 'mutation');
+    assert.equal(calls[0][2].env.GITHUB_STEP_SUMMARY, '/tmp/registry-summary.md');
     assert.equal(calls[1][2].env.RAILWAY_API_TOKEN, 'viewer');
     assert.equal(calls[1][2].env.RAILWAY_CONFIG_AUDIT_JOB_STARTED_AT_MS, '1234');
     assert.equal(calls[0][2].env.UNRELATED_SECRET, undefined);

--- a/tests/railway-registry-sync-workflow.test.mjs
+++ b/tests/railway-registry-sync-workflow.test.mjs
@@ -277,7 +277,8 @@ describe('Railway Registry Sync workflow', () => {
     const summary = stepNamed(workflow.jobs.reconcile, 'Explain a failed reconciliation');
     assert.equal(summary.if, 'failure()');
     assert.match(summary.run, /Stale revision/);
-    assert.match(summary.run, /Source branch, check-suite, or required-variable drift/);
+    assert.match(summary.run, /Source branch or check-suite drift/);
+    assert.match(summary.run, /missing source credentials are listed separately and do not fail registry sync/);
     assert.match(summary.run, /GITHUB_STEP_SUMMARY/);
     assert.equal(summary.env, undefined);
   });


### PR DESCRIPTION
## Why

Removing `IMD_API_KEY` caused Railway Registry Sync run [33972836933](https://github.com/koala73/worldmonitor/actions/runs/33972836933) to fail. The reconciler treated a source's missing runtime credentials as a global patch refusal, so it could also block configuration repairs for unrelated services on every qualifying push.

Apply mode now reports missing runtime prerequisites per service and continues to reconcile deployment configuration.

## Scope

- Use configuration-only findings for apply and convergence. Collect prerequisite notices from the same configuration read.
- Print missing service/variable names in the log, JSON report, and GitHub step summary without printing values or writing variables.
- Preserve the strict standalone readiness audit, low-level patch guards, source-health verdicts, and existing incident deduplication.
- Correct workflow repair guidance and document the distinction between configuration convergence and source health.

## Blast Radius

This changes the registry apply verdict for missing runtime credentials. Missing services, invalid identity/root configuration, failed CLI calls, and non-convergence still fail. A successful registry sync does not claim that a disabled source is healthy. No production configuration or credentials were changed during implementation.

## Verification

- Reproduced the original failure through the real registry runner with a fake Railway CLI and the IMD key absent.
- 231 focused and related tests passed. They cover credential notices, unrelated configuration repair, an idempotent second run, no secret writes/disclosure, JSON and workflow summaries, strict readiness checks, unsafe changes, read/write failures, non-convergence, disabled IMD coverage, and duplicate health incidents.
- `npm run lint:md` and `git diff --check` passed.
