### PR TITLE
fix(docs-mcp): force no-store on every proxied response

### DIFF
--- a/api/docs-mcp.ts
+++ b/api/docs-mcp.ts
@@ -51,7 +51,21 @@ const FORWARDED_REQUEST_HEADERS = [
 
 // Hop-by-hop / recomputed response headers that must not be forwarded after
 // fetch has already decoded the body.
-const STRIPPED_RESPONSE_HEADERS = new Set(['content-encoding', 'content-length', 'transfer-encoding', 'connection']);
+// Hop-by-hop framing, plus every cache directive: the docs MCP surface is
+// no-store end to end (the #4497 class is a shared-cache HIT of an MCP answer),
+// and the upstream does not promise that. Mintlify answers a bare GET with a 405
+// carrying its default `public, max-age=0, must-revalidate`, which the live
+// sweep (tests/live-api-cache-auth-regression.test.mjs, docs MCP probe) rejects.
+// The policy is owned here, not forwarded.
+const STRIPPED_RESPONSE_HEADERS = new Set([
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'connection',
+  'cache-control',
+  'cdn-cache-control',
+  'vercel-cdn-cache-control',
+]);
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -201,6 +215,7 @@ function upstreamResponseHeaders(upstream: Response): Headers {
   upstream.headers.forEach((value, key) => {
     if (!STRIPPED_RESPONSE_HEADERS.has(key.toLowerCase())) headers.set(key, value);
   });
+  headers.set('Cache-Control', 'no-store');
   return withCors(headers);
 }
 

--- a/api/docs-mcp.ts
+++ b/api/docs-mcp.ts
@@ -51,12 +51,16 @@ const FORWARDED_REQUEST_HEADERS = [
 
 // Hop-by-hop / recomputed response headers that must not be forwarded after
 // fetch has already decoded the body.
-// Hop-by-hop framing, plus every cache directive: the docs MCP surface is
-// no-store end to end (the #4497 class is a shared-cache HIT of an MCP answer),
-// and the upstream does not promise that. Mintlify answers a bare GET with a 405
-// carrying its default `public, max-age=0, must-revalidate`, which the live
-// sweep (tests/live-api-cache-auth-regression.test.mjs, docs MCP probe) rejects.
-// The policy is owned here, not forwarded.
+// Hop-by-hop framing, plus every header that can carry a shared-cache policy:
+// the docs MCP surface is no-store end to end (the #4497 class is a shared-cache
+// HIT of an MCP answer), and the upstream does not promise that. Mintlify answers
+// a bare GET with a 405 carrying its default `public, max-age=0, must-revalidate`,
+// which the live sweep (tests/live-api-cache-auth-regression.test.mjs, docs MCP
+// probe) rejects. Vercel reads Vercel-CDN-Cache-Control > CDN-Cache-Control >
+// Cache-Control and Cloudflare reads Cloudflare-CDN-Cache-Control >
+// CDN-Cache-Control > Cache-Control, so a CDN-specific header left in place
+// would silently outrank the `no-store` set below; the list mirrors
+// tests/helpers/shared-cache-policy.mjs, whose CDN_CACHE_HEADERS pins it.
 const STRIPPED_RESPONSE_HEADERS = new Set([
   'content-encoding',
   'content-length',
@@ -65,6 +69,8 @@ const STRIPPED_RESPONSE_HEADERS = new Set([
   'cache-control',
   'cdn-cache-control',
   'vercel-cdn-cache-control',
+  'cloudflare-cdn-cache-control',
+  'surrogate-control',
 ]);
 
 const CORS_HEADERS: Record<string, string> = {

--- a/tests/docs-mcp.test.mjs
+++ b/tests/docs-mcp.test.mjs
@@ -301,6 +301,28 @@ describe('docs-mcp handler', () => {
     assert.equal(await res.text(), sse);
   });
 
+  it('forces no-store on proxied responses, including the cacheable 405 Mintlify returns for a bare GET', async () => {
+    clearUpstashEnv();
+    globalThis.fetch = async () =>
+      new Response('{"jsonrpc":"2.0","error":{"code":-32000,"message":"Method not allowed."},"id":null}', {
+        status: 405,
+        headers: {
+          'content-type': 'application/json',
+          'cache-control': 'public, max-age=0, must-revalidate',
+          'cdn-cache-control': 'public, s-maxage=600, stale-while-revalidate=60',
+          'vercel-cdn-cache-control': 'public, s-maxage=600',
+        },
+      });
+    const res = await handler(
+      new Request('https://www.worldmonitor.app/api/docs-mcp', { method: 'GET', headers: { accept: 'application/json' } }),
+    );
+    assert.equal(res.status, 405, 'the upstream status is preserved');
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.equal(res.headers.get('cdn-cache-control'), null);
+    assert.equal(res.headers.get('vercel-cdn-cache-control'), null);
+    assert.equal(res.headers.get('content-type'), 'application/json');
+  });
+
   it('answers OPTIONS preflight locally with permissive CORS', async () => {
     const res = await handler(
       new Request('https://www.worldmonitor.app/api/docs-mcp', { method: 'OPTIONS' }),

--- a/tests/docs-mcp.test.mjs
+++ b/tests/docs-mcp.test.mjs
@@ -11,6 +11,7 @@ import handler, {
   liftProtocolErrorFromToolResult,
   normalizeToolCallResponseBody,
 } from '../api/docs-mcp.ts';
+import { CACHE_POLICY_HEADER_NAME, CDN_CACHE_HEADERS } from './helpers/shared-cache-policy.mjs';
 
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
@@ -303,23 +304,29 @@ describe('docs-mcp handler', () => {
 
   it('forces no-store on proxied responses, including the cacheable 405 Mintlify returns for a bare GET', async () => {
     clearUpstashEnv();
+    // Every header that can carry a shared-cache policy, from the shared list:
+    // a CDN-specific one left in place outranks the handler's no-store.
+    const upstreamHeaders = {
+      'content-type': 'application/json',
+      'cache-control': 'public, max-age=0, must-revalidate',
+      ...Object.fromEntries(CDN_CACHE_HEADERS.map((name) => [name.toLowerCase(), 'public, s-maxage=600, stale-while-revalidate=60'])),
+    };
     globalThis.fetch = async () =>
       new Response('{"jsonrpc":"2.0","error":{"code":-32000,"message":"Method not allowed."},"id":null}', {
         status: 405,
-        headers: {
-          'content-type': 'application/json',
-          'cache-control': 'public, max-age=0, must-revalidate',
-          'cdn-cache-control': 'public, s-maxage=600, stale-while-revalidate=60',
-          'vercel-cdn-cache-control': 'public, s-maxage=600',
-        },
+        headers: upstreamHeaders,
       });
     const res = await handler(
       new Request('https://www.worldmonitor.app/api/docs-mcp', { method: 'GET', headers: { accept: 'application/json' } }),
     );
     assert.equal(res.status, 405, 'the upstream status is preserved');
     assert.equal(res.headers.get('cache-control'), 'no-store');
-    assert.equal(res.headers.get('cdn-cache-control'), null);
-    assert.equal(res.headers.get('vercel-cdn-cache-control'), null);
+    for (const name of CDN_CACHE_HEADERS) {
+      assert.equal(res.headers.get(name), null, `${name} must be stripped from the proxied response`);
+    }
+    for (const [name, value] of res.headers) {
+      assert.ok(!CACHE_POLICY_HEADER_NAME.test(name) || value === 'no-store', `${name}: ${value} is a shared-cache policy`);
+    }
     assert.equal(res.headers.get('content-type'), 'application/json');
   });
 


### PR DESCRIPTION
## Why

The Live API Cache/Auth Sweep still fails one assertion after the #7755 API-rule correction and the #7768 RSC-guard fix went live: the docs MCP probe (`GET /docs/mcp` with `Accept: application/json`) expects `Cache-Control: no-store` and gets `public, max-age=0, must-revalidate` (runs 34022679595, 34022530602). That assertion was masked until now because the RSC negative control in the same probe group failed first.

`/docs/mcp` rewrites to `api/docs-mcp.ts`, which proxies `worldmonitor.mintlify.dev/docs/mcp` and forwarded the upstream's cache headers verbatim. Mintlify answers a bare GET with a 405 carrying its default `public, max-age=0, must-revalidate`.

## What

- `api/docs-mcp.ts`: strip `cache-control`, `cdn-cache-control` and `vercel-cdn-cache-control` from upstream responses and set `Cache-Control: no-store` on every proxied response (status and body preserved). The MCP surface is no-store end to end; the policy is owned here, not forwarded.
- `tests/docs-mcp.test.mjs`: regression for the cacheable upstream 405 on a bare GET. It fails against the previous handler.

## Verification

- docs-mcp unit tests: 20 pass; the new test is red without the handler change.
- After deploy, the Live API Cache/Auth Sweep runs on the Production `deployment_status` event (#7755) and should reach 9/9.

https://claude.ai/code/session_019i8RX12WsDVKgtcwxRFjSi
