### PR TITLE
fix(railway): recover the full Cross-Strait history archive

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -816,13 +816,23 @@ npm run railway:cross-strait-history:force -- \
   --confirm-production
 ```
 
+The recovery contract is the full retained archive (365 MND reporting days plus
+reviewed Japan rows), not the newest 150 history rows. Scheduled ticks still
+cap each append at 150. The one-off batches through that same boundary so
+embedding cost stays bounded per batch, then requires a lossless same-run
+receipt: validation drops (blank title, missing `occurredAt`, over-limit
+fields) still fail postflight. Confirm `seed-bundle-derived-signals` has
+deployed this batching revision before running; an older seeder will slice the
+archive and the command will exit 75.
+
 The Railway sandbox also has a 15-minute server idle timeout as a cleanup
 backstop if the local process loses its response before it can read the sandbox
-ID. Verify the terminal run plus seed metadata and compact health after the
-authorized execution. Other immediate long-cron backfills still require a
-controlled temporary Railway cron execution, captured command and schedule
-restoration, and a repeated operational-config audit. The full rollback-safe
-sequence is documented in
+ID. Verify the terminal run, the same-run ingest-health receipt, Convex
+intel-history for `domain=military` `resource=cross-strait-activity`, and
+compact health after the authorized execution. Other immediate long-cron
+backfills still require a controlled temporary Railway cron execution, captured
+command and schedule restoration, and a repeated operational-config audit. The
+full rollback-safe sequence is documented in
 [A merged seeder fix is not live until its cron fires](solutions/integration-issues/merged-is-not-ran-long-cron-seeders.md).
 
 ---

--- a/scripts/_seed-history.mjs
+++ b/scripts/_seed-history.mjs
@@ -37,7 +37,9 @@ import { embedBatch, normalizeForEmbedding } from './lib/brief-embedding.mjs';
 
 // Per-run cap. A seed tick that suddenly emits thousands of "historic"
 // rows is a bug upstream, not a reason to spend the embedding budget —
-// keep the newest slice and drop the tail.
+// keep the newest slice and drop the tail. The Cross-Strait one-off
+// reuses this as a batch size so a full retained archive can still
+// postflight as lossless; it does not mean recovery may drop the tail.
 export const HISTORY_MAX_RECORDS_PER_RUN = 150;
 
 // Records per POST. Matches the batch sizes used by the other relay

--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -2,12 +2,18 @@
 import {
   CROSS_STRAIT_ACTIVITY_KEY,
   CROSS_STRAIT_BLOCKED_SOURCE_REASONS,
+  MND_RETENTION_REPORTING_DAYS,
+  REVIEWED_JAPAN_MOD_OBSERVATIONS,
   fetchCrossStraitActivitySnapshot,
   validateCrossStraitActivitySnapshot,
 } from './cross-strait-activity/adapters.mjs';
 import { DAY_MIN, tokensToContentMeta } from './_content-age-helpers.mjs';
 import { loadEnvFile, readSeedSnapshot, runSeed, writeExtraKey } from './_seed-utils.mjs';
-import { makeSeedHistoryAfterPublish } from './_seed-history.mjs';
+import {
+  HISTORY_MAX_RECORDS_PER_RUN,
+  appendSeedHistory,
+  makeSeedHistoryAfterPublish,
+} from './_seed-history.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -21,6 +27,13 @@ export const CROSS_STRAIT_ACTIVITY_FETCH_PHASE_TIMEOUT_MS = 240_000;
 // archive, its compact bootstrap projection, and both source-health records.
 export const CROSS_STRAIT_ACTIVITY_PUBLISH_CLEANUP_HEADROOM_MS = 40_000;
 export const CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS = 320_000;
+// One-off recovery batches the full retained archive through the shared
+// 150-row embedding cap. Each batch still spends the 30s history append
+// budget, so the lock has to cover fetch + every batch + publish cleanup.
+export const CROSS_STRAIT_ACTIVITY_ONE_OFF_LOCK_TTL_MS = 480_000;
+export const CROSS_STRAIT_HISTORY_MAX_RECORDS =
+  MND_RETENTION_REPORTING_DAYS + REVIEWED_JAPAN_MOD_OBSERVATIONS.length;
+const HISTORY_APPEND_BUDGET_MS = 30_000;
 // Keep this literal inside scripts/: Railway's nixpacks service copies only
 // scripts/, so importing the shared browser/Edge registry would crash at boot.
 // The production-registration test pins it to BOOTSTRAP_CACHE_KEYS.
@@ -35,6 +48,20 @@ if (CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS <= (
   CROSS_STRAIT_ACTIVITY_FETCH_PHASE_TIMEOUT_MS + CROSS_STRAIT_ACTIVITY_PUBLISH_CLEANUP_HEADROOM_MS
 )) {
   throw new Error('cross-Strait activity lock TTL must exceed fetch deadline plus publish cleanup headroom');
+}
+
+if (CROSS_STRAIT_ACTIVITY_ONE_OFF_LOCK_TTL_MS <= (
+  CROSS_STRAIT_ACTIVITY_FETCH_PHASE_TIMEOUT_MS
+  + CROSS_STRAIT_ACTIVITY_PUBLISH_CLEANUP_HEADROOM_MS
+  + Math.ceil(CROSS_STRAIT_HISTORY_MAX_RECORDS / HISTORY_MAX_RECORDS_PER_RUN) * HISTORY_APPEND_BUDGET_MS
+)) {
+  throw new Error('cross-Strait one-off lock TTL must cover fetch, full-archive history batches, and publish cleanup');
+}
+
+export function crossStraitActivityLockTtlMs(env = process.env) {
+  return env.WM_ONE_OFF_HISTORY_RECEIPT === '1'
+    ? CROSS_STRAIT_ACTIVITY_ONE_OFF_LOCK_TTL_MS
+    : CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS;
 }
 
 function withoutRevisionHistory(observation) {
@@ -247,13 +274,73 @@ export function buildCrossStraitHistoryRecords(snapshot) {
   }).filter(Boolean);
 }
 
+/**
+ * Scheduled ticks keep the shared 150-row embedding cap. The guarded one-off
+ * reuses that cap as a batch size so the full retained archive can still
+ * satisfy lossless postflight (validation drops fail; cap slicing does not).
+ */
+export async function appendCrossStraitHistoryArchive(
+  args,
+  { append = appendSeedHistory } = {},
+) {
+  const records = Array.isArray(args?.records) ? args.records : [];
+  if (records.length > CROSS_STRAIT_HISTORY_MAX_RECORDS) {
+    throw new Error(
+      `cross-Strait history archive has ${records.length} records; maximum is ${CROSS_STRAIT_HISTORY_MAX_RECORDS}`,
+    );
+  }
+
+  const aggregate = {
+    inserted: 0,
+    skipped: 0,
+    retracted: 0,
+    chunks: 0,
+    abandoned: 0,
+    failedChunks: 0,
+    inputRecords: 0,
+    normalizedRecords: 0,
+    droppedRecords: 0,
+  };
+  const batches = records.length > 0
+    ? Array.from(
+      { length: Math.ceil(records.length / HISTORY_MAX_RECORDS_PER_RUN) },
+      (_, index) => records.slice(
+        index * HISTORY_MAX_RECORDS_PER_RUN,
+        (index + 1) * HISTORY_MAX_RECORDS_PER_RUN,
+      ),
+    )
+    : [[]];
+
+  for (const batch of batches) {
+    const result = await append({ ...args, records: batch });
+    if (result?.skipped === 'unconfigured') return result;
+    for (const field of Object.keys(aggregate)) {
+      aggregate[field] += Number(result?.[field]) || 0;
+    }
+  }
+  return aggregate;
+}
+
 // This seeder's completion marker rides afterFreshness, so history takes the
 // afterPublish slot.
-export const crossStraitHistoryAfterPublish = makeSeedHistoryAfterPublish({
+const standardCrossStraitHistoryAfterPublish = makeSeedHistoryAfterPublish({
   domain: 'military',
   resource: 'cross-strait-activity',
   buildRecords: buildCrossStraitHistoryRecords,
 });
+
+export function crossStraitHistoryAfterPublish(data, meta, deps = {}) {
+  const fullArchive = process.env.WM_ONE_OFF_HISTORY_RECEIPT === '1';
+  const append = fullArchive
+    ? (args) => appendCrossStraitHistoryArchive(args, {
+      append: deps.append ?? appendSeedHistory,
+    })
+    : (deps.append ?? appendSeedHistory);
+  return standardCrossStraitHistoryAfterPublish(data, meta, {
+    ...deps,
+    append,
+  });
+}
 
 function validatePublishableSnapshot(snapshot) {
   if (!validateCrossStraitActivitySnapshot(snapshot)) return false;
@@ -269,7 +356,7 @@ function validatePublishableSnapshot(snapshot) {
 if (process.argv[1]?.endsWith('seed-cross-strait-activity.mjs')) {
   runSeed('military', 'cross-strait-activity', CROSS_STRAIT_ACTIVITY_KEY, fetchSnapshot, {
     ttlSeconds: CROSS_STRAIT_ACTIVITY_TTL_SECONDS,
-    lockTtlMs: CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS,
+    lockTtlMs: crossStraitActivityLockTtlMs(),
     fetchPhaseTimeoutMs: CROSS_STRAIT_ACTIVITY_FETCH_PHASE_TIMEOUT_MS,
     validateFn: validatePublishableSnapshot,
     declareRecords: (snapshot) => snapshot.observations.length,

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -14,7 +14,9 @@ import {
   CROSS_STRAIT_ACTIVITY_COMPLETION_META_KEY,
   CROSS_STRAIT_ACTIVITY_FETCH_PHASE_TIMEOUT_MS,
   CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS,
+  CROSS_STRAIT_ACTIVITY_ONE_OFF_LOCK_TTL_MS,
   CROSS_STRAIT_ACTIVITY_PUBLISH_CLEANUP_HEADROOM_MS,
+  CROSS_STRAIT_HISTORY_MAX_RECORDS,
   CROSS_STRAIT_ACTIVITY_SOURCE_FAILURE_TTL_SECONDS,
   CROSS_STRAIT_ACTIVITY_TTL_SECONDS,
   crossStraitActivityAfterPublish,
@@ -586,6 +588,13 @@ test('cross-Strait shipping budgets preserve Railway cleanup headroom', () => {
     new RegExp(`seedMetaKey:\\s*'${CROSS_STRAIT_ACTIVITY_COMPLETION_META_KEY.replace('seed-meta:', '')}'`),
   );
   assert.ok(CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS > 310_000);
+  assert.ok(
+    CROSS_STRAIT_ACTIVITY_ONE_OFF_LOCK_TTL_MS > (
+      CROSS_STRAIT_ACTIVITY_FETCH_PHASE_TIMEOUT_MS
+      + CROSS_STRAIT_ACTIVITY_PUBLISH_CLEANUP_HEADROOM_MS
+      + Math.ceil(CROSS_STRAIT_HISTORY_MAX_RECORDS / 150) * 30_000
+    ),
+  );
 });
 
 test('degraded cross-Strait source health publishes the error metadata before its detail record', async () => {

--- a/tests/cross-strait-history-one-off.test.mjs
+++ b/tests/cross-strait-history-one-off.test.mjs
@@ -198,6 +198,17 @@ describe('Cross-Strait history Railway one-off', () => {
       lastRetracted: 2,
     };
     assert.doesNotThrow(() => validateHistoryPostflightRecord(healthy, 'run-42'));
+    assert.doesNotThrow(() => validateHistoryPostflightRecord({
+      ...healthy,
+      lastChunks: 8,
+      lastInputRecords: 367,
+      lastNormalizedRecords: 367,
+      lastDroppedRecords: 0,
+      lastAcceptedRecords: 367,
+      lastInserted: 367,
+      lastDeduped: 0,
+      lastRetracted: 0,
+    }, 'run-42'));
     for (const record of [
       { ...healthy, lastRunId: 'run-41' },
       { ...healthy, state: 'failing' },

--- a/tests/seed-history-wiring.test.mjs
+++ b/tests/seed-history-wiring.test.mjs
@@ -25,9 +25,15 @@ const {
   energyIntelAfterPublish,
 } = await import('../scripts/seed-energy-intelligence.mjs');
 const {
+  CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS,
+  CROSS_STRAIT_ACTIVITY_ONE_OFF_LOCK_TTL_MS,
+  CROSS_STRAIT_HISTORY_MAX_RECORDS,
+  appendCrossStraitHistoryArchive,
   buildCrossStraitHistoryRecords,
+  crossStraitActivityLockTtlMs,
   crossStraitHistoryAfterPublish,
 } = await import('../scripts/seed-cross-strait-activity.mjs');
+const { HISTORY_MAX_RECORDS_PER_RUN } = await import('../scripts/_seed-history.mjs');
 
 const ACLED_EVENT = {
   id: 'acled-SUD12345',
@@ -173,6 +179,141 @@ test('buildCrossStraitHistoryRecords drops observations without id or any date',
     ],
   });
   assert.deepEqual(records, []);
+});
+
+test('the guarded Cross-Strait recovery appends the full retained archive in bounded batches', async () => {
+  const batchSizes = [];
+  const result = await appendCrossStraitHistoryArchive({
+    domain: 'military',
+    resource: 'cross-strait-activity',
+    runId: 'run-full-archive',
+    records: Array.from({ length: CROSS_STRAIT_HISTORY_MAX_RECORDS }, (_, index) => ({
+      dedupeKey: `military:cross-strait-activity:mnd-${index}`,
+      title: `Cross-Strait activity ${index}`,
+      occurredAt: Date.parse('2026-09-05') - index * 86_400_000,
+    })),
+  }, {
+    append: async ({ records }) => {
+      batchSizes.push(records.length);
+      return {
+        inserted: records.length,
+        skipped: 0,
+        retracted: 0,
+        chunks: Math.ceil(records.length / 50),
+        abandoned: 0,
+        failedChunks: 0,
+        inputRecords: records.length,
+        normalizedRecords: records.length,
+        droppedRecords: 0,
+      };
+    },
+  });
+
+  assert.deepEqual(batchSizes, [
+    HISTORY_MAX_RECORDS_PER_RUN,
+    HISTORY_MAX_RECORDS_PER_RUN,
+    CROSS_STRAIT_HISTORY_MAX_RECORDS - 2 * HISTORY_MAX_RECORDS_PER_RUN,
+  ]);
+  assert.equal(result.inputRecords, CROSS_STRAIT_HISTORY_MAX_RECORDS);
+  assert.equal(result.normalizedRecords, CROSS_STRAIT_HISTORY_MAX_RECORDS);
+  assert.equal(result.droppedRecords, 0);
+  assert.equal(result.inserted, CROSS_STRAIT_HISTORY_MAX_RECORDS);
+  assert.equal(result.chunks, 8);
+});
+
+test('the guarded Cross-Strait recovery rejects records beyond canonical retention', async () => {
+  let appendCalls = 0;
+  await assert.rejects(
+    appendCrossStraitHistoryArchive({
+      records: Array.from({ length: CROSS_STRAIT_HISTORY_MAX_RECORDS + 1 }, () => ({})),
+    }, {
+      append: async () => { appendCalls += 1; },
+    }),
+    new RegExp(`${CROSS_STRAIT_HISTORY_MAX_RECORDS + 1} records; maximum is ${CROSS_STRAIT_HISTORY_MAX_RECORDS}`),
+  );
+  assert.equal(appendCalls, 0);
+});
+
+test('full-archive aggregation still reports validation drops to postflight', async () => {
+  const result = await appendCrossStraitHistoryArchive({
+    records: Array.from({ length: HISTORY_MAX_RECORDS_PER_RUN + 1 }, (_, index) => ({
+      dedupeKey: `military:cross-strait-activity:mnd-${index}`,
+      title: `Cross-Strait activity ${index}`,
+      occurredAt: Date.parse('2026-09-05') - index * 86_400_000,
+    })),
+  }, {
+    append: async ({ records }) => ({
+      inserted: Math.max(0, records.length - 1),
+      skipped: 0,
+      retracted: 0,
+      chunks: 1,
+      abandoned: 0,
+      failedChunks: 0,
+      inputRecords: records.length,
+      normalizedRecords: records.length - 1,
+      droppedRecords: 1,
+    }),
+  });
+
+  assert.equal(result.droppedRecords, 2);
+  assert.notEqual(result.inputRecords, result.normalizedRecords);
+});
+
+test('only the guarded one-off extends the Cross-Strait seed lock', () => {
+  assert.equal(crossStraitActivityLockTtlMs({}), CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS);
+  assert.equal(
+    crossStraitActivityLockTtlMs({ WM_ONE_OFF_HISTORY_RECEIPT: '1' }),
+    CROSS_STRAIT_ACTIVITY_ONE_OFF_LOCK_TTL_MS,
+  );
+});
+
+test('the one-off history hook records one aggregate receipt for the full archive', async () => {
+  const previous = process.env.WM_ONE_OFF_HISTORY_RECEIPT;
+  const batchSizes = [];
+  const healthObservations = [];
+  process.env.WM_ONE_OFF_HISTORY_RECEIPT = '1';
+  try {
+    await crossStraitHistoryAfterPublish({
+      observations: Array.from({ length: CROSS_STRAIT_HISTORY_MAX_RECORDS }, (_, index) => ({
+        ...CROSS_STRAIT_OBSERVATION,
+        id: `mnd-${index}`,
+        sourceId: index < 365 ? 'taiwan-mnd' : 'japan-mod',
+        reportingDay: new Date(Date.parse('2026-09-05') - index * 86_400_000)
+          .toISOString()
+          .slice(0, 10),
+      })),
+    }, { runId: 'run-full-hook' }, {
+      append: async ({ records }) => {
+        batchSizes.push(records.length);
+        return {
+          inserted: records.length,
+          skipped: 0,
+          retracted: 0,
+          chunks: Math.ceil(records.length / 50),
+          abandoned: 0,
+          failedChunks: 0,
+          inputRecords: records.length,
+          normalizedRecords: records.length,
+          droppedRecords: 0,
+        };
+      },
+      recordHealth: async (observation) => { healthObservations.push(observation); },
+    });
+  } finally {
+    if (previous === undefined) delete process.env.WM_ONE_OFF_HISTORY_RECEIPT;
+    else process.env.WM_ONE_OFF_HISTORY_RECEIPT = previous;
+  }
+
+  assert.deepEqual(batchSizes, [
+    HISTORY_MAX_RECORDS_PER_RUN,
+    HISTORY_MAX_RECORDS_PER_RUN,
+    CROSS_STRAIT_HISTORY_MAX_RECORDS - 2 * HISTORY_MAX_RECORDS_PER_RUN,
+  ]);
+  assert.equal(healthObservations.length, 1);
+  assert.equal(healthObservations[0].runId, 'run-full-hook');
+  assert.equal(healthObservations[0].result.inputRecords, CROSS_STRAIT_HISTORY_MAX_RECORDS);
+  assert.equal(healthObservations[0].result.normalizedRecords, CROSS_STRAIT_HISTORY_MAX_RECORDS);
+  assert.equal(healthObservations[0].result.droppedRecords, 0);
 });
 
 const HOOKS = [


### PR DESCRIPTION
## Why

PR #7725 required lossless same-run history postflight (`lastDroppedRecords === 0`). Scheduled history appends still slice to 150. A live Cross-Strait archive retains 365 MND reporting days plus reviewed Japan rows, so the operator command could never succeed against production data.

## Scope

- Keep the 150-row embedding cap for cron ticks.
- Batch the guarded one-off through that same boundary and record one aggregate receipt for the full retained archive.
- Reject archives larger than the canonical retention window.
- Keep validation drops as a postflight failure.
- Lengthen the one-off seed lock so fetch plus every history batch still fits.
- Document the full-archive recovery contract in the Railway seeder runbook.

## Tradeoffs

- Cron cost is unchanged. Recovery spends one 30s history budget per 150-row batch.
- This PR does not execute `HISTORY_POSTFLIGHT_PROGRAM` under real `node --eval` (#2 from the #7725 review) and does not detach the Railway child from the terminal process group (#9). Those remain optional follow-ups.

## Blast Radius

- Cross-Strait `afterPublish` history path only, and only when `WM_ONE_OFF_HISTORY_RECEIPT=1`.
- Conflict and energy history producers are unchanged.
- No Railway schedule or service config change.

## Verification

- `./node_modules/.bin/tsx --test --test-concurrency=1 tests/seed-history-wiring.test.mjs tests/cross-strait-history-one-off.test.mjs tests/cross-strait-activity-shipping.test.mts tests/seed-history.test.mjs tests/seed-history-ingest-health.test.mjs tests/cross-strait-activity-production-registration.test.mts` — 180 passed.
- Pre-push gates passed.

Follow-up to #7725.