### PR TITLE
fix(seo): separate Google AI visibility surfaces

### DIFF
--- a/docs/research/seo-ai-visibility/README.md
+++ b/docs/research/seo-ai-visibility/README.md
@@ -20,16 +20,28 @@ missing source cannot silently become a zero or a site-wide vanity score.
   `tests/seo-ai-visibility-scorecard.test.mjs` — importer, schema, missingness,
   aggregation, comparison, and reproducibility coverage.
 
-The committed initial period is `2026-07-27`. It contains a four-platform manual
-observation for `q01`. Search Console, Bing Webmaster, and referral values are
-explicitly unavailable because the clean worktree had no property access or
-supported exports. That is an incomplete data source, not zero demand.
+The committed initial period is `2026-07-27`. It uses baseline contract v1 and
+contains a four-platform manual observation for `q01`. Search Console, Bing
+Webmaster, and referral values are explicitly unavailable because the clean
+worktree had no property access or supported exports. That is an incomplete
+data source, not zero demand.
 
 Committed source `property` fields must remain `null`; property identifiers and
 credentials belong only in secure operator configuration. `aiSurfaces` records
 whether each requested surface was available, partial, or unavailable, with a
 reason for any non-available state. `aiObservations` contains only
 query/platform pairs that were actually inspected.
+
+Baseline contract v1 is the historical four-surface contract. Its identifiers
+are `chatgpt_search`, `perplexity`, `google_ai`, and `copilot_search`, for a full
+target of 25 × 4 = 100 query/surface pairs. Keep `google_ai` and its recorded
+Google AI Overview label unchanged in historical files.
+
+Baseline contract v2 is the five-surface contract for new cycles. Its
+identifiers are `chatgpt_search`, `perplexity`, `google_ai_overview`,
+`google_ai_mode`, and `copilot_search`, for a full target of 25 × 5 = 125 pairs.
+Do not use legacy `google_ai` in a v2 baseline. Overview and Mode are separate
+observations even when they answer the same query in the same cycle.
 
 ## Reproduce the current scorecard
 
@@ -43,11 +55,13 @@ node scripts/seo-ai-visibility-scorecard.mjs \
   --check
 ```
 
-To generate a later scorecard, copy the prior baseline to a new dated file,
-replace only observations and supported-export values, then omit `--check` and
-point `--output` at the new date. Do not edit an older observation in place.
-The copied `querySetDigest` pins the exact query text, intent, target, conversion,
-and reference-entity contract used by the period.
+To generate a later scorecard under the same baseline contract, copy the prior
+baseline to a new dated file, replace only observations and supported-export
+values, then omit `--check` and point `--output` at the new date. Do not edit an
+older observation in place. Start the first v2 cycle through the collector with
+`schemaVersion: 2`; do not relabel a historical v1 observation. The copied
+`querySetDigest` pins the exact query text, intent, target, conversion, and
+reference-entity contract used by the period.
 
 If any comparison-critical query field changes, assign a new `querySetId` and
 start a new baseline series with the digest computed by
@@ -74,6 +88,8 @@ node scripts/seo-ai-visibility-collector.mjs \
 
 The manifest is intentionally narrow:
 
+- `schemaVersion` selects the baseline contract. Omit it only when reproducing
+  a v1 template. Set it to `2` for every new five-surface cycle.
 - `googleSearchConsole` and `bingWebmaster.search` contain trailing `28d` and
   `90d` windows with aggregate metrics, exact reviewed `query`/`queryId` rows,
   and `page`/`pageFamily` rows. Query text must exactly match `query-set.json`;
@@ -92,6 +108,34 @@ The manifest is intentionally narrow:
   whitelist. Unknown provider fields and raw prompt, account/session, key, and
   user-level payload fields are never written to the baseline; keep personal
   prompt content out of the reviewed summary fields as well.
+
+For a v2 cycle, `aiSurfaces` is required and must contain every v2 identifier
+exactly once. Use `available`, `partial` with a reason, or `unavailable` with a
+reason based on the actual collection result. The collector does not infer one
+Google experience from the other. A minimal manifest can start with all five
+surfaces explicitly unavailable and no observations:
+
+```json
+{
+  "schemaVersion": 2,
+  "aiSurfaces": [
+    { "platform": "chatgpt_search", "status": "unavailable", "reason": "Record the actual reason." },
+    { "platform": "perplexity", "status": "unavailable", "reason": "Record the actual reason." },
+    { "platform": "google_ai_overview", "status": "unavailable", "reason": "Record the actual reason." },
+    { "platform": "google_ai_mode", "status": "unavailable", "reason": "Record the actual reason." },
+    { "platform": "copilot_search", "status": "unavailable", "reason": "Record the actual reason." }
+  ],
+  "aiObservations": []
+}
+```
+
+Add an observation only after that exact surface was inspected. Each observation
+requires `queryId`, the v2 `platform` identifier, `observedAt`, `geography`,
+`locale`, `signedInState`, `brandMention`, `directCitation`, `citedUrls`,
+`competitorsCited`, `sentiment`, `accuracy`, `summary`, and `limitations`.
+`geography`, `locale`, and `signedInState` must match the declared
+`collectionContext`. Extra fields such as raw prompts, account/session IDs,
+tokens, property IDs, and provider payload extensions are discarded.
 
 For every source, use `status: "partial"` when only some windows/metrics are
 supported and `status: "unavailable"` with a reason when access is missing.
@@ -147,12 +191,13 @@ impressions, clicks, or rank.
 
 ### 3. Manual AI-answer panel
 
-Run the exact query text without paraphrasing. The target matrix is 25 queries
-by four surfaces:
+Run the exact query text without paraphrasing. New v2 cycles use a target matrix
+of 25 queries by five surfaces:
 
 - ChatGPT Search
 - Perplexity
-- Google AI Overview/AI Mode where available
+- Google AI Overview
+- Google AI Mode
 - Copilot Search
 
 For each observation record:
@@ -219,6 +264,8 @@ node scripts/seo-ai-visibility-scorecard.mjs \
 
 The comparison reports:
 
+- the platform coverage in each period, including surfaces that exist in only
+  one contract or are unavailable in either period;
 - new and lost direct citations only when the same exact query, platform,
   geography, locale, and signed-in context was observed in both periods and its
   citation state changed;
@@ -238,6 +285,13 @@ device, or signed-in schedule. The report prints the exact previous/current
 provider date ranges beside meaningful deltas. Change comparison dimensions by
 starting a new baseline series instead of presenting incomparable audits as
 month-over-month movement.
+
+For a v1-to-v2 comparison, legacy `google_ai` is comparable only with
+`google_ai_overview`, which preserves its recorded Google AI Overview meaning.
+It is never treated as an AI Mode observation. `google_ai_mode` observations are
+reported as not comparable until both periods use that independently measured
+surface. Like-for-like v2 periods can then report real AI Mode citation gains or
+losses.
 
 Thresholds are diagnostics, not causal claims. A single answer, citation, or
 traffic change never proves uplift. Sparse observations, a missing provider, or

--- a/scripts/seo-ai-visibility-collector.mjs
+++ b/scripts/seo-ai-visibility-collector.mjs
@@ -22,12 +22,12 @@ import { execFileSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 
 import {
-  AI_PLATFORMS,
   PAGE_FAMILIES,
   BING_AI_METRICS,
   REFERRAL_METRICS,
   SEARCH_PERFORMANCE_METRICS,
   SEARCH_METRICS,
+  aiPlatformsForSchemaVersion,
   computeQuerySetDigest,
   isNonEmptyString,
   isWorldMonitorUrl,
@@ -849,9 +849,13 @@ function normalizeCollectionContext(raw, fallback) {
   };
 }
 
-function normalizeAiSurfaces(raw) {
+function normalizeAiSurfaces(raw, schemaVersion) {
+  const supportedPlatforms = aiPlatformsForSchemaVersion(schemaVersion);
+  if (schemaVersion === 2) {
+    invariant(raw != null, 'aiSurfaces is required for baseline schemaVersion 2');
+  }
   const surfaces = raw == null
-    ? AI_PLATFORMS.map((platform) => ({
+    ? supportedPlatforms.map((platform) => ({
       platform,
       status: 'unavailable',
       reason: 'No current AI surface manifest was supplied.',
@@ -1012,6 +1016,8 @@ export function collectBaseline({
     'repositoryRevision must be supplied when the local git revision is unavailable',
   );
   const normalizedRevision = boundedNonEmptyString(repositoryRevision, 'repositoryRevision');
+  const schemaVersion = sources.schemaVersion ?? template.schemaVersion;
+  aiPlatformsForSchemaVersion(schemaVersion);
 
   const googleSearchConsole = normalizeSearchExport(
     sources.googleSearchConsole,
@@ -1035,12 +1041,12 @@ export function collectBaseline({
     sources.collectionContext,
     template.collectionContext,
   );
-  const aiSurfaces = normalizeAiSurfaces(sources.aiSurfaces);
+  const aiSurfaces = normalizeAiSurfaces(sources.aiSurfaces, schemaVersion);
   const aiObservations = normalizeAiObservations(sources.aiObservations, querySet);
   const opportunities = normalizeOpportunities(sources.opportunities, template.opportunities);
   const guardrails = normalizeStringArray(template.guardrails, 'template.guardrails');
   const baseline = {
-    schemaVersion: template.schemaVersion,
+    schemaVersion,
     baselineId: observedAt.slice(0, 10),
     querySetId: querySet.querySetId,
     querySetDigest: computeQuerySetDigest(querySet),

--- a/scripts/seo-ai-visibility-scorecard.mjs
+++ b/scripts/seo-ai-visibility-scorecard.mjs
@@ -37,12 +37,21 @@ const domainLabels = (domain) => Object.freeze(Object.fromEntries(
   domain.map(({ id, label }) => [id, label]),
 ));
 
-const AI_PLATFORM_DOMAIN = defineDomain([
-  ['chatgpt_search', 'ChatGPT Search'],
-  ['perplexity', 'Perplexity'],
-  ['google_ai', 'Google AI Overview'],
-  ['copilot_search', 'Copilot Search'],
-]);
+const AI_PLATFORM_DOMAINS = Object.freeze({
+  1: defineDomain([
+    ['chatgpt_search', 'ChatGPT Search'],
+    ['perplexity', 'Perplexity'],
+    ['google_ai', 'Google AI Overview'],
+    ['copilot_search', 'Copilot Search'],
+  ]),
+  2: defineDomain([
+    ['chatgpt_search', 'ChatGPT Search'],
+    ['perplexity', 'Perplexity'],
+    ['google_ai_overview', 'Google AI Overview'],
+    ['google_ai_mode', 'Google AI Mode'],
+    ['copilot_search', 'Copilot Search'],
+  ]),
+});
 const PAGE_FAMILY_DOMAIN = defineDomain([
   ['homepage', 'Homepage'],
   ['dashboard', 'Dashboard'],
@@ -63,7 +72,7 @@ const INTENT_DOMAIN = defineDomain([
   ['branded_entity', 'Branded / entity'],
 ]);
 
-export const AI_PLATFORMS = domainIds(AI_PLATFORM_DOMAIN);
+export const AI_PLATFORMS = domainIds(AI_PLATFORM_DOMAINS[1]);
 export const PAGE_FAMILIES = domainIds(PAGE_FAMILY_DOMAIN);
 const INTENTS = domainIds(INTENT_DOMAIN);
 
@@ -99,12 +108,21 @@ export const BING_AI_METRICS = Object.freeze([
   'averageCitedPages',
 ]);
 
-const PLATFORM_LABELS = domainLabels(AI_PLATFORM_DOMAIN);
+const PLATFORM_LABELS = domainLabels(Object.values(AI_PLATFORM_DOMAINS).flat());
 const PAGE_FAMILY_LABELS = domainLabels(PAGE_FAMILY_DOMAIN);
 const INTENT_LABELS = domainLabels(INTENT_DOMAIN);
 
 function invariant(condition, message) {
   if (!condition) throw new Error(`[seo-visibility] ${message}`);
+}
+
+export function aiPlatformsForSchemaVersion(schemaVersion) {
+  invariant(
+    schemaVersion === 1 || schemaVersion === 2,
+    'baseline schemaVersion must be 1 or 2',
+  );
+  const domain = AI_PLATFORM_DOMAINS[schemaVersion];
+  return domainIds(domain);
 }
 
 export function isNonEmptyString(value) {
@@ -448,16 +466,16 @@ export function isWorldMonitorUrl(value) {
   }
 }
 
-function validateAiSurfaces(aiSurfaces) {
+function validateAiSurfaces(aiSurfaces, supportedPlatforms) {
   invariant(Array.isArray(aiSurfaces), 'aiSurfaces must be an array');
   invariant(
-    aiSurfaces.length === AI_PLATFORMS.length,
+    aiSurfaces.length === supportedPlatforms.length,
     'aiSurfaces must contain every supported platform exactly once',
   );
   const platforms = new Set();
   for (const [index, surface] of aiSurfaces.entries()) {
     const label = `aiSurfaces[${index}]`;
-    invariant(AI_PLATFORMS.includes(surface.platform), `${label}.platform is invalid`);
+    invariant(supportedPlatforms.includes(surface.platform), `${label}.platform is invalid`);
     invariant(!platforms.has(surface.platform), `duplicate AI surface ${surface.platform}`);
     platforms.add(surface.platform);
     invariant(
@@ -468,7 +486,7 @@ function validateAiSurfaces(aiSurfaces) {
       invariant(isNonEmptyString(surface.reason), `${label}.reason is required`);
     }
   }
-  for (const platform of AI_PLATFORMS) {
+  for (const platform of supportedPlatforms) {
     invariant(platforms.has(platform), `aiSurfaces is missing ${platform}`);
   }
   return new Map(aiSurfaces.map((surface) => [surface.platform, surface]));
@@ -538,7 +556,7 @@ export function validateQuerySet(querySet) {
 
 export function validateBaseline(baseline, querySet) {
   validateQuerySet(querySet);
-  invariant(baseline?.schemaVersion === 1, 'baseline schemaVersion must be 1');
+  const supportedPlatforms = aiPlatformsForSchemaVersion(baseline?.schemaVersion);
   invariant(isNonEmptyString(baseline.baselineId), 'baselineId is required');
   invariant(
     baseline.querySetId === querySet.querySetId,
@@ -579,7 +597,7 @@ export function validateBaseline(baseline, querySet) {
     'collectionContext.limitations must be an array',
   );
 
-  const aiSurfaces = validateAiSurfaces(baseline.aiSurfaces);
+  const aiSurfaces = validateAiSurfaces(baseline.aiSurfaces, supportedPlatforms);
   const queryIds = new Set(querySet.queries.map((query) => query.id));
   invariant(baseline.search && typeof baseline.search === 'object', 'search is required');
   validateSearchSource(
@@ -640,7 +658,7 @@ export function validateBaseline(baseline, querySet) {
   for (const [index, observation] of baseline.aiObservations.entries()) {
     const label = `aiObservations[${index}]`;
     invariant(queryIds.has(observation.queryId), `${label}.queryId is unknown`);
-    invariant(AI_PLATFORMS.includes(observation.platform), `${label}.platform is invalid`);
+    invariant(supportedPlatforms.includes(observation.platform), `${label}.platform is invalid`);
     invariant(
       aiSurfaces.get(observation.platform)?.status !== 'unavailable',
       `${label}.platform is unavailable`,
@@ -868,13 +886,14 @@ function buildReferralSlices(referrals, domain, matchesSegment) {
 
 export function buildScorecard(querySet, baseline) {
   validateBaseline(baseline, querySet);
+  const supportedPlatforms = aiPlatformsForSchemaVersion(baseline.schemaVersion);
   const observations = structuredClone(baseline.aiObservations);
   const mentions = observations.filter((observation) => observation.brandMention).length;
   const citations = observations.filter((observation) => observation.directCitation).length;
   const eligiblePlatformCount = baseline.aiSurfaces.filter(
     ({ status }) => status !== 'unavailable',
   ).length;
-  const targetPossible = querySet.queries.length * AI_PLATFORMS.length;
+  const targetPossible = querySet.queries.length * supportedPlatforms.length;
   const possible = querySet.queries.length * eligiblePlatformCount;
   const byIntent = buildSlices(
     querySet,
@@ -903,7 +922,7 @@ export function buildScorecard(querySet, baseline) {
   );
 
   return {
-    schemaVersion: 1,
+    schemaVersion: baseline.schemaVersion,
     baselineId: baseline.baselineId,
     querySetId: querySet.querySetId,
     querySetDigest: baseline.querySetDigest,
@@ -949,24 +968,73 @@ export function buildScorecard(querySet, baseline) {
   };
 }
 
+function comparisonPlatform(platform) {
+  return platform === 'google_ai' ? 'google_ai_overview' : platform;
+}
+
 function observationKey(observation) {
   return JSON.stringify([
     observation.queryId,
-    observation.platform,
+    comparisonPlatform(observation.platform),
     observation.geography,
     observation.locale,
     observation.signedInState,
   ]);
 }
 
-function observationIndex(scorecard) {
+function observationIndex(scorecard, comparablePlatforms) {
   return new Map(
     scorecard.ai.observations
+      .filter((observation) => comparablePlatforms.has(
+        comparisonPlatform(observation.platform),
+      ))
       .map((observation) => [
         observationKey(observation),
         observation,
       ]),
   );
+}
+
+function platformCoverage(previous, current) {
+  const indexSurfaces = (scorecard) => new Map(scorecard.ai.surfaces.map((surface) => [
+    comparisonPlatform(surface.platform),
+    surface,
+  ]));
+  const previousSurfaces = indexSurfaces(previous);
+  const currentSurfaces = indexSurfaces(current);
+  const previousPlatforms = [...previousSurfaces.keys()];
+  const currentPlatforms = [...currentSurfaces.keys()];
+  const previousOnly = previousPlatforms.filter(
+    (platform) => !currentSurfaces.has(platform),
+  );
+  const currentOnly = currentPlatforms.filter(
+    (platform) => !previousSurfaces.has(platform),
+  );
+  const shared = previousPlatforms.filter((platform) => currentSurfaces.has(platform));
+  const comparable = shared.filter((platform) => (
+    previousSurfaces.get(platform).status !== 'unavailable'
+      && currentSurfaces.get(platform).status !== 'unavailable'
+  ));
+  const availabilityChanges = shared
+    .filter((platform) => (
+      previousSurfaces.get(platform).status !== currentSurfaces.get(platform).status
+    ))
+    .map((platform) => ({
+      platform,
+      previous: previousSurfaces.get(platform).status,
+      current: currentSurfaces.get(platform).status,
+    }));
+  return {
+    changed: previousOnly.length > 0
+      || currentOnly.length > 0
+      || availabilityChanges.length > 0,
+    previous: previousPlatforms,
+    current: currentPlatforms,
+    comparable,
+    previousOnly,
+    currentOnly,
+    availabilityChanges,
+  };
 }
 
 function assertComparableScorecards(previous, current) {
@@ -1092,8 +1160,10 @@ function compareWindowedSource(previous, current, metricNames, label) {
 
 export function compareScorecards(previous, current) {
   assertComparableScorecards(previous, current);
-  const previousObservations = observationIndex(previous);
-  const currentObservations = observationIndex(current);
+  const coverage = platformCoverage(previous, current);
+  const comparablePlatforms = new Set(coverage.comparable);
+  const previousObservations = observationIndex(previous, comparablePlatforms);
+  const currentObservations = observationIndex(current, comparablePlatforms);
   const newCitations = [];
   const lostCitations = [];
   const newlyObserved = [];
@@ -1117,6 +1187,20 @@ export function compareScorecards(previous, current) {
   const byObservationKey = (left, right) => (
     observationKey(left).localeCompare(observationKey(right))
   );
+  const notComparable = {
+    previous: previous.ai.observations
+      .filter((observation) => !comparablePlatforms.has(
+        comparisonPlatform(observation.platform),
+      ))
+      .map((observation) => structuredClone(observation))
+      .sort(byObservationKey),
+    current: current.ai.observations
+      .filter((observation) => !comparablePlatforms.has(
+        comparisonPlatform(observation.platform),
+      ))
+      .map((observation) => structuredClone(observation))
+      .sort(byObservationKey),
+  };
 
   return {
     previousBaselineId: previous.baselineId,
@@ -1125,6 +1209,8 @@ export function compareScorecards(previous, current) {
     lostCitations: lostCitations.sort(byObservationKey),
     newlyObserved: newlyObserved.sort(byObservationKey),
     noLongerObserved: noLongerObserved.sort(byObservationKey),
+    platformCoverage: coverage,
+    notComparable,
     search: {
       googleSearchConsole: compareWindowedSource(
         previous.search.googleSearchConsole,
@@ -1255,6 +1341,24 @@ function formatComparison(comparison) {
     `${observation.queryId} on ${PLATFORM_LABELS[observation.platform]}`
     + ` (${observation.geography}, ${observation.locale}, ${observation.signedInState})`
   );
+  const platformLabel = (platform) => `${PLATFORM_LABELS[platform]} (\`${platform}\`)`;
+  const platformList = (platforms) => (
+    platforms.length ? platforms.map(platformLabel).join(', ') : 'none'
+  );
+  const availabilityChanges = comparison.platformCoverage.availabilityChanges.map((change) => (
+    `${platformLabel(change.platform)} ${change.previous} → ${change.current}`
+  ));
+  const coverageSummary = comparison.platformCoverage.changed
+    ? `changed; comparable: ${platformList(comparison.platformCoverage.comparable)}; previous-only: ${platformList(comparison.platformCoverage.previousOnly)}; current-only: ${platformList(comparison.platformCoverage.currentOnly)}; availability changes: ${availabilityChanges.length ? availabilityChanges.join(', ') : 'none'}`
+    : `unchanged; comparable: ${platformList(comparison.platformCoverage.comparable)}`;
+  const notComparable = [
+    ...comparison.notComparable.previous.map(
+      (observation) => `previous ${citationLabel(observation)}`,
+    ),
+    ...comparison.notComparable.current.map(
+      (observation) => `current ${citationLabel(observation)}`,
+    ),
+  ];
   const meaningfulSearch = [];
   const indexingRegressions = [];
   const periodTransition = ({ previousPeriod, currentPeriod }) => (
@@ -1298,6 +1402,8 @@ function formatComparison(comparison) {
     '',
     `Compared \`${comparison.previousBaselineId}\` with \`${comparison.currentBaselineId}\`.`,
     '',
+    `- Platform coverage ${coverageSummary}`,
+    `- Not comparable because the surface was not measurable in both periods: ${notComparable.length ? notComparable.join('; ') : 'none'}`,
     `- Compared provider periods: ${comparedPeriods.length ? comparedPeriods.join('; ') : 'none available'}`,
     `- New citations: ${comparison.newCitations.length ? comparison.newCitations.map(citationLabel).join('; ') : 'none'}`,
     `- Lost citations: ${comparison.lostCitations.length ? comparison.lostCitations.map(citationLabel).join('; ') : 'none'}`,
@@ -1320,6 +1426,9 @@ export function formatScorecardMarkdown(scorecard) {
     `\`${scorecard.generatedAt}\`. Missing provider data is reported as unavailable,`,
     'never coerced to zero.',
     `Query contract: \`${scorecard.querySetId}\` / \`${scorecard.querySetDigest}\`.`,
+    ...(scorecard.schemaVersion === 2
+      ? [`Baseline contract: v${scorecard.schemaVersion}.`]
+      : []),
     '',
     '## Collection context',
     '',
@@ -1399,8 +1508,17 @@ export function formatScorecardMarkdown(scorecard) {
     '',
     '## AI-answer audit',
     '',
-    `Coverage: ${scorecard.ai.observed}/${scorecard.ai.possible} (${percent(scorecard.ai.coverageRate)}).`,
-    `Full target matrix: ${scorecard.ai.targetPossible} query/platform pairs.`,
+    ...(scorecard.schemaVersion === 2
+      ? [
+        `Actual observations: ${scorecard.ai.observed}.`,
+        `Available-surface target: ${scorecard.ai.possible} query/platform pairs.`,
+        `Available-surface coverage: ${scorecard.ai.observed}/${scorecard.ai.possible} (${percent(scorecard.ai.coverageRate)}).`,
+        `Full target matrix: ${scorecard.ai.targetPossible} query/platform pairs.`,
+      ]
+      : [
+        `Coverage: ${scorecard.ai.observed}/${scorecard.ai.possible} (${percent(scorecard.ai.coverageRate)}).`,
+        `Full target matrix: ${scorecard.ai.targetPossible} query/platform pairs.`,
+      ]),
     `Observed mention rate: ${percent(scorecard.ai.brandMentionRate)}.`,
     `Observed direct-citation rate: ${percent(scorecard.ai.directCitationRate)}.`,
     'These are descriptive observations, not causal or population-level estimates.',

--- a/tests/seo-ai-visibility-collector.test.mjs
+++ b/tests/seo-ai-visibility-collector.test.mjs
@@ -7,6 +7,11 @@ import {
   normalizeSearchExport,
   runCli,
 } from '../scripts/seo-ai-visibility-collector.mjs';
+import {
+  buildScorecard,
+  formatScorecardMarkdown,
+  runCli as runScorecardCli,
+} from '../scripts/seo-ai-visibility-scorecard.mjs';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -562,6 +567,111 @@ describe('SEO/AI visibility collector', () => {
     assert.deepEqual(
       Object.keys(baseline.opportunities[0]).sort(),
       ['evidence', 'experiment', 'priority', 'queryIds', 'successCriteria', 'title'],
+    );
+  });
+
+  it('imports independent Google Overview and Mode observations under contract v2', async () => {
+    const googleObservation = template.aiObservations.find(
+      ({ platform }) => platform === 'google_ai',
+    );
+    const sources = {
+      schemaVersion: 2,
+      googleSearchConsole: { status: 'unavailable', reason: 'No export.' },
+      bingWebmaster: { status: 'unavailable', reason: 'No export.' },
+      referrals: { status: 'unavailable', reason: 'No export.' },
+      aiSurfaces: [
+        { platform: 'chatgpt_search', status: 'unavailable', reason: 'Not collected.' },
+        { platform: 'perplexity', status: 'unavailable', reason: 'Not collected.' },
+        { platform: 'google_ai_overview', status: 'available' },
+        { platform: 'google_ai_mode', status: 'available' },
+        { platform: 'copilot_search', status: 'unavailable', reason: 'Not collected.' },
+      ],
+      aiObservations: [
+        {
+          ...structuredClone(googleObservation),
+          platform: 'google_ai_overview',
+          prompt: 'must never be copied',
+        },
+        {
+          ...structuredClone(googleObservation),
+          platform: 'google_ai_mode',
+          directCitation: false,
+          citedUrls: [],
+          summary: 'Google AI Mode mentioned World Monitor without a direct citation.',
+          accountId: 'must never be copied',
+        },
+      ],
+    };
+
+    const current = collectBaseline({
+      template,
+      querySet,
+      sources,
+      observedAt,
+      repositoryRevision: 'test-revision',
+    });
+
+    assert.equal(current.schemaVersion, 2);
+    assert.deepEqual(
+      current.aiObservations.map(({ queryId, platform }) => ({ queryId, platform })),
+      [
+        { queryId: 'q01', platform: 'google_ai_overview' },
+        { queryId: 'q01', platform: 'google_ai_mode' },
+      ],
+    );
+    assert.equal(JSON.stringify(current).includes('must never be copied'), false);
+
+    const markdown = formatScorecardMarkdown(buildScorecard(querySet, current));
+    assert.match(markdown, /\| q01 \| Google AI Overview \|/);
+    assert.match(markdown, /\| q01 \| Google AI Mode \|/);
+
+    const directory = mkdtempSync(join(tmpdir(), 'seo-visibility-five-surface-'));
+    const sourcesPath = join(directory, 'sources.json');
+    const baselinePath = join(directory, 'baseline.json');
+    const scorecardPath = join(directory, 'scorecard.md');
+    writeFileSync(sourcesPath, JSON.stringify(sources));
+    try {
+      await runCli([
+        '--queries', 'docs/research/seo-ai-visibility/query-set.json',
+        '--template', 'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
+        '--sources', sourcesPath,
+        '--observed-at', observedAt,
+        '--repository-revision', 'test-revision',
+        '--output', baselinePath,
+      ]);
+      await runScorecardCli([
+        '--queries', 'docs/research/seo-ai-visibility/query-set.json',
+        '--baseline', baselinePath,
+        '--output', scorecardPath,
+      ]);
+      await runScorecardCli([
+        '--queries', 'docs/research/seo-ai-visibility/query-set.json',
+        '--baseline', baselinePath,
+        '--output', scorecardPath,
+        '--check',
+      ]);
+      assert.equal(JSON.parse(readFileSync(baselinePath, 'utf8')).schemaVersion, 2);
+      assert.match(readFileSync(scorecardPath, 'utf8'), /Full target matrix: 125/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('requires an explicit five-surface availability manifest for contract v2', () => {
+    assert.throws(
+      () => collectBaseline({
+        template,
+        querySet,
+        sources: {
+          schemaVersion: 2,
+          googleSearchConsole: { status: 'unavailable', reason: 'No export.' },
+          bingWebmaster: { status: 'unavailable', reason: 'No export.' },
+          referrals: { status: 'unavailable', reason: 'No export.' },
+        },
+        observedAt,
+        repositoryRevision: 'test-revision',
+      }),
+      /aiSurfaces is required for baseline schemaVersion 2/,
     );
   });
 

--- a/tests/seo-ai-visibility-scorecard.test.mjs
+++ b/tests/seo-ai-visibility-scorecard.test.mjs
@@ -30,6 +30,34 @@ const baseline = readJson(
   'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
 );
 
+const AI_PLATFORMS_V2 = Object.freeze([
+  'chatgpt_search',
+  'perplexity',
+  'google_ai_overview',
+  'google_ai_mode',
+  'copilot_search',
+]);
+
+function fiveSurfaceBaseline(source = baseline) {
+  const next = structuredClone(source);
+  next.schemaVersion = 2;
+  next.aiSurfaces = source.aiSurfaces.flatMap((surface) => (
+    surface.platform === 'google_ai'
+      ? [
+        { ...structuredClone(surface), platform: 'google_ai_overview' },
+        { ...structuredClone(surface), platform: 'google_ai_mode' },
+      ]
+      : [structuredClone(surface)]
+  ));
+  next.aiObservations = source.aiObservations.map((observation) => ({
+    ...structuredClone(observation),
+    platform: observation.platform === 'google_ai'
+      ? 'google_ai_overview'
+      : observation.platform,
+  }));
+  return next;
+}
+
 function buildComparableScorecards() {
   const currentBaseline = structuredClone(baseline);
   currentBaseline.baselineId = '2026-08-27';
@@ -320,6 +348,88 @@ describe('SEO and AI visibility baseline', () => {
     assert.equal(scorecard.ai.possible, 75);
     assert.equal(scorecard.ai.observed, 3);
     assert.equal(scorecard.ai.coverageRate, 0.04);
+  });
+
+  it('validates the explicit five-surface contract and separates its coverage denominators', () => {
+    const current = fiveSurfaceBaseline();
+    const modeObservation = {
+      ...structuredClone(
+        current.aiObservations.find(({ platform }) => platform === 'google_ai_overview'),
+      ),
+      platform: 'google_ai_mode',
+      directCitation: false,
+      citedUrls: [],
+      summary: 'Google AI Mode mentioned World Monitor without a direct citation.',
+    };
+    current.aiObservations.push(modeObservation);
+    const perplexity = current.aiSurfaces.find(({ platform }) => platform === 'perplexity');
+    perplexity.status = 'unavailable';
+    perplexity.reason = 'The surface was unavailable for this cycle.';
+    current.aiObservations = current.aiObservations.filter(
+      ({ platform }) => platform !== 'perplexity',
+    );
+
+    assert.doesNotThrow(() => validateBaseline(current, querySet));
+    assert.deepEqual(
+      current.aiSurfaces.map(({ platform }) => platform),
+      AI_PLATFORMS_V2,
+    );
+    const scorecard = buildScorecard(querySet, current);
+    assert.equal(scorecard.ai.targetPossible, 125);
+    assert.equal(scorecard.ai.possible, 100);
+    assert.equal(scorecard.ai.observed, 4);
+
+    const markdown = formatScorecardMarkdown(scorecard);
+    assert.match(markdown, /Google AI Overview/);
+    assert.match(markdown, /Google AI Mode/);
+    assert.match(markdown, /Actual observations: 4\./);
+    assert.match(markdown, /Available-surface target: 100 query\/platform pairs\./);
+    assert.match(markdown, /Full target matrix: 125 query\/platform pairs\./);
+  });
+
+  it('rejects duplicate, unknown, missing, and unavailable five-surface observations', () => {
+    const current = fiveSurfaceBaseline();
+    const overview = current.aiObservations.find(
+      ({ platform }) => platform === 'google_ai_overview',
+    );
+
+    const duplicate = structuredClone(current);
+    duplicate.aiObservations.push(structuredClone(overview));
+    assert.throws(
+      () => validateBaseline(duplicate, querySet),
+      /duplicate AI observation q01:google_ai_overview/,
+    );
+
+    const unknown = structuredClone(current);
+    unknown.aiSurfaces.find(
+      ({ platform }) => platform === 'google_ai_mode',
+    ).platform = 'google_ai_unknown';
+    assert.throws(
+      () => validateBaseline(unknown, querySet),
+      /aiSurfaces\[3\]\.platform is invalid/,
+    );
+
+    const missing = structuredClone(current);
+    missing.aiSurfaces = missing.aiSurfaces.filter(
+      ({ platform }) => platform !== 'google_ai_mode',
+    );
+    assert.throws(
+      () => validateBaseline(missing, querySet),
+      /aiSurfaces must contain every supported platform exactly once/,
+    );
+
+    const unavailable = structuredClone(current);
+    const mode = unavailable.aiSurfaces.find(({ platform }) => platform === 'google_ai_mode');
+    mode.status = 'unavailable';
+    mode.reason = 'The surface was unavailable for this cycle.';
+    unavailable.aiObservations.push({
+      ...structuredClone(overview),
+      platform: 'google_ai_mode',
+    });
+    assert.throws(
+      () => validateBaseline(unavailable, querySet),
+      /aiObservations\[4\]\.platform is unavailable/,
+    );
   });
 
   it('rejects committed property IDs, malformed guardrails, and invalid priorities', () => {
@@ -879,6 +989,85 @@ describe('scorecard computation', () => {
       })),
       [{ queryId: 'q01', platform: 'chatgpt_search' }],
     );
+  });
+
+  it('marks newly tracked surfaces not comparable across contract versions', () => {
+    const previousBaseline = structuredClone(baseline);
+    const previousOverview = previousBaseline.aiObservations.find(
+      ({ platform }) => platform === 'google_ai',
+    );
+    previousOverview.directCitation = false;
+    previousOverview.citedUrls = [];
+
+    const currentBaseline = fiveSurfaceBaseline();
+    currentBaseline.baselineId = '2026-08-27';
+    currentBaseline.observedAt = '2026-08-27T12:00:00Z';
+    const currentOverview = currentBaseline.aiObservations.find(
+      ({ platform }) => platform === 'google_ai_overview',
+    );
+    currentBaseline.aiObservations.push({
+      ...structuredClone(currentOverview),
+      platform: 'google_ai_mode',
+      summary: 'Google AI Mode directly cited World Monitor.',
+    });
+
+    const previous = buildScorecard(querySet, previousBaseline);
+    const current = buildScorecard(querySet, currentBaseline);
+    const comparison = compareScorecards(previous, current);
+
+    assert.deepEqual(comparison.platformCoverage.previousOnly, []);
+    assert.deepEqual(comparison.platformCoverage.currentOnly, ['google_ai_mode']);
+    assert.deepEqual(
+      comparison.newCitations.map(({ queryId, platform }) => ({ queryId, platform })),
+      [{ queryId: 'q01', platform: 'google_ai_overview' }],
+    );
+    assert.deepEqual(comparison.newlyObserved, []);
+    assert.deepEqual(
+      comparison.notComparable.current.map(({ queryId, platform }) => ({ queryId, platform })),
+      [{ queryId: 'q01', platform: 'google_ai_mode' }],
+    );
+
+    current.comparison = comparison;
+    const markdown = formatScorecardMarkdown(current);
+    assert.match(markdown, /Platform coverage changed/);
+    assert.match(markdown, /current-only: Google AI Mode \(`google_ai_mode`\)/);
+    assert.match(markdown, /Not comparable.*q01 on Google AI Mode/);
+  });
+
+  it('compares like-for-like AI Mode observations in five-surface cycles', () => {
+    const previousBaseline = fiveSurfaceBaseline();
+    previousBaseline.baselineId = '2026-08-01';
+    previousBaseline.observedAt = '2026-08-01T12:00:00Z';
+    const overview = previousBaseline.aiObservations.find(
+      ({ platform }) => platform === 'google_ai_overview',
+    );
+    previousBaseline.aiObservations.push({
+      ...structuredClone(overview),
+      platform: 'google_ai_mode',
+      directCitation: false,
+      citedUrls: [],
+      summary: 'Google AI Mode mentioned World Monitor without a direct citation.',
+    });
+    const currentBaseline = structuredClone(previousBaseline);
+    currentBaseline.baselineId = '2026-08-27';
+    currentBaseline.observedAt = '2026-08-27T12:00:00Z';
+    const currentMode = currentBaseline.aiObservations.find(
+      ({ platform }) => platform === 'google_ai_mode',
+    );
+    currentMode.directCitation = true;
+    currentMode.citedUrls = ['https://www.worldmonitor.app/'];
+    currentMode.summary = 'Google AI Mode directly cited World Monitor.';
+
+    const comparison = compareScorecards(
+      buildScorecard(querySet, previousBaseline),
+      buildScorecard(querySet, currentBaseline),
+    );
+
+    assert.deepEqual(
+      comparison.newCitations.map(({ queryId, platform }) => ({ queryId, platform })),
+      [{ queryId: 'q01', platform: 'google_ai_mode' }],
+    );
+    assert.deepEqual(comparison.notComparable, { previous: [], current: [] });
   });
 
   it('compares finite metrics from partial provider exports', () => {


### PR DESCRIPTION
## Summary

Operators can now record Google AI Overview and Google AI Mode as separate observations in the same collection cycle without changing historical results. Baseline contract v2 defines five explicit surfaces and a 125-pair full matrix, while contract v1 keeps its four recorded surfaces, 100-pair denominator, legacy `google_ai` identifier, and byte-identical report output.

Cross-period reports compare only surfaces that were independently measurable in both periods. A legacy Google observation maps only to Overview, and a newly tracked Mode observation is disclosed as not comparable instead of appearing as a citation gain or loss. The collector requires an explicit v2 availability manifest and keeps the existing size limits and output whitelist for prompts, account data, credentials, and provider payload fields.

Fixes #7766.

## Validation

- `node --test tests/seo-ai-visibility-scorecard.test.mjs tests/seo-ai-visibility-collector.test.mjs` - 60 passed.
- The committed v1 scorecard passed its real `--check` reproduction command without a diff.
- A synthetic v2 manifest passed the real collector, renderer, and renderer `--check` CLIs; the report showed separate Overview and Mode rows, a 125-pair full target, and Mode as current-only in a v1-to-v2 comparison.
- `npm run typecheck` passed.
- Biome passed for both changed scripts and both changed test files.
- The pre-push suite also passed API type checks, Markdown lint, version checks, and the changed tests.
- `git diff --check` passed, and the query registry, committed baselines, and historical scorecard are unchanged.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This change affects only local file-based collection and reporting scripts plus their documentation; it does not change a deployed service or worker path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/GPT--5-000000)
