### PR TITLE
fix(blog): remove unsupported competitor price claims

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,7 @@ jobs:
             # snapshot whose figures the committed page no longer matches -
             # surfacing later as a confusing failure on an unrelated PR.
             /^docs\/snapshots\/resilience-ranking-[0-9-]+\.json$/ { count++; next }
+            /^blog-site\/src\/content\/blog\/.*\.md$/ { count++; next }
             /\.md$/ { next }
             /^docs\// { next }
             /^src-tauri\// && $0 !~ /^src-tauri\/sidecar\// && $0 !~ /^src-tauri\/.*\.json$/ { next }

--- a/blog-site/src/content/blog/free-vs-paid-real-time-intelligence-dashboards.md
+++ b/blog-site/src/content/blog/free-vs-paid-real-time-intelligence-dashboards.md
@@ -6,7 +6,7 @@ keywords: "free vs paid intelligence dashboard, real-time intelligence dashboard
 audience: "Buyers evaluating intelligence tooling, analysts justifying budget, procurement teams, researchers deciding whether to upgrade"
 heroImage: "/blog/images/blog/free-vs-paid-real-time-intelligence-dashboards.jpg"
 pubDate: "2026-07-07"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-05"
 ---
 
 Most buyers evaluating real-time intelligence dashboards compare the wrong things. The honest answer to "free versus paid" is that free tiers now cover **awareness** — seeing what is happening in the world right now — remarkably well, while paid tiers sell the **decision layer**: analysis, alert routing, programmatic access, and deployment control. If your job ends at "know what's happening," a good free dashboard is enough. If your job is "decide, notify, and integrate," you are buying one of those three things, and you should price them separately.
@@ -61,8 +61,8 @@ Realistic anchors across the spectrum:
 | Free / open source | $0 | Aggregated multi-domain awareness, community support | World Monitor free tier, self-hosted OSINT stacks |
 | Prosumer / analyst | ~$30–80/month | AI analysis, digests, alerting, personal workflows | World Monitor Pro at $39.99/month |
 | API / developer | ~$100–250/month | Programmatic quotas, webhooks, structured data | World Monitor API at $99.99–299.99/month |
-| Enterprise SaaS | Six figures/year | Team seats, SLAs, integrations, support | Dataminr-class licenses |
-| Terminal / platform | $24,000/year per seat and up | Deep proprietary data, execution workflows | Bloomberg Terminal; Palantir deployments start in the millions |
+| Enterprise SaaS | Undisclosed (enterprise-negotiated) | Team seats, SLAs, integrations, support | Dataminr-class licenses |
+| Terminal / platform | $24,000/year per seat (reported by Quartz, 2022) | Deep proprietary data, execution workflows | Bloomberg Terminal |
 
 Two things follow from this table. First, the gap between $0 and $24,000 is not 24,000× the intelligence — it is depth in one domain (Bloomberg's tick-level market data) or organizational integration (Palantir), which you should buy only if you specifically need it. We've published a [detailed head-to-head comparison](https://www.worldmonitor.app/blog/posts/worldmonitor-vs-traditional-intelligence-tools/) if that's your decision. Second, the prosumer tier is new: the $40/month analyst desk simply did not exist a few years ago, and it is the right answer for most individual professionals.
 
@@ -116,7 +116,7 @@ Delivery. Free tiers require you to look at the dashboard; paid tiers push intel
 
 **How much should an individual analyst expect to pay in 2026?**
 
-Around $30–80/month for the prosumer tier. World Monitor Pro is $39.99/month ($359.99/year). Compare that against enterprise anchors — Bloomberg Terminal at $24,000/year per seat, Dataminr licenses in six figures — and price the specific capability gap, not the brand.
+Around $30–80/month for the prosumer tier. World Monitor Pro is $39.99/month ($359.99/year). Compare that against enterprise anchors — Bloomberg Terminal at $24,000/year per seat as reported by Quartz in 2022, and negotiated enterprise licensing for vendors such as Dataminr — and price the specific capability gap, not the brand.
 
 **Do paid intelligence platforms train AI on my queries?**
 

--- a/blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md
+++ b/blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md
@@ -1,15 +1,15 @@
 ---
 title: "World Monitor vs Bloomberg, Palantir, Dataminr, and Recorded Future"
-description: "Compare World Monitor to Bloomberg, Palantir, Dataminr, and Recorded Future. Free, open-source multi-domain intelligence vs. six-figure enterprise platforms."
+description: "Compare World Monitor with Bloomberg, Palantir, Dataminr, and Recorded Future across capabilities, licensing models, and data coverage."
 metaTitle: "World Monitor vs Bloomberg, Palantir, Dataminr"
 keywords: "Bloomberg Terminal alternative free, Palantir alternative open source, Dataminr alternative, intelligence platform comparison, free OSINT alternative"
 audience: "Analysts evaluating tools, budget-conscious teams, procurement decision-makers, open-source advocates"
 heroImage: "/blog/images/blog/worldmonitor-vs-traditional-intelligence-tools.jpg"
 pubDate: "2026-03-11"
-modifiedDate: "2026-09-03"
+modifiedDate: "2026-09-05"
 ---
 
-A [Bloomberg Terminal](https://www.bloomberg.com/professional/products/bloomberg-terminal/) costs $24,000 per year. A [Palantir](https://www.palantir.com/) deployment starts in the millions. [Dataminr](https://www.dataminr.com/) licenses run six figures for enterprise teams. [Recorded Future](https://www.recordedfuture.com/) isn't cheap either.
+[Quartz reported in 2022](https://qz.com/84961/this-is-how-much-a-bloomberg-terminal-costs) that a [Bloomberg Terminal](https://www.bloomberg.com/professional/products/bloomberg-terminal/) single subscription cost $24,000 per year. [Palantir](https://www.palantir.com/), [Dataminr](https://www.dataminr.com/), and [Recorded Future](https://www.recordedfuture.com/) use enterprise-negotiated licensing with no published list price.
 
 These tools are powerful. They're also gatekept behind budgets that exclude most of the world's analysts, researchers, journalists, and security professionals.
 
@@ -35,7 +35,7 @@ Let's be direct about what World Monitor is and isn't relative to established pl
 - Conflict and military monitoring (Bloomberg has zero)
 - Visual map-based interface with a shared map-layer catalog
 - AI analysis that runs locally (Bloomberg's AI is cloud-only)
-- Price: free vs. $24,000/year
+- Price: free vs. $24,000/year (Quartz, 2022)
 - Open source transparency
 
 **Best for:** Traders who need geopolitical context for macro positioning, not tick-level execution.
@@ -57,7 +57,7 @@ Let's be direct about what World Monitor is and isn't relative to established pl
 - Public OSINT aggregation out of the box
 - Self-service without enterprise contracts
 - Community-driven development
-- Price: free vs. multi-million dollar contracts
+- Price: free vs. undisclosed enterprise-negotiated licensing
 
 **Best for:** Analysts who need public OSINT aggregation today, not a 6-month enterprise deployment.
 
@@ -77,7 +77,7 @@ Let's be direct about what World Monitor is and isn't relative to established pl
 - AI analysis with local LLM option
 - Interactive map visualization
 - No vendor dependency
-- Price: free vs. six-figure annual licenses
+- Price: free vs. undisclosed enterprise-negotiated licensing
 
 **Best for:** Analysts who need multi-domain intelligence, not just social media monitoring.
 
@@ -98,7 +98,7 @@ Let's be direct about what World Monitor is and isn't relative to established pl
 - Interactive visual map interface
 - Local AI processing
 - Real-time conflict and disaster monitoring
-- Price: free vs. enterprise licensing
+- Price: free vs. undisclosed enterprise-negotiated licensing
 
 **Best for:** Analysts who need geopolitical intelligence alongside cyber threat data.
 
@@ -116,7 +116,7 @@ The fundamental difference isn't any single feature. It's that World Monitor fus
 | Natural disasters | No | Custom | Limited | No | USGS + NASA FIRMS + EONET |
 | AI analysis (local) | No | No | No | No | Ollama + LM Studio + browser ML |
 | Prediction markets | No | No | No | No | Polymarket integration |
-| Price | $24K/yr | $1M+ | $100K+ | Enterprise | Free |
+| Price | $24K/yr (Quartz, 2022) | Undisclosed (enterprise-negotiated) | Undisclosed (enterprise-negotiated) | Undisclosed (enterprise-negotiated) | Free |
 | Open source | No | No | No | No | AGPL-3.0 |
 
 No single traditional tool covers all these domains. Analysts typically cobble together 5-6 subscriptions. World Monitor provides integrated coverage across all of them. For a deeper dive into the market intelligence capabilities, see [Real-Time Market Intelligence for Traders](/blog/posts/real-time-market-intelligence-for-traders-and-analysts/).

--- a/scripts/build-comparison-pages.mjs
+++ b/scripts/build-comparison-pages.mjs
@@ -573,7 +573,7 @@ function renderCompareHub({ tpl, baseUrl, lastmod }) {
     cards,
     '      </div>',
     '      <h2>Editorial comparison</h2>',
-    '      <p>The blog post <a href="/blog/posts/worldmonitor-vs-traditional-intelligence-tools/">World Monitor vs Bloomberg, Palantir, Dataminr, and Recorded Future</a> compares enterprise platforms with a full price matrix.</p>',
+    '      <p>The blog post <a href="/blog/posts/worldmonitor-vs-traditional-intelligence-tools/">World Monitor vs Bloomberg, Palantir, Dataminr, and Recorded Future</a> compares their capabilities and distinguishes published prices from enterprise-negotiated licensing.</p>',
     '      <p class="source">Prices and capabilities were checked at publication time and can change.</p>',
   ].join('\n');
   return pageDocument({

--- a/tests/blog-seo-contract.test.mjs
+++ b/tests/blog-seo-contract.test.mjs
@@ -24,6 +24,66 @@ function parsePost(file) {
 
 const posts = postFiles.map(parsePost);
 
+const RESTRICTED_VENDOR_PRICE_ALLOWLIST = new Map();
+const UNSUPPORTED_VENDOR_PRICE_SOURCE = String.raw`(?:\$\s*\d[\d,.]*(?:[KM])?\+?|\b\d[\d,.]*(?:[KM])\b\+?|multi[- ]?million|six[- ]?figures?)`;
+const UNSUPPORTED_VENDOR_PRICE_TERMS = new RegExp(UNSUPPORTED_VENDOR_PRICE_SOURCE, 'i');
+const DISALLOWED_COMPARISON_PRICE_TERMS = /\$1M\+|\$100K\+|multi[- ]?million|six[- ]?figures?/i;
+const RESTRICTED_VENDORS = ['Palantir', 'Dataminr', 'Recorded Future', 'Crisis24', 'Everbridge'];
+
+function markdownTableCells(line) {
+  if (!line.startsWith('|') || !line.endsWith('|')) return [];
+  return line.slice(1, -1).split('|').map((cell) => cell.trim());
+}
+
+function assertNoUnsupportedVendorPrice(post, vendor) {
+  const namedPriceSource = RESTRICTED_VENDOR_PRICE_ALLOWLIST.get(`${post.file}:${vendor}`);
+  if (namedPriceSource) {
+    assert.ok(post.source.includes(namedPriceSource), `${post.file}: ${vendor} allowlist entry must name its price source`);
+    return;
+  }
+
+  const vendorPattern = new RegExp(`\\b${vendor}\\b`, 'i');
+  const directPricePattern = new RegExp(
+    `(?:\\b${vendor}\\b[^\\n.]{0,120}${UNSUPPORTED_VENDOR_PRICE_SOURCE}|${UNSUPPORTED_VENDOR_PRICE_SOURCE}(?:\\s+[\\w/-]+){0,3}\\s+\\b${vendor}\\b)`,
+    'i',
+  );
+  assert.doesNotMatch(
+    post.source,
+    directPricePattern,
+    `${post.file}: ${vendor} pricing needs a named source before publication`,
+  );
+
+  for (const section of post.source.split(/(?=^#{1,6}\\s)/m)) {
+    const heading = section.split('\n', 1)[0];
+    if (vendorPattern.test(heading)) {
+      assert.doesNotMatch(
+        section,
+        UNSUPPORTED_VENDOR_PRICE_TERMS,
+        `${post.file}: ${vendor} pricing needs a named source before publication`,
+      );
+    }
+  }
+
+  const lines = post.source.split('\n');
+  for (let lineIndex = 0; lineIndex < lines.length - 2; lineIndex += 1) {
+    const header = markdownTableCells(lines[lineIndex]);
+    const vendorColumn = header.findIndex((cell) => vendorPattern.test(cell));
+    if (vendorColumn === -1 || !/^\\|(?:\\s*:?-{3,}:?\\s*\\|)+\\s*$/.test(lines[lineIndex + 1])) continue;
+
+    for (let rowIndex = lineIndex + 2; rowIndex < lines.length; rowIndex += 1) {
+      const row = markdownTableCells(lines[rowIndex]);
+      if (!row.length) break;
+      if (/^price$/i.test(row[0])) {
+        assert.doesNotMatch(
+          row[vendorColumn] ?? '',
+          UNSUPPORTED_VENDOR_PRICE_TERMS,
+          `${post.file}: ${vendor} table price needs a named source before publication`,
+        );
+      }
+    }
+  }
+}
+
 describe('blog SEO and GEO corpus contract', () => {
   it('keeps every post complete, unique, current, and answer-first', () => {
     assert.ok(posts.length >= 53, 'expected the complete published blog corpus');
@@ -80,6 +140,40 @@ describe('blog SEO and GEO corpus contract', () => {
       corpus,
       /\b(?:58 map layers|28 languages|29 stock exchanges|14 central banks|63 (?:live )?(?:geopolitical intelligence )?tools)\b/i,
     );
+  });
+
+  it('does not publish unsupported prices for enterprise-negotiated vendors', () => {
+    for (const post of posts) {
+      for (const vendor of RESTRICTED_VENDORS) {
+        assertNoUnsupportedVendorPrice(post, vendor);
+      }
+    }
+
+    for (const source of [
+      '### World Monitor vs. Dataminr\n\n- Price: free vs. six-figure annual licenses',
+      '| Product | Dataminr |\n| --- | --- |\n| Price | $50K |',
+      'A $100K+ Palantir license',
+      'A Palantir license costs 100K+ annually',
+    ]) {
+      assert.throws(
+        () => assertNoUnsupportedVendorPrice({ file: 'price-claim-fixture.md', source }, source.includes('Palantir') ? 'Palantir' : 'Dataminr'),
+        /pricing needs a named source|table price needs a named source/,
+      );
+    }
+
+    const comparison = posts.find((post) => post.file === 'worldmonitor-vs-traditional-intelligence-tools.md');
+    assert.ok(comparison, 'missing the traditional intelligence comparison post');
+    assert.match(
+      comparison.source,
+      /Quartz reported in 2022[^\n]*\$24,000 per year/,
+      'the Bloomberg figure must name its published source and year',
+    );
+    assert.match(
+      comparison.source,
+      /\| Price \| \$24K\/yr \(Quartz, 2022\) \| Undisclosed \(enterprise-negotiated\) \| Undisclosed \(enterprise-negotiated\) \| Undisclosed \(enterprise-negotiated\) \| Free \|/,
+      'the price row must not turn negotiated vendor prices into estimates',
+    );
+    assert.doesNotMatch(comparison.source, DISALLOWED_COMPARISON_PRICE_TERMS);
   });
 
   // The explainer's own contract lives in scripts/docs-stats.mjs — its numeric

--- a/tests/blog-seo-contract.test.mjs
+++ b/tests/blog-seo-contract.test.mjs
@@ -53,7 +53,7 @@ function assertNoUnsupportedVendorPrice(post, vendor) {
     `${post.file}: ${vendor} pricing needs a named source before publication`,
   );
 
-  for (const section of post.source.split(/(?=^#{1,6}\\s)/m)) {
+  for (const section of post.source.split(/(?=^#{1,6}\s)/m)) {
     const heading = section.split('\n', 1)[0];
     if (vendorPattern.test(heading)) {
       assert.doesNotMatch(
@@ -150,7 +150,7 @@ describe('blog SEO and GEO corpus contract', () => {
     }
 
     for (const source of [
-      '### World Monitor vs. Dataminr\n\n- Price: free vs. six-figure annual licenses',
+      '---\ntitle: Pricing fixture\n---\n\nThis preamble is not a vendor heading.\n\n### World Monitor vs. Dataminr\n\n- Price: free vs. six-figure annual licenses',
       '| Product | Dataminr |\n| --- | --- |\n| Price | $50K |',
       'A $100K+ Palantir license',
       'A Palantir license costs 100K+ annually',

--- a/tests/ci-code-path-filter.test.mjs
+++ b/tests/ci-code-path-filter.test.mjs
@@ -61,6 +61,10 @@ describe('#6038 CI code-path filter', () => {
     assert.equal(runFilter(program, ['docs/snapshots/resilience-ranking-2026-10-01.json']), '1');
   });
 
+  it('routes published blog Markdown to the unit job that guards it', () => {
+    assert.equal(runFilter(program, ['blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md']), '1');
+  });
+
   it('still excludes ordinary markdown and docs', () => {
     assert.equal(runFilter(program, ['README.md']), '0');
     assert.equal(runFilter(program, ['docs/about.mdx']), '0');

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -4377,6 +4377,8 @@ describe('crawlable corpus generator', () => {
         assert.match(compareHub, new RegExp('href="' + page.path.replaceAll('/', '/') + '"'));
       }
       assert.match(compareHub, /href="\/blog\/posts\/worldmonitor-vs-traditional-intelligence-tools\/"/);
+      assert.match(compareHub, /distinguishes published prices from enterprise-negotiated licensing/);
+      assert.doesNotMatch(compareHub, /full price matrix/);
       for (const page of COMPARISON_PAGES) {
         const html = read(outDir, 'compare/' + page.slug + '/index.html');
         const ld = jsonLdObjects(html);
@@ -4549,6 +4551,24 @@ describe('crawlable corpus generator', () => {
       // Unnamed third-party enterprise price claims must never be published.
       const dataminrPage = read(outDir, 'compare/worldmonitor-vs-dataminr/index.html');
       const recordedFuturePage = read(outDir, 'compare/worldmonitor-vs-recorded-future/index.html');
+      const enterpriseVendors = ['Dataminr', 'Recorded Future', 'Crisis24', 'Everbridge'];
+      const undisclosedEnterprisePrices = new Set([
+        'Enterprise-negotiated (undisclosed)',
+        'Undisclosed (enterprise-negotiated)',
+      ]);
+      const comparisonHtml = [
+        compareHub,
+        ...COMPARISON_PAGES.map((page) => read(outDir, 'compare/' + page.slug + '/index.html')),
+      ];
+      for (const vendor of enterpriseVendors) {
+        const priceCells = comparisonHtml.flatMap((html) => [
+          ...html.matchAll(new RegExp(`<tr><td>${vendor}(?=\\s|\\(|<)[^<]*</td><td>([^<]*)</td>`, 'g')),
+        ].map((match) => match[1]));
+        assert.ok(priceCells.length > 0, `${vendor} must appear in a generated comparison matrix`);
+        for (const price of priceCells) {
+          assert.ok(undisclosedEnterprisePrices.has(price), `${vendor} must not publish an unsupported price`);
+        }
+      }
       for (const [label, html] of [['dataminr', dataminrPage], ['recorded-future', recordedFuturePage]]) {
         assert.doesNotMatch(html, /six figures|\$100K|\$300K/i, label + ' must omit enterprise figures without a named source');
         assert.match(html, /does not publish list pricing/);


### PR DESCRIPTION
## Summary

Published comparison content no longer presents unsupported Palantir, Dataminr, or Recorded Future prices as facts. Bloomberg keeps the $24,000 annual figure with a named 2022 Quartz source. Enterprise vendors now use `Undisclosed (enterprise-negotiated)`.

The price-policy tests reject direct prose, vendor sections, and Markdown table claims across the blog corpus. They also verify the generated comparison output. The comparison hub no longer promises a full price matrix.

Fixes #7737.

## Validation

- `node --test tests/blog-seo-contract.test.mjs`
- `node --import tsx --test --test-name-pattern='builds a non-trivial static corpus with canonical raw HTML pages' tests/crawlable-corpus.test.mjs`
- `npm run build:blog:raw`
- `npm run typecheck`
- `npm run lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
