### PR TITLE
docs(embed): explain setup options and developer contracts

### DIFF
--- a/docs/embed-live-map.mdx
+++ b/docs/embed-live-map.mdx
@@ -1,27 +1,104 @@
 ---
 title: "Embed World Monitor Panels"
-description: "Embed allowlisted World Monitor panels in a partner product with a script tag or iframe. The live map has a free keyless tier; keyed panels check the embedding account, not the page visitor."
+description: "Add a free live map or paid World Monitor panels to your website. Start with a snippet, then use the developer reference for layers, keys, and integration details."
 ---
 
-World Monitor exposes partner embeds at `/embed`. [WebMCP](/webmcp) is not an embedding mechanism—it registers tools so a browser agent can drive the top-level World Monitor site, while embed routes explicitly expose no WebMCP tools. Use `/embed` (or the loader below) to pull an allowlisted panel into another product.
+You can put a World Monitor map, Chokepoint Monitor, or Fear & Greed gauge on your website. Copy a snippet into your page's HTML. Your visitors do not need a World Monitor account.
+
+The free map needs no account or key. A paid plan adds more map layers and access to the other supported panels through an embed key. Every embed includes a visible link back to World Monitor.
+
+## Allowlisted panels
+
+These are the supported embeds. The full dashboard and its other panels are not available through `/embed`.
+
+| Panel | What visitors see | Access |
+| --- | --- | --- |
+| Live Map | An interactive map with your selected layers and starting view. | Free, or paid with more layers and faster refresh. |
+| Chokepoint Monitor | A compact strip of maritime chokepoint status and flow information. | Embed key from an account with embed access. |
+| Fear & Greed | The composite market sentiment score, label, and gauge. | Embed key from an account with embed access. |
+
+### Live map tiers
+
+| | Free map | Paid map |
+| --- | --- | --- |
+| Key | None. | A `wme_…` embed key. |
+| Available layers | Conflicts, earthquakes, and weather. | All 14 [supported map layers](#supported-map-layers). |
+| Map refresh | Every hour. | Every 10 minutes. |
+| Attribution link | Required. | Required. |
+
+The paid map displays the layers you select. Adding a key does not turn on every available layer. Both tiers start with conflicts, earthquakes, and weather if you omit the layer setting.
+
+Map refresh pauses while the page is hidden and resumes when it becomes visible. Source data has its own update schedule. Static infrastructure layers do not become live feeds on the paid tier.
+
+The Chokepoint Monitor and Fear & Greed panels load data when the iframe opens. They do not refresh on the map's schedule. Reload the iframe to fetch data again.
+
+## Copy a map from the dashboard
+
+1. Open the [World Monitor dashboard](https://www.worldmonitor.app/dashboard).
+2. Set the map position, zoom, theme, and layers.
+3. Click **Embed** on the map.
+4. Click **Copy snippet** under **Free — no key needed** or **With your embed key**.
+5. Paste the snippet into your website's HTML.
+
+The paid option appears for accounts with embed access. Replace `YOUR_WME_EMBED_KEY` with a key from **Settings → Embeds** before you publish it.
+
+<Note>
+The dialog preview uses the free map, even for a paid account. The snippets preserve the starting view and supported layer selection. Dashboard layers outside the embed list are omitted, and the free snippet displays only free layers.
+</Note>
+
+## Create and manage an embed key
+
+Skip this section for the free map. Embed access is available on every [paid plan](/pricing), including plans without REST API access.
+
+1. Sign in to the account that will provide the embed.
+2. Open **Settings → Embeds**. You can also click **Manage embed keys** in the map's Embed dialog.
+3. Enter a key name, such as `marketing-site`.
+4. Click **Create Embed Key**.
+5. Copy the key immediately. It is shown only once.
+6. Paste the key into the snippet's `data-key` attribute.
+
+You can have up to five active embed keys. The Embeds tab lists their names, prefixes, and usage information. If you lose a key, create a replacement. To rotate a key, update your website with the replacement, check the embed, then revoke the old key in the same tab.
+
+<Warning>
+An embed key is visible in your page's HTML. Use a scoped `wme_…` key there. Do not publish a user API key that starts with `wm_` or an enterprise key. Those credentials can authorize requests beyond embeds.
+</Warning>
+
+Revocation stops new key validation within about a minute. It does not erase content that a visitor has already loaded. Paid panels can remain visible until reload. A paid map grant remains valid for up to 30 minutes; a denied renewal returns the map to its free tier. Temporary failures can leave the last map frame visible for longer. See [failure behavior](#failure-behavior).
 
 ## Copy-paste loader
 
-Partners should ship one script tag. The live map needs no credential at all:
+Choose a snippet below. Paste it into a custom HTML block or your page template. Each script creates one iframe at that position, with the full width of its container.
 
-```html
+For a paid embed, replace `YOUR_WME_EMBED_KEY` with your embed key. Change `data-layers`, `data-center`, and `data-zoom` to set a map's starting view.
+
+<CodeGroup>
+
+```html Free map
 <script
   src="https://www.worldmonitor.app/embed.js"
   data-panel="map"
+  data-layers="conflicts,earthquakes,weather"
   data-theme="dark"
   data-height="420"
   async
 ></script>
 ```
 
-Keyed panels add `data-key`, and the loader posts that key to the frame after load. **Never put a key in the iframe URL** — query-string keys are rejected.
+```html Paid map
+<script
+  src="https://www.worldmonitor.app/embed.js"
+  data-panel="map"
+  data-key="YOUR_WME_EMBED_KEY"
+  data-layers="conflicts,earthquakes,weather,protests,cables"
+  data-center="25.2,55.3"
+  data-zoom="4"
+  data-theme="dark"
+  data-height="420"
+  async
+></script>
+```
 
-```html
+```html Chokepoint Monitor
 <script
   src="https://www.worldmonitor.app/embed.js"
   data-panel="chokepoint-strip"
@@ -32,42 +109,90 @@ Keyed panels add `data-key`, and the loader posts that key to the frame after lo
 ></script>
 ```
 
-<Warning>
-`data-key` sits in your page's public HTML, so treat it as published. Do not put a key there that can do more than embed: a World Monitor user API key (`wm_…`) unlocks your whole paid REST allowance, and an enterprise key bypasses entitlement checks entirely. Scoped embed keys (`wme_…`) exist for this — they authorise embedding and nothing else.
+```html Fear & Greed
+<script
+  src="https://www.worldmonitor.app/embed.js"
+  data-panel="fear-greed"
+  data-key="YOUR_WME_EMBED_KEY"
+  data-theme="light"
+  data-height="360"
+  async
+></script>
+```
 
-Mint one yourself: World Monitor dashboard → **Settings → Embeds → Create Embed Key**. The tab appears on every paid plan (it is gated on embed access, not on API access). The key is shown once at creation and never again, so copy it then. New reads with a revoked key are denied within about a minute. Already rendered paid-only panels remain visible until reload. A live map frame already on its paid tier holds its `POST /api/embed/session` grant for up to 30 more minutes, then falls back to the free tier.
-</Warning>
+</CodeGroup>
 
-## Live map tiers
+If your editor removes script tags, use the [free iframe](#iframe-live-map). Paid embeds need JavaScript on the host page to send the key. An iframe URL alone cannot supply it.
 
-The map is the one panel that renders without a credential, and the keyless tier is a supported product surface, not a trial.
+## Troubleshoot an embed
 
-| | Free (keyless) | Paid (embed key) |
+| What you see | What to check |
+| --- | --- |
+| No embed appears. | Confirm that your editor kept the script or iframe. If your site sets a Content Security Policy, allow `https://www.worldmonitor.app` in `frame-src` and, for the loader, `script-src`. |
+| A paid map shows only free layers. | Check the `wme_` key, the account's embed access, and `data-layers`. The placeholder does not activate paid access. The dashboard preview is always free. |
+| A paid panel asks for an embedding API key. | Supply a `wme_` embed key through `data-key`. The error uses the older term "API key." Signing in as a visitor does not authorize the embed. |
+| The account is not entitled. | Check the plan on the account that created the key. After you restore access, reload the iframe. |
+| A layer is missing. | Use an ID from the supported layer table. A source can also be unavailable. A paid key does not add unsupported dashboard layers. |
+| Data looks unchanged. | Check the refresh behavior above. The two paid panels need a reload, and map sources can update less often than the frame. |
+| The embed could not load. | Inspect the iframe's browser console and network requests. Reload after the source or service recovers. |
+
+## Developer reference
+
+### Query parameters
+
+These parameters configure `/embed`. The loader forwards the matching `data-*` attributes to that URL.
+
+| Parameter | Default | Values and behavior |
 | --- | --- | --- |
-| Layers | `conflicts`, `earthquakes`, `weather` | all fourteen, including `protests` and the static infrastructure and market layers |
-| Refresh | hourly | every 10 minutes |
-| Credential | none | `wme_…` embed key on the embedding account |
-| Attribution | required | required |
+| `panel` | `map` | `map`, `chokepoint-strip`, or `fear-greed`. Unknown values show an error. |
+| `layers` | `conflicts,earthquakes,weather` | Map only. Comma-separated IDs from the layer table. Unknown IDs are ignored. An explicit empty value or `none` selects no overlays. |
+| `center` | `20,0` | Map only. Latitude,longitude. Latitude is clamped to -90 through 90, longitude to -180 through 180. Invalid numeric values use the default. |
+| `zoom` | `1` | Map only. A number clamped to 1 through 10. Invalid values use the default. |
+| `theme` | `dark` | `dark` or `light`. Invalid values use `dark`. |
+| `variant` | `full` | `full`, `tech`, `finance`, `commodity`, `happy`, or `energy`. Invalid values use `full`. This does not change embed access or the layer list. |
+| `key` | Not supported. | Send a key through the loader or the credential message below. Never place credentials in a URL. |
 
-Both tiers read one endpoint, `GET /api/embed/map-frame`, and every embed carries a permanent attribution link back to World Monitor. A paid frame exchanges its `wme_` key for a short-lived grant at `POST /api/embed/session` once per session, so the key itself never rides the refresh loop. A frame whose key is missing, lapsed, or unreachable keeps rendering the free tier rather than going blank.
+The loader accepts `data-panel`, `data-layers`, `data-center`, `data-zoom`, `data-theme`, and `data-variant`. It also accepts these attributes:
 
-Layers you request but are not entitled to are reported back as `not-entitled` and simply do not draw; the rest of the frame still renders.
-
-## Allowlisted panels
-
-| `panel` | Label | Entitlement |
+| Attribute | Default | Behavior |
 | --- | --- | --- |
-| `map` (aliases: `live-map`, `live_map`, `livemap`) | Live Map | Free tier needs no key; the full layer set needs an embed key. Default when `panel` is omitted. |
-| `chokepoint-strip` (aliases: `chokepoints`, `chokepoint`, `chokepoint-monitor`) | Chokepoint Monitor | Embedding key with embed access. No free tier. |
-| `fear-greed` (aliases: `feargreed`, `fear_greed`, `markets-fear-greed`) | Fear & Greed | Embedding key with embed access. No free tier. |
+| `data-key` | No key. | The embedding account's `wme_` key. The literals `YOUR_WME_EMBED_KEY` and `YOUR_WM_API_KEY` are treated as no key. |
+| `data-height` | `420` | Iframe height in pixels, clamped to 120 through 1200. The iframe width is 100% of its container. |
 
-Unknown `panel` values do not render. X / tweet-body panels are not embeddable: partners receive derived facts plus permalinks only, never post text.
+Supported panel aliases are retained for existing integrations. Use the canonical IDs in new snippets.
 
-Every panel in the table above now takes `wme_` embed keys. `wm_` user keys and enterprise keys still work on the two paid panels so nothing breaks mid-flight, but they are deprecated there: the frame logs a migration warning to your browser console, and both credentials do far more than embed. Replace them with an embed key from Settings → Embeds. No removal date is set.
+| Canonical panel ID | Aliases |
+| --- | --- |
+| `map` | `live-map`, `live_map`, `livemap` |
+| `chokepoint-strip` | `chokepoints`, `chokepoint`, `chokepoint-monitor` |
+| `fear-greed` | `feargreed`, `fear_greed`, `markets-fear-greed` |
 
-## Iframe (live map)
+### Supported map layers
 
-The map remains available as a direct iframe. Omitting `panel` keeps the historical map-only contract.
+Use these IDs in `layers` or `data-layers`. The `waterways` map layer marks chokepoints on the map. The separate `chokepoint-strip` panel displays status and flow information.
+
+| Layer ID | Content | Free map | Paid map |
+| --- | --- | --- | --- |
+| `conflicts` | Conflict events. | Yes | Yes |
+| `earthquakes` | Earthquakes and natural events. | Yes | Yes |
+| `weather` | Weather alerts. | Yes | Yes |
+| `protests` | Protest events. | No | Yes |
+| `cables` | Undersea cables. | No | Yes |
+| `pipelines` | Pipelines. | No | Yes |
+| `waterways` | Maritime chokepoints. | No | Yes |
+| `tradeRoutes` | Trade routes. | No | Yes |
+| `economic` | Economic centers. | No | Yes |
+| `stockExchanges` | Stock exchanges. | No | Yes |
+| `financialCenters` | Financial centers. | No | Yes |
+| `centralBanks` | Central banks. | No | Yes |
+| `commodityHubs` | Commodity hubs. | No | Yes |
+| `gulfInvestments` | GCC investments. | No | Yes |
+
+The infrastructure and market layers, from `cables` through `gulfInvestments`, use static map data. Aircraft, live vessels, satellite tracking, and other dashboard layers outside this list are not supported. X post bodies are not embeddable.
+
+### Iframe (live map)
+
+A direct iframe is sufficient for the free map. Omitting `panel` selects the map.
 
 ```html
 <iframe
@@ -80,42 +205,85 @@ The map remains available as a direct iframe. Omitting `panel` keeps the histori
 ></iframe>
 ```
 
-Keyed panels can also use an iframe at `/embed?panel=fear-greed`, but the partner page must `postMessage` `{ source: "worldmonitor-embed", type: "credential", key }` to the frame after it loads. Prefer the script loader.
+<Accordion title="Use a direct iframe with an embed key">
 
-## Query parameters
+Prefer `embed.js`, which handles the credential exchange. For a custom integration, install the message listener before you set the iframe's URL. The frame accepts a credential from its parent during its initial three-second wait.
 
-| Parameter | Example | Notes |
-| --- | --- | --- |
-| `panel` | `chokepoint-strip` | Allowlisted panel id. Default `map`. |
-| `layers` | `conflicts,earthquakes,weather` | Map only. Keyless: `conflicts`, `earthquakes`, `weather`. An embed key adds `protests` and the static infrastructure and market layers. Unknown ids are ignored; unentitled ids come back `not-entitled` and do not draw. |
-| `center` | `25.2,55.3` | Map only. Latitude and longitude, clamped to valid ranges. |
-| `zoom` | `4` | Map only. Clamped between `1` and `10`. |
-| `theme` | `dark` | `dark` or `light`. |
-| `variant` | `full` | One of `full`, `tech`, `finance`, `commodity`, `happy`, or `energy`. |
-| `key` | — | **Not accepted.** Keys belong in `X-WorldMonitor-Key` via the loader, never in the query string. |
+The frame sends `{ source: "worldmonitor-embed", type: "ready" }`. Check both the message origin and the sending window. Reply to the exact World Monitor origin with `{ source: "worldmonitor-embed", type: "credential", key }`.
 
-Loader `data-*` attributes:
+```html
+<div id="wm-embed"></div>
+<script>
+  const origin = 'https://www.worldmonitor.app';
+  const key = 'YOUR_WME_EMBED_KEY';
+  const frame = document.createElement('iframe');
+  frame.title = 'World Monitor Fear & Greed';
+  frame.referrerPolicy = 'strict-origin-when-cross-origin';
+  frame.style.cssText = 'width:100%;height:360px;border:0;display:block';
 
-| Attribute | Example | Notes |
-| --- | --- | --- |
-| `data-panel` | `fear-greed` | Same allowlist as `?panel=`. |
-| `data-key` | `wme_…` | Embed key for the embedding account. Omitted for the free live map. The literals `YOUR_WME_EMBED_KEY` and `YOUR_WM_API_KEY` both read as "no key", so an unedited snippet renders the free tier instead of handshaking with a placeholder. |
-| `data-theme` | `dark` | Passed through to the iframe. |
-| `data-height` | `360` | Iframe height in pixels, clamped 120–1200. |
-| `data-layers` | `conflicts,protests,cables` | Map only. Forwarded to `?layers=`. |
-| `data-center` | `25.2,55.3` | Map only. Forwarded to `?center=`. |
-| `data-zoom` | `4` | Map only. Forwarded to `?zoom=`. |
-| `data-variant` | `finance` | Forwarded to `?variant=`. |
+  function sendKey() {
+    frame.contentWindow?.postMessage(
+      { source: 'worldmonitor-embed', type: 'credential', key },
+      origin,
+    );
+  }
 
-## Entitlement
+  window.addEventListener('message', (event) => {
+    if (event.origin !== origin || event.source !== frame.contentWindow) return;
+    if (event.data?.source === 'worldmonitor-embed' && event.data?.type === 'ready') {
+      sendKey();
+    }
+  });
+  frame.addEventListener('load', sendKey);
+  frame.src = origin + '/embed?panel=fear-greed&theme=dark';
+  document.getElementById('wm-embed').appendChild(frame);
+</script>
+```
 
-Keyed panels check the **embedding account**, not the person viewing the host page:
+Set the panel to `map` and add map query parameters to use the same exchange for a paid map. Keep the key out of `frame.src`. In a component-based application, remove the frame and message listener when the component unmounts.
 
-- The iframe fetches `/api/embed/entitlement?panel=` with `credentials: 'omit'` and `X-WorldMonitor-Key`.
-- Viewer cookies and anonymous `wms_` session tokens are ignored.
-- A panel with a free tier answers `public` without reading the credential at all, so a lapsed key never costs you the free render.
-- For paid panels, an embed key whose owner has active `features.embedAccess` is accepted, as are the deprecated `wm_` user key and enterprise key.
-- The two paid panels read their own data endpoint with the same key. An embed key authorises exactly those endpoints and no other part of the REST API.
-- Use the dashboard **Embed** button on the map to generate both snippets: the free iframe, and — if your plan carries embed access — the keyed loader for the view you are looking at.
+</Accordion>
 
-Each embed includes a permanent attribution link back to World Monitor with source campaign parameters.
+### Entitlement
+
+Paid embeds check the account that owns the key. Viewer cookies and anonymous `wms_` session tokens do not provide embed access. Embed requests omit cookies.
+
+| Embed | Request flow |
+| --- | --- |
+| Free map | Reads `GET /api/embed/map-frame` without a key or grant. |
+| Paid map | Sends the `wme_` key in `X-WorldMonitor-Key` to `POST /api/embed/session?panel=map`. Uses the returned `wmg_` grant in `X-WorldMonitor-Grant` for map-frame reads. Renews the grant as it nears expiry. |
+| Chokepoint Monitor | Checks `GET /api/embed/entitlement?panel=chokepoint-strip`, then reads `/api/supply-chain/v1/get-chokepoint-status` with the same `X-WorldMonitor-Key`. |
+| Fear & Greed | Checks `GET /api/embed/entitlement?panel=fear-greed`, then reads `/api/market/v1/get-fear-greed-index` with the same `X-WorldMonitor-Key`. |
+
+Map grants last 30 minutes and are scoped to the account and panel. The map's entitlement endpoint answers `public` for its free tier; that response does not prove paid access. The paid map session accepts `wme_` keys, not user API keys or enterprise keys.
+
+An embed key authorizes the embed session, entitlement check, and the two panel data routes above. It does not unlock the general REST API. The free map uses the composed map-frame endpoint; it does not grant anonymous access to the underlying conflict, earthquake, natural-event, or unrest REST routes. See [API authentication](/usage-auth) for direct data access.
+
+Embed keys are not restricted to a website domain. The key model can store `allowedOrigins`, but requests do not enforce that field, and the Settings form does not expose it.
+
+### Failure behavior
+
+The map starts at the free tier and upgrades after a successful key exchange. Only selected, available, entitled layers draw.
+
+| Condition | Map behavior |
+| --- | --- |
+| No key, placeholder, or denied initial exchange. | Continues at the free tier. Paid layers do not draw. |
+| Key or plan is denied at renewal. | Drops the grant and requests a free frame. |
+| Initial exchange is temporarily unavailable or rate limited. | Keeps the free map and retries. |
+| Renewal is temporarily unavailable. | Keeps the last frame. After grant expiry, holds map reads until verification can succeed or return a definite denial. |
+| A frame request fails. | Keeps the previous frame. Temporary server failures and rate limits trigger retries. |
+| One layer's source fails. | Other layers can render. The affected layer can be partial or unavailable. |
+
+The map-frame response reports `tier`, `refreshMs`, `generatedAt`, `layers`, and `data`. Layer states are `ok`, `partial`, `unavailable`, or `not-entitled`. A free request can omit paid layers before the request is sent, so a missing layer is not always an explicit `not-entitled` result. A visible frame after an outage can contain older data.
+
+The two paid panels have no free fallback or automatic refresh loop. They show an error if the initial key check or data load fails. Reload them after you correct the key, restore access, or wait for service recovery.
+
+### Migrate an older embed
+
+Existing keyless map URLs still select `map` by default. The free layer set is conflicts, earthquakes, and weather. Protests and static infrastructure layers need paid embed access.
+
+The two paid panels still accept eligible `wm_` user keys and configured enterprise keys for compatibility. They log a browser console warning. These credentials are deprecated for embeds, with no removal date set. Replace them with `wme_` keys from **Settings → Embeds**. A `wm_` key cannot upgrade the map.
+
+### Other integrations
+
+[WebMCP](/webmcp) lets browser agents use tools on the main World Monitor site. Embed routes expose no WebMCP tools. [MCP Apps](/mcp-apps) provide widgets inside compatible AI clients. Use `/embed` for a panel on your website.

--- a/docs/zh/embed-live-map.mdx
+++ b/docs/zh/embed-live-map.mdx
@@ -1,27 +1,104 @@
 ---
 title: "嵌入 World Monitor 面板"
-description: "通过一段 script 或 iframe，将白名单内的 World Monitor 面板嵌入合作方产品。实时地图提供免费的无密钥层级；需密钥的面板按嵌入账户校验，而不是按页面访客校验。"
+description: "在你的网站中加入免费实时地图或付费 World Monitor 面板。先复制嵌入代码，再查看图层、密钥和集成方式的开发者参考。"
 ---
 
-World Monitor 在 `/embed` 提供合作方嵌入。[WebMCP](/zh/webmcp) 不是嵌入机制——它注册工具，让浏览器智能体驱动顶层 World Monitor 站点；嵌入路由则明确不暴露任何 WebMCP 工具。要把允许列表中的面板拉进其他产品，请使用 `/embed` 或下方加载器。
+你可以在自己的网站中放置 World Monitor 地图、咽喉要道监测面板或恐惧与贪婪仪表。将嵌入代码复制到网页 HTML 中即可。访客无需 World Monitor 账户。
+
+免费地图无需账户或密钥。付费套餐通过嵌入密钥提供更多地图图层，并开放其他受支持的面板。每个嵌入都带有可见的 World Monitor 归属链接。
+
+## 允许嵌入的面板
+
+下表列出了支持的嵌入内容。`/embed` 不提供完整仪表盘或其他仪表盘面板。
+
+| 面板 | 访客看到的内容 | 访问条件 |
+| --- | --- | --- |
+| 实时地图 | 使用你所选图层和初始视图的交互式地图。 | 免费，或使用付费版本获得更多图层和更快刷新。 |
+| 咽喉要道监测 | 海上咽喉要道状态和流量信息的紧凑条带。 | 来自具备嵌入权限账户的嵌入密钥。 |
+| 恐惧与贪婪 | 市场情绪综合分数、标签和仪表。 | 来自具备嵌入权限账户的嵌入密钥。 |
+
+### 实时地图层级
+
+| | 免费地图 | 付费地图 |
+| --- | --- | --- |
+| 密钥 | 无需密钥。 | `wme_…` 嵌入密钥。 |
+| 可用图层 | 冲突、地震和天气。 | 全部 14 个[支持的地图图层](#支持的地图图层)。 |
+| 地图刷新 | 每小时。 | 每 10 分钟。 |
+| 归属链接 | 必需。 | 必需。 |
+
+付费地图显示你选择的图层。添加密钥不会自动打开所有可用图层。两个层级在省略图层设置时，都默认显示冲突、地震和天气。
+
+页面隐藏时，地图暂停刷新；页面恢复可见时，刷新恢复。数据源各有更新周期。付费版本中的静态基础设施图层不会变成实时数据流。
+
+咽喉要道监测和恐惧与贪婪面板在 iframe 打开时加载数据，不按地图的周期刷新。重新加载 iframe 才会再次获取数据。
+
+## 从仪表盘复制地图
+
+1. 打开 [World Monitor 仪表盘](https://www.worldmonitor.app/dashboard)。
+2. 设置地图位置、缩放、主题和图层。
+3. 点击地图上的 **Embed**。
+4. 在 **Free — no key needed** 或 **With your embed key** 下点击 **Copy snippet**。
+5. 将代码粘贴到网站的 HTML 中。
+
+付费选项仅向具备嵌入权限的账户显示。发布前，将 `YOUR_WME_EMBED_KEY` 替换为从 **Settings → Embeds** 创建的密钥。
+
+<Note>
+对话框预览始终使用免费地图，即使当前账户已付费。代码保留初始视图和支持的图层选择。嵌入列表之外的仪表盘图层会被省略，免费代码只显示免费图层。
+</Note>
+
+## 创建和管理嵌入密钥
+
+免费地图可以跳过本节。每个[付费套餐](/zh/pricing)都提供嵌入权限，包括不提供 REST API 访问的套餐。
+
+1. 登录用于提供嵌入内容的账户。
+2. 打开 **Settings → Embeds**。也可以点击地图嵌入对话框中的 **Manage embed keys**。
+3. 输入密钥名称，例如 `marketing-site`。
+4. 点击 **Create Embed Key**。
+5. 立即复制密钥。密钥只显示一次。
+6. 将密钥粘贴到代码的 `data-key` 属性中。
+
+每个账户最多保留五个有效嵌入密钥。Embeds 标签页列出名称、前缀和使用信息。如果丢失密钥，请创建替代密钥。轮换密钥时，先在网站中使用新密钥并检查嵌入，再到同一标签页吊销旧密钥。
+
+<Warning>
+嵌入密钥在网页 HTML 中可见。请使用权限仅限嵌入的 `wme_…` 密钥。不要发布以 `wm_` 开头的用户 API 密钥或企业密钥。这些凭据可以授权嵌入之外的请求。
+</Warning>
+
+吊销会在约一分钟内阻止新的密钥校验，但不会清除访客已经加载的内容。付费面板可以继续显示，直到重新加载。付费地图的授权令牌最多仍可有效 30 分钟；续期被拒绝后，地图返回免费层级。临时故障可能让最后一帧保留更久。请参阅[故障行为](#故障行为)。
 
 ## 可复制加载器
 
-合作方应只放一个 script 标签。实时地图完全不需要任何凭据：
+选择下方的一段代码，粘贴到自定义 HTML 块或页面模板中。每个脚本在所在位置创建一个 iframe，宽度占满容器。
 
-```html
+对于付费嵌入，将 `YOUR_WME_EMBED_KEY` 替换为你的嵌入密钥。通过 `data-layers`、`data-center` 和 `data-zoom` 设置地图初始视图。
+
+<CodeGroup>
+
+```html 免费地图
 <script
   src="https://www.worldmonitor.app/embed.js"
   data-panel="map"
+  data-layers="conflicts,earthquakes,weather"
   data-theme="dark"
   data-height="420"
   async
 ></script>
 ```
 
-需密钥的面板另外使用 `data-key`，加载器会在加载后把该密钥 `postMessage` 给 iframe。**不要把密钥放进 iframe URL** —— 查询字符串中的密钥会被拒绝。
+```html 付费地图
+<script
+  src="https://www.worldmonitor.app/embed.js"
+  data-panel="map"
+  data-key="YOUR_WME_EMBED_KEY"
+  data-layers="conflicts,earthquakes,weather,protests,cables"
+  data-center="25.2,55.3"
+  data-zoom="4"
+  data-theme="dark"
+  data-height="420"
+  async
+></script>
+```
 
-```html
+```html 咽喉要道监测
 <script
   src="https://www.worldmonitor.app/embed.js"
   data-panel="chokepoint-strip"
@@ -32,42 +109,90 @@ World Monitor 在 `/embed` 提供合作方嵌入。[WebMCP](/zh/webmcp) 不是�
 ></script>
 ```
 
-<Warning>
-`data-key` 位于你页面的公开 HTML 中，因此应当视为已经公开。不要在那里放置权限超出嵌入范围的密钥：World Monitor 用户 API 密钥（`wm_…`）会解锁你的全部付费 REST 额度，而企业密钥则完全绕过授权校验。作用域受限的嵌入密钥（`wme_…`）正是为此而设——它们只授权嵌入，不授权其他任何能力。
+```html 恐惧与贪婪
+<script
+  src="https://www.worldmonitor.app/embed.js"
+  data-panel="fear-greed"
+  data-key="YOUR_WME_EMBED_KEY"
+  data-theme="light"
+  data-height="360"
+  async
+></script>
+```
 
-你可以自助签发：World Monitor 仪表盘 → **设置 → Embeds → Create Embed Key**。该标签页对所有付费套餐可见（它按嵌入权限而非 API 权限开放）。密钥只在创建时显示一次，之后无法找回，请当场复制。吊销后，使用该密钥的新读取请求会在约一分钟内被拒绝。已经渲染的付费专属面板会继续显示，直到重新加载。已经处于付费层级的实时地图帧还会持有 `POST /api/embed/session` 的 grant 最多 30 分钟，之后回落到免费层级。
-</Warning>
+</CodeGroup>
 
-## 实时地图层级
+如果编辑器移除了 script 标签，请使用[免费 iframe](#iframe（实时地图）)。付费嵌入需要宿主页面的 JavaScript 发送密钥。仅有 iframe URL 无法提供密钥。
 
-地图是唯一无需凭据即可渲染的面板，且这个无密钥层级是正式的产品能力，而非试用。
+## 排查嵌入问题
 
-| | 免费（无密钥） | 付费（嵌入密钥） |
+| 现象 | 检查方法 |
+| --- | --- |
+| 没有显示嵌入内容。 | 确认编辑器保留了 script 或 iframe。如果网站配置了内容安全策略，请在 `frame-src` 中允许 `https://www.worldmonitor.app`；使用加载器时，还需在 `script-src` 中允许该来源。 |
+| 付费地图只显示免费图层。 | 检查 `wme_` 密钥、账户嵌入权限和 `data-layers`。占位符不会启用付费访问。仪表盘中的预览始终免费。 |
+| 付费面板提示需要嵌入 API 密钥。 | 通过 `data-key` 提供 `wme_` 嵌入密钥。错误信息沿用了旧称“API key”。访客登录不会为嵌入提供授权。 |
+| 提示账户无权访问。 | 检查创建密钥的账户套餐。恢复权限后重新加载 iframe。 |
+| 缺少图层。 | 使用支持图层表中的 ID。也可能是数据源不可用。付费密钥不会开放列表之外的仪表盘图层。 |
+| 数据看起来没有变化。 | 检查上方的刷新行为。两个付费面板需要重新加载，地图数据源的更新频率也可能低于地图帧刷新频率。 |
+| 嵌入无法加载。 | 查看 iframe 的浏览器控制台和网络请求。数据源或服务恢复后重新加载。 |
+
+## 开发者参考
+
+### 查询参数
+
+以下参数配置 `/embed`。加载器将对应的 `data-*` 属性转发到该 URL。
+
+| 参数 | 默认值 | 值和行为 |
 | --- | --- | --- |
-| 图层 | `conflicts`、`earthquakes`、`weather` | 全部十四个，包含 `protests` 以及静态基础设施与市场图层 |
-| 刷新 | 每小时 | 每 10 分钟 |
-| 凭据 | 无 | 嵌入账户的 `wme_…` 嵌入密钥 |
-| 归属链接 | 必需 | 必需 |
+| `panel` | `map` | `map`、`chokepoint-strip` 或 `fear-greed`。未知值会显示错误。 |
+| `layers` | `conflicts,earthquakes,weather` | 仅地图使用。以逗号分隔的图层 ID。未知 ID 被忽略。显式空值或 `none` 表示不显示叠加图层。 |
+| `center` | `20,0` | 仅地图使用。纬度,经度。纬度限制在 -90 到 90，经度限制在 -180 到 180。无效数字使用默认值。 |
+| `zoom` | `1` | 仅地图使用。数值限制在 1 到 10。无效值使用默认值。 |
+| `theme` | `dark` | `dark` 或 `light`。无效值使用 `dark`。 |
+| `variant` | `full` | `full`、`tech`、`finance`、`commodity`、`happy` 或 `energy`。无效值使用 `full`。此参数不改变嵌入权限或图层列表。 |
+| `key` | 不支持。 | 通过加载器或下方的凭据消息发送密钥。不要在 URL 中放置凭据。 |
 
-两个层级都读取同一个端点 `GET /api/embed/map-frame`，并且每个嵌入都带有指向 World Monitor 的永久归属链接。付费帧每个会话只在 `POST /api/embed/session` 用 `wme_` 密钥换取一个短期 grant，因此密钥本身不会参与刷新轮询。密钥缺失、过期或暂时不可用时，帧会继续渲染免费层级，而不是变成空白。
+加载器接受 `data-panel`、`data-layers`、`data-center`、`data-zoom`、`data-theme` 和 `data-variant`，以及下列属性：
 
-你请求但未获授权的图层会以 `not-entitled` 返回并且不会绘制，帧的其余部分照常渲染。
-
-## 允许嵌入的面板
-
-| `panel` | 名称 | 授权 |
+| 属性 | 默认值 | 行为 |
 | --- | --- | --- |
-| `map`（别名：`live-map`、`live_map`、`livemap`） | 实时地图 | 免费层级无需密钥；完整图层集需要嵌入密钥。省略 `panel` 时的默认值。 |
-| `chokepoint-strip`（别名：`chokepoints`、`chokepoint`、`chokepoint-monitor`） | 咽喉要道监测 | 具备嵌入权限的嵌入密钥。无免费层级。 |
-| `fear-greed`（别名：`feargreed`、`fear_greed`、`markets-fear-greed`） | 恐惧与贪婪 | 具备嵌入权限的嵌入密钥。无免费层级。 |
+| `data-key` | 无密钥。 | 嵌入账户的 `wme_` 密钥。字面值 `YOUR_WME_EMBED_KEY` 和 `YOUR_WM_API_KEY` 均视为无密钥。 |
+| `data-height` | `420` | iframe 高度，单位为像素，限制在 120 到 1200。宽度为容器的 100%。 |
 
-未知 `panel` 不会渲染。X / 推文正文面板不可嵌入：合作方只获得派生事实和永久链接，不会获得帖子正文。
+为兼容现有集成，面板别名仍然有效。新代码请使用规范 ID。
 
-上表中的每个面板现在都接受 `wme_` 嵌入密钥。为了不打断正在运行的集成，两个付费面板仍然接受 `wm_` 用户密钥和企业密钥，但它们在这里已被弃用：帧会向你的浏览器控制台输出迁移警告，而且这两种凭据的权限都远超嵌入所需。请改用「设置 → Embeds」中签发的嵌入密钥。目前没有设定下线日期。
+| 规范面板 ID | 别名 |
+| --- | --- |
+| `map` | `live-map`、`live_map`、`livemap` |
+| `chokepoint-strip` | `chokepoints`、`chokepoint`、`chokepoint-monitor` |
+| `fear-greed` | `feargreed`、`fear_greed`、`markets-fear-greed` |
 
-## iframe（实时地图）
+### 支持的地图图层
 
-地图仍可作为直接 iframe 使用。省略 `panel` 时保持历史的仅地图契约。
+在 `layers` 或 `data-layers` 中使用这些 ID。`waterways` 图层在地图上标记咽喉要道；独立的 `chokepoint-strip` 面板显示状态和流量信息。
+
+| 图层 ID | 内容 | 免费地图 | 付费地图 |
+| --- | --- | --- | --- |
+| `conflicts` | 冲突事件。 | 是 | 是 |
+| `earthquakes` | 地震和自然事件。 | 是 | 是 |
+| `weather` | 天气警报。 | 是 | 是 |
+| `protests` | 抗议事件。 | 否 | 是 |
+| `cables` | 海底电缆。 | 否 | 是 |
+| `pipelines` | 管道。 | 否 | 是 |
+| `waterways` | 海上咽喉要道。 | 否 | 是 |
+| `tradeRoutes` | 贸易路线。 | 否 | 是 |
+| `economic` | 经济中心。 | 否 | 是 |
+| `stockExchanges` | 证券交易所。 | 否 | 是 |
+| `financialCenters` | 金融中心。 | 否 | 是 |
+| `centralBanks` | 中央银行。 | 否 | 是 |
+| `commodityHubs` | 大宗商品枢纽。 | 否 | 是 |
+| `gulfInvestments` | 海湾合作委员会投资。 | 否 | 是 |
+
+从 `cables` 到 `gulfInvestments` 的基础设施和市场图层使用静态地图数据。不支持飞机、实时船舶、卫星跟踪及列表之外的其他仪表盘图层。X 帖子正文不可嵌入。
+
+### Iframe（实时地图）
+
+免费地图只需直接使用 iframe。省略 `panel` 时选择地图。
 
 ```html
 <iframe
@@ -80,42 +205,85 @@ World Monitor 在 `/embed` 提供合作方嵌入。[WebMCP](/zh/webmcp) 不是�
 ></iframe>
 ```
 
-需密钥的面板也可以使用 `/embed?panel=fear-greed` iframe，但宿主页必须在 iframe 加载后 `postMessage` `{ source: "worldmonitor-embed", type: "credential", key }`。优先使用 script 加载器。
+<Accordion title="直接在 iframe 中使用嵌入密钥">
 
-## 查询参数
+优先使用 `embed.js`，由它完成凭据交换。自定义集成必须先安装消息监听器，再设置 iframe URL。iframe 在最初的三秒等待期内接受来自父页面的凭据。
 
-| 参数 | 示例 | 说明 |
-| --- | --- | --- |
-| `panel` | `chokepoint-strip` | 白名单面板 id。默认 `map`。 |
-| `layers` | `conflicts,earthquakes,weather` | 仅地图。无密钥可用：`conflicts`、`earthquakes`、`weather`。嵌入密钥另外解锁 `protests` 以及静态基础设施与市场图层。未知 id 会被忽略；未获授权的 id 以 `not-entitled` 返回且不会绘制。 |
-| `center` | `25.2,55.3` | 仅地图。纬度和经度，会被限制在有效范围内。 |
-| `zoom` | `4` | 仅地图。限制在 `1` 与 `10` 之间。 |
-| `theme` | `dark` | `dark` 或 `light`。 |
-| `variant` | `full` | `full`、`tech`、`finance`、`commodity`、`happy` 或 `energy` 之一。 |
-| `key` | — | **不接受。** 密钥只能通过加载器以 `X-WorldMonitor-Key` 传递，不得出现在查询字符串中。 |
+iframe 发送 `{ source: "worldmonitor-embed", type: "ready" }`。检查消息来源和发送窗口。向准确的 World Monitor 来源回复 `{ source: "worldmonitor-embed", type: "credential", key }`。
 
-加载器 `data-*` 属性：
+```html
+<div id="wm-embed"></div>
+<script>
+  const origin = 'https://www.worldmonitor.app';
+  const key = 'YOUR_WME_EMBED_KEY';
+  const frame = document.createElement('iframe');
+  frame.title = 'World Monitor Fear & Greed';
+  frame.referrerPolicy = 'strict-origin-when-cross-origin';
+  frame.style.cssText = 'width:100%;height:360px;border:0;display:block';
 
-| 属性 | 示例 | 说明 |
-| --- | --- | --- |
-| `data-panel` | `fear-greed` | 与 `?panel=` 相同的允许列表。 |
-| `data-key` | `wme_…` | 嵌入账户的嵌入密钥。免费实时地图可省略。字面量 `YOUR_WME_EMBED_KEY` 与 `YOUR_WM_API_KEY` 都会被视为「没有密钥」，因此未经编辑的代码片段会渲染免费层级，而不是拿占位符去做凭据握手。 |
-| `data-theme` | `dark` | 传到 iframe。 |
-| `data-height` | `360` | iframe 高度（像素），限制在 120–1200。 |
-| `data-layers` | `conflicts,protests,cables` | 仅地图。转发到 `?layers=`。 |
-| `data-center` | `25.2,55.3` | 仅地图。转发到 `?center=`。 |
-| `data-zoom` | `4` | 仅地图。转发到 `?zoom=`。 |
-| `data-variant` | `finance` | 转发到 `?variant=`。 |
+  function sendKey() {
+    frame.contentWindow?.postMessage(
+      { source: 'worldmonitor-embed', type: 'credential', key },
+      origin,
+    );
+  }
 
-## 授权
+  window.addEventListener('message', (event) => {
+    if (event.origin !== origin || event.source !== frame.contentWindow) return;
+    if (event.data?.source === 'worldmonitor-embed' && event.data?.type === 'ready') {
+      sendKey();
+    }
+  });
+  frame.addEventListener('load', sendKey);
+  frame.src = origin + '/embed?panel=fear-greed&theme=dark';
+  document.getElementById('wm-embed').appendChild(frame);
+</script>
+```
 
-需密钥的面板校验的是**嵌入账户**，而不是宿主页的访客：
+将面板设为 `map` 并添加地图查询参数，即可通过同样的交换方式显示付费地图。不要将密钥放进 `frame.src`。在组件式应用中，组件卸载时要移除 iframe 和消息监听器。
 
-- iframe 以 `credentials: 'omit'` 和 `X-WorldMonitor-Key` 请求 `/api/embed/entitlement?panel=`。
-- 访客 cookie 和匿名 `wms_` 会话令牌会被忽略。
-- 具有免费层级的面板会直接返回 `public`，完全不读取凭据，因此密钥过期也不会让你失去免费渲染。
-- 对付费面板，所有者具有有效 `features.embedAccess` 的嵌入密钥可通过；已弃用的 `wm_` 用户密钥和企业密钥同样可通过。
-- 两个付费面板会用同一个密钥读取各自的数据端点。嵌入密钥只授权这些端点，不授权 REST API 的任何其他部分。
-- 使用地图上的 **Embed（嵌入）** 按钮即可同时生成两段代码：免费 iframe，以及——若你的套餐包含嵌入权限——针对当前视图的带密钥加载器。
+</Accordion>
 
-每个嵌入都包含一个指向 World Monitor 的永久归属链接，并带有来源活动参数。
+### 授权
+
+付费嵌入校验密钥所属账户。访客 Cookie 和匿名 `wms_` 会话令牌不提供嵌入权限。嵌入请求不发送 Cookie。
+
+| 嵌入 | 请求流程 |
+| --- | --- |
+| 免费地图 | 无需密钥或授权令牌，读取 `GET /api/embed/map-frame`。 |
+| 付费地图 | 在 `X-WorldMonitor-Key` 中将 `wme_` 密钥发送到 `POST /api/embed/session?panel=map`。随后在 `X-WorldMonitor-Grant` 中使用返回的 `wmg_` 授权令牌读取地图帧，并在令牌接近过期时续期。 |
+| 咽喉要道监测 | 检查 `GET /api/embed/entitlement?panel=chokepoint-strip`，再使用相同的 `X-WorldMonitor-Key` 读取 `/api/supply-chain/v1/get-chokepoint-status`。 |
+| 恐惧与贪婪 | 检查 `GET /api/embed/entitlement?panel=fear-greed`，再使用相同的 `X-WorldMonitor-Key` 读取 `/api/market/v1/get-fear-greed-index`。 |
+
+地图授权令牌有效期为 30 分钟，权限限定到账户和面板。地图的 entitlement 端点为免费层级返回 `public`，该结果不代表付费访问有效。付费地图会话接受 `wme_` 密钥，不接受用户 API 密钥或企业密钥。
+
+嵌入密钥授权嵌入会话、权限检查和上表中的两个面板数据路由，不开放通用 REST API。免费地图使用聚合后的 map-frame 端点，不提供对底层冲突、地震、自然事件或社会动荡 REST 路由的匿名访问。直接获取数据请参阅 [API 身份验证](/zh/usage-auth)。
+
+嵌入密钥不限制网站域名。密钥模型可以保存 `allowedOrigins`，但请求不会强制执行该字段，设置表单也不提供该选项。
+
+### 故障行为
+
+地图先以免费层级启动，密钥交换成功后升级。只有已选择、可用且获得授权的图层才会显示。
+
+| 条件 | 地图行为 |
+| --- | --- |
+| 无密钥、使用占位符，或初次交换被拒绝。 | 保持免费层级，不显示付费图层。 |
+| 续期时密钥或套餐被拒绝。 | 丢弃授权令牌并请求免费地图帧。 |
+| 初次交换暂时不可用或触发限流。 | 保留免费地图并重试。 |
+| 续期暂时不可用。 | 保留最后一帧。令牌过期后，暂停读取地图数据，直到校验成功或明确拒绝。 |
+| 地图帧请求失败。 | 保留前一帧。临时服务器故障和限流会触发重试。 |
+| 某图层的数据源失败。 | 其他图层仍可显示，受影响的图层可能部分可用或不可用。 |
+
+map-frame 响应包含 `tier`、`refreshMs`、`generatedAt`、`layers` 和 `data`。图层状态为 `ok`、`partial`、`unavailable` 或 `not-entitled`。免费请求可能在发出前省略付费图层，因此缺失图层不一定有显式的 `not-entitled` 结果。故障后仍可见的地图帧可能包含旧数据。
+
+两个付费面板没有免费回退或自动刷新循环。初次密钥检查或数据加载失败时，它们显示错误。修正密钥、恢复权限或等待服务恢复后，请重新加载。
+
+### 迁移旧嵌入
+
+现有的无密钥地图 URL 仍默认选择 `map`。免费图层为冲突、地震和天气。抗议和静态基础设施图层需要付费嵌入权限。
+
+为保持兼容，两个付费面板仍接受符合条件的 `wm_` 用户密钥和已配置的企业密钥，并在浏览器控制台输出警告。这些凭据已不推荐用于嵌入，目前没有移除日期。请替换为 **Settings → Embeds** 中创建的 `wme_` 密钥。`wm_` 密钥不能升级地图。
+
+### 其他集成
+
+[WebMCP](/zh/webmcp) 让浏览器智能体在 World Monitor 主站上使用工具，嵌入路由不暴露 WebMCP 工具。[MCP Apps](/zh/mcp-apps) 在兼容的 AI 客户端中提供组件。要在网站上放置面板，请使用 `/embed`。


### PR DESCRIPTION
The embed guide did not give website owners a complete setup path after #7704, #7705, #7706, and #7707. It also overstated fallback and revocation behavior and left the supported layer set implicit.

Update the English and Chinese Mintlify pages with a plain-language choice of embeds, dashboard and key setup, and copyable examples. Put the full layer and parameter reference, credential exchange, failure behavior, and legacy-key migration after those steps. Preserve the page paths and existing section anchors. Only these two documentation files change.

## Verification

- 143 focused tests passed across the loader, URL and panel contracts, sessions, entitlement, map frames, dashboard dialog, settings, and data loader.
- Executed all six documented HTML examples in a local harness. Checked key delivery, origin and window validation, view parameters, matching examples in both languages, all layer IDs, and panel aliases.
- `lint:public-docs`, `lint:mintlify-slugs`, `docs:check`, and `git diff --check` passed.
- Mintlify 4.2.866 exported 507 pages. The rendered anchor check passed. Inspected both languages in the local Mintlify preview and exercised the code tabs and iframe accordion.

These checks verify the documentation and local contracts. Publication requires the normal merge and documentation deployment.

## Documentation alignment

| Claim group | Source checked |
| --- | --- |
| Supported panels, tiers, layer IDs, cadence, and aliases | `shared/embed-panels.ts`, `src/embed/embed-url.ts` |
| Loader options and parent-frame credential exchange | `public/embed.js`, `src/embed/embed-credential.ts` |
| Key issuance, five-key limit, account access, and origin limitations | `convex/embedKeys.ts`, `shared/embed-access.ts`, `src/components/UnifiedSettings.ts` |
| Map grant lifetime, renewal, partial failures, and retained frames | `server/_shared/embed-grant.ts`, `server/_shared/embed-session.ts`, `src/embed/embed-data-loader.ts` |
| Paid-panel initial data loads and legacy credentials | `src/embed-main.ts`, `src/embed/panels/`, `server/_shared/embed-entitlement.ts`, `server/gateway.ts` |
| Dashboard snippets and free preview | `src/app/event-handlers.ts` |

- [x] Claim ledger included above.
- [x] Examples checked against the current source and local fixtures.
- Generated OpenAPI, proto, and Redis-key claims are unchanged.
- No Audit Council signoff is claimed. This update has one source and documentation review; no review automation was requested.
