### PR TITLE
fix(corpus): stop country briefs rendering markdown and ISO headings

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -3003,7 +3003,10 @@ ${faqs.map((faq) => `        <details data-country-faq><summary>${escapeHtml(faq
 const INTEL_BRIEF_SECTION_RE = /^(SITUATION NOW|WHAT THIS MEANS FOR\b.*|KEY RISKS|OUTLOOK|WATCH ITEMS)\s*$/i;
 
 function unwrapBriefEmphasisLine(line) {
-  return String(line || '').replace(/^\*\*(.*)\*\*$/, '$1').trim();
+  return String(line || '')
+    .replace(/^\*\*(.*)\*\*$/, '$1')
+    .replace(/^#{1,6}\s+/, '')
+    .trim();
 }
 
 function applyCrawlableBriefEmphasis(escaped) {
@@ -3064,9 +3067,9 @@ export function formatCrawlableIntelBrief(text, countryName) {
       out.push('          <h3>Watch items</h3>');
       continue;
     }
-    if (/^[•\-]\s*/.test(trimmed)) {
+    if (/^(?:[•\-]\s*|\*\s+)/.test(trimmed)) {
       openList();
-      const item = applyCrawlableBriefEmphasis(escapeHtml(trimmed.replace(/^[•\-]\s*/, '')));
+      const item = applyCrawlableBriefEmphasis(escapeHtml(trimmed.replace(/^(?:[•\-]\s*|\*\s+)/, '')));
       out.push(`            <li>${item}</li>`);
       continue;
     }
@@ -3266,7 +3269,7 @@ export function assertCountryDevelopmentsRendered({ pagePath, html, developments
       .map((line) => unwrapBriefEmphasisLine(line.trim()))
       .filter(Boolean)
       .filter((line) => !INTEL_BRIEF_SECTION_RE.test(line))
-      .map((line) => line.replace(/^[•\-]\s*/, '').replace(/\*\*/g, ''));
+      .map((line) => line.replace(/^(?:[•\-]\s*|\*\s+)/, '').replace(/\*\*/g, ''));
     const anchors = [contentLines[0], contentLines.at(-1)]
       .filter((line, index, all) => line && all.indexOf(line) === index)
       .map((line) => escapeHtml(line.slice(0, 120)));
@@ -3309,6 +3312,8 @@ function corpusVisibleText(html) {
 // crawlers saw literal `**` and `WHAT THIS MEANS FOR NO`. Fail the build
 // when either artifact reaches <main>, including section titles that are
 // still plain text rather than <h*> tags.
+const MEANS_FOR_ISO_RE = /\bwhat this means for [a-z]{2}\b/i;
+
 export function assertCountryBriefPresentation({ pagePath, html }) {
   const main = corpusMainHtml(html);
   if (main.includes('**')) {
@@ -3317,11 +3322,11 @@ export function assertCountryBriefPresentation({ pagePath, html }) {
   const headingHits = [...main.matchAll(/<h[1-6]\b[^>]*>([\s\S]*?)<\/h[1-6]>/gi)];
   for (const hit of headingHits) {
     const text = hit[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-    if (/\bFOR [A-Z]{2}\b/.test(text)) {
+    if (MEANS_FOR_ISO_RE.test(text)) {
       throw new Error(`${pagePath} heading leaks ISO code: ${text}`);
     }
   }
-  if (/\bWHAT THIS MEANS FOR [A-Z]{2}\b/.test(corpusVisibleText(html))) {
+  if (MEANS_FOR_ISO_RE.test(corpusVisibleText(html))) {
     throw new Error(`${pagePath} brief heading leaks an ISO-3166 alpha-2 code`);
   }
 }

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -128,7 +128,7 @@ export const CHOKEPOINT_PAGE_LASTMOD_PATHS = Object.freeze([
 // families take the later of this version and their own committed source date,
 // so template changes are reflected without pretending every deploy is fresh.
 export const CORPUS_GENERATOR_CONTENT_VERSION = '2026-09-01';
-export const COUNTRY_PAGE_CONTENT_VERSION = '2026-09-03';
+export const COUNTRY_PAGE_CONTENT_VERSION = '2026-09-05';
 export const CII_COUNTRY_PAGE_CONTENT_VERSION = '2026-09-03';
 // Exported so the #7533 guard test can recompute every family clock without
 // re-implementing the version constants themselves.
@@ -3000,6 +3000,92 @@ ${faqs.map((faq) => `        <details data-country-faq><summary>${escapeHtml(faq
 // numbers moved in the same window the reporting was captured. Asserting that
 // a headline *drove* a score move would be fabrication — only an analyst (or
 // the brief, which cites its sources) may draw that link.
+const INTEL_BRIEF_SECTION_RE = /^(SITUATION NOW|WHAT THIS MEANS FOR\b.*|KEY RISKS|OUTLOOK|WATCH ITEMS)\s*$/i;
+
+function unwrapBriefEmphasisLine(line) {
+  return String(line || '').replace(/^\*\*(.*)\*\*$/, '$1').trim();
+}
+
+function applyCrawlableBriefEmphasis(escaped) {
+  return escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>').replace(/\*\*/g, '');
+}
+
+// Frozen intel briefs are markdown-ish LLM text. Country pages are prerendered
+// HTML for crawlers, so convert emphasis and promote the five section titles
+// rather than injecting the string into a <p>. Always rewrite the "means for"
+// title from the page's country name: stored briefs still contain ISO codes
+// from the TIER1-only prompt fallback (#7738).
+export function formatCrawlableIntelBrief(text, countryName) {
+  const name = String(countryName || '').trim();
+  if (!name) throw new Error('formatCrawlableIntelBrief requires a country name');
+  const out = [];
+  let listOpen = false;
+  const closeList = () => {
+    if (listOpen) {
+      out.push('          </ul>');
+      listOpen = false;
+    }
+  };
+  const openList = () => {
+    if (!listOpen) {
+      out.push('          <ul>');
+      listOpen = true;
+    }
+  };
+
+  for (const rawLine of String(text || '').split('\n')) {
+    const trimmed = unwrapBriefEmphasisLine(rawLine.trim());
+    if (!trimmed) {
+      closeList();
+      continue;
+    }
+    if (/^WHAT THIS MEANS FOR\b/i.test(trimmed)) {
+      closeList();
+      out.push(`          <h3>What this means for ${escapeHtml(name)}</h3>`);
+      continue;
+    }
+    if (/^SITUATION NOW\b/i.test(trimmed)) {
+      closeList();
+      out.push('          <h3>Situation now</h3>');
+      continue;
+    }
+    if (/^KEY RISKS\b/i.test(trimmed)) {
+      closeList();
+      out.push('          <h3>Key risks</h3>');
+      continue;
+    }
+    if (/^OUTLOOK\b/i.test(trimmed)) {
+      closeList();
+      out.push('          <h3>Outlook</h3>');
+      continue;
+    }
+    if (/^WATCH ITEMS\b/i.test(trimmed)) {
+      closeList();
+      out.push('          <h3>Watch items</h3>');
+      continue;
+    }
+    if (/^[•\-]\s*/.test(trimmed)) {
+      openList();
+      const item = applyCrawlableBriefEmphasis(escapeHtml(trimmed.replace(/^[•\-]\s*/, '')));
+      out.push(`            <li>${item}</li>`);
+      continue;
+    }
+    closeList();
+    if (/^NEXT \d/i.test(trimmed)) {
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx !== -1) {
+        const label = applyCrawlableBriefEmphasis(escapeHtml(trimmed.slice(0, colonIdx)));
+        const body = applyCrawlableBriefEmphasis(escapeHtml(trimmed.slice(colonIdx + 1).trim()));
+        out.push(`          <p><strong>${label}:</strong> ${body}</p>`);
+        continue;
+      }
+    }
+    out.push(`          <p>${applyCrawlableBriefEmphasis(escapeHtml(trimmed))}</p>`);
+  }
+  closeList();
+  return out.join('\n');
+}
+
 export function renderCountryDevelopments({ countryName, developments, ciiEntry = null, pulse = null }) {
   const name = String(countryName || '').trim();
   if (!name) throw new Error('renderCountryDevelopments requires a country name');
@@ -3037,9 +3123,9 @@ export function renderCountryDevelopments({ countryName, developments, ciiEntry 
     parts.push(`        <ul>\n${items}\n        </ul>`);
   }
   if (brief) {
-    const briefHtml = escapeHtml(brief.text).replace(/\n/g, '<br>');
+    const briefHtml = formatCrawlableIntelBrief(brief.text, name);
     const generatedLine = `Brief generated <time datetime="${escapeHtml(brief.generatedAt)}">${escapeHtml(formatStaticDateTime(brief.generatedAt))}</time>`;
-    parts.push(`        <div data-intel-brief>\n          <h3>Country brief</h3>\n          <p>${briefHtml}</p>\n          <p class="source">${generatedLine}${brief.model ? ` by ${escapeHtml(brief.model)}` : ''} from ${brief.sources.length} grounding sources.</p>\n        </div>`);
+    parts.push(`        <div data-intel-brief>\n          <h3>Country brief</h3>\n${briefHtml}\n          <p class="source">${generatedLine}${brief.model ? ` by ${escapeHtml(brief.model)}` : ''} from ${brief.sources.length} grounding sources.</p>\n        </div>`);
   }
   if (timeline.length > 0) {
     const events = timeline
@@ -3172,12 +3258,16 @@ export function assertCountryDevelopmentsRendered({ pagePath, html, developments
     }
   }
   if (rows.brief && typeof rows.brief.text === 'string' && rows.brief.text.trim()) {
-    // Anchor on the first AND last non-empty lines: every generated brief
-    // opens with the same boilerplate header, so the first line alone cannot
-    // catch a cross-country brief swap. The renderer escapes newlines to
-    // <br>, so raw multi-line slices never appear verbatim.
-    const nonEmpty = rows.brief.text.trim().split('\n').map((line) => line.trim()).filter(Boolean);
-    const anchors = [nonEmpty[0], nonEmpty.at(-1)]
+    // Anchor on first AND last content lines after stripping section titles,
+    // bullets, and emphasis markers. Every generated brief opens with the same
+    // boilerplate header, so the first line alone cannot catch a cross-country
+    // swap; markdown conversion means raw `**` and ISO titles never appear.
+    const contentLines = rows.brief.text.trim().split('\n')
+      .map((line) => unwrapBriefEmphasisLine(line.trim()))
+      .filter(Boolean)
+      .filter((line) => !INTEL_BRIEF_SECTION_RE.test(line))
+      .map((line) => line.replace(/^[•\-]\s*/, '').replace(/\*\*/g, ''));
+    const anchors = [contentLines[0], contentLines.at(-1)]
       .filter((line, index, all) => line && all.indexOf(line) === index)
       .map((line) => escapeHtml(line.slice(0, 120)));
     for (const anchor of anchors) {
@@ -3199,6 +3289,40 @@ export function assertCountryDevelopmentsRendered({ pagePath, html, developments
     if (typeof event.occurredAt === 'string' && !html.includes(`datetime="${escapeHtml(event.occurredAt)}"`)) {
       throw new Error(`${pagePath} dropped the date of frozen timeline event ${event.title}`);
     }
+  }
+}
+
+function corpusMainHtml(html) {
+  const source = String(html || '');
+  const match = source.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
+  const main = match ? match[1] : source;
+  return main
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
+}
+
+function corpusVisibleText(html) {
+  return corpusMainHtml(html).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+// #7738: prerendered country briefs were injected as escaped markdown, so
+// crawlers saw literal `**` and `WHAT THIS MEANS FOR NO`. Fail the build
+// when either artifact reaches <main>, including section titles that are
+// still plain text rather than <h*> tags.
+export function assertCountryBriefPresentation({ pagePath, html }) {
+  const main = corpusMainHtml(html);
+  if (main.includes('**')) {
+    throw new Error(`${pagePath} renders literal markdown emphasis in <main>`);
+  }
+  const headingHits = [...main.matchAll(/<h[1-6]\b[^>]*>([\s\S]*?)<\/h[1-6]>/gi)];
+  for (const hit of headingHits) {
+    const text = hit[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (/\bFOR [A-Z]{2}\b/.test(text)) {
+      throw new Error(`${pagePath} heading leaks ISO code: ${text}`);
+    }
+  }
+  if (/\bWHAT THIS MEANS FOR [A-Z]{2}\b/.test(corpusVisibleText(html))) {
+    throw new Error(`${pagePath} brief heading leaks an ISO-3166 alpha-2 code`);
   }
 }
 
@@ -3475,6 +3599,7 @@ ${analysis.readingGuide ? `      <h2>How to use this evidence</h2>
     scriptSrcs: ['/tools/live-tools.js'],
   });
   assertCountryDevelopmentsRendered({ pagePath: path, html, developments });
+  assertCountryBriefPresentation({ pagePath: path, html });
   return html;
 }
 

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -3003,10 +3003,16 @@ ${faqs.map((faq) => `        <details data-country-faq><summary>${escapeHtml(faq
 const INTEL_BRIEF_SECTION_RE = /^(SITUATION NOW|WHAT THIS MEANS FOR\b.*|KEY RISKS|OUTLOOK|WATCH ITEMS)\s*$/i;
 
 function unwrapBriefEmphasisLine(line) {
-  return String(line || '')
-    .replace(/^\*\*(.*)\*\*$/, '$1')
-    .replace(/^#{1,6}\s+/, '')
-    .trim();
+  let current = String(line || '').trim();
+  for (let i = 0; i < 4; i++) {
+    const next = current
+      .replace(/^#{1,6}\s+/, '')
+      .replace(/^\*\*(.*)\*\*$/, '$1')
+      .trim();
+    if (next === current) break;
+    current = next;
+  }
+  return current;
 }
 
 function applyCrawlableBriefEmphasis(escaped) {
@@ -3308,6 +3314,11 @@ function corpusVisibleText(html) {
   return corpusMainHtml(html).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
+function intelBriefHtml(html) {
+  const match = corpusMainHtml(html).match(/<div\b[^>]*\bdata-intel-brief\b[^>]*>([\s\S]*?)<\/div>/i);
+  return match ? match[1] : null;
+}
+
 // #7738: prerendered country briefs were injected as escaped markdown, so
 // crawlers saw literal `**` and `WHAT THIS MEANS FOR NO`. Fail the build
 // when either artifact reaches <main>, including section titles that are
@@ -3319,14 +3330,16 @@ export function assertCountryBriefPresentation({ pagePath, html }) {
   if (main.includes('**')) {
     throw new Error(`${pagePath} renders literal markdown emphasis in <main>`);
   }
-  const headingHits = [...main.matchAll(/<h[1-6]\b[^>]*>([\s\S]*?)<\/h[1-6]>/gi)];
+  const brief = intelBriefHtml(html);
+  const headingSource = brief ?? main;
+  const headingHits = [...headingSource.matchAll(/<h[1-6]\b[^>]*>([\s\S]*?)<\/h[1-6]>/gi)];
   for (const hit of headingHits) {
     const text = hit[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
     if (MEANS_FOR_ISO_RE.test(text)) {
       throw new Error(`${pagePath} heading leaks ISO code: ${text}`);
     }
   }
-  if (MEANS_FOR_ISO_RE.test(corpusVisibleText(html))) {
+  if (MEANS_FOR_ISO_RE.test(corpusVisibleText(brief ?? html))) {
     throw new Error(`${pagePath} brief heading leaks an ISO-3166 alpha-2 code`);
   }
 }

--- a/server/_shared/country-normalize.ts
+++ b/server/_shared/country-normalize.ts
@@ -53,11 +53,23 @@ const ISO2_TO_DISPLAY_NAME = (() => {
   return out;
 })();
 
+function intlRegionName(iso: string): string | null {
+  try {
+    const name = new Intl.DisplayNames(['en'], { type: 'region' }).of(iso);
+    if (typeof name === 'string' && name.trim() && name.toUpperCase() !== iso) {
+      return name;
+    }
+  } catch {
+    // Intl.DisplayNames missing or unknown region — gazetteer fallback below.
+  }
+  return null;
+}
+
 export function displayNameForIso2(raw: unknown): string | null {
   if (typeof raw !== 'string') return null;
   const upper = raw.trim().toUpperCase();
-  if (!/^[A-Z]{2}$/.test(upper)) return null;
-  return ISO2_TO_DISPLAY_NAME.get(upper) ?? null;
+  if (!/^[A-Z]{2}$/.test(upper) || !ISO2_SET.has(upper)) return null;
+  return intlRegionName(upper) ?? ISO2_TO_DISPLAY_NAME.get(upper) ?? null;
 }
 
 export function normalizeCountryToIso2(raw: unknown): string | null {

--- a/server/_shared/country-normalize.ts
+++ b/server/_shared/country-normalize.ts
@@ -23,6 +23,43 @@ const COUNTRY_NAMES = COUNTRY_NAMES_RAW as Record<string, string>;
 // validated against the authoritative gazetteer.
 const ISO2_SET = new Set<string>(Object.values(COUNTRY_NAMES));
 
+function titleCaseName(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+// Reverse the gazetteer once. Several aliases map to the same ISO2; prefer a
+// real name over abbreviations ("usa", "uk", "u s") so callers never have to
+// fall back to the code itself.
+const ISO2_TO_DISPLAY_NAME = (() => {
+  const aliases = new Map<string, string[]>();
+  for (const [name, code] of Object.entries(COUNTRY_NAMES)) {
+    const iso = String(code || '').toUpperCase();
+    if (!/^[A-Z]{2}$/.test(iso)) continue;
+    const list = aliases.get(iso) || [];
+    list.push(name);
+    aliases.set(iso, list);
+  }
+  const out = new Map<string, string>();
+  for (const [iso, names] of aliases) {
+    const preferred = names.find((candidate) => candidate.replace(/[^a-z]/g, '').length > 3)
+      ?? names[0];
+    if (!preferred) continue;
+    out.set(iso, titleCaseName(preferred));
+  }
+  return out;
+})();
+
+export function displayNameForIso2(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const upper = raw.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(upper)) return null;
+  return ISO2_TO_DISPLAY_NAME.get(upper) ?? null;
+}
+
 export function normalizeCountryToIso2(raw: unknown): string | null {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();

--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/intelligence/v1/service_server';
 
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
+import { displayNameForIso2 } from '../../../_shared/country-normalize';
 import { UPSTREAM_TIMEOUT_MS, TIER1_COUNTRIES, sha256Hex } from './_shared';
 import { callLlm } from '../../../_shared/llm';
 import { verifyCitationIndexes, checkLeadGrounding } from '../../../../shared/brief-llm-core.js';
@@ -176,7 +177,10 @@ export async function getCountryIntelBrief(
     energyYear,
     energyImportYear,
   });
-  const countryName = TIER1_COUNTRIES[req.countryCode.toUpperCase()] || req.countryCode;
+  const countryCode = req.countryCode.toUpperCase();
+  const countryName = TIER1_COUNTRIES[countryCode]
+    || displayNameForIso2(countryCode)
+    || req.countryCode;
   const dateStr = new Date().toISOString().split('T')[0];
 
   const systemPrompt = `You are a senior intelligence analyst. Current date: ${dateStr}.
@@ -211,6 +215,7 @@ Rules:
 - If no infrastructure context is provided, use named economic sectors or companies instead.
 - Be specific. Avoid generic phrases like "supply chain disruption risk".
 - If "Brief source articles" are provided, cite supporting claims with bracket markers like [1] or [2]. Do not invent source numbers or URLs.
+- Do not use markdown. Do not wrap names or phrases in ** or other emphasis markers.
 - No speculation beyond what data supports.${lang === 'fr' ? '\n- IMPORTANT: You MUST respond ENTIRELY in French language.' : ''}`;
 
   let result: GetCountryIntelBriefResponse | null = null;

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -695,6 +695,7 @@ export class CountryBriefPage implements CountryBriefPanel {
         : headlineCount > 0
           ? { count: headlineCount, hrefPrefix: '#cb-news-' }
           : undefined,
+      this.currentName ?? undefined,
     );
   }
 

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -3754,6 +3754,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         : headlineCount > 0
           ? { count: headlineCount, hrefPrefix: '#cdp-news-' }
           : undefined,
+      this.currentName ?? undefined,
     );
   }
 

--- a/src/utils/format-intel-brief.ts
+++ b/src/utils/format-intel-brief.ts
@@ -12,7 +12,7 @@ type IntelBriefCitationOptions =
   | { count: number; hrefPrefix: string };
 
 function unwrapBriefEmphasisLine(line: string): string {
-  return line.replace(/^\*\*(.*)\*\*$/, '$1').trim();
+  return line.replace(/^\*\*(.*)\*\*$/, '$1').replace(/^#{1,6}\s+/, '').trim();
 }
 
 function applyBriefEmphasis(escaped: string): string {
@@ -53,8 +53,8 @@ export function formatIntelBrief(
       if (inSection) out.push('</div>');
       out.push(`<div class="brief-section"><div class="brief-section-header">${displayBriefHeader(trimmed, countryName)}</div>`);
       inSection = true;
-    } else if (trimmed.startsWith('•') || trimmed.startsWith('-')) {
-      out.push(`<div class="brief-bullet">${applyBriefEmphasis(trimmed.replace(/^[•-]\s*/, ''))}</div>`);
+    } else if (/^(?:[•\-]\s*|\*\s+)/.test(trimmed)) {
+      out.push(`<div class="brief-bullet">${applyBriefEmphasis(trimmed.replace(/^(?:[•\-]\s*|\*\s+)/, ''))}</div>`);
     } else if (trimmed.startsWith('NEXT ')) {
       const colonIdx = trimmed.indexOf(':');
       if (colonIdx !== -1) {

--- a/src/utils/format-intel-brief.ts
+++ b/src/utils/format-intel-brief.ts
@@ -11,6 +11,21 @@ type IntelBriefCitationOptions =
   | { sources: readonly IntelBriefCitationSource[] }
   | { count: number; hrefPrefix: string };
 
+function unwrapBriefEmphasisLine(line: string): string {
+  return line.replace(/^\*\*(.*)\*\*$/, '$1').trim();
+}
+
+function applyBriefEmphasis(escaped: string): string {
+  return escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>').replace(/\*\*/g, '');
+}
+
+function displayBriefHeader(line: string, countryName?: string): string {
+  if (countryName && /^WHAT THIS MEANS FOR\b/i.test(line)) {
+    return `What this means for ${escapeHtml(countryName)}`;
+  }
+  return applyBriefEmphasis(line);
+}
+
 /**
  * Converts structured LLM intel brief text into HTML.
  * Handles the 5-section format (SITUATION NOW / WHAT THIS MEANS FOR / KEY RISKS / OUTLOOK / WATCH ITEMS).
@@ -18,10 +33,12 @@ type IntelBriefCitationOptions =
  *
  * @param text         Raw brief text from LLM
  * @param citationOpts Optional citation link config for source references like [1], [2]
+ * @param countryName  Display name used to replace ISO-code "WHAT THIS MEANS FOR XX" titles
  */
 export function formatIntelBrief(
   text: string,
   citationOpts?: IntelBriefCitationOptions,
+  countryName?: string,
 ): string {
   const escaped = escapeHtml(text);
   const lines = escaped.split('\n');
@@ -29,26 +46,26 @@ export function formatIntelBrief(
   let inSection = false;
 
   for (const line of lines) {
-    const trimmed = line.trim();
+    const trimmed = unwrapBriefEmphasisLine(line.trim());
     const isHeader = SECTION_HEADERS.some(h => trimmed.toUpperCase().startsWith(h));
 
     if (isHeader) {
       if (inSection) out.push('</div>');
-      out.push(`<div class="brief-section"><div class="brief-section-header">${trimmed}</div>`);
+      out.push(`<div class="brief-section"><div class="brief-section-header">${displayBriefHeader(trimmed, countryName)}</div>`);
       inSection = true;
     } else if (trimmed.startsWith('•') || trimmed.startsWith('-')) {
-      out.push(`<div class="brief-bullet">${trimmed.replace(/^[•-]\s*/, '')}</div>`);
+      out.push(`<div class="brief-bullet">${applyBriefEmphasis(trimmed.replace(/^[•-]\s*/, ''))}</div>`);
     } else if (trimmed.startsWith('NEXT ')) {
       const colonIdx = trimmed.indexOf(':');
       if (colonIdx !== -1) {
-        const label = trimmed.slice(0, colonIdx);
-        const body = trimmed.slice(colonIdx + 1).trim();
+        const label = applyBriefEmphasis(trimmed.slice(0, colonIdx));
+        const body = applyBriefEmphasis(trimmed.slice(colonIdx + 1).trim());
         out.push(`<div class="brief-outlook-row"><strong class="brief-outlook-label">${label}:</strong> ${body}</div>`);
       } else {
-        out.push(`<div class="brief-para">${trimmed}</div>`);
+        out.push(`<div class="brief-para">${applyBriefEmphasis(trimmed)}</div>`);
       }
     } else if (trimmed) {
-      out.push(`<div class="brief-para">${trimmed.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')}</div>`);
+      out.push(`<div class="brief-para">${applyBriefEmphasis(trimmed)}</div>`);
     }
   }
 

--- a/src/utils/format-intel-brief.ts
+++ b/src/utils/format-intel-brief.ts
@@ -12,7 +12,16 @@ type IntelBriefCitationOptions =
   | { count: number; hrefPrefix: string };
 
 function unwrapBriefEmphasisLine(line: string): string {
-  return line.replace(/^\*\*(.*)\*\*$/, '$1').replace(/^#{1,6}\s+/, '').trim();
+  let current = line.trim();
+  for (let i = 0; i < 4; i++) {
+    const next = current
+      .replace(/^#{1,6}\s+/, '')
+      .replace(/^\*\*(.*)\*\*$/, '$1')
+      .trim();
+    if (next === current) break;
+    current = next;
+  }
+  return current;
 }
 
 function applyBriefEmphasis(escaped: string): string {

--- a/tests/brief-contract.test.mjs
+++ b/tests/brief-contract.test.mjs
@@ -250,11 +250,8 @@ describe('brief-contract wiring (source-textual)', () => {
 
   it('country-intel brief interpolates gazetteer names, not ISO-code fallbacks (#7738)', () => {
     const src = readSrc('server/worldmonitor/intelligence/v1/get-country-intel-brief.ts');
-    assert.match(src, /displayNameForIso2/);
-    assert.doesNotMatch(
-      src,
-      /TIER1_COUNTRIES\[req\.countryCode\.toUpperCase\(\)\] \|\| req\.countryCode/,
-    );
+    assert.match(src, /displayNameForIso2\(/);
+    assert.match(src, /TIER1_COUNTRIES\[countryCode\]\s*\|\|\s*displayNameForIso2\(countryCode\)/);
   });
 
   it('panel keeps cited story lines behind a disclosure and renders the freshness footer', () => {

--- a/tests/brief-contract.test.mjs
+++ b/tests/brief-contract.test.mjs
@@ -248,6 +248,15 @@ describe('brief-contract wiring (source-textual)', () => {
     assert.match(src, /brief: citationCheck\.text/);
   });
 
+  it('country-intel brief interpolates gazetteer names, not ISO-code fallbacks (#7738)', () => {
+    const src = readSrc('server/worldmonitor/intelligence/v1/get-country-intel-brief.ts');
+    assert.match(src, /displayNameForIso2/);
+    assert.doesNotMatch(
+      src,
+      /TIER1_COUNTRIES\[req\.countryCode\.toUpperCase\(\)\] \|\| req\.countryCode/,
+    );
+  });
+
   it('panel keeps cited story lines behind a disclosure and renders the freshness footer', () => {
     const src = readSrc('src/components/InsightsPanel.ts');
     assert.match(src, /renderBriefExtras/);

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -199,6 +199,17 @@ describe('normalizeCountryToIso2', () => {
   });
 });
 
+describe('displayNameForIso2', () => {
+  it('resolves non-tier-1 codes such as Norway instead of leaking the ISO code', async () => {
+    const { displayNameForIso2 } = await import('../server/_shared/country-normalize.ts');
+    assert.equal(displayNameForIso2('NO'), 'Norway');
+    assert.equal(displayNameForIso2('no'), 'Norway');
+    assert.equal(displayNameForIso2('US'), 'United States');
+    assert.equal(displayNameForIso2('GB'), 'United Kingdom');
+    assert.equal(displayNameForIso2('ZZ'), null);
+  });
+});
+
 // ── Cache-key stability ──────────────────────────────────────────────────
 
 describe('cache key identity', () => {

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -206,6 +206,10 @@ describe('displayNameForIso2', () => {
     assert.equal(displayNameForIso2('no'), 'Norway');
     assert.equal(displayNameForIso2('US'), 'United States');
     assert.equal(displayNameForIso2('GB'), 'United Kingdom');
+    assert.equal(displayNameForIso2('PS'), 'Palestinian Territories');
+    assert.equal(displayNameForIso2('CD'), 'Congo - Kinshasa');
+    assert.equal(displayNameForIso2('LA'), 'Laos');
+    assert.equal(displayNameForIso2('KR'), 'South Korea');
     assert.equal(displayNameForIso2('ZZ'), null);
   });
 });

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -20,6 +20,7 @@ import {
   buildChokepointHubRows,
   buildCorpus,
   buildMicrostateCoverageStory,
+  assertCountryBriefPresentation,
   assertCountryDevelopmentsRendered,
   assertDevelopmentsCoverage,
   CHOKEPOINT_PAGE_CONTENT_VERSION,
@@ -5186,7 +5187,7 @@ describe('live-pulse snapshot injection (#7533)', () => {
   // #7533-allowlist: 2026-08-08 x3 2026-08-09 x4 2026-08-10 x4 2026-08-11 x3 2026-08-12 x3 2026-08-13 x4 — sourcePageLastmod pure-function fixtures
   // #7533-allowlist: 2026-08-29 x5 — STORY_CAPTURED_AT synthetic story clock and static snapshot-path fixtures
   // #7533-allowlist: 2026-09-01 x4 — CORPUS_GENERATOR_CONTENT_VERSION and synthetic development fixtures
-  // #7533-allowlist: 2026-09-02 x11 — synthetic developments timestamps
+  // #7533-allowlist: 2026-09-02 x13 — synthetic developments timestamps
   // #7533-allowlist: 2026-09-03 x13 — genuinely static: research lastmod, DataCatalog render fixture, datasetObservationCoverage fixtures
   it('rejects undocumented calendar-date literals in this file', () => {
     const source = readFileSync(fileURLToPath(import.meta.url), 'utf8');
@@ -5278,13 +5279,83 @@ describe('country recent developments', () => {
     assert.ok(!html.toLowerCase().includes('driven by'));
     // Brief body, generation line and grounding source count.
     assert.ok(html.includes('data-intel-brief'));
-    assert.ok(html.includes('SITUATION NOW<br>Convoys move under escort [1].'));
+    assert.ok(html.includes('<h3>Situation now</h3>'));
+    assert.ok(html.includes('Convoys move under escort [1].'));
     assert.ok(html.includes('<time datetime="2026-09-02T12:00:00.000Z">'));
     assert.ok(html.includes('from 2 grounding sources'));
     // Timeline event with summary, domain and source link.
     assert.ok(html.includes('data-intel-timeline'));
     assert.ok(html.includes('Port call logged in SD'));
     assert.ok(html.includes('<a href="https://example.test/port-call">source</a>'));
+  });
+
+  it('rejects literal markdown emphasis and ISO brief-heading leaks (#7738)', () => {
+    assert.throws(
+      () => assertCountryBriefPresentation({
+        pagePath: '/countries/norway/',
+        html: '<main><h3>Country brief</h3><p>**NBIM** proposed a sale [1].</p></main>',
+      }),
+      /literal markdown emphasis/,
+    );
+    assert.throws(
+      () => assertCountryBriefPresentation({
+        pagePath: '/countries/norway/',
+        html: '<main><h3>WHAT THIS MEANS FOR NO</h3><p>Named entity impact [1].</p></main>',
+      }),
+      /heading leaks ISO code/,
+    );
+    assert.throws(
+      () => assertCountryBriefPresentation({
+        pagePath: '/countries/norway/',
+        html: '<main><h3>Country brief</h3><p>WHAT THIS MEANS FOR NO<br>Named entity impact [1].</p></main>',
+      }),
+      /brief heading leaks an ISO-3166 alpha-2 code/,
+    );
+    assert.doesNotThrow(() => assertCountryBriefPresentation({
+      pagePath: '/countries/norway/',
+      html: '<main><h3>What this means for Norway</h3><p><strong>NBIM</strong> proposed a sale [1].</p></main>',
+    }));
+  });
+
+  it('renders frozen intel briefs as HTML with country names, not markdown or ISO codes (#7738)', () => {
+    const html = renderCountryDevelopments({
+      countryName: 'Norway',
+      developments: {
+        headlines: [],
+        brief: {
+          text: [
+            'SITUATION NOW',
+            'Norway’s sovereign wealth fund proposed cutting U.S. Treasury holdings [1].',
+            '',
+            'WHAT THIS MEANS FOR NO',
+            '• **Norges Bank Investment Management (NBIM)**: Proposed slashing of U.S. Treasury holdings [1].',
+            '• **Russian ship seizure**: Sparks diplomatic retaliation from Moscow.',
+            '',
+            'KEY RISKS',
+            '• **Retaliatory Russian actions**: maritime restrictions.',
+            '',
+            'OUTLOOK',
+            'NEXT 24H: Officials respond.',
+            '',
+            'WATCH ITEMS',
+            'NBIM asset allocation announcement · Russian maritime declarations',
+          ].join('\n'),
+          model: 'test-model',
+          generatedAt: '2026-09-02T08:16:38.074Z',
+          sources: [HEADLINE],
+        },
+        timeline: [],
+        briefSkipped: null,
+        capturedAt: '2026-09-02T08:16:38.074Z',
+      },
+    });
+    assertCountryBriefPresentation({ pagePath: '/countries/norway/', html });
+    assert.ok(!html.includes('**'), 'emphasis markers must not reach the page');
+    assert.ok(html.includes('<strong>Norges Bank Investment Management (NBIM)</strong>'));
+    assert.ok(html.includes('<h3>What this means for Norway</h3>'));
+    assert.ok(!/\bFOR [A-Z]{2}\b/.test(html.replace(/<[^>]+>/g, ' ')));
+    assert.ok(html.includes('<h3>Situation now</h3>'));
+    assert.ok(html.includes('Norway’s sovereign wealth fund proposed cutting U.S. Treasury holdings [1].'));
   });
 
   it('appends brief-only sources without duplicating headline URLs', () => {
@@ -5650,6 +5721,22 @@ describe('country recent developments', () => {
       'a country with no frozen developments renders no section');
     const plainWebPage = jsonLdObjects(plain).find((entry) => entry['@type'] === 'WebPage');
     assert.ok(!('dateModified' in plainWebPage), 'no items means no dateModified claim');
+  });
+
+  it('sweeps every frozen pulse brief for markdown and ISO heading leaks (#7738)', async () => {
+    const data = await loadCorpusData({ rootDir: repoRoot });
+    const names = new Map(data.countries.map((entry) => [entry.code, entry.name]));
+    let briefCount = 0;
+    for (const [code, row] of Object.entries(data.livePulse?.countries || {})) {
+      const developments = row?.developments;
+      if (!developments?.brief?.text) continue;
+      briefCount += 1;
+      const name = names.get(code);
+      assert.ok(name, `pulse country ${code} must resolve to a display name`);
+      const html = renderCountryDevelopments({ countryName: name, developments });
+      assertCountryBriefPresentation({ pagePath: `/countries/${code}/`, html });
+    }
+    assert.ok(briefCount >= 10, `expected frozen briefs to sweep, got ${briefCount}`);
   });
 });
 describe('GEO residue #7616 (U2b changelog lastmod)', () => {

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -5187,7 +5187,7 @@ describe('live-pulse snapshot injection (#7533)', () => {
   // #7533-allowlist: 2026-08-08 x3 2026-08-09 x4 2026-08-10 x4 2026-08-11 x3 2026-08-12 x3 2026-08-13 x4 — sourcePageLastmod pure-function fixtures
   // #7533-allowlist: 2026-08-29 x5 — STORY_CAPTURED_AT synthetic story clock and static snapshot-path fixtures
   // #7533-allowlist: 2026-09-01 x4 — CORPUS_GENERATOR_CONTENT_VERSION and synthetic development fixtures
-  // #7533-allowlist: 2026-09-02 x13 — synthetic developments timestamps
+  // #7533-allowlist: 2026-09-02 x15 — synthetic developments timestamps
   // #7533-allowlist: 2026-09-03 x13 — genuinely static: research lastmod, DataCatalog render fixture, datasetObservationCoverage fixtures
   it('rejects undocumented calendar-date literals in this file', () => {
     const source = readFileSync(fileURLToPath(import.meta.url), 'utf8');
@@ -5326,6 +5326,10 @@ describe('country recent developments', () => {
       pagePath: '/countries/tools/',
       html: '<main><h3>WATCH FOR AI</h3><p>Unrelated heading.</p></main>',
     }));
+    assert.doesNotThrow(() => assertCountryBriefPresentation({
+      pagePath: '/countries/norway/',
+      html: '<main><p>Analysts asked what this means for us.</p><div data-intel-brief><h3>What this means for Norway</h3></div></main>',
+    }));
   });
 
   it('renders frozen intel briefs as HTML with country names, not markdown or ISO codes (#7738)', () => {
@@ -5365,6 +5369,23 @@ describe('country recent developments', () => {
     assert.ok(html.includes('<strong>Norges Bank Investment Management (NBIM)</strong>'));
     assert.ok(html.includes('<h3>What this means for Norway</h3>'));
     assert.ok(!/\bFOR [A-Z]{2}\b/.test(html.replace(/<[^>]+>/g, ' ')));
+    const combined = renderCountryDevelopments({
+      countryName: 'Norway',
+      developments: {
+        headlines: [],
+        brief: {
+          text: '### **WHAT THIS MEANS FOR NO**\nNamed infrastructure impact [1].',
+          model: 'test-model',
+          generatedAt: '2026-09-02T08:16:38.074Z',
+          sources: [HEADLINE],
+        },
+        timeline: [],
+        briefSkipped: null,
+        capturedAt: '2026-09-02T08:16:38.074Z',
+      },
+    });
+    assertCountryBriefPresentation({ pagePath: '/countries/norway/', html: combined });
+    assert.ok(combined.includes('<h3>What this means for Norway</h3>'));
     assert.ok(html.includes('<h3>Situation now</h3>'));
     assert.ok(html.includes('Norway’s sovereign wealth fund proposed cutting U.S. Treasury holdings [1].'));
   });

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -5307,6 +5307,13 @@ describe('country recent developments', () => {
     assert.throws(
       () => assertCountryBriefPresentation({
         pagePath: '/countries/norway/',
+        html: '<main><h3>What this means for NO</h3><p>Named entity impact [1].</p></main>',
+      }),
+      /heading leaks ISO code/,
+    );
+    assert.throws(
+      () => assertCountryBriefPresentation({
+        pagePath: '/countries/norway/',
         html: '<main><h3>Country brief</h3><p>WHAT THIS MEANS FOR NO<br>Named entity impact [1].</p></main>',
       }),
       /brief heading leaks an ISO-3166 alpha-2 code/,
@@ -5314,6 +5321,10 @@ describe('country recent developments', () => {
     assert.doesNotThrow(() => assertCountryBriefPresentation({
       pagePath: '/countries/norway/',
       html: '<main><h3>What this means for Norway</h3><p><strong>NBIM</strong> proposed a sale [1].</p></main>',
+    }));
+    assert.doesNotThrow(() => assertCountryBriefPresentation({
+      pagePath: '/countries/tools/',
+      html: '<main><h3>WATCH FOR AI</h3><p>Unrelated heading.</p></main>',
     }));
   });
 

--- a/tests/format-intel-brief.test.mts
+++ b/tests/format-intel-brief.test.mts
@@ -54,4 +54,15 @@ describe('formatIntelBrief markdown and ISO headings', () => {
     assert.match(html, /What this means for Georgia/);
     assert.doesNotMatch(html, /\bFOR GE\b/);
   });
+
+  it('strips markdown heading markers before rewriting ISO titles', () => {
+    const html = formatIntelBrief(
+      '# WHAT THIS MEANS FOR NO\n* **NBIM**: sale.',
+      undefined,
+      'Norway',
+    );
+    assert.match(html, /What this means for Norway/);
+    assert.match(html, /<strong>NBIM<\/strong>/);
+    assert.doesNotMatch(html, /\bFOR NO\b/);
+  });
 });

--- a/tests/format-intel-brief.test.mts
+++ b/tests/format-intel-brief.test.mts
@@ -65,4 +65,14 @@ describe('formatIntelBrief markdown and ISO headings', () => {
     assert.match(html, /<strong>NBIM<\/strong>/);
     assert.doesNotMatch(html, /\bFOR NO\b/);
   });
+
+  it('unwraps combined heading markers before rewriting ISO titles', () => {
+    const html = formatIntelBrief(
+      '### **WHAT THIS MEANS FOR NO**\nNamed infrastructure impact.',
+      undefined,
+      'Norway',
+    );
+    assert.match(html, /What this means for Norway/);
+    assert.doesNotMatch(html, /\bFOR NO\b/);
+  });
 });

--- a/tests/format-intel-brief.test.mts
+++ b/tests/format-intel-brief.test.mts
@@ -23,3 +23,35 @@ describe('formatIntelBrief citations', () => {
     assert.match(html, /href="#cb-news-2"/);
   });
 });
+
+describe('formatIntelBrief markdown and ISO headings', () => {
+  it('converts emphasis markers inside bullets, not just paragraphs', () => {
+    const html = formatIntelBrief(
+      'WHAT THIS MEANS FOR NO\n• **Norges Bank Investment Management (NBIM)**: sale [1].',
+      { sources: [{ title: 'CNBC', url: 'https://example.com/nbim' }] },
+      'Norway',
+    );
+    assert.match(html, /<strong>Norges Bank Investment Management \(NBIM\)<\/strong>/);
+    assert.doesNotMatch(html, /\*\*/);
+  });
+
+  it('rewrites ISO-code section titles to the country name', () => {
+    const html = formatIntelBrief(
+      'WHAT THIS MEANS FOR NO\nNamed infrastructure impact.',
+      undefined,
+      'Norway',
+    );
+    assert.match(html, /What this means for Norway/);
+    assert.doesNotMatch(html, /\bFOR NO\b/);
+  });
+
+  it('recognizes section titles wrapped in markdown emphasis', () => {
+    const html = formatIntelBrief(
+      '**WHAT THIS MEANS FOR GE**\nNamed infrastructure impact.',
+      undefined,
+      'Georgia',
+    );
+    assert.match(html, /What this means for Georgia/);
+    assert.doesNotMatch(html, /\bFOR GE\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Country pages no longer show literal `**` emphasis or headings like `WHAT THIS MEANS FOR NO`. Frozen intel briefs render as HTML with the country name, and new briefs get a real name in the prompt instead of a two-letter code.

Fixes #7738

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [x] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: crawlable `/countries/*` corpus

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [x] Claim ledger attached or linked — N/A (no documentation claims changed)
- [x] All required Audit Council role signoffs attached — N/A
- [x] Generated docs regenerated from proto where applicable — N/A
- [x] Fixture-backed examples recomputed — N/A
- [x] Redis writers/readers enumerated for every documented key — N/A

## Screenshots

Not captured. This is prerendered HTML, proven by corpus generation plus a sweep of every frozen pulse brief.

Before (live `/countries/norway/`): `WHAT THIS MEANS FOR NO` and `**Norges Bank Investment Management (NBIM)**` inside `<main>`.

After: `<h3>What this means for Norway</h3>` and `<strong>Norges Bank Investment Management (NBIM)</strong>`.

## Validation

- `tests/crawlable-corpus.test.mjs`: 113/113, including a full corpus build (196 country pages) and a sweep of every frozen pulse brief (40 briefs; 32 had `**`, 23 had `FOR [A-Z]{2}`).
- `tests/format-intel-brief.test.mts`, `tests/brief-why-matters-analyst.test.mjs`, `tests/brief-contract.test.mjs`.
- `npm run typecheck` and `npm run typecheck:api`.
- Pre-push gates passed (boundaries, safe HTML, handler tests, edge bundles).

## Review Gates

Code review: completed (`status: complete`, `run_id: 7738-corpus-brief`, `artifact_path: /tmp/ce-code-review/7738-corpus-brief`). Security review found no XSS. Applied: Intl.DisplayNames for ISO2 labels, case-insensitive heading guard, `#` / `*` brief variants.

## Residual Findings

- P3: the `**` guard still scans all of `<main>`, as #7738 asked. A news headline that contains `**` would fail the corpus build.

## Post-Deploy Monitoring & Validation

After the next crawlable-corpus build/deploy:

- Open `/countries/norway/` and confirm `<main>` has no literal `**` and no `What this means for NO`.
- Spot-check Georgia (`**WHAT THIS MEANS FOR GE**` in the frozen brief) and a TIER1 country (United States).
- Failure signal: crawlers still extract `WHAT THIS MEANS FOR [A-Z]{2}` or `**` from country `<main>`. Rollback: revert this PR and rebuild the corpus.
- Window: first production corpus deploy after merge. Owner: merging author.

Related: #7615

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)