### PR TITLE
fix(pro-test): type-check the marketing bundle in CI and fix six errors

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -57,3 +57,14 @@ jobs:
       # and `--no-verify` bypasses can't land stale convex/_generated
       # types. See .husky/pre-push for the rationale.
       - run: npx tsc --noEmit -p convex/tsconfig.json
+      # The marketing bundle has its own tsconfig and node_modules, so nothing
+      # above reaches it and no other workflow ran its `lint` — `pro-test` was
+      # sitting on six undetected type errors, five of them at the Sentry
+      # `beforeSend` boundary that decides what gets filtered. Installed
+      # separately because it is a distinct package root; scripts stay blocked,
+      # matching `build:pro`. Same required context as the checks above, so no
+      # branch-protection list has to change.
+      - run: npm --prefix pro-test ci --prefer-offline
+        env:
+          npm_config_allow_scripts: ''
+      - run: npm --prefix pro-test run lint

--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -26,6 +26,14 @@
  * than re-deriving them from source text — same reason as `./sentry-allow-urls.ts`.
  */
 
+/**
+ * Mirror of `@sentry/core`'s `Primitive`, restated rather than imported to keep
+ * this module dependency-free. It must stay a superset of what the SDK puts in
+ * `tags`, or `ErrorEvent` stops satisfying `PolicyEvent` and every
+ * `marketingBeforeSend` call site fails to compile.
+ */
+type PolicyPrimitive = number | string | boolean | bigint | symbol | null | undefined;
+
 /** Minimal structural view of the Sentry event fields this policy reads. */
 interface PolicyFrame {
   filename?: string;
@@ -37,7 +45,7 @@ interface PolicyException {
 }
 export interface PolicyEvent {
   exception?: { values?: PolicyException[] };
-  tags?: Record<string, string | number | boolean | undefined>;
+  tags?: { [key: string]: PolicyPrimitive };
   /**
    * Where Sentry parks the rejected value when a promise rejects with a
    * non-Error: `eventFromUnknownInput` synthesises the exception and copies the

--- a/pro-test/src/services/checkout-intent-url.ts
+++ b/pro-test/src/services/checkout-intent-url.ts
@@ -96,6 +96,9 @@ export function buildCheckoutReturnUrl(
     discountCode?: string;
     attributionSource?: string;
     checkoutAttribution?: CheckoutAttribution;
+    // Read below to re-stamp CHECKOUT_HANDOFF_PARAM, and passed by
+    // PricingSection; the declaration was the only piece missing.
+    desktopHandoff?: boolean;
   },
 ): string {
   const url = new URL(currentHref);


### PR DESCRIPTION
## Summary

The marketing bundle's TypeScript was never checked by anything. It has its own tsconfig and `node_modules`, so the root `npm run typecheck` doesn't reach it, and no workflow ran its `lint` script — `test.yml` mentions `pro-test` exactly once, at line 259, to cache its lockfile. `npm --prefix pro-test run lint` has been failing on `main` with six errors, unnoticed.

Five of them sat in `src/sentry.ts`, at the `beforeSend` boundary that decides which marketing events reach Sentry — which is precisely where an unchecked type error is most expensive.

**Why the five happened.** `marketingBeforeSend` is already generic over `<T extends PolicyEvent>`, so it should hand back whatever it was given. But `PolicyEvent.tags` was declared narrower than the SDK's:

```
// policy                                        // @sentry/core
Record<string, string|number|boolean|undefined>  { [key: string]: Primitive }
                                                 // …also bigint, symbol, null
```

`ErrorEvent` therefore failed the constraint, `T` never resolved to it, and `.request` vanished from the result — hence `Property 'request' does not exist on type 'PolicyEvent'` three times over. Restating the full `Primitive` union as an index signature fixes all five at once. The single consumer of `tags` already guards with `typeof action === 'string'`, so widening it weakens no check, and the module stays dependency-free as its header requires.

**The sixth** is unrelated: `buildCheckoutReturnUrl` reads `options?.desktopHandoff` and `PricingSection` passes it, but the parameter type omitted the field. Declaration only — no behaviour change.

The new step joins the existing required `typecheck` context rather than adding a job, following the precedent already documented in that file, so no branch-protection context list has to change. Scripts stay blocked on the install, matching `build:pro`.

## Validation

| Check | Result |
|---|---|
| `npm --prefix pro-test run lint` before | 6 errors, reproduced on a clean `origin/main` checkout |
| After, following a verbatim `npm ci` with scripts blocked | clean |
| `tests/pro-sentry-filter-policy.test.mts` + `pro-sentry-chunk` | 96/96 pass |
| Root `npm run typecheck` | clean |
| `typecheck.yml` parsed with js-yaml | valid; both steps resolve as intended |

The install and lint steps were run locally exactly as CI will run them, including `npm_config_allow_scripts=''`.

I also confirmed the gate actually fires for this bundle: `changes` computes `code` from an *exclusion* list (`.md`, `docs/`, `src-tauri/`, …) and `pro-test/**` is not in it, so a pro-test-only PR sets `code=true` and reaches the new step. A guard that never runs on the PRs it exists for would have been the easy mistake here.

Both fixes are type-level; no runtime behaviour changes in this diff.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_014qiv5bDjrAiVfzgcdL9xKR
