### PR TITLE
fix(market-breadth): recover missed refreshes with source dates

### DIFF
--- a/docs/solutions/integration-issues/barchart-waf-challenge-answers-202-and-passes-resp-ok.md
+++ b/docs/solutions/integration-issues/barchart-waf-challenge-answers-202-and-passes-resp-ok.md
@@ -77,3 +77,58 @@ The replacement removes the dependence on a rendered page entirely. The scanner 
 - PR #7723 (the fix).
 - `docs/solutions/integration-issues/upstash-max-request-size-counts-one-command-and-answers-http-200.md`: another upstream that reports success on the status line while the body says otherwise.
 - `seed-fear-greed.mjs` still scrapes `$CPC` (total put/call) from Barchart; the status gate is now `status !== 200` so a 202 logs as HTTP 202 instead of "price not found". It still degrades to null and needs its own source. TradingView lists `USI:PCC` but the scanner does not serve it.
+
+## Recovery after a repaired deployment
+
+A source repair that arrives after a Saturday run can wait until Tuesday under
+the `0 2 * * 2-6` schedule. This is a recovery gap even when the scheduler works.
+
+The desired cron is now `0 2,8 * * *`. Two daily attempts cap the normal wait at
+18 hours, including weekends and holidays. `runSeed` retains its four-attempt
+limit and exponential backoff. Each scan has a 15-second timeout. The breadth
+fetch phase has a 90-second deadline. A challenge or incomplete scan ends the
+attempt without immediate retries. There are at most eight source requests per
+day under persistent transient failure.
+
+The scanner request includes `time`, the source daily-bar open timestamp.
+All rows must belong to the same completed weekday session. New York time
+handles DST. The seeder waits until 16:00 even on early-close days. It uses the
+source session date for history, so a weekend or holiday attempt cannot create
+a weekend or holiday row. Repeat attempts update the same latest row. An older
+session cannot replace a newer published session. Missed sessions are not backfilled.
+
+Failed requests, incomplete readings, and invalid dates preserve both last-good
+history and success metadata. The existing 96-hour seed-age health budget is
+unchanged. A new five-day content-age limit starts at the source bar's open,
+which precedes overnight collection. That extra calendar day covers the timestamp
+offset and holiday collection window. It prevents repeated valid responses from
+keeping an unchanged source healthy forever. A short failed refresh retains its
+previous health verdict until the real seed or source budget expires.
+
+`tests/market-breadth-recovery.test.mts` executes the real seeder and `runSeed`
+against a fake Redis transport. It checks the health classifier, RPC reader,
+bootstrap envelope reader, and Fear & Greed breadth reader. The original code
+fails the Sunday recovery case by storing September 5 for September 4 data.
+It also republishes an old source. The fixed tests cover repeat attempts,
+failed and partial scans, and bounded transient retries.
+
+### Pending operator application
+
+After the code has merged and the deployed service includes the session-date
+guards, an operator must authorize the following change for `seed-market-breadth`:
+
+- Set **Cron Schedule** to `0 2,8 * * *` in Railway.
+- Keep **Start Command** as `node seed-market-breadth.mjs`.
+- Verify the adapter and seeder remain in the service watch paths.
+
+Do not apply the more frequent schedule before the date guards are deployed.
+The old worker stamps rows with its wall-clock date. The fleet-wide
+`audit-railway-watch-paths.mjs --apply` can change other services and is not a
+scoped application command for this repair.
+
+After application, wait for a natural scheduled run. Confirm the deployed commit,
+complete constituent scan, source session date, canonical envelope, and
+`seed-meta:market:breadth-history` advancement. Confirm that the breadth RPC and
+Fear & Greed reader agree on the published 200-day reading. Check the next repeat
+attempt for a duplicate-free history and unchanged source timestamp.
+A successful deployment or green CI alone does not establish production acceptance.

--- a/scripts/_sp500-breadth.mjs
+++ b/scripts/_sp500-breadth.mjs
@@ -14,7 +14,8 @@ const WINDOWS = [
   { field: 'pctAbove50d', column: 'SMA50' },
   { field: 'pctAbove200d', column: 'SMA200' },
 ];
-const COLUMNS = ['name', 'close', ...WINDOWS.map((w) => w.column)];
+const COLUMNS = ['name', 'close', ...WINDOWS.map((w) => w.column), 'time'];
+const TIME_INDEX = COLUMNS.indexOf('time');
 const CLOSE_INDEX = 1;
 const FIRST_SMA_INDEX = 2;
 // Pin the page so a library-default [0, 50] cannot pass the 450-row floor as
@@ -23,6 +24,11 @@ const SCAN_RANGE = [0, 1000];
 
 export const BREADTH_HISTORY_KEY = 'market:breadth-history:v1';
 export const HISTORY_LENGTH = 252;
+// Daily bars start at the open, before the overnight seed. Allow that extra
+// calendar day in the content budget; the existing seed-age budget stays 96h.
+export const MAX_SESSION_AGE_MIN = 7200;
+const SESSION_DATE = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
+const SESSION_HOUR = new Intl.DateTimeFormat('en-US', { timeZone: 'America/New_York', hour: '2-digit', hourCycle: 'h23' });
 
 // The index holds ~503 tickers (dual share classes included). A window with
 // fewer valid rows than this is a partial scan, and a percentage of a partial
@@ -38,7 +44,7 @@ function scanError(message, { status, nonRetryable = true, retryAfterMs } = {}) 
 }
 
 /**
- * @param {Array<{ s: string, d: Array<string|number|null> }>} rows scanner rows, d = [name, close, SMA20, SMA50, SMA200]
+ * @param {Array<{ s: string, d: Array<string|number|null> }>} rows scanner rows, d = [name, close, SMA20, SMA50, SMA200, time]
  * @returns {{ readings: Record<string, number|null>, constituents: number, valid: Record<string, number> }}
  */
 export function computeBreadth(rows, minValid = MIN_VALID_CONSTITUENTS) {
@@ -69,6 +75,7 @@ export function requireCompleteReadings(readings) {
 export function mergeBreadthHistory(history, readings, today, maxLength = HISTORY_LENGTH) {
   const next = Array.isArray(history) ? history.map((entry) => ({ ...entry })) : [];
   const last = next.at(-1);
+  if (last?.date > today) throw scanError(`Breadth session ${today} is older than published ${last.date}`);
   const updatedExisting = last?.date === today;
   if (updatedExisting) {
     last.pctAbove20d = readings.pctAbove20d;
@@ -134,7 +141,7 @@ export async function readPublishedPctAbove200d(opts) {
   return Number.isFinite(value) ? value : null;
 }
 
-export async function fetchSp500Breadth({ fetchImpl = fetch, timeoutMs = 15_000 } = {}) {
+export async function fetchSp500Breadth({ fetchImpl = fetch, timeoutMs = 15_000, now = Date.now() } = {}) {
   const resp = await fetchImpl(SCANNER_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': CHROME_UA },
@@ -166,5 +173,25 @@ export async function fetchSp500Breadth({ fetchImpl = fetch, timeoutMs = 15_000 
       `TradingView scan truncated: totalCount=${body.totalCount} data=${body.data.length}`,
     );
   }
-  return computeBreadth(body.data);
+  const breadth = computeBreadth(body.data);
+  requireCompleteReadings(breadth.readings);
+  const sourceSessionAt = body.data[0]?.d?.[TIME_INDEX] * 1000;
+  if (!Number.isFinite(sourceSessionAt) || sourceSessionAt <= 0 || sourceSessionAt > now
+      || now - sourceSessionAt > MAX_SESSION_AGE_MIN * 60_000) {
+    throw scanError('Breadth source session is missing, future, or stale');
+  }
+  const sessionDate = SESSION_DATE.format(sourceSessionAt);
+  if (body.data.some((row) => !Number.isFinite(row?.d?.[TIME_INDEX])
+      || row.d[TIME_INDEX] <= 0 || row.d[TIME_INDEX] * 1000 > now
+      || SESSION_DATE.format(row.d[TIME_INDEX] * 1000) !== sessionDate)) {
+    throw scanError('Breadth scan contains missing or mixed source sessions');
+  }
+  const weekday = new Date(`${sessionDate}T12:00:00Z`).getUTCDay();
+  // A daily bar's timestamp is its open. Wait until the regular close even
+  // on early-close days; the twice-daily cron runs outside trading hours.
+  if (weekday === 0 || weekday === 6
+      || (sessionDate === SESSION_DATE.format(now) && Number(SESSION_HOUR.format(now)) < 16)) {
+    throw scanError('Breadth source session has not closed or is not a weekday');
+  }
+  return { ...breadth, sessionDate, sourceSessionAt };
 }

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1483,6 +1483,7 @@
     "entry": "scripts/seed-market-breadth.mjs",
     "deployMode": "nixpacks-root-scripts",
     "service": "seed-market-breadth",
+    "cronSchedule": "0 2,8 * * *",
     "watchPatterns": [
       "scripts/_proxy-utils.cjs",
       "scripts/_seed-contract.mjs",

--- a/scripts/seed-market-breadth.mjs
+++ b/scripts/seed-market-breadth.mjs
@@ -3,6 +3,7 @@
 import { loadEnvFile, runSeed } from './_seed-utils.mjs';
 import {
   BREADTH_HISTORY_KEY,
+  MAX_SESSION_AGE_MIN,
   fetchSp500Breadth,
   mergeBreadthHistory,
   readBreadthHistory,
@@ -13,7 +14,7 @@ loadEnvFile(import.meta.url);
 const BREADTH_TTL = 2592000; // 30 days
 
 async function fetchAll() {
-  const { readings, constituents, valid } = await fetchSp500Breadth();
+  const { readings, constituents, valid, sessionDate, sourceSessionAt } = await fetchSp500Breadth();
 
   console.log(`  TradingView: ${constituents} S&P 500 constituents (valid 20d=${valid.pctAbove20d} | 50d=${valid.pctAbove50d} | 200d=${valid.pctAbove200d})`);
   console.log(`    20d=${readings.pctAbove20d ?? 'null'} | 50d=${readings.pctAbove50d ?? 'null'} | 200d=${readings.pctAbove200d ?? 'null'}`);
@@ -24,24 +25,20 @@ async function fetchAll() {
     url: process.env.UPSTASH_REDIS_REST_URL,
     token: process.env.UPSTASH_REDIS_REST_TOKEN,
   });
-  // ET trading day: Railway cron fires at 9 PM ET which is 01:00-02:00 UTC on
-  // the NEXT calendar day, so UTC date would stamp today's session with
-  // tomorrow's date. en-CA locale returns ISO YYYY-MM-DD; America/New_York
-  // handles DST automatically.
-  const today = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date());
   const { history, current, updatedExisting } = mergeBreadthHistory(
     existing?.history ?? [],
     readings,
-    today,
+    sessionDate,
   );
   if (updatedExisting) {
-    console.log(`  Updated existing entry for ${today}`);
+    console.log(`  Updated existing entry for ${sessionDate}`);
   } else {
-    console.log(`  Appended new entry for ${today} (history: ${history.length} days)`);
+    console.log(`  Appended new entry for ${sessionDate} (history: ${history.length} days)`);
   }
 
   return {
     updatedAt: new Date().toISOString(),
+    sourceSessionAt,
     current,
     history,
   };
@@ -65,11 +62,14 @@ export function declareRecords(data) {
 runSeed('market', 'breadth-history', BREADTH_HISTORY_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: BREADTH_TTL,
+  fetchPhaseTimeoutMs: 90_000,
+  contentMeta: (data) => ({ newestItemAt: data.sourceSessionAt, oldestItemAt: data.sourceSessionAt }),
+  maxContentAgeMin: MAX_SESSION_AGE_MIN,
 
   declareRecords,
   schemaVersion: 1,
   maxStaleMin: 2880,
-  sourceVersion: 'market-breadth-v1',
+  sourceVersion: 'market-breadth-v2',
 }).catch((err) => {
   console.error('FATAL:', err.message || err);
   process.exit(1);

--- a/tests/market-breadth-recovery.test.mts
+++ b/tests/market-breadth-recovery.test.mts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { installRedis } from './helpers/fake-upstash-redis.mts';
+import { getMarketBreadthHistory } from '../server/worldmonitor/market/v1/get-market-breadth-history';
+import { readPublishedPctAbove200d } from '../scripts/_sp500-breadth.mjs';
+import { stripSeedEnvelope } from '../scripts/_seed-envelope-source.mjs';
+import { __testing__ } from '../api/health.js';
+
+const ROOT = fileURLToPath(new URL('../', import.meta.url));
+const KEY = 'market:breadth-history:v1';
+const META = 'seed-meta:market:breadth-history';
+const prior = {
+  [KEY]: { _seed: { fetchedAt: Date.parse('2026-09-02T02:00:00Z'), recordCount: 1, state: 'OK', sourceVersion: 'market-breadth-v1', schemaVersion: 1 },
+    data: { updatedAt: '2026-09-02T02:00:00Z', current: { pctAbove20d: 20, pctAbove50d: 50, pctAbove200d: 80 },
+      history: [{ date: '2026-09-01', pctAbove20d: 20, pctAbove50d: 50, pctAbove200d: 80 }] } },
+  [META]: { fetchedAt: Date.parse('2026-09-02T02:00:00Z'), recordCount: 1, sourceVersion: 'market-breadth-v1' },
+};
+
+function runSeed(now: string, fixtures: Record<string, unknown> = prior, failure = '') {
+  const code = `
+    import { installRedis } from './tests/helpers/fake-upstash-redis.mts';
+    const realDate = Date;
+    globalThis.Date = class extends realDate {
+      constructor(...args) { super(...(args.length ? args : [${JSON.stringify(now)}])); }
+      static now() { return realDate.parse(${JSON.stringify(now)}); }
+    };
+    const fake = installRedis(${JSON.stringify(fixtures)});
+    let scans = 0;
+    globalThis.fetch = async (url, init) => {
+      if (${JSON.stringify(failure)} === 'redis' && String(url).endsWith('/get/' + encodeURIComponent(${JSON.stringify(KEY)}))) return new Response('', { status: 503 });
+      if (String(url) !== 'https://scanner.tradingview.com/america/scan') return fake.fetchImpl(url, init);
+      scans++;
+      if (${JSON.stringify(failure)} === 'http' || (${JSON.stringify(failure)} === 'transient' && scans === 1)) return new Response('', { status: 503 });
+      const data = Array.from({ length: 503 }, (_, i) => ({ s: 'NYSE:T' + i, d: ['T' + i, 100, 90, 110, ${JSON.stringify(failure)} === 'partial' ? null : 90, realDate.parse('2026-09-04T13:30:00Z') / 1000] }));
+      return Response.json({ totalCount: 503, data });
+    };
+    process.on('exit', () => console.log('RESULT ' + JSON.stringify({ scans, redis: Object.fromEntries([...fake.redis].map(([k,v]) => [k, JSON.parse(v)]).filter(([k]) => !k.includes(':staging:'))), expires: Object.fromEntries(fake.expires) })));
+    await import('./scripts/seed-market-breadth.mjs');
+  `;
+  const child = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', code], {
+    cwd: ROOT, encoding: 'utf8', timeout: 15_000,
+    env: { PATH: process.env.PATH, NODE_TEST_CONTEXT: 'child-v8', WM_SEED_RETRY_DELAY_MS: '0' },
+  });
+  assert.ifError(child.error);
+  const line = child.stdout.split('\n').find((line) => line.startsWith('RESULT '));
+  assert.ok(line, `${child.stdout}\n${child.stderr}`);
+  return { ...JSON.parse(line.slice(7)), status: child.status, output: child.stdout + child.stderr };
+}
+
+function health(fixtures: Record<string, unknown>, now: string) {
+  return __testing__.classifyKey('breadthHistory', KEY, { allowOnDemand: false }, {
+    keyStrens: new Map([[KEY, JSON.stringify(fixtures[KEY]).length]]), keyErrors: new Map(),
+    keyMetaValues: new Map([[META, JSON.stringify(fixtures[META])]]), keyMetaErrors: new Map(), now: Date.parse(now),
+  });
+}
+
+test('recovers a missed Friday close on Sunday through the real producer and readers without inventing sessions', async () => {
+  assert.equal(health(prior, '2026-09-06T03:00:00Z').status, 'STALE_SEED');
+  const first = runSeed('2026-09-06T08:00:00Z');
+  assert.equal(first.status, 0, first.output);
+  assert.equal(first.scans, 1);
+  assert.deepEqual(first.redis[KEY].data.history.map((r: { date: string }) => r.date), ['2026-09-01', '2026-09-04']);
+  assert.equal(first.redis[KEY]._seed.newestItemAt, Date.parse('2026-09-04T13:30:00Z'));
+  assert.equal(first.redis[META].maxContentAgeMin, 7200);
+  assert.equal(health(first.redis, '2026-09-06T08:00:00Z').status, 'OK');
+  const second = runSeed('2026-09-07T08:00:00Z', first.redis);
+  assert.equal(second.status, 0, second.output);
+  assert.deepEqual(second.redis[KEY].data.history, first.redis[KEY].data.history);
+  assert.equal(second.redis[KEY]._seed.newestItemAt, first.redis[KEY]._seed.newestItemAt);
+  assert.equal(health(second.redis, '2026-09-09T02:00:00Z').status, 'OK');
+  assert.equal(health(second.redis, '2026-09-09T14:00:00Z').status, 'STALE_CONTENT');
+  const fetchBefore = globalThis.fetch;
+  try {
+    installRedis(second.redis);
+    const rpc = await getMarketBreadthHistory({} as never, {});
+    assert.equal(rpc.unavailable, false);
+    assert.deepEqual(rpc.history, second.redis[KEY].data.history);
+    assert.equal(rpc.currentPctAbove200d, 100);
+    const bootstrap = stripSeedEnvelope(second.redis[KEY]);
+    assert.deepEqual(bootstrap.history, rpc.history);
+    assert.equal(await readPublishedPctAbove200d({ url: process.env.UPSTASH_REDIS_REST_URL, token: process.env.UPSTASH_REDIS_REST_TOKEN }), rpc.currentPctAbove200d);
+  } finally { globalThis.fetch = fetchBefore; }
+});
+
+for (const [failure, attempts] of [['http', 4], ['partial', 1], ['redis', 4]] as const) {
+  test(`${failure} scan preserves last-good and success metadata with ${attempts} bounded attempt(s)`, () => {
+    const result = runSeed('2026-09-06T08:00:00Z', prior, failure);
+    assert.equal(result.status, 75, result.output);
+    assert.equal(result.scans, attempts);
+    assert.deepEqual(result.redis[KEY], prior[KEY]);
+    assert.deepEqual(result.redis[META], prior[META]);
+    assert.equal(result.expires[KEY], 2592000);
+    assert.equal(health(result.redis, '2026-09-06T08:00:00Z').status, 'STALE_SEED');
+  });
+}
+
+test('a restart after canonical publication but before metadata converges to one session row', () => {
+  const first = runSeed('2026-09-06T08:00:00Z');
+  const interrupted = { ...first.redis, [META]: prior[META] };
+  const next = runSeed('2026-09-07T02:00:00Z', interrupted);
+  assert.equal(next.status, 0, next.output);
+  assert.deepEqual(next.redis[KEY].data.history, first.redis[KEY].data.history);
+  assert.equal(next.redis[META].recordCount, 2);
+  assert.equal(next.redis[META].fetchedAt, Date.parse('2026-09-07T02:00:00Z'));
+});
+
+test('a transient scan failure recovers in the same run without duplicate rows', () => {
+  const result = runSeed('2026-09-06T08:00:00Z', prior, 'transient');
+  assert.equal(result.status, 0, result.output);
+  assert.equal(result.scans, 2);
+  assert.equal(result.redis[KEY].data.history.length, 2);
+});
+
+test('a brief failed refresh remains healthy until the real source or seed budget expires', () => {
+  const fresh = runSeed('2026-09-06T08:00:00Z');
+  const result = runSeed('2026-09-07T02:00:00Z', fresh.redis, 'partial');
+  assert.equal(result.status, 75, result.output);
+  assert.deepEqual(result.redis[KEY], fresh.redis[KEY]);
+  assert.deepEqual(result.redis[META], fresh.redis[META]);
+  assert.equal(health(result.redis, '2026-09-07T02:00:00Z').status, 'OK');
+});
+
+test('an unchanged old source cannot keep re-anchoring success metadata', () => {
+  const fresh = runSeed('2026-09-07T08:00:00Z');
+  const result = runSeed('2026-09-10T02:00:00Z', fresh.redis);
+  assert.equal(result.status, 75, result.output);
+  assert.deepEqual(result.redis[KEY], fresh.redis[KEY]);
+  assert.deepEqual(result.redis[META], fresh.redis[META]);
+  assert.equal(health(result.redis, '2026-09-10T02:00:00Z').status, 'STALE_CONTENT');
+});
+
+test('the desired cron retries after a missed run or Saturday repair within 18 hours', () => {
+  const registry = JSON.parse(readFileSync(new URL('../scripts/railway-services.json', import.meta.url), 'utf8'));
+  const entries = Array.isArray(registry) ? registry : registry.services;
+  const service = entries.find((s: { service: string }) => s.service === 'seed-market-breadth');
+  assert.equal(service.cronSchedule, '0 2,8 * * *');
+  const hours = service.cronSchedule.split(' ')[1].split(',').map(Number);
+  const ticks: number[] = [];
+  for (let day = 5; day <= 9; day++) for (const hour of hours) ticks.push(Date.parse(`2026-09-${String(day).padStart(2, '0')}T${String(hour).padStart(2, '0')}:00:00Z`));
+  for (const trigger of [Date.parse('2026-09-05T02:00:00Z'), Date.parse('2026-09-05T15:40:00Z')]) {
+    assert.ok(ticks.find((time) => time > trigger)! - trigger <= 18 * 3600_000);
+  }
+});

--- a/tests/sp500-breadth.test.mjs
+++ b/tests/sp500-breadth.test.mjs
@@ -13,9 +13,9 @@ import {
   requireCompleteReadings,
 } from '../scripts/_sp500-breadth.mjs';
 
-// Scanner row shape: d = [name, close, SMA20, SMA50, SMA200].
-function row(name, close, sma20, sma50, sma200) {
-  return { s: `NYSE:${name}`, d: [name, close, sma20, sma50, sma200] };
+// Scanner row shape: d = [name, close, SMA20, SMA50, SMA200, time].
+function row(name, close, sma20, sma50, sma200, time = Date.parse('2026-09-04T13:30:00Z') / 1000) {
+  return { s: `NYSE:${name}`, d: [name, close, sma20, sma50, sma200, time] };
 }
 
 function universe(size, build) {
@@ -93,6 +93,10 @@ describe('requireCompleteReadings', () => {
 });
 
 describe('mergeBreadthHistory', () => {
+  it('rejects an older session instead of appending a duplicate and regressing current', () => {
+    const prior = ['2026-09-03', '2026-09-04'].map((date) => ({ date, ...completeReadings() }));
+    assert.throws(() => mergeBreadthHistory(prior, completeReadings(), '2026-09-03'), /older/);
+  });
   it('appends a new day and sets current from the last history row', () => {
     const prior = [{ date: '2026-09-01', ...completeReadings() }];
     const nextReadings = { pctAbove20d: 30, pctAbove50d: 40, pctAbove200d: 70 };
@@ -166,16 +170,53 @@ describe('fetchSp500Breadth', () => {
       const rows = universe(503, (i) => row(`T${i}`, 100, 90, 90, 90));
       return new Response(JSON.stringify({ totalCount: rows.length, data: rows }), { status: 200 });
     };
-    const { readings, constituents } = await fetchSp500Breadth({ fetchImpl });
+    const { readings, constituents, sessionDate } = await fetchSp500Breadth({ fetchImpl, now: Date.parse('2026-09-06T02:00:00Z') });
     assert.equal(captured.url, 'https://scanner.tradingview.com/america/scan');
     assert.equal(captured.init.method, 'POST');
     assert.equal(captured.init.headers['User-Agent'], CHROME_UA);
     const body = JSON.parse(captured.init.body);
     assert.deepEqual(body.symbols, { symbolset: ['SYML:SP;SPX'] });
-    assert.deepEqual(body.columns, ['name', 'close', 'SMA20', 'SMA50', 'SMA200']);
+    assert.deepEqual(body.columns, ['name', 'close', 'SMA20', 'SMA50', 'SMA200', 'time']);
     assert.deepEqual(body.range, [0, 1000]);
     assert.equal(constituents, 503);
+    assert.equal(sessionDate, '2026-09-04');
     assert.deepEqual(readings, { pctAbove20d: 100, pctAbove50d: 100, pctAbove200d: 100 });
+  });
+
+  for (const now of ['2026-09-05T02:00:00Z', '2026-09-06T08:00:00Z', '2026-09-07T08:00:00Z', '2026-09-08T08:00:00Z']) {
+    it(`keeps Friday's source session on weekend/holiday recovery at ${now}`, async () => {
+      const data = universe(503, (i) => row(`T${i}`, 100, 90, 90, 90));
+      const result = await fetchSp500Breadth({ now: Date.parse(now), fetchImpl: async () => Response.json({ totalCount: 503, data }) });
+      assert.equal(result.sessionDate, '2026-09-04');
+      assert.equal(result.sourceSessionAt, Date.parse('2026-09-04T13:30:00Z'));
+    });
+  }
+
+  for (const [label, time, now] of [
+    ['missing time', null, '2026-09-06T02:00:00Z'],
+    ['weekend session', '2026-09-05T13:30:00Z', '2026-09-06T02:00:00Z'],
+    ['future session', '2026-09-08T13:30:00Z', '2026-09-06T02:00:00Z'],
+    ['unfinished session', '2026-09-04T13:30:00Z', '2026-09-04T19:59:59Z'],
+    ['old source', '2026-09-01T13:30:00Z', '2026-09-07T02:00:00Z'],
+  ]) {
+    it(`rejects ${label}`, async () => {
+      const seconds = time == null ? null : Date.parse(time) / 1000;
+      const data = universe(503, (i) => row(`T${i}`, 100, 90, 90, 90, seconds));
+      await assert.rejects(fetchSp500Breadth({ now: Date.parse(now), fetchImpl: async () => Response.json({ totalCount: 503, data }) }), /session/i);
+    });
+  }
+
+  it('rejects mixed source sessions even with 503 valid prices', async () => {
+    const data = universe(503, (i) => row(`T${i}`, 100, 90, 90, 90));
+    data[0].d[5] -= 86400;
+    await assert.rejects(fetchSp500Breadth({ now: Date.parse('2026-09-06T02:00:00Z'), fetchImpl: async () => Response.json({ totalCount: 503, data }) }), /session/i);
+  });
+
+  it('uses New York close across the winter UTC date boundary', async () => {
+    const data = universe(503, (i) => row(`T${i}`, 100, 90, 90, 90, Date.parse('2026-01-09T14:30:00Z') / 1000));
+    const fetchImpl = async () => Response.json({ totalCount: 503, data });
+    await assert.rejects(fetchSp500Breadth({ now: Date.parse('2026-01-09T20:59:59Z'), fetchImpl }), /session/i);
+    assert.equal((await fetchSp500Breadth({ now: Date.parse('2026-01-10T02:00:00Z'), fetchImpl })).sessionDate, '2026-01-09');
   });
 
   async function rejected(run) {


### PR DESCRIPTION
## Summary

Breadth history can stay stale through a weekend after its source is repaired. The Tue-Sat schedule offers no further attempt until Tuesday after a missed Saturday run. This repair prepares two daily attempts, with at most 18 hours between opportunities, and dates each row from the actual source session. A Sunday recovery records Friday's close once, with no invented weekend rows or backfill.

The adapter rejects missing, mixed, unfinished, regressed, or expired sessions. Failed and incomplete scans keep the last-good payload and success metadata. Existing `runSeed` retries remain bounded to four attempts; the fetch phase has a 90-second deadline. The existing 96-hour seed-age health budget is unchanged. A new five-day content-age cap starts at daily-bar open before overnight collection. It prevents an unchanged source from staying healthy through repeated successful scans while covering holiday collection timing.

Related: #7723

## Verification

- The original adapter fails 13 new regression cases. The original seeder fails the fake-Redis process proof by stamping a Friday fixture as Saturday and republishing an expired source.
- **115 focused tests pass**, including real seeder -> `runSeed` -> fake Redis -> health classifier, breadth RPC, bootstrap envelope reader, and Fear & Greed breadth reader. Coverage includes failed history reads, partial/failed scans, four-attempt limits, transient recovery, repeat attempts, interrupted publication, winter/summer boundaries, holidays, and source-age expiry.
- **141 Railway registry tests and 65 source-health tests pass.** Browser/API typechecks, Biome, Markdown lint, import boundaries, source-attribution consistency, and `git diff --check` pass.
- The fixed adapter was also checked with a read-only public source request. Production writes were not used for validation.
- `ce-code-review` completed with sequential inline criteria per the repository Task mapping. No actionable P0/P1/P2 findings remain. This was not an independent multi-agent review.

## Post-Deploy Monitoring & Validation

**The schedule change remains pending operator authorization.**

1. After merge, confirm that the deployed `seed-market-breadth` includes the source-session guards. Do not enable the new cron on the old worker.
2. Set that service's Railway **Cron Schedule** to `0 2,8 * * *`. Keep **Start Command** as `node seed-market-breadth.mjs`. The checked-in registry is the desired configuration. A fleet-wide config apply is outside this scoped repair.
3. Wait for the next natural 02:00 or 08:00 UTC run. Read bounded service logs for `TradingView:`, `Appended new entry`, `Updated existing entry`, `FETCH FAILED`, and `Done`. Confirm complete readings, a genuine source session, canonical and seed-meta advancement, and breadth/Fear & Greed 200-day parity.
4. Observe the next repeat attempt. History must have no duplicate or holiday row, and source time must not advance unless the source does. Confirm health clears the stale seed warning.

The operator and existing read-only health monitor own natural-run observation. Acceptance remains pending until the first successful scheduled publication and the next repeat are observed. If source checks fail, preserve last-good and investigate the source. If the new cadence causes failures, an operator can restore the old cron; do not roll back date guards while the frequent cron is active. Tests do not establish Railway execution, deployed Edge behavior, or production acceptance.

## Type of change

- [x] Bug fix
- [x] CI / Build / Infrastructure
- [x] Documentation

## Checklist

- [x] No API keys, secrets, or private operational observations published
- [x] TypeScript compiles without errors
- [x] Producer and reader fixtures verified
- [x] Existing seed-age health budget retained
- Browser variants and proto definitions are unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6_Codex-000000)
