### PR TITLE
perf(map): skip unchanged map-control hint scans

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -172,6 +172,7 @@ import { fetchWebcamImage } from '@/services/webcams';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { summarizeRenderTiming, formatRenderTiming } from '@/components/map/render-timing';
 import { DeferredHeavyCommit } from '@/components/map/deferred-layer-commit';
+import { ZoomHintGuard } from '@/components/map/zoom-hint-guard';
 import { dispatchWebcamLayerClick, resolveWebcamStreamUrl, type WebcamLeafLike } from '@/components/map/webcam-click';
 import {
   type BBox,
@@ -637,6 +638,10 @@ export class DeckGLMap {
   private tradeAnimationTime = 0;
   private tradeAnimationFrame: number | null = null;
   private tradeAnimationFrameCount = 0;
+  // Guards updateZoomHints() so the trade-animation's every-other-frame
+  // updateLayers() pass skips the toggle-DOM scan when zoom, layer flags,
+  // and row nodes are unchanged (#7776).
+  private readonly zoomHintGuard = new ZoomHintGuard();
   private tradeReducedMotionMedia: MediaQueryList | null = null;
   private storedChokepointData: GetChokepointStatusResponse | null = null;
   private highlightedRouteIds: Set<string> = new Set();
@@ -6214,12 +6219,19 @@ export class DeckGLMap {
   private updateZoomHints(): void {
     const toggleList = this.container.querySelector('.deckgl-layer-toggles .toggle-list');
     if (!toggleList) return;
+    // Mirror isLayerVisible()'s zoom source exactly so the guard key can
+    // never disagree with the visibility computation it protects.
+    const zoom = this.maplibreMap?.getZoom() || 2;
+    // Skip the full toggle-DOM scan when neither the visibility inputs
+    // (zoom, layer flags) nor the row nodes changed (#7776).
+    if (!this.zoomHintGuard.shouldScan({ zoom, layers: this.state.layers }, toggleList)) return;
     for (const [key, enabled] of Object.entries(this.state.layers)) {
       const toggle = toggleList.querySelector(`.layer-toggle[data-layer="${key}"]`) as HTMLElement | null;
       if (!toggle) continue;
       const zoomHidden = !!enabled && !this.isLayerVisible(key as keyof MapLayers);
       toggle.classList.toggle('zoom-hidden', zoomHidden);
     }
+    this.zoomHintGuard.markScanned({ zoom, layers: this.state.layers }, toggleList);
   }
 
   private markViewportMoving(target: { lat: number; lon: number; zoom: number }, fallbackMs: number): number {

--- a/src/components/map/zoom-hint-guard.ts
+++ b/src/components/map/zoom-hint-guard.ts
@@ -1,0 +1,71 @@
+import type { MapLayers } from '@/types';
+
+export interface ZoomHintInputs {
+  zoom: number;
+  layers: MapLayers;
+}
+
+/**
+ * Guard that suppresses unchanged map-control zoom-hint scans (#7776).
+ *
+ * `updateZoomHints()` runs on every `updateLayers()` pass — including the
+ * trade-animation's every-other-frame `render()` — but a hint pass only needs
+ * to touch the DOM when its visibility inputs or its DOM rows changed:
+ *
+ *   - `zoom`: feeds `isLayerVisible()` via the per-layer minZoom thresholds,
+ *     so crossing a threshold flips `zoomHidden` for gated rows.
+ *   - `layers`: enabled/disabled state flips `zoomHidden` directly, and a
+ *     disabled layer must not retain an enabled-layer zoom warning.
+ *   - rows: locale or layout reconstruction replaces the row nodes, so fresh
+ *     nodes must invalidate the guard even when zoom/layer values match.
+ *     Any innerHTML rebuild replaces every child, so first-child identity
+ *     plus child count detects rebuilds and row add/remove without a DOM
+ *     query; the suppressed path is three property reads and pure-JS flag
+ *     compares, with zero selector queries or class toggles.
+ *
+ * Zoom alone is not a complete invalidation key: a layer flip at a constant
+ * zoom changes hints, so both zoom and the full layer-flag set are keyed.
+ */
+export class ZoomHintGuard {
+  private lastZoom: number | null = null;
+  private lastLayers: MapLayers | null = null;
+  private lastToggleList: Element | null = null;
+  private lastChildCount = -1;
+  private lastFirstChild: Element | null = null;
+
+  invalidate(): void {
+    this.lastZoom = null;
+    this.lastLayers = null;
+    this.lastToggleList = null;
+    this.lastChildCount = -1;
+    this.lastFirstChild = null;
+  }
+
+  shouldScan(inputs: ZoomHintInputs, toggleList: Element): boolean {
+    if (this.lastZoom !== inputs.zoom) return true;
+    if (!this.lastLayers || !sameLayerFlags(this.lastLayers, inputs.layers)) return true;
+    if (this.lastToggleList !== toggleList) return true;
+    // Rebuilt rows are fresh nodes without hint classes even when the key
+    // set is unchanged (locale/layout reconstruction). A rebuild replaces
+    // every child, so first-child identity catches it; the count catches
+    // added/removed rows. Both are property reads, not selector queries.
+    if (toggleList.childElementCount !== this.lastChildCount) return true;
+    if (toggleList.firstElementChild !== this.lastFirstChild) return true;
+    return false;
+  }
+
+  markScanned(inputs: ZoomHintInputs, toggleList: Element): void {
+    this.lastZoom = inputs.zoom;
+    this.lastLayers = { ...inputs.layers };
+    this.lastToggleList = toggleList;
+    this.lastChildCount = toggleList.childElementCount;
+    this.lastFirstChild = toggleList.firstElementChild;
+  }
+}
+
+function sameLayerFlags(a: MapLayers, b: MapLayers): boolean {
+  const keysA = Object.keys(a) as (keyof MapLayers)[];
+  const keysB = Object.keys(b) as (keyof MapLayers)[];
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((key) => a[key] === b[key]);
+}

--- a/tests/map-zoom-hint-guard.test.mts
+++ b/tests/map-zoom-hint-guard.test.mts
@@ -184,6 +184,22 @@ describe('zoom-hint guard (#7776)', () => {
     assert.equal(hintState(toggleList, 'datacenters'), false);
   });
 
+  it('invalidate() forces the next pass to rescan', () => {
+    const document = freshDom();
+    const toggleList = buildToggleList(document, HINT_KEYS);
+    const guard = new ZoomHintGuard();
+    const layers = makeLayers();
+    scanCount = 0;
+
+    guardedPass(guard, toggleList, layers, 2);
+    guardedPass(guard, toggleList, layers, 2);
+    assert.equal(scanCount, 1);
+    guard.invalidate();
+    assert.equal(guard.shouldScan({ zoom: 2, layers }, toggleList), true);
+    guardedPass(guard, toggleList, layers, 2);
+    assert.equal(scanCount, 2);
+  });
+
   it('wires the guard into DeckGLMap.updateZoomHints with the isLayerVisible zoom source', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const deckGlMapSrc = readFileSync(resolve(here, '../src/components/DeckGLMap.ts'), 'utf-8');

--- a/tests/map-zoom-hint-guard.test.mts
+++ b/tests/map-zoom-hint-guard.test.mts
@@ -1,0 +1,199 @@
+/**
+ * Zoom-hint scan suppression (#7776).
+ *
+ * `updateZoomHints()` runs on every `updateLayers()` pass — including the
+ * trade-animation's every-other-frame `render()`. These tests drive the real
+ * `ZoomHintGuard` against a real DOM toggle list and count hint scans (full
+ * passes over the toggle rows), proving suppression is keyed on the actual
+ * visibility inputs rather than only inspecting output classes.
+ *
+ * The guard lives in src/components/map/zoom-hint-guard.ts so it is
+ * unit-testable without DOM/WebGL; DeckGLMap.updateZoomHints() wires it in.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Window } from 'happy-dom';
+
+import { ZoomHintGuard } from '../src/components/map/zoom-hint-guard.ts';
+import type { MapLayers } from '../src/types/index.ts';
+
+// Visibility thresholds mirrored from DeckGLMap.LAYER_ZOOM_THRESHOLDS for the
+// acceptance cases: nuclear/base/economic at zoom 3, irradiators at 4,
+// datacenters at 5.
+const MIN_ZOOM: Partial<Record<string, number>> = {
+  bases: 3,
+  nuclear: 3,
+  economic: 3,
+  irradiators: 4,
+  datacenters: 5,
+  conflicts: 1,
+};
+
+const HINT_KEYS = ['bases', 'nuclear', 'economic', 'irradiators', 'datacenters', 'conflicts'];
+
+function makeLayers(overrides: Partial<Record<string, boolean>> = {}): MapLayers {
+  const layers = {} as Record<string, boolean>;
+  for (const key of HINT_KEYS) layers[key] = true;
+  Object.assign(layers, overrides);
+  return layers as MapLayers;
+}
+
+function buildToggleList(document: Document, keys: string[]): Element {
+  const list = document.createElement('div');
+  list.className = 'toggle-list';
+  for (const key of keys) {
+    const toggle = document.createElement('label');
+    toggle.className = 'layer-toggle';
+    toggle.setAttribute('data-layer', key);
+    list.appendChild(toggle);
+  }
+  return list;
+}
+
+/** Faithful copy of the DeckGLMap.updateZoomHints() scan body. */
+function scanHints(toggleList: Element, layers: MapLayers, zoom: number): void {
+  scanCount += 1;
+  for (const key of HINT_KEYS) {
+    const toggle = toggleList.querySelector(`.layer-toggle[data-layer="${key}"]`);
+    if (!toggle) continue;
+    const enabled = layers[key as keyof MapLayers] ?? false;
+    const threshold = MIN_ZOOM[key] ?? 0;
+    const zoomHidden = enabled && zoom < threshold;
+    toggle.classList.toggle('zoom-hidden', zoomHidden);
+  }
+}
+
+let scanCount = 0;
+
+function guardedPass(guard: ZoomHintGuard, toggleList: Element, layers: MapLayers, zoom: number): void {
+  if (!guard.shouldScan({ zoom, layers }, toggleList)) return;
+  scanHints(toggleList, layers, zoom);
+  guard.markScanned({ zoom, layers }, toggleList);
+}
+
+function hintState(toggleList: Element, key: string): boolean {
+  return toggleList.querySelector(`.layer-toggle[data-layer="${key}"]`)?.classList.contains('zoom-hidden') ?? false;
+}
+
+function freshDom(): Document {
+  const window = new Window({ url: 'https://worldmonitor.app/' });
+  return window.document as unknown as Document;
+}
+
+describe('zoom-hint guard (#7776)', () => {
+  it('scans once, then suppresses an unchanged 61-frame animation sequence', () => {
+    const document = freshDom();
+    const toggleList = buildToggleList(document, HINT_KEYS);
+    const guard = new ZoomHintGuard();
+    const layers = makeLayers();
+    scanCount = 0;
+
+    guardedPass(guard, toggleList, layers, 2);
+    for (let frame = 0; frame < 61; frame++) {
+      guardedPass(guard, toggleList, layers, 2);
+    }
+    assert.equal(scanCount, 1, '61 unchanged frames must cause zero additional hint scans');
+  });
+
+  it('updates hints in both directions across all configured visibility thresholds', () => {
+    const document = freshDom();
+    const toggleList = buildToggleList(document, HINT_KEYS);
+    const guard = new ZoomHintGuard();
+    const layers = makeLayers();
+    scanCount = 0;
+
+    const cases: Array<{ key: string; hiddenZoom: number; visibleZoom: number }> = [
+      { key: 'nuclear', hiddenZoom: 2, visibleZoom: 3 },
+      { key: 'bases', hiddenZoom: 2, visibleZoom: 3 },
+      { key: 'economic', hiddenZoom: 2, visibleZoom: 3 },
+      { key: 'irradiators', hiddenZoom: 3, visibleZoom: 4 },
+      { key: 'datacenters', hiddenZoom: 4, visibleZoom: 5 },
+    ];
+    for (const { key, hiddenZoom, visibleZoom } of cases) {
+      guardedPass(guard, toggleList, layers, hiddenZoom);
+      assert.equal(hintState(toggleList, key), true, `${key} must warn below its threshold`);
+      guardedPass(guard, toggleList, layers, visibleZoom);
+      assert.equal(hintState(toggleList, key), false, `${key} must clear at its threshold`);
+    }
+    assert.ok(scanCount > 0, 'threshold crossings must scan');
+    const before = scanCount;
+    guardedPass(guard, toggleList, layers, 5);
+    assert.equal(scanCount, before, 'repeating the same zoom must not scan again');
+  });
+
+  it("rescans on layer enable/disable and clears disabled layers' stale warnings", () => {
+    const document = freshDom();
+    const toggleList = buildToggleList(document, HINT_KEYS);
+    const guard = new ZoomHintGuard();
+    scanCount = 0;
+
+    // Nuclear enabled below its threshold: warning set.
+    guardedPass(guard, toggleList, makeLayers({ nuclear: true }), 2);
+    assert.equal(hintState(toggleList, 'nuclear'), true);
+    // Disable nuclear at the same zoom: must rescan and drop the stale warning.
+    guardedPass(guard, toggleList, makeLayers({ nuclear: false }), 2);
+    assert.equal(hintState(toggleList, 'nuclear'), false, 'disabled layers must not retain an enabled-layer zoom warning');
+    // Re-enable at the same zoom: warning returns.
+    guardedPass(guard, toggleList, makeLayers({ nuclear: true }), 2);
+    assert.equal(hintState(toggleList, 'nuclear'), true);
+  });
+
+  it('invalidates on toggle-list rebuild and missing rows even when inputs match', () => {
+    const document = freshDom();
+    const layers = makeLayers();
+    const guard = new ZoomHintGuard();
+    scanCount = 0;
+
+    const first = buildToggleList(document, HINT_KEYS);
+    guardedPass(guard, first, layers, 2);
+    assert.equal(scanCount, 1);
+
+    // Locale/layout reconstruction replaces the row nodes with identical keys.
+    const rebuilt = buildToggleList(document, HINT_KEYS);
+    assert.equal(guard.shouldScan({ zoom: 2, layers }, rebuilt), true, 'rebuilt rows must invalidate the guard');
+    guardedPass(guard, rebuilt, layers, 2);
+    assert.equal(scanCount, 2);
+    // Same rebuilt list, same inputs: suppressed again.
+    guardedPass(guard, rebuilt, layers, 2);
+    assert.equal(scanCount, 2);
+
+    // A row is missing entirely: the row set changed, so rescan.
+    const missing = buildToggleList(document, HINT_KEYS.filter((key) => key !== 'datacenters'));
+    assert.equal(guard.shouldScan({ zoom: 2, layers }, missing), true, 'missing rows must invalidate the guard');
+  });
+
+  it('zoom alone is not a complete key: layer flips at constant zoom rescan', () => {
+    const document = freshDom();
+    const toggleList = buildToggleList(document, HINT_KEYS);
+    const guard = new ZoomHintGuard();
+    scanCount = 0;
+
+    const enabled = makeLayers({ datacenters: true });
+    guardedPass(guard, toggleList, enabled, 4);
+    assert.equal(hintState(toggleList, 'datacenters'), true);
+    const disabled = makeLayers({ datacenters: false });
+    assert.equal(
+      guard.shouldScan({ zoom: 4, layers: disabled }, toggleList),
+      true,
+      'zoom-only keys would miss a layer flip at constant zoom',
+    );
+    guardedPass(guard, toggleList, disabled, 4);
+    assert.equal(hintState(toggleList, 'datacenters'), false);
+  });
+
+  it('wires the guard into DeckGLMap.updateZoomHints with the isLayerVisible zoom source', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const deckGlMapSrc = readFileSync(resolve(here, '../src/components/DeckGLMap.ts'), 'utf-8');
+    const start = deckGlMapSrc.indexOf('private updateZoomHints');
+    assert.ok(start >= 0, 'DeckGLMap.updateZoomHints must exist');
+    const body = deckGlMapSrc.slice(start, deckGlMapSrc.indexOf('\n  }\n', start));
+    assert.match(body, /this\.zoomHintGuard\.shouldScan\(/, 'updateZoomHints must consult the guard before scanning');
+    assert.match(body, /this\.zoomHintGuard\.markScanned\(/, 'updateZoomHints must record the scanned inputs');
+    // The guard key must mirror isLayerVisible()'s `getZoom() || 2` source;
+    // `?? state.zoom` would disagree at zoom 0 and stale-gate the hints.
+    assert.match(body, /getZoom\(\) \|\| 2/, 'guard zoom must mirror isLayerVisible getZoom() || 2 source');
+  });
+});


### PR DESCRIPTION
Closes #7776.

updateZoomHints() runs on every updateLayers() pass, including the trade-animation every-other-frame render(). A ZoomHintGuard (src/components/map/zoom-hint-guard.ts) now skips the toggle-DOM scan when zoom, layer flags, and row nodes are unchanged. Guard zoom mirrors isLayerVisible()'s getZoom() || 2 source exactly. Keyed on (zoom, full layer flags, toggle-list identity + child count + first child); zoom alone is not a key. Layer construction untouched; no trade-animation isolation or generic DOM cache.

Verification (before/after command, deterministic fixtures):
- node scripts/run-data-tests.mjs tests/map-zoom-hint-guard.test.mts -> 7 pass (new: 61-frame suppression = 1 scan; bidirectional threshold crossings nuclear/base/economic z3, irradiator z4, datacenter z5; disable clears stale warning; rebuild/missing-row invalidation; zoom-only insufficiency; invalidate(); source wiring pin)
- node scripts/run-data-tests.mjs tests/map-trade-animation-loop.test.mjs tests/deckgl-layer-state-aliasing.test.mjs tests/map-trade-trip-position.test.mjs -> 31 pass (unchanged baseline)
- npm run typecheck -> clean; npm run lint:boundaries -> clean; git diff --check -> clean

Evidence limits: counts are hint-scan counts from a happy-dom toggle list replicating the scan body, not FPS or production measurements. No private /tmp artifacts used. Does not claim #5160.