### PR TITLE
fix(pro-test): keep the leaked deadline visible (WORLDMONITOR-11Y)

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -355,7 +355,6 @@ const STACK_OVERFLOW = /Maximum call stack size exceeded|too much recursion/i;
  * abort that genuinely escaped a `.catch`.
  */
 const LEAKED_ABORT = /^(?:AbortError: )?The user aborted a request\.?$/;
-const LEAKED_DEADLINE = /^(?:TimeoutError: )?signal timed out$/;
 /**
  * A marketing document frame: `/`, `/pro`, or an absolute URL on any production,
  * preview, or custom host with one of those paths. Query strings, hashes, and a
@@ -493,19 +492,24 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // in `src/bootstrap/sentry-init.ts`.
   if (!hasFirstParty && LEAKED_ABORT.test(msg)) return null;
 
-  // The deadline sibling (WORLDMONITOR-11Y). `AbortSignal.timeout` rejects with
-  // this exact wording, and `createTimeoutSignal` reproduces it on engines
-  // lacking the native API. So unlike the bare-abort case above, this message
-  // CAN be ours. The census argument that justifies LEAKED_ABORT does not
-  // transfer here.
+  // No deadline sibling here, deliberately. `TimeoutError: signal timed out`
+  // (WORLDMONITOR-11Y) looks like an obvious companion to the abort rule above,
+  // and it is not: the `!hasFirstParty` gate cannot carry it.
   //
-  // What carries it instead is the frame gate alone. The browser fires these
-  // from internal infra at the timer boundary, so a leaked deadline arrives with
-  // zero frames; a first-party fetch that genuinely failed to handle its own
-  // deadline surfaces a `/pro/assets/*.js` frame and is kept. Dashboard-side the
-  // same class is dropped by the `!hasFirstParty` gate in
-  // `src/bootstrap/sentry-init.ts` (WORLDMONITOR-66/-62).
-  if (!hasFirstParty && LEAKED_DEADLINE.test(msg)) return null;
+  // `AbortSignal.timeout` builds its DOMException at the timer boundary, so the
+  // reason's stack holds only engine-internal frames and never the caller's.
+  // A marketing fetch that loses its own catch therefore reaches
+  // `unhandledrejection` with the SAME zero-frame shape as third-party noise;
+  // ownership adds no `/pro/assets/*.js` frame to distinguish them. Six call
+  // sites here carry a timeout signal, including `checkout.ts` and
+  // `checkout-transport.ts`, so suppressing the shape would blind a revenue
+  // path to silence one event. Same keep-visible reasoning as the zero-frame
+  // stack overflow in WORLDMONITOR-WK.
+  //
+  // The dashboard's gate in `src/bootstrap/sentry-init.ts` (WORLDMONITOR-66/-62)
+  // is not a precedent to copy: that bundle mints its own `signal timed out`
+  // DOMException in first-party code, which does carry caller frames.
+  // `tests/pro-sentry-filter-policy.test.mts` locks this absence in.
 
   // Safari-masked injected script. The observed event (WORLDMONITOR-110,
   // `TypeError: Attempting to change value of a readonly property.` on iOS

--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -355,6 +355,7 @@ const STACK_OVERFLOW = /Maximum call stack size exceeded|too much recursion/i;
  * abort that genuinely escaped a `.catch`.
  */
 const LEAKED_ABORT = /^(?:AbortError: )?The user aborted a request\.?$/;
+const LEAKED_DEADLINE = /^(?:TimeoutError: )?signal timed out$/;
 /**
  * A marketing document frame: `/`, `/pro`, or an absolute URL on any production,
  * preview, or custom host with one of those paths. Query strings, hashes, and a
@@ -491,6 +492,20 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // covered by the standing `(?:AbortError: )?The user aborted a request` entry
   // in `src/bootstrap/sentry-init.ts`.
   if (!hasFirstParty && LEAKED_ABORT.test(msg)) return null;
+
+  // The deadline sibling (WORLDMONITOR-11Y). `AbortSignal.timeout` rejects with
+  // this exact wording, and `createTimeoutSignal` reproduces it on engines
+  // lacking the native API. So unlike the bare-abort case above, this message
+  // CAN be ours. The census argument that justifies LEAKED_ABORT does not
+  // transfer here.
+  //
+  // What carries it instead is the frame gate alone. The browser fires these
+  // from internal infra at the timer boundary, so a leaked deadline arrives with
+  // zero frames; a first-party fetch that genuinely failed to handle its own
+  // deadline surfaces a `/pro/assets/*.js` frame and is kept. Dashboard-side the
+  // same class is dropped by the `!hasFirstParty` gate in
+  // `src/bootstrap/sentry-init.ts` (WORLDMONITOR-66/-62).
+  if (!hasFirstParty && LEAKED_DEADLINE.test(msg)) return null;
 
   // Safari-masked injected script. The observed event (WORLDMONITOR-110,
   // `TypeError: Attempting to change value of a readonly property.` on iOS

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -1050,3 +1050,28 @@ describe('marketingBeforeSend — leaked fetch abort (WORLDMONITOR-11M)', () => 
     assert.equal(marketingBeforeSend(kept), kept);
   });
 });
+
+describe('marketingBeforeSend — leaked fetch deadline (WORLDMONITOR-11Y)', () => {
+  const TIMED_OUT = 'TimeoutError: signal timed out';
+
+  it('drops the zero-frame deadline rejection', () => {
+    assert.equal(marketingBeforeSend(event(TIMED_OUT)), null);
+    // Chrome reports it without the type prefix in `value` too.
+    assert.equal(marketingBeforeSend(event('signal timed out')), null);
+  });
+
+  it('keeps the same message when a marketing-bundle frame is present', () => {
+    const kept = event(TIMED_OUT, ['/pro/assets/main-Ab12Cd.js']);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  it('keeps the same message when a source-mapped frame is present', () => {
+    const kept = event(TIMED_OUT, ['src/services/teasers.ts']);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  it('keeps an unrelated timeout-flavoured message', () => {
+    const kept = event('Entitlement poll signal timed out after 8s');
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+});

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -1051,22 +1051,39 @@ describe('marketingBeforeSend — leaked fetch abort (WORLDMONITOR-11M)', () => 
   });
 });
 
-describe('marketingBeforeSend — leaked fetch deadline (WORLDMONITOR-11Y)', () => {
+/**
+ * The deadline shape stays visible on purpose (WORLDMONITOR-11Y).
+ *
+ * It reads as an obvious sibling of the leaked-abort rule above, and a
+ * suppression was written and reverted before this test existed. The reason it
+ * cannot ship: `AbortSignal.timeout` constructs its DOMException at the timer
+ * boundary, so the reason's stack carries only engine-internal frames.
+ * Confirmed directly, the reason's own stack reads
+ * `at new DOMException (node:internal/per_context/domexception)` then
+ * `at Timeout._onTimeout (node:internal/abort_controller)`, with no caller.
+ *
+ * So a marketing fetch that loses its catch arrives frameless, exactly like
+ * third-party noise, and `!hasFirstParty` cannot separate them. Six call sites
+ * on this surface carry a timeout signal, `checkout.ts` and
+ * `checkout-transport.ts` among them.
+ *
+ * Same disposition as the zero-frame stack overflow in WORLDMONITOR-WK: an
+ * ambiguous frameless error at low volume stays reportable. If this shape ever
+ * earns suppression it needs positive third-party provenance, not a frame gate.
+ */
+describe('marketingBeforeSend — leaked fetch deadline stays visible (WORLDMONITOR-11Y)', () => {
   const TIMED_OUT = 'TimeoutError: signal timed out';
 
-  it('drops the zero-frame deadline rejection', () => {
-    assert.equal(marketingBeforeSend(event(TIMED_OUT)), null);
-    // Chrome reports it without the type prefix in `value` too.
-    assert.equal(marketingBeforeSend(event('signal timed out')), null);
+  it('keeps the zero-frame deadline rejection', () => {
+    const kept = event(TIMED_OUT);
+    assert.equal(marketingBeforeSend(kept), kept,
+      'a frameless deadline is indistinguishable from a first-party leak — see the block comment');
+    const bare = event('signal timed out');
+    assert.equal(marketingBeforeSend(bare), bare);
   });
 
-  it('keeps the same message when a marketing-bundle frame is present', () => {
+  it('keeps it when a marketing-bundle frame is present', () => {
     const kept = event(TIMED_OUT, ['/pro/assets/main-Ab12Cd.js']);
-    assert.equal(marketingBeforeSend(kept), kept);
-  });
-
-  it('keeps the same message when a source-mapped frame is present', () => {
-    const kept = event(TIMED_OUT, ['src/services/teasers.ts']);
     assert.equal(marketingBeforeSend(kept), kept);
   });
 


### PR DESCRIPTION
## Summary

`TimeoutError: signal timed out` (WORLDMONITOR-11Y) reaches Sentry from the marketing bundle and looks like an obvious sibling of the leaked-abort rule that sits right above it. It is not, and this PR records why, so the next person to notice the gap finds a red test instead of shipping the same wrong fix.

This PR originally added that suppression. The Codex review caught it and was right.

**The mechanism.** `AbortSignal.timeout` constructs its DOMException at the timer boundary, so the reason's stack holds only engine-internal frames and never the caller's. Verified directly rather than argued:

```
name: TimeoutError
stack: TimeoutError: The operation was aborted due to timeout
    at new DOMException (node:internal/per_context/domexception:76:18)
    at Timeout._onTimeout (node:internal/abort_controller:210:9)
```

No caller frame. A marketing fetch that loses its own catch therefore reaches `unhandledrejection` frameless, exactly like third-party noise, so `!hasFirstParty` cannot separate them and the gate would have dropped both. The preservation tests passed only because they manufacture frames a real leak does not have, which is precisely what the review pointed out.

**Why keeping it visible is the right call, not just the safe one.** Six call sites on this surface carry a timeout signal, `checkout.ts` and `checkout-transport.ts` among them. Suppressing the shape trades visibility on a revenue path for silence on a single event. That is the same disposition the repo already reached for the zero-frame stack overflow in WORLDMONITOR-WK: an ambiguous frameless error at low volume stays reportable.

The dashboard's gate in `src/bootstrap/sentry-init.ts` (WORLDMONITOR-66/-62) is not a precedent to copy here. That bundle mints its own `signal timed out` DOMException in first-party code, which does carry caller frames, so its gate is separating something this one cannot.

## What ships

No behaviour change to the filter. What lands is the absence, made enforceable: a test asserting the shape is kept, with the mechanism recorded beside it.

If this shape ever earns suppression it needs positive third-party provenance, not a frame gate.

## Validation

`tests/pro-sentry-filter-policy.test.mts` and `pro-sentry-chunk`: 99/99 pass. `npm --prefix pro-test run lint` clean.

The lock-in was mutation-tested, since a guard that cannot fail is worth nothing. Re-adding the suppression turns `keeps the zero-frame deadline rejection` red:

```
✖ keeps the zero-frame deadline rejection
ℹ pass 90   ℹ fail 1
```

History keeps the full arc: the failing repro, the suppression, then the revert with the evidence that refuted it.

Related: WORLDMONITOR-11Y

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_014qiv5bDjrAiVfzgcdL9xKR
