### PR TITLE
fix(health): bound pending failures and honor optional sources

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,6 +132,8 @@ The `api/` directory holds two kinds of endpoints, both deployed as Vercel Edge 
 - **Domain intelligence gateways** — generated from proto contracts and backed by handlers under `server/worldmonitor/**`. The per-domain thin entry points (`api/<domain>/v<N>/[rpc].ts`) are produced via `createDomainGateway` (`server/gateway.ts`) and esbuild-bundled, so the *deployed* artifact is self-contained even though the source composes server-side modules.
 - **Operational endpoints** — hand-written for concerns that don't fit the contract model: auth/session, checkout and customer portal, MCP, bootstrap/health, notifications, cache invalidation, and user workflows (e.g. `api/create-checkout.ts`, `api/customer-portal.ts`, `api/mcp.ts`, `api/user-prefs.ts`).
 
+Compact health separates actionable `problems` from bounded `pending` diagnostics. Both retain the source diagnosis. Pending deadlines also bound the Redis verdict cache lifetime.
+
 Edge functions are bundled per file: each deployed function may not pull in unrelated modules at runtime, a constraint enforced by `tests/edge-functions.test.mjs` and the pre-push esbuild bundle check. Hand-written endpoints that genuinely cannot be proto-defined are listed in `api/api-route-exceptions.json` and enforced by `npm run lint:api-contract`.
 
 ### Shared Helpers

--- a/api/health.js
+++ b/api/health.js
@@ -745,7 +745,15 @@ const SEED_META = {
   chinaStockConnect: { key: 'seed-meta:market:china-stock-connect', maxStaleMin: 180 },
   crossStraitActivity: { key: 'seed-meta:military:cross-strait-activity', maxStaleMin: 720 },
   crossStraitActivityBootstrap: { key: 'seed-meta:military:cross-strait-activity-bootstrap', maxStaleMin: 720 },
-  crossStraitActivityTaiwanMnd: { key: 'seed-meta:military:cross-strait-activity:taiwan-mnd', maxStaleMin: 720 },
+  crossStraitActivityTaiwanMnd: {
+    key: 'seed-meta:military:cross-strait-activity:taiwan-mnd',
+    maxStaleMin: 720,
+    sourceFailure: {
+      warnAfterConsecutive: 2,
+      maxPendingMin: 210,
+      failureCodePattern: /^MND_[A-Z0-9_]{1,60}$/,
+    },
+  },
   crossStraitActivityJapanMod:  { key: 'seed-meta:military:cross-strait-activity:japan-mod', maxStaleMin: 720 },
   chinaPolicyEvents: { key: 'seed-meta:china:policy-events', maxStaleMin: 2_160 },
   // decisionGroups (#6060): the seeder's afterPublish diagnostics name which
@@ -866,12 +874,12 @@ const SEED_META = {
   imdCycloneMarine: {
     key: 'seed-meta:weather:imd-cyclone-marine',
     maxStaleMin: 45, // 3× the live */15 Railway cron
-    activationKey: 'seed-activated:weather:imd-cyclone-marine',
+    activationKey: 'seed-activated:weather:imd-cyclone-marine:v2',
     cutover: {
       mode: 'activation-marker',
       fromKey: null,
       issue: 7005,
-      activationKey: 'seed-activated:weather:imd-cyclone-marine',
+      activationKey: 'seed-activated:weather:imd-cyclone-marine:v2',
     },
   },
   canadaRoads:      {
@@ -976,7 +984,7 @@ const SEED_META = {
   },
   torontoTps: {
     key: 'seed-meta:safety:toronto-tps',
-    maxStaleMin: 45, // TPS public map 15–20min; 45 = 3× interval
+    maxStaleMin: 90,
     activationKey: 'seed-activated:safety:toronto-tps',
     cutover: {
       mode: 'activation-marker',
@@ -2193,7 +2201,7 @@ function parseFiniteRecordCount(raw) {
   return null;
 }
 
-function projectSourceFailure(meta, policy) {
+function projectSourceFailure(meta, policy, now, maxStaleMin) {
   if (!policy || meta?.sourceState !== 'degraded') return null;
   const errorCode = typeof meta?.errorCode === 'string'
     && policy.failureCodePattern.test(meta.errorCode)
@@ -2208,14 +2216,29 @@ function projectSourceFailure(meta, policy) {
     && meta.consecutiveSourceFailures >= 1
     ? Math.min(meta.consecutiveSourceFailures, 100)
     : null;
-  const pending = lastSourceFailureCode === errorCode
+  let pending = lastSourceFailureCode === errorCode
     && consecutiveSourceFailures !== null
     && consecutiveSourceFailures < policy.warnAfterConsecutive;
+  let pendingUntil = null;
+  if (policy.maxPendingMin != null) {
+    const first = meta.firstSourceFailureAt;
+    const attempt = meta.lastSourceAttemptAt;
+    const success = meta.fetchedAt;
+    const validEpisode = [first, attempt, success].every((value) => Number.isSafeInteger(value) && value > 0)
+      && success <= first && first <= attempt && attempt <= now;
+    const deadline = validEpisode
+      ? Math.min(first + policy.maxPendingMin * 60_000, success + maxStaleMin * 60_000)
+      : NaN;
+    pending = pending && parseFiniteRecordCount(meta.count ?? meta.recordCount) > 0
+      && Number.isFinite(deadline) && now < deadline;
+    if (pending) pendingUntil = new Date(deadline).toISOString();
+  }
   return {
     errorCode,
     consecutiveSourceFailures,
     lastSourceFailureCode,
     pending,
+    pendingUntil,
   };
 }
 
@@ -2313,7 +2336,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   // transport path is externally blocked. Keep that state visible without
   // treating it as a broken producer that can be repaired by another retry.
   const sourceBlocked = meta?.sourceState === 'blocked';
-  const sourceFailure = projectSourceFailure(meta, seedCfg.sourceFailure);
+  const sourceFailure = projectSourceFailure(meta, seedCfg.sourceFailure, now, seedCfg.maxStaleMin);
   // Source-specific producers can preserve usable last-good records while a
   // current upstream attempt is degraded. Surface that state immediately as a
   // warning without discarding the retained record count from health output.
@@ -2600,11 +2623,9 @@ function classifyKey(name, redisKey, opts, ctx) {
   const rankableRecordCount = name === 'educationAttainment' && Object.hasOwn(ctx, 'educationPayloadRankableCount')
     ? ctx.educationPayloadRankableCount
     : metaRankableCount;
-  // IMD is optional before its first successful publish, but a deployment that
-  // has already activated and then loses its IMD credentials needs operator action.
-  // Do not let the generic unconfigured-source exemption hide that regression.
   const sourceUnavailableAfterActivation = sourceUnavailable
     && name === 'imdCycloneMarine'
+    && errorCode !== 'IMD_API_KEY_MISSING'
     && ctx.activationStates?.get(name) === true;
 
   // Pending activation: the producer has never published a contentFreshness
@@ -2881,7 +2902,12 @@ function classifyKey(name, redisKey, opts, ctx) {
     if (sourceFailure.lastSourceFailureCode) {
       entry.lastSourceFailureCode = sourceFailure.lastSourceFailureCode;
     }
-    if (sourceFailure.pending) entry.sourceFailurePending = true;
+    if (sourceFailure.pendingUntil) {
+      if (status === 'OK' && hasData && records > 0 && metaCount > 0 && seedStale === false) {
+        entry.status = 'SEED_ERROR';
+        entry.sourceFailurePendingUntil = sourceFailure.pendingUntil;
+      }
+    } else if (sourceFailure.pending) entry.sourceFailurePending = true;
   }
   // Coarse producer-run diagnostic, relayed whenever the producer recorded it —
   // the whole point of #6323 is that a coverage shortfall's dominant cause is
@@ -2989,6 +3015,9 @@ const STATUS_COUNTS = {
 };
 
 function healthStatusBucket(entry, now) {
+  if (entry?.status === 'SEED_ERROR'
+    && typeof entry.sourceFailurePendingUntil === 'string'
+    && !isExpiredDeadline(entry.sourceFailurePendingUntil, now)) return 'ok';
   if (
     entry?.status === 'STALE_CONTENT'
     && Object.prototype.hasOwnProperty.call(entry, 'staleContentGraceUntil')
@@ -3204,10 +3233,14 @@ function isProblemStatus(status) {
   return STATUS_COUNTS[status] !== 'ok';
 }
 
+function isPendingHealthEntry(entry, now) {
+  return isProblemStatus(entry?.status) && healthStatusBucket(entry, now) === 'ok';
+}
+
 /**
  * True when a cached verdict still carries a health softening whose published
  * deadline has passed. Reads both snapshot shapes:
- * the full one keyed by `checks`, the compact one by `problems`.
+ * the full one keyed by `checks`, the compact one by `problems` and `pending`.
  */
 function isExpiredDeadline(raw, now) {
   const until = Date.parse(typeof raw === 'string' ? raw : '');
@@ -3229,6 +3262,7 @@ const ENTRY_SOFTENING_DEADLINES = [
   { field: 'rolloutPendingUntil', kind: 'rollout', status: 'ROLLOUT_PENDING' },
   { field: 'contentFreshnessPendingUntil', kind: 'content', status: null },
   { field: 'staleContentGraceUntil', kind: 'content', status: null },
+  { field: 'sourceFailurePendingUntil', kind: 'source', status: 'SEED_ERROR' },
 ];
 
 function entryDeadlineRaw(entry, { field, status }) {
@@ -3236,16 +3270,19 @@ function entryDeadlineRaw(entry, { field, status }) {
   return Object.prototype.hasOwnProperty.call(entry ?? {}, field) ? entry[field] : undefined;
 }
 
+function snapshotCheckEntries(snapshot) {
+  return [snapshot?.checks ?? snapshot?.problems, snapshot?.pending]
+    .filter((entries) => entries && typeof entries === 'object')
+    .flatMap((entries) => Object.values(entries));
+}
+
 function hasExpiredActivationGrace(snapshot, now, { includeRollout = true, includeContent = true } = {}) {
-  const included = { rollout: includeRollout, content: includeContent };
-  const entries = snapshot?.checks ?? snapshot?.problems;
-  if (entries && typeof entries === 'object') {
-    for (const entry of Object.values(entries)) {
-      for (const spec of ENTRY_SOFTENING_DEADLINES) {
-        if (!included[spec.kind]) continue;
-        const raw = entryDeadlineRaw(entry, spec);
-        if (raw !== undefined && isExpiredDeadline(raw, now)) return true;
-      }
+  const included = { rollout: includeRollout, content: includeContent, source: true };
+  for (const entry of snapshotCheckEntries(snapshot)) {
+    for (const spec of ENTRY_SOFTENING_DEADLINES) {
+      if (!included[spec.kind]) continue;
+      const raw = entryDeadlineRaw(entry, spec);
+      if (raw !== undefined && isExpiredDeadline(raw, now)) return true;
     }
   }
   if (includeContent) {
@@ -3272,13 +3309,10 @@ function nearestActivationDeadlineMs(snapshot, now) {
     const deadline = Number.isFinite(parsed) ? parsed : now;
     if (deadline < nearest) nearest = deadline;
   };
-  const entries = snapshot?.checks ?? snapshot?.problems;
-  if (entries && typeof entries === 'object') {
-    for (const entry of Object.values(entries)) {
-      for (const spec of ENTRY_SOFTENING_DEADLINES) {
-        const raw = entryDeadlineRaw(entry, spec);
-        if (raw !== undefined) consider(raw);
-      }
+  for (const entry of snapshotCheckEntries(snapshot)) {
+    for (const spec of ENTRY_SOFTENING_DEADLINES) {
+      const raw = entryDeadlineRaw(entry, spec);
+      if (raw !== undefined) consider(raw);
     }
   }
   const summaryDeadlines = snapshot?.summary?.contentFreshnessPendingUntil;
@@ -3370,13 +3404,8 @@ function healthResponseBody(snapshot, compact) {
     return body;
   }
 
-  // Two shapes reach here. A freshly-swept verdict (and the full cached snapshot)
-  // carries `checks`, so derive `problems` from it. The compact snapshot key stores
-  // `problems` already computed — that is why a browser poll reads ~1 KB instead of
-  // the full 20 KB check map. Passing a compact snapshot back through here is a
-  // no-op, which is what makes buildCompactVerdictSnapshot() below safe.
-  const problems = snapshot.checks
-    ? Object.fromEntries(Object.entries(snapshot.checks).filter(
+  const entries = snapshot.checks
+    ? Object.entries(snapshot.checks).filter(
       ([name, check]) => name !== 'chinaDecisionSignals' && (
         isProblemStatus(check.status)
         || (
@@ -3385,12 +3414,14 @@ function healthResponseBody(snapshot, compact) {
           && check.chinaStatus !== 'healthy'
         )
       ),
-    ))
-    : { ...(snapshot.problems ?? {}) };
+    )
+    : Object.entries({ ...(snapshot.pending ?? {}), ...(snapshot.problems ?? {}) });
+  const evaluatedAt = Date.parse(snapshot.checkedAt);
+  const problems = Object.fromEntries(entries.filter(([, check]) => !isPendingHealthEntry(check, evaluatedAt)));
+  const pending = Object.fromEntries(entries.filter(([, check]) => isPendingHealthEntry(check, evaluatedAt)));
   // Older compact snapshots may predate the operator-only China health
   // projection. Strip it again at the response boundary so a cached value
   // cannot leak source freshness details to anonymous status readers.
-  delete problems.chinaDecisionSignals;
   // Same rule, applied per field rather than per check (#6060): a check's
   // STATUS is public, but its named entities are operator-only. `staleCountries`
   // and the decision-group breakdown identify WHICH source is degraded, which
@@ -3399,19 +3430,23 @@ function healthResponseBody(snapshot, compact) {
   // source is unusable, so it falls under the same rule. Runs on both shapes so
   // a cached compact snapshot written before this rule is scrubbed on the way
   // out too.
-  for (const [name, check] of Object.entries(problems)) {
-    if (check?.contentFreshness === undefined
-      && check?.decisionGroups === undefined
-      && check?.chinaRow === undefined) continue;
-    const {
-      contentFreshness: _detail,
-      decisionGroups: _groups,
-      chinaRow: _chinaRow,
-      ...publicFields
-    } = check;
-    problems[name] = publicFields;
+  for (const collection of [problems, pending]) {
+    delete collection.chinaDecisionSignals;
+    for (const [name, check] of Object.entries(collection)) {
+      if (check?.contentFreshness === undefined
+        && check?.decisionGroups === undefined
+        && check?.chinaRow === undefined) continue;
+      const {
+        contentFreshness: _detail,
+        decisionGroups: _groups,
+        chinaRow: _chinaRow,
+        ...publicFields
+      } = check;
+      collection[name] = publicFields;
+    }
   }
   if (Object.keys(problems).length > 0) body.problems = problems;
+  if (Object.keys(pending).length > 0) body.pending = pending;
   return body;
 }
 
@@ -3757,7 +3792,7 @@ export async function handleHealth(req, ctx, options = {}) {
   };
   const checks = {};
   const contentFreshnessPendingUntil = {};
-  const counts = { ok: 0, warn: 0, onDemandWarn: 0, staleContent: 0, rolloutPending: 0, crit: 0 };
+  const counts = { ok: 0, warn: 0, onDemandWarn: 0, staleContent: 0, rolloutPending: 0, pending: 0, crit: 0 };
   let totalChecks = 0;
 
   const sources = [
@@ -3814,6 +3849,7 @@ export async function handleHealth(req, ctx, options = {}) {
   for (const entry of Object.values(checks)) {
     const bucket = healthStatusBucket(entry, evaluationNow);
     counts[bucket]++;
+    if (isPendingHealthEntry(entry, evaluationNow)) counts.pending++;
     if (entry.status === 'EMPTY_ON_DEMAND') counts.onDemandWarn++;
     // STALE_CONTENT = "seeder is fresh but the upstream DATA stopped advancing"
     // (a frozen feed — see issue #3845). This sub-count stays a plain census of
@@ -3885,6 +3921,7 @@ export async function handleHealth(req, ctx, options = {}) {
       // entry inside its bounded `staleContentGraceUntil` window is counted
       // here while its severity bucket is `ok`, so this can exceed `warn`.
       staleContent: counts.staleContent,
+      ...(counts.pending > 0 ? { pending: counts.pending } : {}),
       // `rolloutPending` is a SUBSET of `warn` (#6059) — a newly deployed
       // schema whose producer has not reached its first scheduled run yet.
       // Bounded: each entry carries a `rolloutPendingUntil` deadline, after

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -15,7 +15,7 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 
 | Parameter | Values | Description |
 |-----------|--------|-------------|
-| `compact` | `1` | Omit per-key details; only return keys with problems. Public — no key required. |
+| `compact` | `1` | Return actionable problems and bounded pending diagnostics. Public, no key required. |
 | `history` | `1` | Operator history view of past health snapshots. Requires an operator/enterprise API key. |
 
 ### Response Status Codes
@@ -57,9 +57,9 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 }
 ```
 
-`summary` fields: `total` is one entry per probed key, and grows as panels are added — read it from your own response rather than from this page. `warn` **excludes** on-demand-empty keys — those are surfaced separately as `onDemandWarn` so they don't drive the overall verdict to `WARNING`. `staleContent` counts all `STALE_CONTENT` diagnostics. It can be greater than `warn` while a source is inside its three-hour `staleContentGraceUntil` window. The source stays visible in `problems`, but it counts in `ok` until that deadline. `rolloutPending` is a **subset** of `warn` (a newly deployed schema still inside its bounded deploy-before-cron window). Only `crit` (`EMPTY`/`EMPTY_DATA`) drives `DEGRADED`/`UNHEALTHY`.
+`summary.total` counts probed keys. `warn` excludes on-demand empty keys, which appear in `onDemandWarn` and do not change the overall verdict. `staleContent` counts all `STALE_CONTENT` diagnostics, including entries inside their finite three-hour grace period. Active grace entries count in `ok` and the optional `pending` sub-count, not `warn`. `rolloutPending` is a subset of `warn`. Only `crit` drives `DEGRADED` or `UNHEALTHY`.
 
-With `?compact=1`, the `checks` object is replaced by `problems` containing only non-OK keys.
+With `?compact=1`, `problems` contains actionable failures and on-demand empty entries. `pending` contains diagnostics inside an active grace period. Empty maps are omitted. Full `checks` retain the same diagnosis and deadline. Cached verdicts expire at these deadlines, and the scheduled monitor rechecks them before suppressing an alert.
 
 ### Bundle tick heartbeats
 
@@ -101,7 +101,7 @@ Keys are grouped into three tiers that determine alert severity:
 | `SOURCE_BLOCKED` | Green | The Japan MOD adapter proved no transport path reaches the publisher while retaining fresh reviewed records — either an upstream HTTP 403 after a successful proxy CONNECT (`HTTP_403`), or a target-scoped proxy CONNECT refusal corroborated by a successful control tunnel (`PROXY_TARGET_FORBIDDEN`). Uncorroborated CONNECT refusals, stale, empty, or unreviewed states still fail closed |
 | `COVERAGE_MARGIN_LOW` | Green | Every configured pool clears its floor, but at least one is within `poolCountMargin` of it (`scorecardFiveFactor`, margin 10). Informational, and deliberately not a warning: this probe's health minimums equal the producer's publication floors, so a passing cohort sitting a few records above the line is the normal steady state. Per-pool headroom is on `poolCoverageMargin` for every status, in the full payload (`?compact=1` omits `checks`); an actual breach is still `COVERAGE_PARTIAL` |
 | `STALE_SEED` | Warn | Data present but `seed-meta` age exceeds `maxStaleMin` |
-| `STALE_CONTENT` | Warn after grace | Seeder is fresh but the upstream content stopped advancing or has no usable timestamp. It is counted in `summary.staleContent` and remains in `problems` during the three-hour grace. `staleContentGraceUntil` gives the deadline. At and after that time, it counts in `summary.warn` as usual. |
+| `STALE_CONTENT` | Warn after grace | Seeder is fresh but the upstream content stopped advancing or has no usable timestamp. During the three-hour grace, it appears in compact `pending` and counts in `summary.staleContent` and `summary.pending`. At `staleContentGraceUntil`, it moves to `problems` and counts in `summary.warn`. |
 | `COVERAGE_PARTIAL` | Warn | Aggregate records or a required subgroup is below the key's declared coverage floor (for example, 139/174 PortWatch countries or an empty prediction-market pool) |
 | `COVERAGE_DEGRADED` | Warn | The producer's own coverage diagnostics are missing, or its completion ratio is below the key's `minSuccessRate` (for example, a consumer-price market that completed 4 of 12 retailer pages) |
 | `ROLLOUT_PENDING` | Warn | A newly deployed schema whose producer has not reached its first scheduled run yet. **Bounded**: the health runtime persists a deployment-relative `rolloutPendingUntil` deadline in Redis, and the state becomes `EMPTY` (crit) once that passes or once the producer writes its durable activation marker. Counted in `summary.rolloutPending` |
@@ -111,7 +111,17 @@ Keys are grouped into three tiers that determine alert severity:
 | `EMPTY` | Crit | Bootstrap or seeded standalone key has no data. Outranks any concurrent producer fault, which would otherwise report the softer `SEED_ERROR` (see below) |
 | `EMPTY_DATA` | Crit | Key exists but contains zero records (and 0 is not a valid state for it) |
 
+### Optional IMD Configuration
+
+IMD is optional when `IMD_API_KEY` is absent, including after intentional removal. Its disabled snapshot reports `NOT_CONFIGURED`, not an all-clear. Invalid configuration after activation and failed requests with credentials remain actionable.
+
+The v2 activation marker requires a successful documented-product response. Valid quiet responses qualify. Total failures and carried-only snapshots do not. The older marker is ignored because failed product batches could write it.
+
 ### Producers That Serve Last-Known-Good
+
+Taiwan MND records failed source attempts in its source metadata. One failed attempt is pending only while positive last-good records remain fresh. The same error on the next distinct attempt warns. The pending deadline is 210 minutes after the first failure, or the last-good freshness deadline if earlier. A different error does not extend that deadline. Health reads do not advance the failure count.
+
+Unknown predecessor state stays actionable until a successful source run establishes a new baseline. Compact health retains the `SEED_ERROR` diagnosis under `pending` with `sourceFailurePendingUntil` until it becomes actionable. Dashboard freshness badges retain the diagnosis and data age from both compact maps. Pending does not mean newly published data.
 
 Some producers are expected to miss individual runs — an LLM synthesis stage
 whose provider times out, for example — while the payload they last published
@@ -510,6 +520,7 @@ Selected thresholds from `SEED_META`:
 | Market quotes, crypto, sectors, earthquakes, insights | 30 | High-frequency relay loops / critical event data |
 | Military flights | 30 | Near-real-time tracking |
 | Predictions, flight delays (FAA) | 90 | Polymarket / airport snapshots |
+| Toronto TPS live calls | 90 | 30-minute bundle member, 90-minute seed and content budgets, three-hour cache lifetime |
 | Unrest | 120 | 45min cron, 2h grace |
 | Cyber threats | 240 | APT data updated less frequently |
 | Wildfires | 360 | FIRMS NRT accumulates over hours |

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -15,6 +15,16 @@ export function validateCompactHealthPayload(payload) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
     throw new Error('Compact health payload must be an object');
   }
+  if (Object.hasOwn(payload, 'pending')) {
+    if (!payload.pending || typeof payload.pending !== 'object' || Array.isArray(payload.pending)) {
+      throw new Error('Compact health pending must be an object');
+    }
+    for (const entry of Object.values(payload.pending)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new Error('Compact health pending entries must be objects');
+      }
+    }
+  }
   // Compact health omits `problems` entirely when every check is healthy.
   if (payload.problems == null && payload.status === 'HEALTHY') return payload;
   if (!payload.problems || typeof payload.problems !== 'object' || Array.isArray(payload.problems)) {
@@ -80,7 +90,7 @@ export const STALE_CONTENT_GRACE_SKEW_SLACK_MS = 5 * 60 * 1000;
 export const MAX_STALE_CONTENT_GRACE_MS = 3 * 60 * 60 * 1000 + STALE_CONTENT_GRACE_SKEW_SLACK_MS;
 
 function hasActiveBoundedDeadline(raw, now, maxWindowMs) {
-  const until = Date.parse(raw ?? '');
+  const until = Date.parse(typeof raw === 'string' ? raw : '');
   if (!Number.isFinite(until)) return false;
   if (until - now > maxWindowMs) return false;
   return now < until;
@@ -100,32 +110,39 @@ export function isStaleContentGraceProblem(problem, now = Date.now()) {
   );
 }
 
-/**
- * Sources that are diagnosed STALE_CONTENT but still inside their bounded grace.
- *
- * These are deliberately NOT operational failures yet — that is the whole point
- * of the grace — but filtering them out of the run entirely would make a green
- * report indistinguishable from one where nothing is wrong at all. Surfacing
- * them separately keeps "three feeds are mid-grace, alerting at 14:05Z" visible
- * to whoever reads the run.
- */
-export function findGracedStaleContent(payload, now = Date.now()) {
-  return Object.entries(payload.problems ?? {})
-    .filter(([, problem]) => isStaleContentGraceProblem(problem, now))
+export function isSourceFailurePendingProblem(problem, now = Date.now()) {
+  return problem?.status === 'SEED_ERROR'
+    && Number.isFinite(problem.records) && problem.records > 0
+    && Number.isFinite(problem.seedAgeMin) && problem.seedAgeMin >= 0
+    && Number.isFinite(problem.maxStaleMin) && problem.seedAgeMin <= problem.maxStaleMin
+    && problem.consecutiveSourceFailures === 1
+    && typeof problem.errorCode === 'string' && /^MND_[A-Z0-9_]{1,60}$/.test(problem.errorCode)
+    && problem.errorCode === problem.lastSourceFailureCode
+    && hasActiveBoundedDeadline(problem.sourceFailurePendingUntil, now, 215 * 60_000);
+}
+
+export function findPendingDiagnostics(payload, now = Date.now()) {
+  return compactHealthEntries(payload)
+    .filter(([, problem]) => isStaleContentGraceProblem(problem, now) || isSourceFailurePendingProblem(problem, now))
     .map(([name, problem]) => ({
       name,
       status: problem?.status ?? 'UNKNOWN',
-      graceUntil: problem?.staleContentGraceUntil ?? null,
+      graceUntil: problem?.staleContentGraceUntil ?? problem?.sourceFailurePendingUntil ?? null,
     }));
 }
 
-export function findOperationalProblems(payload, now = Date.now()) {
+function compactHealthEntries(payload) {
   validateCompactHealthPayload(payload);
-  return Object.entries(payload.problems ?? {})
+  return Object.entries({ ...(payload.pending ?? {}), ...(payload.problems ?? {}) });
+}
+
+export function findOperationalProblems(payload, now = Date.now()) {
+  return compactHealthEntries(payload)
     .filter(([, problem]) => (
       !isOnDemandProblem(problem)
       && !isRolloutPendingProblem(problem, now)
       && !isStaleContentGraceProblem(problem, now)
+      && !isSourceFailurePendingProblem(problem, now)
     ))
     .map(([name, problem]) => ({
       name,
@@ -458,7 +475,7 @@ export function buildAcceptanceObservation(payload, baseline, now = Date.now()) 
     version: 1,
     checkedAt,
     acceptance,
-    graced: findGracedStaleContent(payload, now),
+    graced: findPendingDiagnostics(payload, now),
     report: formatAcceptanceReport(acceptance, checkedAt),
   };
 }

--- a/scripts/lib/imd-cyclone-marine.mjs
+++ b/scripts/lib/imd-cyclone-marine.mjs
@@ -1097,6 +1097,18 @@ export function declareImdRecords(data) {
     + (data.coastalBulletins?.length || 0);
 }
 
+/**
+ * Activation proves this IMD deployment has received at least one documented
+ * product response. A valid empty/NIL response counts; carried last-good data,
+ * disabled products, and a total auth/product failure do not.
+ */
+export function shouldActivateImdSnapshot(data) {
+  return IMD_PRODUCT_IDS.some((id) => (
+    IMD_PRODUCTS[id].schema === 'documented'
+    && data?.products?.[id]?.status === 'ok'
+  ));
+}
+
 export function imdContentMeta(data, nowMs = Date.now()) {
   const stamps = [];
   const bags = [

--- a/scripts/lib/toronto-official-cad.mjs
+++ b/scripts/lib/toronto-official-cad.mjs
@@ -33,8 +33,8 @@ export const TPS_METADATA_URL = `${TPS_LAYER_URL}?f=pjson`;
 export const TPS_QUERY_URL = 'https://services.arcgis.com/S9th0jAJ7bqgIRjw/arcgis/rest/services/C4S_Public_NoGO/FeatureServer/0/query';
 export const TPS_SOURCE = 'toronto-tps';
 export const TPS_KEY = 'safety:toronto-tps:v1';
-export const TPS_MAX_STALE_MIN = 45;
-export const TPS_TTL_SECONDS = 5400;
+export const TPS_MAX_STALE_MIN = 90;
+export const TPS_TTL_SECONDS = 10800;
 export const TPS_SOURCE_VERSION = 'toronto-tps-c4s-v1';
 
 export const TORONTO_CAD_JURISDICTION = 'Toronto';

--- a/scripts/seed-bundle-canada.mjs
+++ b/scripts/seed-bundle-canada.mjs
@@ -71,8 +71,8 @@ const CANADA_SECTIONS = [
   // after the first successful canonical publish.
   { label: 'Toronto-TFS', script: 'seed-toronto-tfs.mjs', seedMetaKey: 'seed-meta:safety:toronto-tfs', canonicalKey: 'safety:toronto-tfs:v1', completionMetaKey: 'seed-completion:safety:toronto-tfs', intervalMs: 5 * MIN, timeoutMs: 60_000 },
   // Official TPS C4S_Public_NoGO FeatureServer. Own key; privacy exclusions
-  // stay empty. 15min matches the 15–20min map refresh; stale at 45min.
-  { label: 'Toronto-TPS', script: 'seed-toronto-tps.mjs', seedMetaKey: 'seed-meta:safety:toronto-tps', canonicalKey: 'safety:toronto-tps:v1', completionMetaKey: 'seed-completion:safety:toronto-tps', intervalMs: 15 * MIN, timeoutMs: 105_000 },
+  // stay empty.
+  { label: 'Toronto-TPS', script: 'seed-toronto-tps.mjs', seedMetaKey: 'seed-meta:safety:toronto-tps', canonicalKey: 'safety:toronto-tps:v1', completionMetaKey: 'seed-completion:safety:toronto-tps', intervalMs: 30 * MIN, timeoutMs: 105_000 },
   // TPS Open Data (#7012/#7036) — the retrospective MCI and annual Calls
   // Attended datasets, distinct from the live C4S CAD member above.
   //

--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -134,13 +134,107 @@ function sourceRecordCount(snapshot, sourceId) {
   return (snapshot?.observations ?? []).filter((row) => row?.sourceId === sourceId).length;
 }
 
-export async function writeSourceHealth(snapshot, writer = writeExtraKey) {
+const MND_SOURCE_FAILURE_CODE = /^MND_[A-Z0-9_]{1,60}$/;
+
+function positiveTimestamp(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function sourceAttemptMeta(previous, source, attemptedAt) {
+  const errorCode = typeof source?.errorCodes?.[0] === 'string'
+    && MND_SOURCE_FAILURE_CODE.test(source.errorCodes[0])
+    ? source.errorCodes[0]
+    : 'MND_SOURCE_ERROR';
+  const priorAttemptAt = previous?.lastSourceAttemptAt ?? previous?.fetchedAt;
+  const ordered = positiveTimestamp(attemptedAt)
+    && positiveTimestamp(priorAttemptAt)
+    && attemptedAt > priorAttemptAt;
+  const reset = {
+    firstSourceFailureAt: null,
+    lastSourceAttemptAt: positiveTimestamp(attemptedAt) ? attemptedAt : 0,
+    lastSourceFailureCode: null,
+    consecutiveSourceFailures: 0,
+  };
+  const currentSuccess = source?.transportStatus === 'fresh'
+    && positiveTimestamp(attemptedAt)
+    && Date.parse(source.lastSuccessAt ?? '') === attemptedAt;
+  if (currentSuccess && (
+    !positiveTimestamp(priorAttemptAt)
+    || ordered
+    || (attemptedAt === priorAttemptAt && previous?.sourceState === 'ok')
+  )) return reset;
+
+  const actionable = {
+    errorCode,
+    ...reset,
+    lastSourceAttemptAt: Math.max(reset.lastSourceAttemptAt, positiveTimestamp(priorAttemptAt) ? priorAttemptAt : 0),
+    lastSourceFailureCode: errorCode,
+    consecutiveSourceFailures: 2,
+  };
+  if (source?.transportStatus === 'fresh') return actionable;
+  const priorSuccess = previous?.sourceState === 'ok'
+    && previous?.stale === false
+    && positiveTimestamp(previous?.fetchedAt)
+    && previous.fetchedAt <= priorAttemptAt
+    && Number.isInteger(previous?.recordCount) && previous.recordCount > 0
+    && (Object.keys(reset).every((field) => !Object.hasOwn(previous, field)) || (
+      previous.consecutiveSourceFailures === 0
+      && previous.firstSourceFailureAt === null
+      && previous.lastSourceFailureCode === null
+      && previous.lastSourceAttemptAt === previous.fetchedAt
+    ));
+  if (ordered && priorSuccess) {
+    return { ...actionable, consecutiveSourceFailures: 1, firstSourceFailureAt: attemptedAt };
+  }
+  const priorFailure = previous?.sourceState === 'degraded'
+    && previous?.stale === true
+    && positiveTimestamp(previous?.firstSourceFailureAt)
+    && positiveTimestamp(previous?.lastSourceAttemptAt)
+    && previous.firstSourceFailureAt <= priorAttemptAt
+    && positiveTimestamp(previous?.fetchedAt)
+    && previous.fetchedAt <= previous.firstSourceFailureAt
+    && Number.isInteger(previous?.recordCount) && previous.recordCount > 0
+    && MND_SOURCE_FAILURE_CODE.test(previous?.errorCode ?? '')
+    && previous.errorCode === previous.lastSourceFailureCode
+    && Number.isInteger(previous.consecutiveSourceFailures)
+    && previous.consecutiveSourceFailures >= 1 && previous.consecutiveSourceFailures <= 100;
+  if (!priorFailure) return actionable;
+  const sameCode = previous.lastSourceFailureCode === errorCode;
+  if (attemptedAt === priorAttemptAt && sameCode) {
+    return {
+      ...actionable,
+      consecutiveSourceFailures: previous.consecutiveSourceFailures,
+      firstSourceFailureAt: previous.firstSourceFailureAt,
+    };
+  }
+  if (!ordered) return actionable;
+  return {
+    ...actionable,
+    consecutiveSourceFailures: sameCode ? Math.min(previous.consecutiveSourceFailures + 1, 100) : 1,
+    firstSourceFailureAt: previous.firstSourceFailureAt,
+  };
+}
+
+export async function writeSourceHealth(snapshot, writer = writeExtraKey, reader = readSeedSnapshot) {
   const outcomes = await Promise.allSettled((snapshot?.sources ?? []).map(async (source) => {
-    const healthy = source?.transportStatus === 'fresh';
-    const blocked = CROSS_STRAIT_BLOCKED_SOURCE_REASONS.includes(source?.blockedReason);
+    let healthy = source?.transportStatus === 'fresh';
+    const blocked = source.id !== 'taiwan-mnd'
+      && CROSS_STRAIT_BLOCKED_SOURCE_REASONS.includes(source?.blockedReason);
     const fetchedAt = Date.parse(
       blocked ? snapshot?.generatedAt ?? '' : source?.lastSuccessAt ?? '',
     );
+    let attemptMeta = {};
+    if (source.id === 'taiwan-mnd') {
+      let previous = null;
+      try {
+        previous = await reader(sourceHealthMetaKey(source.id), { strict: true });
+      } catch {
+        previous = null;
+      }
+      const attemptedAt = Date.parse(snapshot?.generatedAt ?? '');
+      attemptMeta = sourceAttemptMeta(previous, source, attemptedAt);
+      healthy = healthy && attemptMeta.consecutiveSourceFailures === 0;
+    }
     const metaTtlSeconds = healthy || blocked
       ? CROSS_STRAIT_ACTIVITY_TTL_SECONDS
       : CROSS_STRAIT_ACTIVITY_SOURCE_FAILURE_TTL_SECONDS;
@@ -152,8 +246,9 @@ export async function writeSourceHealth(snapshot, writer = writeExtraKey) {
     const writeMeta = () => writer(sourceHealthMetaKey(source.id), {
       fetchedAt: Number.isFinite(fetchedAt) ? fetchedAt : 0,
       recordCount: sourceRecordCount(snapshot, source.id),
-      sourceState: healthy ? 'ok' : (blocked ? 'blocked' : 'error'),
+      sourceState: healthy ? 'ok' : (source.id === 'taiwan-mnd' ? 'degraded' : (blocked ? 'blocked' : 'error')),
       stale: !healthy && !blocked,
+      ...attemptMeta,
     }, metaTtlSeconds);
 
     // Never leave health claiming success when an error detail write fails.

--- a/scripts/seed-imd-cyclone-marine.mjs
+++ b/scripts/seed-imd-cyclone-marine.mjs
@@ -16,18 +16,19 @@ import {
   fetchImdCycloneMarine,
   imdAfterPublish,
   imdContentMeta,
+  shouldActivateImdSnapshot,
   validateImdEnvelope,
 } from './lib/imd-cyclone-marine.mjs';
 
 loadEnvFile(import.meta.url);
 
-export const IMD_ACTIVATION_KEY = 'seed-activated:weather:imd-cyclone-marine';
+export const IMD_ACTIVATION_KEY = 'seed-activated:weather:imd-cyclone-marine:v2';
 
 const CACHE_TTL = 5400;
 
 async function markImdActivated(data) {
   const result = imdAfterPublish(data);
-  if (data?.coverageState === 'disabled') return result;
+  if (!shouldActivateImdSnapshot(data)) return result;
   try {
     const creds = getOptionalUpstashCreds();
     if (!creds) return result;

--- a/scripts/seed-toronto-tps.mjs
+++ b/scripts/seed-toronto-tps.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Official Toronto Police Service Calls for Service public map (#6682).
-// Member of seed-bundle-canada, gated on intervalMs 15min (layer refresh
-// 15–20 min). Own key — do not append to canadaAlerts / canadaRoads /
+// Member of seed-bundle-canada, gated on intervalMs 30min with a 90min
+// freshness budget. Own key — do not append to canadaAlerts / canadaRoads /
 // torontoRoads. Privacy exclusions stay empty; do not fill from radio/news.
 // Last-good is this seeder's runSeed path; a TFS failure cannot wipe it.
 

--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -20,13 +20,14 @@ interface HealthResponse {
   status?: string;
   checkedAt?: string;
   checks?: Record<string, HealthCheck>;
+  pending?: Record<string, HealthCheck>;
   problems?: Record<string, HealthCheck>;
 }
 
 // Detailed /api/health (full `checks`) is operator/enterprise-key-gated since
 // #4715 — an anonymous dashboard calling it 401s on every tick (#4902). The
-// compact variant is keyless: same per-check shape, but only non-OK entries
-// land in `problems` and healthy checks are omitted entirely.
+// compact variant is keyless: non-OK entries use the same per-check shape in
+// `problems` or `pending` during finite grace; healthy checks are omitted.
 const PUBLIC_HEALTH_ENDPOINT = '/api/health?compact=1';
 
 // One 401/403 per window is enough signal that the endpoint got (re-)gated;
@@ -143,7 +144,10 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
   const checkedAtMs = payload.checkedAt ? Date.parse(payload.checkedAt) : Date.now();
   const checkedAt = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
   const updatesBySource = new Map<DataSourceId, SeedHealthUpdate>();
-  const checks: Record<string, HealthCheck> = payload.checks ?? { ...(payload.problems ?? {}) };
+  const checks: Record<string, HealthCheck> = payload.checks ?? {
+    ...(payload.pending ?? {}),
+    ...(payload.problems ?? {}),
+  };
 
   if (Object.keys(checks).length === 0 && isRedisOutageStatus(payload.status)) {
     const status = payload.status;
@@ -157,8 +161,8 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
     return updates.length;
   }
 
-  // Compact responses omit healthy checks (only non-OK entries land in
-  // `problems`), so a mapped check that is absent was evaluated server-side
+  // Compact responses omit healthy checks (non-OK entries land in `problems`
+  // or `pending`), so a mapped check absent from both was evaluated server-side
   // and found within budget. Synthesize OK-as-of-checkedAt for those:
   // seedAgeMin 0 is required because recordSeedHealth keeps lastUpdate null
   // on an age-less update and calculateStatus then reports no_data.

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -145,7 +145,7 @@ test('cross-Strait bootstrap is a bounded current projection, not the durable re
   );
 });
 
-test('cross-Strait source transport health degrades immediately without discarding last-good records', () => {
+test('legacy cross-Strait source errors stay actionable without discarding last-good records', () => {
   const { classifyKey, SEED_META, STANDALONE_KEYS } = __testing__;
   const now = Date.parse('2026-07-25T12:00:00.000Z');
   for (const name of ['crossStraitActivityTaiwanMnd', 'crossStraitActivityJapanMod']) {
@@ -167,6 +167,151 @@ test('cross-Strait source transport health degrades immediately without discardi
     assert.equal(entry.status, 'SEED_ERROR', name);
     assert.equal(entry.records, 91, name);
   }
+});
+
+test('MND metadata counts completed source attempts independently of canonical publication', async () => {
+  const { classifyKey, healthStatusBucket, SEED_META, STANDALONE_KEYS } = __testing__;
+  const name = 'crossStraitActivityTaiwanMnd';
+  const metaKey = SEED_META[name].key;
+  const dataKey = STANDALONE_KEYS[name];
+  const start = Date.parse('2026-09-05T12:00:00.000Z');
+  const minute = 60_000;
+  const stored = new Map<string, Record<string, unknown>>();
+  const reads: string[] = [];
+  const write = async (key: string, value: Record<string, unknown>) => { stored.set(key, value); };
+  const reader = async (key: string, options: { strict: boolean }) => {
+    reads.push(key);
+    assert.equal(options.strict, true);
+    return stored.get(key) ?? null;
+  };
+  const publish = async (attemptAt: number, errorCode: string | null, lastSuccessAt = start) => {
+    await writeSourceHealth({
+      generatedAt: new Date(attemptAt).toISOString(),
+      observations: [{ sourceId: 'taiwan-mnd' }],
+      sources: [{
+        id: 'taiwan-mnd',
+        transportStatus: errorCode ? 'error' : 'fresh',
+        errorCodes: errorCode ? [errorCode] : [],
+        lastSuccessAt: new Date(lastSuccessAt).toISOString(),
+      }],
+    }, write, reader);
+    const meta = stored.get(metaKey);
+    assert.ok(meta);
+    return meta;
+  };
+  const classify = (meta: Record<string, unknown>, now: number) => classifyKey(name, dataKey, { allowOnDemand: true }, {
+    keyStrens: new Map([[dataKey, 1024]]),
+    keyErrors: new Map(),
+    keyMetaValues: new Map([[metaKey, JSON.stringify(meta)]]),
+    keyMetaErrors: new Map(),
+    now,
+  });
+  const success = await publish(start, null);
+  assert.equal(success.sourceState, 'ok');
+  assert.equal(success.consecutiveSourceFailures, 0);
+  assert.equal(success.firstSourceFailureAt, null);
+
+  const first = await publish(start + minute, 'MND_HTTP_503');
+  assert.deepEqual(first, {
+    fetchedAt: start,
+    recordCount: 1,
+    sourceState: 'degraded',
+    stale: true,
+    errorCode: 'MND_HTTP_503',
+    lastSourceFailureCode: 'MND_HTTP_503',
+    consecutiveSourceFailures: 1,
+    lastSourceAttemptAt: start + minute,
+    firstSourceFailureAt: start + minute,
+  });
+  assert.deepEqual(await publish(start + minute, 'MND_HTTP_503'), first, 'duplicate source write is not another attempt');
+  const firstEntry = classify(first, start + minute);
+  assert.equal(firstEntry.status, 'SEED_ERROR', 'raw source failure remains visible');
+  assert.equal(healthStatusBucket(firstEntry, start + minute), 'ok');
+  assert.equal(Date.parse(firstEntry.sourceFailurePendingUntil), start + 211 * minute);
+  assert.equal(healthStatusBucket(classify(first, start + 211 * minute), start + 211 * minute), 'warn');
+
+  const second = await publish(start + 181 * minute, 'MND_HTTP_503');
+  assert.equal(second.consecutiveSourceFailures, 2);
+  assert.equal(second.firstSourceFailureAt, first.firstSourceFailureAt);
+  assert.equal(healthStatusBucket(classify(second, start + 181 * minute), start + 181 * minute), 'warn');
+  const changed = await publish(start + 182 * minute, 'MND_PUBLICATION_METADATA_MISSING');
+  assert.equal(changed.consecutiveSourceFailures, 1);
+  assert.equal(changed.firstSourceFailureAt, first.firstSourceFailureAt, 'cause churn keeps the episode deadline');
+
+  const recovered = await publish(start + 183 * minute, null, start + 183 * minute);
+  assert.equal(recovered.consecutiveSourceFailures, 0);
+  assert.equal(recovered.firstSourceFailureAt, null);
+  assert.equal(recovered.lastSourceFailureCode, null);
+  assert.equal(classify(recovered, start + 183 * minute).status, 'OK');
+  const afterCanonicalFailure = await publish(start + 184 * minute, 'MND_HTTP_503', start);
+  assert.equal(afterCanonicalFailure.fetchedAt, start, 'retained record freshness follows the served archive, not an unpublished successful fetch');
+  assert.equal(afterCanonicalFailure.firstSourceFailureAt, start + 184 * minute);
+  assert.ok(reads.every(key => key === metaKey), 'history reads use source metadata, not the canonical archive');
+});
+
+test('MND attempt metadata fails closed for unproved history and failed source writes', async () => {
+  const now = Date.parse('2026-09-05T12:00:00.000Z');
+  const metaKey = 'seed-meta:military:cross-strait-activity:taiwan-mnd';
+  const dataKey = 'military:cross-strait-activity:v1:source:taiwan-mnd';
+  const success = { fetchedAt: now - 60_000, recordCount: 1, sourceState: 'ok', stale: false };
+  const first = {
+    ...success, sourceState: 'degraded', stale: true, errorCode: 'MND_HTTP_503',
+    lastSourceFailureCode: 'MND_HTTP_503', consecutiveSourceFailures: 1,
+    firstSourceFailureAt: now, lastSourceAttemptAt: now,
+  };
+  const snapshot = {
+    generatedAt: new Date(now).toISOString(),
+    observations: [{ sourceId: 'taiwan-mnd' }],
+    sources: [{ id: 'taiwan-mnd', transportStatus: 'error', errorCodes: ['MND_HTTP_502'], lastSuccessAt: new Date(now - 60_000).toISOString() }],
+  };
+  for (const previous of [
+    null, [], 'bad-json', { ...success, sourceState: 'error' },
+    { ...success, lastSourceFailureCode: 'MND_HTTP_503' },
+    { ...success, lastSourceAttemptAt: now - 60_000, consecutiveSourceFailures: 0 },
+    { ...first, firstSourceFailureAt: null },
+    { ...first, lastSourceAttemptAt: now + 60_000 },
+    first,
+  ]) {
+    const writes = new Map<string, Record<string, unknown>>();
+    await writeSourceHealth(snapshot, async (key: string, value: Record<string, unknown>) => { writes.set(key, value); }, async () => previous);
+    const meta = writes.get(metaKey);
+    assert.ok(meta);
+    assert.equal(meta.sourceState, 'degraded');
+    assert.equal(meta.consecutiveSourceFailures, 2, 'unproved or contradictory attempts cannot get pending');
+    assert.equal(meta.firstSourceFailureAt, null);
+    assert.deepEqual([...writes.keys()], [metaKey, dataKey]);
+  }
+  const writes = new Map<string, Record<string, unknown>>();
+  await writeSourceHealth(snapshot, async (key: string, value: Record<string, unknown>) => { writes.set(key, value); }, async () => { throw new Error('read failed'); });
+  assert.equal(writes.get(metaKey)?.consecutiveSourceFailures, 2, 'read failure still publishes actionable diagnostics');
+  await assert.rejects(writeSourceHealth(snapshot, async (key: string, value: Record<string, unknown>) => {
+    writes.set(key, value);
+    if (key === dataKey) throw new Error('detail write failed');
+  }, async () => success), /detail write failed/);
+  const persisted = writes.get(metaKey);
+  assert.ok(persisted);
+  assert.equal(persisted.consecutiveSourceFailures, 1);
+  await writeSourceHealth(snapshot, async (key: string, value: Record<string, unknown>) => { writes.set(key, value); }, async () => persisted);
+  assert.deepEqual(writes.get(metaKey), persisted, 'retry after failed detail write keeps the same attempt');
+
+  for (const code of ['HTTP_503', 'MND_bad', 'MND_' + 'A'.repeat(61), '<secret>', ['MND_HTTP_503']]) {
+    await writeSourceHealth({ ...snapshot, sources: [{ ...snapshot.sources[0], errorCodes: [code] }] },
+      async (key: string, value: Record<string, unknown>) => { writes.set(key, value); }, async () => success);
+    assert.equal(writes.get(metaKey)?.errorCode, 'MND_SOURCE_ERROR');
+  }
+  for (const attemptedAt of [now - 1, now]) {
+    await writeSourceHealth({
+      ...snapshot,
+      generatedAt: new Date(attemptedAt).toISOString(),
+      sources: [{ ...snapshot.sources[0], transportStatus: 'fresh', errorCodes: [], lastSuccessAt: new Date(attemptedAt).toISOString() }],
+    }, async (key: string, value: Record<string, unknown>) => { writes.set(key, value); }, async () => first);
+    assert.equal(writes.get(metaKey)?.sourceState, 'degraded', 'an older or contradictory success cannot reset an episode');
+    assert.equal(writes.get(metaKey)?.firstSourceFailureAt, null);
+  }
+  await writeSourceHealth({ ...snapshot, generatedAt: new Date(now + 1).toISOString() },
+    async (key: string, value: Record<string, unknown>) => { writes.set(key, value); },
+    async () => ({ ...first, errorCode: 'MND_HTTP_502', lastSourceFailureCode: 'MND_HTTP_502', consecutiveSourceFailures: 100 }));
+  assert.equal(writes.get(metaKey)?.consecutiveSourceFailures, 100, 'attempt counter is bounded');
 });
 
 test('a freshly classified blocked source is explicit and does not pin fleet health', async () => {
@@ -607,7 +752,7 @@ test('degraded cross-Strait source health publishes the error metadata before it
     }],
   };
   const writes: string[] = [];
-  await writeSourceHealth(snapshot, async (key: string) => { writes.push(key); });
+  await writeSourceHealth(snapshot, async (key: string) => { writes.push(key); }, async () => null);
 
   assert.deepEqual(writes, [
     'seed-meta:military:cross-strait-activity:taiwan-mnd',
@@ -655,6 +800,7 @@ test('degraded cross-Strait source health bounds the error marker TTL', async ()
 
 test('healthy cross-Strait source health retains the archive TTL', async () => {
   const snapshot = {
+    generatedAt: '2026-07-25T08:00:00.000Z',
     observations: [{ sourceId: 'taiwan-mnd' }],
     sources: [{
       id: 'taiwan-mnd',
@@ -665,7 +811,7 @@ test('healthy cross-Strait source health retains the archive TTL', async () => {
   const writes: Array<{ key: string; ttl: number }> = [];
   await writeSourceHealth(snapshot, async (key: string, _value: object, ttl: number) => {
     writes.push({ key, ttl });
-  });
+  }, async () => null);
 
   assert.deepEqual(writes, [
     {
@@ -685,6 +831,7 @@ test('cross-Strait publish hooks ignore runSeed metadata instead of treating it 
   const originalRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
   const writes: string[] = [];
   const snapshot = {
+    generatedAt: '2026-07-25T08:00:00.000Z',
     observations: [{ sourceId: 'taiwan-mnd' }, { sourceId: 'japan-mod' }],
     sources: [
       { id: 'taiwan-mnd', transportStatus: 'fresh', lastSuccessAt: '2026-07-25T08:00:00.000Z' },
@@ -733,6 +880,7 @@ test('cross-Strait source-health failure settles every write before canonical pu
   let canonicalFetches = 0;
   const writes: string[] = [];
   const snapshot = {
+    generatedAt: '2026-07-25T08:00:00.000Z',
     observations: [{ sourceId: 'taiwan-mnd' }, { sourceId: 'japan-mod' }],
     sources: [
       { id: 'taiwan-mnd', transportStatus: 'fresh', lastSuccessAt: '2026-07-25T08:00:00.000Z' },
@@ -761,7 +909,7 @@ test('cross-Strait source-health failure settles every write before canonical pu
           if (key === 'seed-meta:military:cross-strait-activity:japan-mod') {
             throw new Error('injected source-health failure');
           }
-        }),
+        }, async () => null),
       },
     ).then(
       () => ({ error: null }),
@@ -793,6 +941,7 @@ test('runSeed forwards cross-Strait source health through the pre-publication bo
   const originalSigtermListeners = new Set(process.rawListeners('SIGTERM'));
   const redisCommands: unknown[][] = [];
   const snapshot = {
+    generatedAt: '2026-07-25T08:00:00.000Z',
     observations: [{ sourceId: 'taiwan-mnd' }],
     sources: [{
       id: 'taiwan-mnd',
@@ -824,7 +973,7 @@ test('runSeed forwards cross-Strait source health through the pre-publication bo
           maxStaleMin: 120,
           beforePublish: data => writeSourceHealth(data, async () => {
             throw new Error('injected source-health failure');
-          }),
+          }, async () => null),
         },
       ),
       /injected source-health failure/,

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1449,7 +1449,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     const healthWrites = new Map<string, unknown>();
     await writeSourceHealth(snapshot, async (key: string, value: unknown) => {
       healthWrites.set(key, value);
-    });
+    }, async () => null);
 
     assert.ok(snapshot.observations.length >= 3);
     assert.equal(validateCrossStraitActivitySnapshot(snapshot), true);
@@ -1464,6 +1464,10 @@ describe('quantified cross-Strait activity (#5575)', () => {
         ).length,
         sourceState: 'ok',
         stale: false,
+        firstSourceFailureAt: null,
+        lastSourceAttemptAt: Date.parse(retrievedAt),
+        lastSourceFailureCode: null,
+        consecutiveSourceFailures: 0,
       },
     );
     assert.ok(

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -354,17 +354,87 @@ describe('health freshness ingestion', () => {
     assert.equal(gdelt?.healthStatus, 'STALE_SEED');
     assert.equal(gdelt?.itemCount, 6);
 
-    // weather maps from weatherAlerts, which is absent from `problems` — the
-    // server evaluated it and found it within budget. It must read fresh as of
-    // checkedAt, NOT no_data (a bare OK with no age would leave lastUpdate
-    // null and calculateStatus reports no_data).
     const weather = dataFreshness.getSource('weather');
     assert.equal(weather?.status, 'fresh');
     assert.equal(weather?.healthStatus, 'OK');
     assert.equal(weather?.lastUpdate?.toISOString(), new Date(checkedAtMs).toISOString());
   });
 
-  it('marks all mapped sources healthy on a compact payload with no problems key', async () => {
+  it('preserves stale content and its vintage from a pending-only compact payload', async () => {
+    __resetHealthFreshnessForTests();
+    const checkedAtMs = Date.now();
+    await refreshDataFreshnessFromHealth({
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        status: 'HEALTHY',
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        pending: {
+          blsSeries: {
+            status: 'STALE_CONTENT', records: 9,
+            seedAgeMin: 1, maxStaleMin: 360,
+            contentAgeMin: 90, maxContentAgeMin: 60,
+          },
+        },
+      }),
+    });
+
+    const bls = dataFreshness.getSource('bls');
+    assert.equal(bls?.status, 'stale');
+    assert.equal(bls?.healthStatus, 'STALE_CONTENT');
+    assert.equal(bls?.itemCount, 9);
+    assert.equal(bls?.maxStaleMin, 60);
+    assert.equal(bls?.lastUpdate?.toISOString(), new Date(checkedAtMs - 90 * 60_000).toISOString());
+  });
+
+  it('prefers a compact problem over a duplicate pending check', async () => {
+    __resetHealthFreshnessForTests();
+    const checkedAtMs = Date.now();
+    await refreshDataFreshnessFromHealth({
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        status: 'DEGRADED',
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        pending: {
+          weatherAlerts: { status: 'STALE_CONTENT', records: 2, contentAgeMin: 60, maxContentAgeMin: 45 },
+        },
+        problems: {
+          weatherAlerts: { status: 'STALE_SEED', records: 4, seedAgeMin: 90, maxStaleMin: 45 },
+        },
+      }),
+    });
+
+    const weather = dataFreshness.getSource('weather');
+    assert.equal(weather?.healthStatus, 'STALE_SEED');
+    assert.equal(weather?.itemCount, 4);
+    assert.equal(weather?.maxStaleMin, 45);
+    assert.equal(weather?.lastUpdate?.toISOString(), new Date(checkedAtMs - 90 * 60_000).toISOString());
+  });
+
+  it('keeps full checks authoritative over both compact maps', async () => {
+    __resetHealthFreshnessForTests();
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        status: 'HEALTHY',
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        checks: {
+          weatherAlerts: { status: 'OK', records: 3, seedAgeMin: 5, maxStaleMin: 45 },
+        },
+        pending: { weatherAlerts: { status: 'STALE_CONTENT' } },
+        problems: { weatherAlerts: { status: 'SEED_ERROR' }, gdeltIntel: { status: 'SEED_ERROR' } },
+      }),
+    });
+
+    assert.equal(applied, 1);
+    const weather = dataFreshness.getSource('weather');
+    assert.equal(weather?.status, 'fresh');
+    assert.equal(weather?.healthStatus, 'OK');
+    assert.equal(weather?.itemCount, 3);
+    assert.equal(weather?.lastUpdate?.toISOString(), new Date(checkedAtMs - 5 * 60_000).toISOString());
+  });
+
+  it('marks all mapped sources healthy on a compact payload with no problems or pending keys', async () => {
     __resetHealthFreshnessForTests();
     const mappedSources = new Set(Object.values(HEALTH_CHECK_SOURCE_MAP).flat());
     const checkedAtMs = Date.now();

--- a/tests/global-tender-health.test.mjs
+++ b/tests/global-tender-health.test.mjs
@@ -162,7 +162,8 @@ test('graced stale content stays in compact diagnostics but out of the failure l
     summary: { total: 2, ok: 1, warn: 0, crit: 1 },
     checks,
   }, true);
-  assert.equal(body.problems.temporalAnomalies.status, 'STALE_CONTENT');
+  assert.equal(body.pending.temporalAnomalies.status, 'STALE_CONTENT');
+  assert.equal(body.problems.temporalAnomalies, undefined);
 
   const expired = { ...checks, temporalAnomalies: {
     ...checks.temporalAnomalies,

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -36,6 +36,55 @@ const {
 const NOW = 1_700_000_000_000;
 const ONE_MIN_MS = 60_000;
 
+test('MND first-failure pending requires fresh last-good and expires without another poll', () => {
+  const name = 'crossStraitActivityTaiwanMnd';
+  const key = STANDALONE_KEYS[name];
+  const meta = {
+    fetchedAt: NOW - ONE_MIN_MS,
+    recordCount: 133,
+    sourceState: 'degraded',
+    errorCode: 'MND_PUBLICATION_METADATA_MISSING',
+    consecutiveSourceFailures: 1,
+    lastSourceFailureCode: 'MND_PUBLICATION_METADATA_MISSING',
+    firstSourceFailureAt: NOW,
+    lastSourceAttemptAt: NOW,
+  };
+  const classify = (over = {}, now = NOW, bytes = 1024) => classifyKey(name, key, { allowOnDemand: false }, {
+    ...makeCtx({ strens: { [key]: bytes }, metaValues: { [SEED_META[name].key]: { ...meta, ...over } } }),
+    now,
+  });
+  const entry = classify();
+  assert.equal(entry.status, 'SEED_ERROR', 'retain the source diagnosis');
+  assert.equal(entry.sourceFailurePendingUntil, new Date(NOW + 210 * ONE_MIN_MS).toISOString());
+  assert.equal(__testing__.healthStatusBucket(entry, NOW), 'ok');
+  assert.deepEqual(classify(), entry, 'another health poll is not another failed source attempt');
+  const compact = healthResponseBody({ status: 'HEALTHY', summary: { pending: 1 }, checkedAt: new Date(NOW).toISOString(), checks: { [name]: entry } }, true);
+  assert.deepEqual(compact.pending, { [name]: entry });
+  assert.equal(compact.problems, undefined);
+  const deadline = NOW + 210 * ONE_MIN_MS;
+  assert.equal(__testing__.healthStatusBucket(entry, deadline), 'warn');
+  assert.equal(classify({}, deadline).sourceFailurePendingUntil, undefined);
+  assert.equal(__testing__.hasExpiredActivationGrace(compact, deadline), true);
+  assert.equal(__testing__.snapshotTtlSeconds(compact, deadline - 20_000), 20);
+  for (const over of [
+    { consecutiveSourceFailures: 2 }, { consecutiveSourceFailures: null },
+    { firstSourceFailureAt: null }, { firstSourceFailureAt: NOW + 1 },
+    { lastSourceAttemptAt: NOW + 1 }, { lastSourceAttemptAt: null },
+    { lastSourceFailureCode: 'MND_SOURCE_ERROR' },
+    { fetchedAt: NOW - 721 * ONE_MIN_MS }, { fetchedAt: NOW + 1 }, { fetchedAt: 0 },
+    { recordCount: 0 }, { recordCount: null }, { sourceState: 'error' },
+    { maxContentAgeMin: 60, newestItemAt: NOW - 120 * ONE_MIN_MS },
+  ]) {
+    const failed = classify(over);
+    assert.equal(failed.sourceFailurePendingUntil, undefined, JSON.stringify(over));
+    assert.notEqual(__testing__.healthStatusBucket(failed, NOW), 'ok', JSON.stringify(over));
+  }
+  assert.equal(classify({}, NOW, 0).status, 'EMPTY');
+  assert.equal(classify({}, NOW, 0).sourceFailurePendingUntil, undefined);
+  const nearStale = classify({ fetchedAt: NOW - 719 * ONE_MIN_MS });
+  assert.equal(nearStale.sourceFailurePendingUntil, new Date(NOW + ONE_MIN_MS).toISOString());
+});
+
 // Build the same ctx shape the handler constructs: four Maps + now.
 //   strens:     { redisDataKey -> byteLen }
 //   errors:     { redisDataKey -> errMsg }

--- a/tests/health-content-age.test.mjs
+++ b/tests/health-content-age.test.mjs
@@ -416,7 +416,18 @@ test('just-over-budget content stays diagnostically stale without making health 
     checkedAt: new Date(NOW).toISOString(),
     checks: { diseaseOutbreaks: entry },
   });
-  assert.deepEqual(compact.problems, { diseaseOutbreaks: entry }, 'grace must not hide the diagnostic');
+  assert.deepEqual(compact.pending, { diseaseOutbreaks: entry }, 'grace retains the diagnostic outside problems');
+  assert.equal(compact.problems, undefined);
+  assert.deepEqual(buildCompactVerdictSnapshot(compact), compact, 'compact projection is idempotent');
+  for (const deadline of [new Date(NOW).toISOString(), 'not-a-date', undefined]) {
+    const warning = { ...entry, staleContentGraceUntil: deadline };
+    const expired = buildCompactVerdictSnapshot({
+      ...compact,
+      checks: { diseaseOutbreaks: warning },
+    });
+    assert.deepEqual(expired.problems, { diseaseOutbreaks: warning });
+    assert.equal(expired.pending, undefined, 'unproved grace remains actionable');
+  }
 });
 
 test('null newestItemAt keeps the first Redis deadline when fresh seeder metadata arrives again', () => {

--- a/tests/health-content-freshness.test.mjs
+++ b/tests/health-content-freshness.test.mjs
@@ -637,29 +637,34 @@ describe('portwatchPortActivity classification', () => {
     })));
     assert.equal(entry.status, 'STALE_CONTENT');
 
-    const compact = healthResponseBody({
-      status: 'WARNING',
-      summary: { ok: 1, warning: 1 },
-      checkedAt: '2026-08-02T14:42:58.000Z',
-      checks: { portwatchPortActivity: entry },
-    }, true);
-
-    const problem = compact.problems?.portwatchPortActivity;
-    assert.equal(problem?.status, 'STALE_CONTENT', 'the status stays publicly visible');
-    assert.equal(problem?.contentFreshness, undefined, 'the per-country detail does not');
-    assert.doesNotMatch(JSON.stringify(compact), /"CN"/);
-
-    // Operators still get the whole entry from the authenticated shape.
-    const full = healthResponseBody({
-      status: 'WARNING',
-      summary: { ok: 1, warning: 1 },
-      checkedAt: '2026-08-02T14:42:58.000Z',
-      checks: { portwatchPortActivity: entry },
-    }, false);
-    assert.deepEqual(
-      full.checks.portwatchPortActivity.contentFreshness,
-      entry.contentFreshness,
-    );
+    for (const inGrace of [false, true]) {
+      const diagnostic = {
+        ...entry,
+        decisionGroups: { country: 'CN' },
+        chinaRow: { country: 'CN' },
+        ...(inGrace ? { staleContentGraceUntil: new Date(NOW + MINUTE_MS).toISOString() } : {}),
+      };
+      const snapshot = {
+        status: inGrace ? 'HEALTHY' : 'WARNING',
+        summary: { ok: inGrace ? 1 : 0, warn: inGrace ? 0 : 1 },
+        checkedAt: new Date(NOW).toISOString(),
+        checks: { portwatchPortActivity: diagnostic, chinaDecisionSignals: diagnostic },
+      };
+      const collection = inGrace ? 'pending' : 'problems';
+      for (const source of [snapshot, { ...snapshot, checks: undefined, [collection]: snapshot.checks }]) {
+        const compact = healthResponseBody(source, true);
+        const publicEntry = compact[collection]?.portwatchPortActivity;
+        assert.equal(publicEntry?.status, 'STALE_CONTENT', 'the status stays publicly visible');
+        assert.equal(publicEntry?.staleContentGraceUntil, diagnostic.staleContentGraceUntil);
+        assert.equal(publicEntry?.contentFreshness, undefined, 'the per-country detail does not');
+        assert.equal(publicEntry?.decisionGroups, undefined);
+        assert.equal(publicEntry?.chinaRow, undefined);
+        assert.equal(compact[collection]?.chinaDecisionSignals, undefined);
+        assert.doesNotMatch(JSON.stringify(compact), /"CN"/);
+        assert.deepEqual(healthResponseBody(compact, true), compact);
+      }
+      assert.deepEqual(healthResponseBody(snapshot, false).checks, snapshot.checks);
+    }
   });
 
   // api/_json-response.js strips reserved key names fleet-wide, so an entry

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -549,6 +549,7 @@ test('snapshot TTL is clamped down to the nearest activation deadline', () => {
   // Content deadline on a per-check entry.
   assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'OK', contentFreshnessPendingUntil: at(30_000) } } }, now), 30);
   assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'STALE_CONTENT', staleContentGraceUntil: at(20_000) } } }, now), 20);
+  assert.equal(snapshotTtlSeconds({ problems: {}, pending: { a: { status: 'STALE_CONTENT', staleContentGraceUntil: at(20_000) } } }, now), 20);
   // Rollout deadline, which only counts on a ROLLOUT_PENDING entry.
   assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'ROLLOUT_PENDING', rolloutPendingUntil: at(10_000) } } }, now), 10);
   // Compact shape: deadlines live under `summary`, because a graced check is OK
@@ -573,7 +574,8 @@ test('stale-content grace invalidates full and compact snapshots at the exact de
     checks: { temporalAnomalies: { status: 'STALE_CONTENT', staleContentGraceUntil: deadline } },
   };
   const compact = {
-    problems: { temporalAnomalies: { status: 'STALE_CONTENT', staleContentGraceUntil: deadline } },
+    problems: {},
+    pending: { temporalAnomalies: { status: 'STALE_CONTENT', staleContentGraceUntil: deadline } },
   };
 
   assert.equal(hasExpiredActivationGrace(full, now - 1), false);
@@ -611,6 +613,9 @@ test('a malformed or already-passed deadline collapses the TTL to its floor', ()
       1,
       `${label} must behave identically on the compact shape`,
     );
+    const pending = { pending: { a: { status: 'STALE_CONTENT', staleContentGraceUntil: value } }, problems: {} };
+    assert.equal(snapshotTtlSeconds(pending, now), 1, `${label} must expire pending entries too`);
+    assert.equal(hasExpiredActivationGrace(pending, now), true);
   }
 });
 
@@ -699,10 +704,15 @@ test('handleHealth claims, publishes, and reuses one stale-content deadline', as
     'cleanup must not ride along in the awaited claim pipeline',
   );
 
-  const problem = body.problems?.temporalAnomalies;
+  const problem = body.pending?.temporalAnomalies;
   assert.equal(problem?.status, 'STALE_CONTENT');
+  assert.equal(body.problems?.temporalAnomalies, undefined);
   assert.equal(problem.staleContentGraceUntil, new Date(Number(graceStore.get('temporalAnomalies'))).toISOString());
   assert.equal(body.summary.staleContent, 1, 'the diagnosis stays counted');
+  assert.equal(body.summary.pending, 1, 'active grace is counted separately');
+  const storedFull = JSON.parse(pipelines.flat().find(([op, key]) => op === 'SET' && key === HEALTH_SNAPSHOT_KEY)[2]);
+  assert.deepEqual(storedFull.summary, body.summary, 'full and compact summaries agree');
+  assert.deepEqual(storedFull.checks.temporalAnomalies, problem, 'full checks retain the raw diagnosis');
   // The graced entry is counted in `ok`, not `warn` — measured against the same
   // sweep with the claim failing, so this compares like with like rather than
   // against a hand-written expectation about the rest of the mock registry.
@@ -719,7 +729,7 @@ test('handleHealth claims, publishes, and reuses one stale-content deadline', as
   const second = await sweepCompactBody(sweepFetch({ graceStore }));
   assert.equal(graceStore.get('temporalAnomalies'), pinned, 'HSETNX must not overwrite the anchor');
   assert.equal(
-    second.problems?.temporalAnomalies?.staleContentGraceUntil,
+    second.pending?.temporalAnomalies?.staleContentGraceUntil,
     new Date(Number(pinned)).toISOString(),
   );
 });
@@ -749,7 +759,7 @@ test('handleHealth serves a graced snapshot until its deadline, then sweeps agai
     status: 'HEALTHY',
     summary: { total: 1, ok: 1, warn: 0, onDemandWarn: 0, staleContent: 1, crit: 0 },
     checkedAt: new Date(now - 1000).toISOString(),
-    problems: {
+    pending: {
       temporalAnomalies: {
         status: 'STALE_CONTENT',
         staleContentGraceUntil: new Date(now + 60_000).toISOString(),
@@ -769,10 +779,12 @@ test('handleHealth serves a graced snapshot until its deadline, then sweeps agai
 
   const served = await (await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'))).json();
   assert.equal(served.checkedAt, graced.checkedAt, 'inside the window the cached verdict is reused');
+  assert.deepEqual(served.pending, graced.pending);
+  assert.equal(served.problems, undefined);
   assert.equal(sweeps, 0, 'no sweep while the published grace is still live');
 
   // At the exact deadline the cached verdict is no longer servable.
-  graced.problems.temporalAnomalies.staleContentGraceUntil = new Date(now).toISOString();
+  graced.pending.temporalAnomalies.staleContentGraceUntil = new Date(now).toISOString();
   await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
   assert.equal(sweeps, 1, 'an expired grace must force a fresh sweep, not serve a stale ok');
 });

--- a/tests/imd-cyclone-marine.test.mjs
+++ b/tests/imd-cyclone-marine.test.mjs
@@ -22,6 +22,7 @@ import {
   imdAfterPublish,
   imdLiveFetchEnabled,
   imdProductUrl,
+  shouldActivateImdSnapshot,
   isAllowedImdHost,
   isNilText,
   marineBulletinsFromSnapshot,
@@ -649,6 +650,7 @@ test('fails a batch closed when IMD authentication fails and preserves bounded l
     assert.equal(snapshot.products[id].requestCount, 0);
   }
   assert.equal(snapshot.products.cycloneTrack.carried, true);
+  assert.equal(shouldActivateImdSnapshot(snapshot), false, 'carried last-good data does not prove a new IMD success');
   assert.doesNotMatch(JSON.stringify(snapshot), /operator@example\.com|railway-secret/);
 });
 
@@ -678,7 +680,7 @@ test('rejects malformed IMD authentication responses before product requests', a
   }
 });
 
-test('marks a missing IMD key as an error after the source has activated', () => {
+test('keeps an intentionally disabled IMD source not configured after activation', () => {
   const { ACTIVATION_MARKERS, SEED_META, STANDALONE_KEYS, STATUS_COUNTS, classifyKey } = healthTesting;
   const name = 'imdCycloneMarine';
   const dataKey = STANDALONE_KEYS[name];
@@ -699,11 +701,75 @@ test('marks a missing IMD key as an error after the source has activated', () =>
     now,
   });
 
-  assert.equal(ACTIVATION_MARKERS[name], 'seed-activated:weather:imd-cyclone-marine');
+  assert.equal(ACTIVATION_MARKERS[name], 'seed-activated:weather:imd-cyclone-marine:v2');
   assert.equal(classifyKey(name, dataKey, { allowOnDemand: true }, ctx(false)).status, 'NOT_CONFIGURED');
   const afterActivation = classifyKey(name, dataKey, { allowOnDemand: true }, ctx(true));
-  assert.equal(afterActivation.status, 'SEED_ERROR');
-  assert.equal(STATUS_COUNTS[afterActivation.status], 'warn');
+  assert.equal(afterActivation.status, 'NOT_CONFIGURED');
+  assert.equal(STATUS_COUNTS[afterActivation.status], 'ok');
+
+  const invalidCredentials = classifyKey(name, dataKey, { allowOnDemand: true }, {
+    ...ctx(true),
+    keyMetaValues: new Map([[metaKey, JSON.stringify({
+      fetchedAt: now,
+      recordCount: 0,
+      sourceState: 'degraded',
+      errorCode: 'IMD_PRODUCTS_UNAVAILABLE',
+      coverageState: 'unavailable',
+    })]]),
+  });
+  assert.equal(invalidCredentials.status, 'SEED_ERROR');
+  assert.equal(STATUS_COUNTS[invalidCredentials.status], 'warn');
+});
+
+test('activates IMD only after a real documented product succeeds', () => {
+  const snapshot = (productResults) => assembleImdSnapshot({ productResults, now: NOW });
+  const quietSuccess = snapshot({
+    cycloneTrack: { status: 'ok', records: [] },
+    cycloneWind: { status: 'ok', records: [] },
+    cycloneCou: { status: 'ok', records: [] },
+    portWarning: { status: 'ok', records: [] },
+    seaBulletin: { status: 'ok', records: [] },
+    coastalBulletin: { status: 'ok', records: [] },
+  });
+  assert.equal(quietSuccess.coverageState, 'ok');
+  assert.equal(shouldActivateImdSnapshot(quietSuccess), true, 'valid NIL/empty products prove IMD replied');
+
+  const partialSuccess = snapshot({
+    cycloneTrack: { status: 'ok', records: [] },
+    cycloneWind: { status: 'failed', reason: 'IMD_FETCH_FAILED', records: [] },
+    cycloneCou: { status: 'failed', reason: 'IMD_FETCH_FAILED', records: [] },
+    portWarning: { status: 'failed', reason: 'IMD_FETCH_FAILED', records: [] },
+    seaBulletin: { status: 'failed', reason: 'IMD_FETCH_FAILED', records: [] },
+    coastalBulletin: { status: 'failed', reason: 'IMD_FETCH_FAILED', records: [] },
+  });
+  assert.equal(partialSuccess.coverageState, 'degraded');
+  assert.equal(shouldActivateImdSnapshot(partialSuccess), true, 'one direct product success is enough');
+
+  const totalFailure = snapshot({
+    cycloneTrack: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+    cycloneWind: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+    cycloneCou: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+    portWarning: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+    seaBulletin: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+    coastalBulletin: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+  });
+  assert.equal(totalFailure.coverageState, 'unavailable');
+  assert.equal(shouldActivateImdSnapshot(totalFailure), false);
+
+  const carriedOnly = assembleImdSnapshot({
+    previous: quietSuccess,
+    now: NOW,
+    productResults: {
+      cycloneTrack: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+      cycloneWind: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+      cycloneCou: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+      portWarning: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+      seaBulletin: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+      coastalBulletin: { status: 'failed', reason: 'IMD_AUTH_FAILED', records: [] },
+    },
+  });
+  assert.equal(carriedOnly.coverageState, 'unavailable');
+  assert.equal(shouldActivateImdSnapshot(carriedOnly), false, 'carried records do not prove this attempt reached IMD');
 });
 
 test('never fetches fishermen warning even when live fetch is enabled', async () => {
@@ -734,6 +800,7 @@ test('never fetches fishermen warning even when live fetch is enabled', async ()
   assert.equal(requested.some((url) => String(url).includes('fishermen')), false);
   assert.equal(snapshot.products.fishermenWarning.status, 'disabled');
   assert.equal(snapshot.coverageState, 'ok');
+  assert.equal(shouldActivateImdSnapshot(snapshot), true);
   assert.ok(snapshot.cyclones.length > 0);
 });
 
@@ -758,7 +825,8 @@ test('seeder stays off weather:alerts:v1 and uses the dedicated canonical key', 
   assert.doesNotMatch(seeder, /runSeed\('weather', 'alerts'/);
   assert.equal(IMD_CANONICAL_KEY, 'weather:imd-cyclone-marine:v1');
   assert.match(seeder, /#7005/);
-  assert.match(seeder, /seed-activated:weather:imd-cyclone-marine/);
+  assert.match(seeder, /seed-activated:weather:imd-cyclone-marine:v2/);
+  assert.match(seeder, /shouldActivateImdSnapshot\(data\)/);
   assert.match(seeder, /createImdProxyFetch\(process\.env\.PROXY_URL\)/);
   const lib = readFileSync(join(root, 'scripts/lib/imd-cyclone-marine.mjs'), 'utf8');
   assert.doesNotMatch(lib, /\/api\/v1\/districtnowcast/);

--- a/tests/seed-bundle-canada.test.mjs
+++ b/tests/seed-bundle-canada.test.mjs
@@ -71,7 +71,7 @@ test('per-member cadence is the declared one, not TTC\'s cron inherited', () => 
     ['VIA-Rail-Live', 15 * MIN],
     ['TTC-Alerts', 5 * MIN],
     ['Toronto-TFS', 5 * MIN],
-    ['Toronto-TPS', 15 * MIN],
+    ['Toronto-TPS', 30 * MIN],
     // Retrospective MCI and an annual aggregate: 6h keeps our copy warm inside
     // the 24h canonical TTL rather than chasing upstream, which edits monthly.
     ['TPS-MCI', 6 * HOUR],

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -16,7 +16,7 @@ import {
   formatAcceptanceReport,
   formatAcceptanceMarkdown,
   isOnDemandProblem,
-  findGracedStaleContent,
+  findPendingDiagnostics,
   isStaleContentGraceProblem,
   MAX_STALE_CONTENT_GRACE_MS,
   STALE_CONTENT_GRACE_SKEW_SLACK_MS,
@@ -41,6 +41,29 @@ const readRailwayServices = () => JSON.parse(readFileSync(RAILWAY_SERVICES_URL, 
 describe('production acceptance summary', () => {
   const now = Date.parse('2026-09-05T07:00:00.000Z');
   const baseline = { expiresAt: '2026-09-06', acknowledged: [] };
+
+  it('keeps bounded source failures visible while pending and alerts at the deadline', () => {
+    const problem = {
+      status: 'SEED_ERROR', records: 133, seedAgeMin: 1, maxStaleMin: 720,
+      errorCode: 'MND_SOURCE_ERROR', lastSourceFailureCode: 'MND_SOURCE_ERROR',
+      consecutiveSourceFailures: 1,
+      sourceFailurePendingUntil: new Date(now + 210 * 60_000).toISOString(),
+    };
+    const payload = { status: 'HEALTHY', pending: { crossStraitActivityTaiwanMnd: problem } };
+    assert.deepEqual(findOperationalProblems(payload, now), []);
+    assert.deepEqual(findPendingDiagnostics(payload, now), [{ name: 'crossStraitActivityTaiwanMnd', status: 'SEED_ERROR', graceUntil: problem.sourceFailurePendingUntil }]);
+    for (const over of [
+      { sourceFailurePendingUntil: new Date(now).toISOString() },
+      { sourceFailurePendingUntil: null }, { sourceFailurePendingUntil: 'bad' },
+      { sourceFailurePendingUntil: [problem.sourceFailurePendingUntil] },
+      { sourceFailurePendingUntil: new Date(now + 216 * 60_000).toISOString() },
+      { consecutiveSourceFailures: 2 }, { records: 0 }, { seedAgeMin: 721 },
+      { seedAgeMin: -1 }, { lastSourceFailureCode: 'MND_OTHER' }, { status: 'EMPTY' },
+    ]) {
+      const invalid = { status: 'HEALTHY', pending: { crossStraitActivityTaiwanMnd: { ...problem, ...over } } };
+      assert.equal(findOperationalProblems(invalid, now).length, 1, JSON.stringify(over));
+    }
+  });
   const observation = (problems, accepted = baseline) => buildAcceptanceObservation({
     status: Object.keys(problems).length ? 'WARNING' : 'HEALTHY',
     checkedAt: new Date(now).toISOString(),
@@ -279,15 +302,18 @@ describe('scheduled seed freshness monitor', () => {
     };
 
     assert.equal(isStaleContentGraceProblem(problem, now), true);
-    assert.deepEqual(findOperationalProblems({
-      status: 'HEALTHY',
-      problems: { temporalAnomalies: problem },
-    }, now), []);
+    for (const collection of ['problems', 'pending']) {
+      assert.deepEqual(findOperationalProblems({
+        status: 'HEALTHY',
+        [collection]: { temporalAnomalies: problem },
+      }, now), []);
+    }
 
     for (const [label, candidate] of [
       ['exact deadline', { ...problem, staleContentGraceUntil: new Date(now).toISOString() }],
       ['missing deadline', { status: 'STALE_CONTENT' }],
       ['malformed deadline', { ...problem, staleContentGraceUntil: 'not-a-date' }],
+      ['non-string deadline', { ...problem, staleContentGraceUntil: [problem.staleContentGraceUntil] }],
       ['excessive deadline', {
         ...problem,
         staleContentGraceUntil: new Date(now + MAX_STALE_CONTENT_GRACE_MS + 1).toISOString(),
@@ -299,10 +325,12 @@ describe('scheduled seed freshness monitor', () => {
       ['wrong status', { ...problem, status: 'STALE_SEED' }],
     ]) {
       assert.equal(isStaleContentGraceProblem(candidate, now), false, label);
-      assert.equal(findOperationalProblems({
-        status: 'WARNING',
-        problems: { temporalAnomalies: candidate },
-      }, now).length, 1, label);
+      for (const collection of ['problems', 'pending']) {
+        assert.equal(findOperationalProblems({
+          status: 'HEALTHY',
+          [collection]: { temporalAnomalies: candidate },
+        }, now).length, 1, `${collection}: ${label}`);
+      }
     }
   });
 
@@ -314,7 +342,7 @@ describe('scheduled seed freshness monitor', () => {
     const graceUntil = new Date(now + 60 * 60 * 1000).toISOString();
     const payload = {
       status: 'HEALTHY',
-      problems: {
+      pending: {
         temporalAnomalies: { status: 'STALE_CONTENT', staleContentGraceUntil: graceUntil },
         expired: {
           status: 'STALE_CONTENT',
@@ -323,7 +351,7 @@ describe('scheduled seed freshness monitor', () => {
       },
     };
 
-    assert.deepEqual(findGracedStaleContent(payload, now), [
+    assert.deepEqual(findPendingDiagnostics(payload, now), [
       { name: 'temporalAnomalies', status: 'STALE_CONTENT', graceUntil },
     ]);
     // The expired one is not "in grace" — it is a real operational problem.
@@ -331,6 +359,15 @@ describe('scheduled seed freshness monitor', () => {
       findOperationalProblems(payload, now).map((p) => p.name),
       ['expired'],
     );
+    const duplicateWarning = {
+      ...payload,
+      problems: { temporalAnomalies: { status: 'SEED_ERROR', records: 1 } },
+    };
+    assert.deepEqual(findPendingDiagnostics(duplicateWarning, now), [], 'pending cannot hide a duplicate warning');
+    assert.deepEqual(findOperationalProblems(duplicateWarning, now).map((p) => p.name), ['expired', 'temporalAnomalies']);
+    assert.deepEqual(findPendingDiagnostics({ ...payload, problems: payload.pending }, now), [
+      { name: 'temporalAnomalies', status: 'STALE_CONTENT', graceUntil },
+    ], 'legacy and new collections do not duplicate the same grace');
   });
 
   it('treats every non-on-demand health problem as an operational failure', () => {
@@ -499,6 +536,10 @@ describe('scheduled seed freshness monitor', () => {
       () => validateCompactHealthPayload({ status: 'HEALTHY', problems: [] }),
       /problems/,
     );
+    for (const pending of [[], null, false, 'pending', { source: null }, { source: [] }]) {
+      assert.throws(() => validateCompactHealthPayload({ status: 'HEALTHY', pending }), /pending/);
+      assert.throws(() => findPendingDiagnostics({ status: 'HEALTHY', pending }), /pending/);
+    }
   });
 
   describe('accepted-problem baseline', () => {

--- a/tests/toronto-official-cad.test.mjs
+++ b/tests/toronto-official-cad.test.mjs
@@ -378,9 +378,10 @@ test('health monitors TFS and TPS freshness with durable activation', () => {
   assert.equal(SEED_META.torontoTfs.key, 'seed-meta:safety:toronto-tfs');
   assert.equal(SEED_META.torontoTfs.maxStaleMin, 15);
   assert.equal(SEED_META.torontoTps.key, 'seed-meta:safety:toronto-tps');
-  assert.equal(SEED_META.torontoTps.maxStaleMin, 45);
+  assert.equal(SEED_META.torontoTps.maxStaleMin, 90);
   assert.equal(TFS_MAX_STALE_MIN, 15);
-  assert.equal(TPS_MAX_STALE_MIN, 45);
+  assert.equal(TPS_MAX_STALE_MIN, 90);
+  assert.equal(TPS_TTL_SECONDS, 3 * 60 * 60);
   assert.equal(STANDALONE_KEYS.torontoTfs, TFS_KEY);
   assert.equal(STANDALONE_KEYS.torontoTps, TPS_KEY);
   assert.equal(SEED_META.torontoTfs.cutover.mode, 'activation-marker');
@@ -394,8 +395,8 @@ test('health monitors TFS and TPS freshness with durable activation', () => {
 
   assert.equal(classifyCad('torontoTfs', { fetchedAgeMin: 14 }).status, 'OK');
   assert.equal(classifyCad('torontoTfs', { fetchedAgeMin: 16 }).status, 'STALE_SEED');
-  assert.equal(classifyCad('torontoTps', { fetchedAgeMin: 44 }).status, 'OK');
-  assert.equal(classifyCad('torontoTps', { fetchedAgeMin: 46 }).status, 'STALE_SEED');
+  assert.equal(classifyCad('torontoTps', { fetchedAgeMin: 90 }).status, 'OK');
+  assert.equal(classifyCad('torontoTps', { fetchedAgeMin: 91 }).status, 'STALE_SEED');
 
   assert.equal(classifyCad('torontoTfs', {
     fetchedAgeMin: 1,
@@ -409,12 +410,12 @@ test('health monitors TFS and TPS freshness with durable activation', () => {
   }).status, 'STALE_CONTENT');
   assert.equal(classifyCad('torontoTps', {
     fetchedAgeMin: 1,
-    contentAgeMin: 44,
+    contentAgeMin: 47,
     maxContentAgeMin: TPS_MAX_STALE_MIN,
   }).status, 'OK');
   assert.equal(classifyCad('torontoTps', {
     fetchedAgeMin: 1,
-    contentAgeMin: 46,
+    contentAgeMin: 91,
     maxContentAgeMin: TPS_MAX_STALE_MIN,
   }).status, 'STALE_CONTENT');
   for (const name of ['torontoTfs', 'torontoTps']) {


### PR DESCRIPTION
## Summary

Health should not raise an incident for an intentionally disabled optional source or a small delay while usable last-good data remains available. These changes separate bounded pending diagnostics from actionable problems without changing the underlying error or data timestamps.

- IMD without an API key stays `NOT_CONFIGURED`, including after a prior activation. Activation now requires an accepted documented IMD product response; a valid quiet response counts. A versioned marker ignores the old marker that failed product requests could set. Configured source failures remain visible.
- TPS runs every 30 minutes with 90-minute seed and content budgets and a three-hour cache lifetime. Other Canada bundle members keep their cadence.
- MND's first failed attempt can be pending only after a proved success with usable last-good records. A second distinct failure with the same cause warns. Pending expires after 210 minutes or at the seed deadline, whichever comes first. Changed causes cannot restart that deadline, duplicate writes cannot invent attempts, and missing or contradictory history fails closed.
- Compact health returns active grace entries in `pending` and actionable entries in `problems`. Both retain public diagnostics and redact operator-only details. Cache expiry, monitoring, and dashboard freshness use the same contract. Pending data retains its actual age in the dashboard.

The existing MND adapter and Cross-Strait history repairs remain unchanged. Production's last observed MND failure was at 15:50 UTC, before the 16:38 UTC deployment of the existing adapter repair. News Insights and Cross-Strait history had current successful metadata during this investigation.

Related: #7734

## Validation

- 460 affected tests passed. These cover producer metadata through health classification, duplicate and out-of-order attempts, finite expiry, compact cache round-trips, CLI acceptance, IMD activation, TPS cadence, and the real dashboard freshness reader/tracker.
- The dashboard pending regression failed before its fix and passed after it. An independent reviewer validated the fix. The other actionable review finding, untyped metadata doubles, is also fixed.
- Browser and API typechecks, import boundaries, source attribution, public documentation references, and `git diff --check` passed.
- CI's full data suite passed 30,790 tests with zero failures and 17 skips. All required PR gates passed, including the full application smoke test, sidecar, DOM tests, generated artifacts, and documentation export. The earlier local run found two obsolete assertions; both were fixed before this green CI head.
- No production seeder runs, Redis writes, configuration changes, deployment, or merge were performed. Browser rendering and production acceptance are not established by these local tests.

## Post-Deploy Monitoring & Validation

Owner: PR owner. After an approved merge and deployment, observe natural scheduled runs through `/api/health?compact=1`. Read `seed-meta:weather:imd-cyclone-marine`, `seed-meta:safety:toronto-tps`, and `seed-meta:military:cross-strait-activity:taiwan-mnd`. Search Railway logs for `Toronto-TPS`, `Cross-Strait`, `IMD_API_KEY_MISSING`, and `MND_PUBLICATION_METADATA_MISSING`. Confirm that IMD remains unconfigured without a key, TPS runs at the new cadence, and MND reports a newer attempt than the deployed adapter's prior 15:50 failure. A parent bundle completion alone is not source acceptance.

Observe at least two MND admission cycles and the 210-minute pending deadline. Pending must not extend on repeated reads, duplicate writes, or changed error codes. Any missing or unusable data must remain actionable. Keep News Insights and Cross-Strait history in the same observation window. If pending survives its deadline, missing data becomes non-actionable, or configured IMD failures disappear, stop acceptance and propose reverting this PR. Revert or deployment needs approval. Do not clear markers or manually run seeders to obtain a green result.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
