### PR TITLE
fix(cache): test RSC request headers through the lowercase-keyed map, not names[]

### DIFF
--- a/scripts/cloudflare-cache-rule.mjs
+++ b/scripts/cloudflare-cache-rule.mjs
@@ -236,15 +236,24 @@ function buildCorpusCacheExpression({
     ].join('\n');
   });
   const agentFiles = files.map((file) => `"/${file}"`).join(' ');
-  // Header names arrive lowercased in http.request.headers.names; Accept values
-  // do not, and both origins match media types case-insensitively, hence lower().
+  // Presence of an RSC header is tested through the `http.request.headers[...]`
+  // map, whose keys are the lowercased names, NOT through
+  // `http.request.headers.names[*] == "rsc"`: that array keeps the sender's
+  // casing, and HTTP/1.1 clients send it verbatim (Node's fetch puts `RSC: 1` on
+  // the wire as-is; only HTTP/2 lowercases). Measured 2026-09-06: with the names
+  // form, `RSC: 1` was MISS on /docs/documentation and stored the flight under
+  // the HTML URL, so every later plain request got text/x-component from the
+  // edge until a zone purge; `rsc: 1` was DYNAMIC. The live sweep sends `RSC: 1`
+  // through fetch() and had been reading the cached HTML for the same reason.
+  // Accept values keep their case and both origins match media types
+  // case-insensitively, hence lower().
   // Accept is a list-typed header that may arrive as several lines, and Cloudflare
   // exposes each line as one array element; the origins honour the combined list
   // (`Accept: text/markdown` on a second line still yields markdown), so every
   // element is inspected — `[0]` alone would admit a request whose first line is
   // harmless and whose second asks for markdown.
   const noRscFlight = RSC_REQUEST_HEADERS.map(
-    (name) => `      and not any(http.request.headers.names[*] == "${name}")`,
+    (name) => `      and not any(http.request.headers["${name}"][*] != "")`,
   );
   const noNegotiation = NEGOTIATED_MEDIA_TYPES.map(
     (type) => `      and not any(lower(http.request.headers["accept"][*])[*] contains "${type}")`,

--- a/tests/cloudflare-cache-rule.test.mjs
+++ b/tests/cloudflare-cache-rule.test.mjs
@@ -212,7 +212,11 @@ describe('cloudflare corpus cache rule', () => {
     );
     assert.deepEqual([...NEGOTIATED_MEDIA_TYPES], ['text/markdown', 'text/plain', 'text/x-component']);
     const guards = [
-      ...RSC_REQUEST_HEADERS.map((name) => `not any(http.request.headers.names[*] == "${name}")`),
+      // Presence via the lowercase-keyed headers map, never `headers.names[*] ==`:
+      // that array keeps the sender's casing and an HTTP/1.1 `RSC: 1` (Node's
+      // fetch sends it verbatim) slipped past the guard, read the cached HTML and,
+      // on a MISS, stored the flight under the HTML URL (2026-09-06).
+      ...RSC_REQUEST_HEADERS.map((name) => `not any(http.request.headers["${name}"][*] != "")`),
       // Every Accept value, lowercased: Accept may arrive as several header lines
       // and the origins honour the combined list (measured: a second line
       // `Accept: text/markdown` still yields markdown), and both origins match
@@ -224,6 +228,10 @@ describe('cloudflare corpus cache rule', () => {
       assert.ok(rule.expression.includes(guard), `missing guard: ${guard}`);
     }
     assert.ok(!rule.expression.includes('["accept"][0]'), 'only the first Accept line was inspected');
+    assert.ok(
+      !rule.expression.includes('http.request.headers.names'),
+      'header-name equality is case-sensitive at Cloudflare: an uppercase RSC: 1 would be admitted and poison the HTML entry',
+    );
 
     // Structure: one guard block, gating every HTML document family, disjoined
     // with the single-representation exemption, and closed before the path
@@ -242,7 +250,7 @@ describe('cloudflare corpus cache rule', () => {
       assert.ok(at > exemption && at < guardClose, `${guard} must sit inside the guard block`);
     }
     assert.ok(
-      !lines.slice(blockClose + 1).some((line) => line.includes('headers.names') || line.includes('["accept"]')),
+      !lines.slice(blockClose + 1).some((line) => line.includes('http.request.headers[')),
       'no per-family guard: the block applies to every family once',
     );
   });


### PR DESCRIPTION
## Why

The document cache rule excluded RSC requests with `not any(http.request.headers.names[*] == "rsc")`. That array keeps the sender's casing, and HTTP/1.1 clients send the header name verbatim. Node's `fetch()` puts `RSC: 1` on the wire as-is (verified locally against a raw `http` server); only HTTP/2 lowercases names.

Measured on 2026-09-06 against `www.worldmonitor.app/docs/documentation`:

| Request header | cf-cache-status |
| --- | --- |
| `rsc: 1` | DYNAMIC (excluded, correct) |
| `RSC: 1` | MISS (admitted) |
| `Rsc: 1` | MISS (admitted) |

The admitted MISS stored the RSC flight under the HTML URL. Every plain request then received `text/x-component` from the edge (HIT) until a zone-wide purge; two purge-by-URL calls did not evict it. The Live API Cache/Auth Sweep sends `RSC: 1` through `fetch()`, so its RSC negative control was reading the cached HTML entry and failing with "an RSC request must receive the flight, not a cached HTML document" (runs 34003400437 and 34020837909).

## What

- `scripts/cloudflare-cache-rule.mjs`: test RSC header presence through the `http.request.headers["<name>"]` map (lowercase-keyed, the same mechanism the Accept guard already uses) instead of `headers.names[*] ==`. Comment rewritten with the measurement.
- `tests/cloudflare-cache-rule.test.mjs`: pin the new guard form and reject any return of `http.request.headers.names`.

## Rollout

The generated rule must be applied to the zone once this merges (or before, from this branch):

```
CLOUDFLARE_ALL_ACCESS_TOKEN=... node scripts/cloudflare-cache-rule.mjs --check   # reports drift today
CLOUDFLARE_ALL_ACCESS_TOKEN=... node scripts/cloudflare-cache-rule.mjs --apply
```

Then re-run the Live API Cache/Auth Sweep. After the API-rule correction from #7755 the sweep is at 8/9; this rule is the last red probe.

## Verification

- Cache-rule tests: 35 pass.
- `--check` against the live zone reports `expression differs` (expected until `--apply`).
- Poisoned entry cleared with a zone purge; plain GETs of `/docs/documentation` return HTML again.

https://claude.ai/code/session_019i8RX12WsDVKgtcwxRFjSi
