### PR TITLE
perf(panels): commit heatmap tab changes immediately

### DIFF
--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -157,13 +157,26 @@ export class HeatmapPanel extends Panel {
   constructor() {
     super({ id: 'heatmap', title: t('panels.heatmap'), infoTooltip: t('components.heatmap.infoTooltip') });
     this.content.addEventListener('click', (e) => {
-      const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-tab]');
-      const tab = btn?.dataset.tab;
-      if (tab === 'performance' || tab === 'valuations') {
-        this._tab = tab;
-        this._render();
-      }
+      const tab = this.tabFromEvent(e);
+      if (tab) this.selectTab(tab);
     });
+    this.content.addEventListener('keydown', (e) => {
+      if (e.repeat || (e.key !== 'Enter' && e.key !== ' ')) return;
+      const tab = this.tabFromEvent(e);
+      if (!tab) return;
+      e.preventDefault();
+      this.selectTab(tab);
+    });
+  }
+
+  private tabFromEvent(e: Event): HeatmapTab | null {
+    const tab = (e.target as HTMLElement).closest<HTMLElement>('[data-tab]')?.dataset.tab;
+    return tab === 'performance' || tab === 'valuations' ? tab : null;
+  }
+
+  private selectTab(tab: HeatmapTab): void {
+    this._tab = tab;
+    this._render('user');
   }
 
   public renderHeatmap(
@@ -218,20 +231,27 @@ export class HeatmapPanel extends Panel {
     </div>`;
   }
 
-  private _render(): void {
+  private _render(origin: 'user' | 'data' = 'data'): void {
     if (this._heatmapData.length === 0) {
       this.showRetrying(t('common.failedSectorData'));
       return;
     }
 
     const tabBar = this._buildTabBar();
-
-    if (this._tab === 'valuations' && Object.keys(this._valuations).length > 0) {
-      this.setSafeContent(unsafeRawHtml(tabBar + this._renderValuations(), 'legacy Panel.setContent() migration'));
+    const body =
+      this._tab === 'valuations' && Object.keys(this._valuations).length > 0
+        ? this._renderValuations()
+        : this._renderPerformance();
+    const html = unsafeRawHtml(tabBar + body, 'legacy Panel.setContent() migration');
+    if (origin === 'user') {
+      this.setSafeContentImmediate(html, () => this.restoreSelectedTabFocus());
       return;
     }
+    this.setSafeContent(html);
+  }
 
-    this.setSafeContent(unsafeRawHtml(tabBar + this._renderPerformance(), 'legacy Panel.setContent() migration'));
+  private restoreSelectedTabFocus(): void {
+    this.content.querySelector<HTMLButtonElement>(`.panel-tab[data-tab="${this._tab}"]`)?.focus();
   }
 
   private _renderPerformance(): string {

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -1459,11 +1459,21 @@ export class Panel {
     this.setContentHtml(safeHtmlToString(html), afterUpdate);
   }
 
-  private setContentHtml(html: string, afterUpdate?: () => void): void {
+  /**
+   * User-action twin of `setSafeContent`. Same safe-HTML boundary, lock bail,
+   * error/retry clear, dirty-check, and `setContentImmediate` commit — without
+   * the 150 ms background coalescing timer. A pending coalesced write and its
+   * callback are cancelled so they cannot paint over this interaction.
+   */
+  public setSafeContentImmediate(html: SafeHtml, afterUpdate?: () => void): void {
+    this.setContentHtml(safeHtmlToString(html), afterUpdate, true);
+  }
+
+  private setContentHtml(html: string, afterUpdate?: () => void, immediate = false): void {
     // #6714: clear error state before the lock bail — see setContentNodes.
     this.clearErrorState();
     if (this._locked) return;
-    if (this.pendingContentHtml === html) {
+    if (!immediate && this.pendingContentHtml === html) {
       if (afterUpdate) this.pendingContentCallback = afterUpdate;
       return;
     }
@@ -1481,6 +1491,10 @@ export class Panel {
 
     this.pendingContentHtml = html;
     this.pendingContentCallback = afterUpdate ?? null;
+    if (immediate) {
+      this.setContentImmediate(html);
+      return;
+    }
     if (this.contentDebounceTimer) {
       clearTimeout(this.contentDebounceTimer);
     }

--- a/tests/dom/heatmap-tab-immediate.test.mts
+++ b/tests/dom/heatmap-tab-immediate.test.mts
@@ -1,0 +1,297 @@
+/**
+ * Heatmap tab switches must commit in the user's action (#7775).
+ *
+ * `setSafeContent` coalesces background ticks behind a 150 ms timer. The
+ * Heatmap Performance/Valuations buttons used that path, so a click rebuilt
+ * markup only after the timer and replaced the focused button. These cases
+ * drive the real `HeatmapPanel` buttons and require the new tab's body
+ * without advancing that timer.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HeatmapPanel } from '@/components/MarketPanel';
+import type { SectorValuation } from '@/components/MarketPanel';
+
+import { initTestI18n } from './helpers/i18n.mts';
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+const CONTENT_DEBOUNCE_MS = 150;
+
+const SECTORS = [
+  { symbol: 'XLK', name: 'Technology', change: 1.25 },
+  { symbol: 'XLE', name: 'Energy', change: -0.4 },
+];
+
+const BARS = [
+  { symbol: 'XLK', name: 'Technology', change1d: 1.25 },
+  { symbol: 'XLE', name: 'Energy', change1d: -0.4 },
+];
+
+const VALUATIONS: Record<string, SectorValuation> = {
+  XLK: {
+    trailingPE: 28.1,
+    forwardPE: 24.4,
+    beta: 1.12,
+    ytdReturn: 0.18,
+    threeYearReturn: 0.42,
+    fiveYearReturn: 0.91,
+  },
+  XLE: {
+    trailingPE: 14.2,
+    forwardPE: 12.6,
+    beta: 0.88,
+    ytdReturn: -0.05,
+    threeYearReturn: 0.11,
+    fiveYearReturn: 0.2,
+  },
+};
+
+interface PanelContentInternals {
+  content: HTMLElement;
+  contentDebounceTimer: ReturnType<typeof setTimeout> | null;
+  pendingContentCallback: (() => void) | null;
+  pendingContentHtml: string | null;
+}
+
+let panel: HeatmapPanel;
+
+function internals(): PanelContentInternals {
+  return panel as unknown as PanelContentInternals;
+}
+
+function content(): HTMLElement {
+  return internals().content;
+}
+
+function tabButton(tab: 'performance' | 'valuations'): HTMLButtonElement {
+  const btn = content().querySelector<HTMLButtonElement>(`.panel-tab[data-tab="${tab}"]`);
+  if (!btn) throw new Error(`missing ${tab} tab button`);
+  return btn;
+}
+
+function isPerformance(): boolean {
+  return content().querySelector('.heatmap') !== null && content().querySelector('table') === null;
+}
+
+function isValuations(): boolean {
+  return content().querySelector('table') !== null && content().querySelector('.heatmap') === null;
+}
+
+function activeTab(): string | undefined {
+  return content().querySelector<HTMLElement>('.panel-tab.active')?.dataset.tab;
+}
+
+function populate(flushInitial: boolean): void {
+  panel.renderHeatmap(SECTORS, BARS);
+  panel.updateValuations(VALUATIONS);
+  if (flushInitial) vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+}
+
+function activate(tab: 'performance' | 'valuations', via: 'click' | 'Enter' | ' '): void {
+  const btn = tabButton(tab);
+  btn.focus();
+  if (via === 'click') {
+    btn.click();
+    return;
+  }
+  const event = new KeyboardEvent('keydown', { key: via, bubbles: true, cancelable: true });
+  btn.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(true);
+  if (via === ' ') {
+    btn.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', bubbles: true, cancelable: true }));
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  panel = new HeatmapPanel();
+  document.body.appendChild(panel.getElement());
+});
+
+afterEach(() => {
+  panel.destroy();
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
+
+describe('Heatmap tab commit (#7775)', () => {
+  it('commits Valuations on click without the 150 ms background timer', () => {
+    populate(true);
+    expect(isPerformance()).toBe(true);
+
+    activate('valuations', 'click');
+
+    expect(internals().contentDebounceTimer).toBeNull();
+    expect(isValuations()).toBe(true);
+    expect(activeTab()).toBe('valuations');
+    expect(document.activeElement).toBe(tabButton('valuations'));
+  });
+
+  it.each(['Enter', ' '] as const)(
+    'selects Valuations with %s and keeps focus on the replacement button',
+    (key) => {
+      populate(true);
+      activate('valuations', key);
+
+      expect(internals().contentDebounceTimer).toBeNull();
+      expect(isValuations()).toBe(true);
+      expect(activeTab()).toBe('valuations');
+      expect(document.activeElement).toBe(tabButton('valuations'));
+    },
+  );
+
+  it('selects Performance with Enter after Valuations and keeps focus', () => {
+    populate(true);
+    activate('valuations', 'click');
+    activate('performance', 'Enter');
+
+    expect(internals().contentDebounceTimer).toBeNull();
+    expect(isPerformance()).toBe(true);
+    expect(activeTab()).toBe('performance');
+    expect(document.activeElement).toBe(tabButton('performance'));
+  });
+
+  it('keeps background updates on the 150 ms coalescing timer', () => {
+    populate(false);
+
+    expect(content().querySelector('.heatmap')).toBeNull();
+    expect(internals().contentDebounceTimer).not.toBeNull();
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS - 1);
+    expect(content().querySelector('.heatmap')).toBeNull();
+
+    vi.advanceTimersByTime(1);
+    expect(isPerformance()).toBe(true);
+  });
+
+  it('rapid Performance/Valuations/Performance settles on the last tab', () => {
+    populate(true);
+
+    activate('valuations', 'click');
+    activate('performance', 'click');
+    activate('valuations', 'click');
+    activate('performance', 'click');
+
+    expect(isPerformance()).toBe(true);
+    expect(activeTab()).toBe('performance');
+    expect(internals().contentDebounceTimer).toBeNull();
+    expect(document.activeElement).toBe(tabButton('performance'));
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS * 3);
+    expect(isPerformance()).toBe(true);
+    expect(activeTab()).toBe('performance');
+  });
+
+  it('a refresh queued before a click cannot restore the older tab', () => {
+    populate(true);
+    panel.renderHeatmap(
+      [
+        { symbol: 'XLK', name: 'Queued Technology', change: 3.5 },
+        { symbol: 'XLE', name: 'Queued Energy', change: 1.1 },
+      ],
+      BARS,
+    );
+    expect(internals().contentDebounceTimer).not.toBeNull();
+    expect(isPerformance()).toBe(true);
+
+    const superseded = vi.fn();
+    internals().pendingContentCallback = superseded;
+
+    activate('valuations', 'click');
+
+    expect(isValuations()).toBe(true);
+    expect(superseded).not.toHaveBeenCalled();
+    expect(internals().pendingContentCallback).toBeNull();
+    expect(content().querySelector('.heatmap')).toBeNull();
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS * 3);
+    expect(isValuations()).toBe(true);
+    expect(content().querySelector('.heatmap')).toBeNull();
+    expect(superseded).not.toHaveBeenCalled();
+  });
+
+  it('a refresh arriving after a click renders the selected tab, not the previous one', () => {
+    populate(true);
+    activate('valuations', 'click');
+    expect(isValuations()).toBe(true);
+
+    panel.renderHeatmap(
+      [
+        { symbol: 'XLK', name: 'Refreshed Technology', change: 0.5 },
+        { symbol: 'XLE', name: 'Refreshed Energy', change: 0.1 },
+      ],
+      BARS,
+    );
+
+    expect(isValuations()).toBe(true);
+    expect(content().textContent).not.toContain('Refreshed Technology');
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    expect(isValuations()).toBe(true);
+    expect(content().textContent).toContain('Refreshed Technology');
+    expect(content().querySelector('.heatmap')).toBeNull();
+  });
+
+  it('does not move focus onto a tab during a background refresh', () => {
+    populate(true);
+    const probe = document.createElement('button');
+    probe.id = 'outside-focus-probe';
+    document.body.appendChild(probe);
+    probe.focus();
+    expect(document.activeElement).toBe(probe);
+
+    panel.renderHeatmap(SECTORS, BARS);
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+
+    expect(isPerformance()).toBe(true);
+    expect(document.activeElement).toBe(probe);
+  });
+
+  it('a queued refresh cannot paint over a lock, including after the timer', () => {
+    populate(true);
+    panel.renderHeatmap(
+      [
+        { symbol: 'XLK', name: 'Locked Technology', change: 2 },
+        { symbol: 'XLE', name: 'Locked Energy', change: 1 },
+      ],
+      BARS,
+    );
+    expect(internals().contentDebounceTimer).not.toBeNull();
+    panel.showLocked(['Heatmap']);
+    expect(content().querySelector('.panel-locked-state')).not.toBeNull();
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS * 3);
+
+    expect(content().querySelector('.panel-locked-state')).not.toBeNull();
+    expect(content().querySelector('.heatmap')).toBeNull();
+    expect(content().querySelector('table')).toBeNull();
+    expect(content().textContent).not.toContain('Locked Technology');
+  });
+
+  it('unlock restoration keeps the pre-lock body and ignores a later timer', () => {
+    populate(true);
+    expect(isPerformance()).toBe(true);
+    panel.renderHeatmap(
+      [
+        { symbol: 'XLK', name: 'Post-lock Technology', change: 2 },
+        { symbol: 'XLE', name: 'Post-lock Energy', change: 1 },
+      ],
+      BARS,
+    );
+    panel.showLocked(['Heatmap']);
+    panel.unlockPanel();
+
+    expect(isPerformance()).toBe(true);
+    expect(content().textContent).toContain('Technology');
+    expect(content().textContent).not.toContain('Post-lock Technology');
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS * 3);
+    expect(isPerformance()).toBe(true);
+    expect(content().querySelector('.panel-locked-state')).toBeNull();
+    expect(content().textContent).not.toContain('Post-lock Technology');
+  });
+});

--- a/tests/dom/panel-content-cache.test.mts
+++ b/tests/dom/panel-content-cache.test.mts
@@ -140,3 +140,119 @@ describe('Panel content dirty-check', () => {
     expect(content().querySelector('.probe-a')).not.toBeNull();
   });
 });
+
+interface ImmediateWriter {
+  setSafeContentImmediate: (html: ReturnType<typeof unsafeRawHtml>, afterUpdate?: () => void) => void;
+  contentDebounceTimer: ReturnType<typeof setTimeout> | null;
+  pendingContentCallback: (() => void) | null;
+  _locked: boolean;
+}
+
+function immediate(): ImmediateWriter {
+  return panel as unknown as ImmediateWriter;
+}
+
+function setBodyImmediate(html: string, afterUpdate?: () => void): void {
+  immediate().setSafeContentImmediate(unsafeRawHtml(html, 'test fixture'), afterUpdate);
+}
+
+describe('Panel immediate safe content commit (#7775)', () => {
+  it('commits through the safe HTML path without the 150 ms timer', () => {
+    setBodyImmediate(BODY_A);
+
+    expect(immediate().contentDebounceTimer).toBeNull();
+    expect(content().querySelector('.probe-a')).not.toBeNull();
+  });
+
+  it('commits a still-queued same body immediately instead of waiting', () => {
+    setBody(BODY_A);
+    panel.setSafeContent(unsafeRawHtml(BODY_B, 'test fixture'));
+    expect(immediate().contentDebounceTimer).not.toBeNull();
+    expect(content().querySelector('.probe-b')).toBeNull();
+
+    setBodyImmediate(BODY_B);
+
+    expect(immediate().contentDebounceTimer).toBeNull();
+    expect(content().querySelector('.probe-b')).not.toBeNull();
+    expect(content().querySelector('.probe-a')).toBeNull();
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS * 3);
+    expect(content().querySelector('.probe-b')).not.toBeNull();
+  });
+
+  it('cancels a queued write and its callback; the surviving callback runs once', () => {
+    setBody(BODY_A);
+    const superseded = vi.fn();
+    const surviving = vi.fn();
+    panel.setSafeContent(unsafeRawHtml(BODY_B, 'test fixture'), superseded);
+    expect(immediate().contentDebounceTimer).not.toBeNull();
+
+    setBodyImmediate(BODY_A.replace('alpha', 'gamma').replace('probe-a', 'probe-c'), surviving);
+
+    expect(superseded).not.toHaveBeenCalled();
+    expect(surviving).toHaveBeenCalledTimes(1);
+    expect(content().querySelector('.probe-c')).not.toBeNull();
+    expect(content().querySelector('.probe-b')).toBeNull();
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS * 3);
+    expect(superseded).not.toHaveBeenCalled();
+    expect(surviving).toHaveBeenCalledTimes(1);
+    expect(content().querySelector('.probe-b')).toBeNull();
+  });
+
+  it('preserves same-content dirty checking and still runs afterUpdate', () => {
+    setBodyImmediate(BODY_A);
+    const first = content().querySelector('.probe-a');
+    const afterUpdate = vi.fn();
+
+    setBodyImmediate(BODY_A, afterUpdate);
+
+    expect(afterUpdate).toHaveBeenCalledTimes(1);
+    expect(content().querySelector('.probe-a')).toBe(first);
+    expect(immediate().contentDebounceTimer).toBeNull();
+  });
+
+  it('does not lower the background coalescing timer', () => {
+    setBodyImmediate(BODY_A);
+    panel.setSafeContent(unsafeRawHtml(BODY_B, 'test fixture'));
+
+    expect(content().querySelector('.probe-b')).toBeNull();
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS - 1);
+    expect(content().querySelector('.probe-b')).toBeNull();
+    vi.advanceTimersByTime(1);
+    expect(content().querySelector('.probe-b')).not.toBeNull();
+  });
+
+  it('bails on a locked panel at schedule time', () => {
+    panel.showLocked(['probe feature']);
+    setBodyImmediate('<div class="premium-payload">paid</div>');
+
+    expect(content().querySelector('.premium-payload')).toBeNull();
+    expect(content().querySelector('.panel-locked-state')).not.toBeNull();
+  });
+
+  it('clears error/retry state on an immediate commit', () => {
+    const retry = vi.fn();
+    panel.showError('boom', retry, 15);
+    expect(content().querySelector('.panel-error-state')).not.toBeNull();
+
+    setBodyImmediate(BODY_A);
+
+    expect(content().querySelector('.probe-a')).not.toBeNull();
+    expect(content().querySelector('.panel-error-state')).toBeNull();
+    expect((panel as unknown as { header: HTMLElement }).header.classList.contains('panel-header-error')).toBe(false);
+    expect((panel as unknown as { retryCountdownTimer: ReturnType<typeof setInterval> | null }).retryCountdownTimer).toBeNull();
+    expect((panel as unknown as { retryAttempt: number }).retryAttempt).toBe(0);
+
+    vi.advanceTimersByTime(60_000);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it('destroy drops a queued callback so it cannot run later', () => {
+    const callback = vi.fn();
+    panel.setSafeContent(unsafeRawHtml(BODY_A, 'test fixture'), callback);
+    panel.destroy();
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS * 3);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Clicking or activating a populated Heatmap Valuations tab now commits the new body in the same action. It no longer waits on the 150 ms background content timer, and the selected replacement button keeps keyboard focus.

This is Wave 1, study item 1 of the dashboard performance plan. Other panel tab interactions and dashboard-level tabs stay on their current paths.

Fixes #7775
Related: #7774
Related: #5043

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [x] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Heatmap panel tabs and Panel safe-content commit

## Behavior

User tab actions use `setSafeContentImmediate`: same safe HTML boundary, lock bail, dirty-check, and `setContentImmediate` writer, without the coalescing timer. Background `renderHeatmap` / `updateValuations` still debounce at 150 ms. A click or Enter/Space cancels any queued older write and its callback. Premium lock, error/retry clear, and destroy cleanup stay on the existing commit path.

| Surface | Click-to-content (populated fixture) |
|---|---|
| Baseline (Chromium, 6 Sep 2026, `88074fe9d`) | 151–154 ms |
| This change, desktop 1280×720 | 2.4 ms |
| This change, mobile 390×844 | 0.2 ms |

These are in-page `click()` / keydown measurements against the same two-sector fixture, not field INP. Local `/api/*` is not the Edge runtime; sector data was fulfilled by the same fixture used in the DOM tests.

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable) — N/A

## Documentation Alignment Checklist

- [x] N/A — this PR does not publish or change documentation claims

## Testing

- `npm run test:dom -- tests/dom/heatmap-tab-immediate.test.mts tests/dom/panel-content-cache.test.mts` — 27/27
- Neighbor suites: `panel-content-write-6678`, `panel-error-latch`, `panel-content-write-guard` — pass
- `npm run typecheck`, `npm run typecheck:dom-tests`, `npm run lint:boundaries`, `git diff --check` — pass
- Pre-push DOM suite and panel-content-write guard — pass
- Chromium verify-worldmonitor finance dashboard, desktop and mobile: click, Enter, Space on the real Heatmap buttons; focus stayed on the selected replacement button

The deterministic tests assert `contentDebounceTimer` is null after the action. They do not wait out a larger timeout.

## Known Residuals

- Background data ticks still replace tab-button nodes through `setSafeContent` innerHTML, so focus on a tab can move to `body` 150 ms after a successful user switch. User-origin restores focus; the data path still does not steal focus from outside the panel. This is the pre-existing string-content replace class.
- Empty-valuations reset during the data debounce window can leave `_tab` on `valuations` if a still-visible Valuations button is clicked before the queued no-tab-bar body commits. The mismatch existed when both writes were debounced.
- Heatmap is not in `WEB_PREMIUM_PANELS`. Lock tests pin the public `showLocked` contract, not a live heatmap paywall.

## Code review

`status: complete`, run `20260906-heatmap-7775`, artifact `/tmp/compound-engineering-501/ce-code-review/20260906-heatmap-7775/report.json`. Correctness and adversarial: no findings. Testing P2s (retry-callback assertion; same-pending immediate commit) applied before push. Verdict: approve.

## Post-Deploy Monitoring & Validation

- **Log / search terms:** none new. Watch Sentry INP for `/dashboard` with interaction targets on Heatmap tab buttons (`Performance`, `Valuations`) if field events name them.
- **Metrics / dashboards:** Sentry web-vital INP for `/dashboard`; no new custom metric.
- **Healthy signals:** Heatmap tab switches paint in the click; Valuations table appears without a 150 ms stall; keyboard focus remains on the selected tab button.
- **Failure signals / rollback:** tab content lags ~150 ms after click; focus lost on every tab change; a refresh restoring the previous tab; locked-panel CTA overwritten by heatmap markup. Rollback is reverting this PR. Panel content is client-rendered; no data migration.
- **Validation window / owner:** first session after deploy that opens a populated Heatmap panel; area: panels / platform: web.

## Screenshots

N/A as committed assets. Before/after captures from the local Chromium drive are session-local under `.claude/verify-evidence/` (gitignored).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
