### PR TITLE
fix(map): keep static facility data stable without stale highlights

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -37,6 +37,7 @@ import type {
   CyberThreat,
   CableHealthRecord,
   MilitaryBaseEnriched,
+  NuclearFacility,
 } from '@/types';
 import { fetchMilitaryBases, type MilitaryBaseCluster as ServerBaseCluster } from '@/services/military-bases';
 import type { AirportDelayAlert, PositionSample } from '@/services/aviation';
@@ -834,6 +835,15 @@ export class DeckGLMap {
   private lastCableHighlightSignature = '';
   private lastCableHealthSignature = '';
   private lastPipelineHighlightSignature = '';
+  // Static facility catalogs filtered once per map instance (#7777). The
+  // nuclear and data-center builders run on every render; a fresh .filter()
+  // per render hands deck.gl a new data container each time, so the
+  // instance attributes are rebuilt even when nothing changed. The
+  // highlight Sets are mutated in place, so the same arrays must stay
+  // referentially stable while a sorted-content signature (never the Set
+  // object) drives updateTriggers.getSize/getColor.
+  private activeNuclearFacilities: NuclearFacility[] | null = null;
+  private activeDatacenters: AIDataCenter[] | null = null;
   private debouncedRebuildLayers: (() => void) & { cancel(): void };
   private debouncedFetchBases: (() => void) & { cancel(): void };
   private debouncedFetchAircraft: (() => void) & { cancel(): void };
@@ -1364,6 +1374,16 @@ export class DeckGLMap {
     return [...set].sort().join('|');
   }
 
+  private getActiveNuclearFacilities(): NuclearFacility[] {
+    this.activeNuclearFacilities ??= NUCLEAR_FACILITIES.filter(f => f.status !== 'decommissioned');
+    return this.activeNuclearFacilities;
+  }
+
+  private getActiveDatacenters(): AIDataCenter[] {
+    this.activeDatacenters ??= AI_DATA_CENTERS.filter(dc => dc.status !== 'decommissioned');
+    return this.activeDatacenters;
+  }
+
   private hasRecentNews(now = Date.now()): boolean {
     for (const ts of this.newsLocationFirstSeen.values()) {
       if (now - ts < 30_000) return true;
@@ -1586,7 +1606,9 @@ export class DeckGLMap {
   }
 
   private rebuildDatacenterSupercluster(): void {
-    const activeDCs = AI_DATA_CENTERS.filter(dc => dc.status !== 'decommissioned');
+    // Share the stable detail-layer array (#7777) so cluster leaf indexes
+    // resolve against the same records detail picking/tooltips identify.
+    const activeDCs = this.getActiveDatacenters();
     this.datacenterSCSource = activeDCs;
     const points = activeDCs.map((dc, i) => ({
       type: 'Feature' as const,
@@ -3002,7 +3024,12 @@ export class DeckGLMap {
 
   private createNuclearLayer(): IconLayer {
     const highlightedNuclear = this.highlightedAssets.nuclear;
-    const data = NUCLEAR_FACILITIES.filter(f => f.status !== 'decommissioned');
+    // Stable catalog array (#7777): same reference across unchanged renders
+    // so deck.gl skips instance-attribute rebuilds; the sorted-content
+    // signature below (never the in-place-mutated Set) invalidates the
+    // highlight-dependent attributes.
+    const data = this.getActiveNuclearFacilities();
+    const highlightSignature = this.getSetSignature(highlightedNuclear);
 
     // Nuclear: HEXAGON icons - yellow/orange color, semi-transparent
     return new IconLayer({
@@ -3026,6 +3053,7 @@ export class DeckGLMap {
       sizeMinPixels: 6,
       sizeMaxPixels: 15,
       pickable: true,
+      updateTriggers: { getSize: highlightSignature, getColor: highlightSignature },
     });
   }
 
@@ -3167,7 +3195,12 @@ export class DeckGLMap {
 
   private createDatacentersLayer(): IconLayer {
     const highlightedDC = this.highlightedAssets.datacenter;
-    const data = AI_DATA_CENTERS.filter(dc => dc.status !== 'decommissioned');
+    // Stable catalog array (#7777): same reference across unchanged renders
+    // so deck.gl skips instance-attribute rebuilds; the sorted-content
+    // signature below (never the in-place-mutated Set) invalidates the
+    // highlight-dependent attributes.
+    const data = this.getActiveDatacenters();
+    const highlightSignature = this.getSetSignature(highlightedDC);
 
     // Datacenters: SQUARE icons - purple color, semi-transparent for layering
     return new IconLayer({
@@ -3191,6 +3224,7 @@ export class DeckGLMap {
       sizeMinPixels: 6,
       sizeMaxPixels: 14,
       pickable: true,
+      updateTriggers: { getSize: highlightSignature, getColor: highlightSignature },
     });
   }
 
@@ -8245,6 +8279,8 @@ export class DeckGLMap {
 
 
     this.layerCache.clear();
+    this.activeNuclearFacilities = null;
+    this.activeDatacenters = null;
 
     this.deckOverlay?.finalize();
     this.deckOverlay = null;

--- a/tests/deckgl-facility-highlight-triggers.test.mjs
+++ b/tests/deckgl-facility-highlight-triggers.test.mjs
@@ -1,0 +1,216 @@
+/**
+ * Renderer-attribute coverage for the static facility IconLayers (#7777).
+ *
+ * DeckGLMap runs in a browser (DOM + WebGL) and cannot be instantiated in
+ * node:test. These tests therefore import the real compiled deck.gl
+ * layer classes and exercise the exact construction semantics the map's
+ * layer builders must keep:
+ *
+ *  1. `diffProps()` against matched old/new IconLayer props — the same
+ *     function deck.gl calls when matching layers by id across renders —
+ *     must invalidate `getSize`/`getColor` attributes when the highlight
+ *     signature changes, and must NOT invalidate them on unchanged renders.
+ *     A Set object reference alone is insufficient (in-place mutation keeps
+ *     the reference), so the builders must pass the sorted-content
+ *     signature, not the Set.
+ *  2. A signature helper replicating `getSetSignature()` must stay stable
+ *     across repeated unchanged renders (same content -> same string, so no
+ *     spurious invalidation) and must change on add/remove/clear/expiry.
+ *  3. The builder source must reuse stable filtered data arrays and pass
+ *     the signature into `updateTriggers.getSize`/`getColor` for both the
+ *     nuclear and datacenter builders.
+ *
+ * Calling the accessors directly or comparing arrays alone cannot detect the
+ * demonstrated failure (probe: array reuse without triggers left nuclear
+ * size 11 instead of highlighted 15 and datacenter size 10 instead of 14,
+ * with stale colors), so (1) inspects the real attribute-invalidation path.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const deckGlMapSrc = readFileSync(resolve(ROOT, 'src/components/DeckGLMap.ts'), 'utf-8');
+
+const { default: IconLayer } = await import(
+  resolve(ROOT, 'node_modules/@deck.gl/layers/dist/index.js')
+).then((m) => ({ default: m.IconLayer }));
+const { diffProps } = await import(
+  resolve(ROOT, 'node_modules/@deck.gl/core/dist/lifecycle/props.js')
+);
+
+// ---------- fixture: mirror of the in-class getSetSignature ----------
+function getSetSignature(set) {
+  return [...set].sort().join('|');
+}
+
+function makeFacilityProps({ data, size, color, highlights }) {
+  const highlighted = highlights;
+  return {
+    id: 'probe-layer',
+    data,
+    getSize: (d) => (highlighted.has(d.id) ? size.highlight : size.base),
+    getColor: (d) => (highlighted.has(d.id) ? color.highlight : color.base),
+    updateTriggers: {
+      getSize: getSetSignature(highlights),
+      getColor: getSetSignature(highlights),
+    },
+  };
+}
+
+function facilityInvalidation(oldProps, newProps) {
+  const data = [{ id: 'a' }, { id: 'b' }];
+  const flags = diffProps(
+    new IconLayer({ ...makeFacilityProps(newProps), data }).props,
+    new IconLayer({ ...makeFacilityProps(oldProps), data }).props,
+  );
+  return flags.updateTriggersChanged || false;
+}
+
+const SIZE = { base: 11, highlight: 15 };
+const COLOR = { base: [255, 220, 0, 200], highlight: [255, 100, 100, 220] };
+
+// ---------- signature stability ----------
+
+describe('facility highlight signature (mirrors getSetSignature)', () => {
+  it('is stable across repeated unchanged renders', () => {
+    const highlights = new Set(['a']);
+    const data = [{ id: 'a' }];
+    const first = makeFacilityProps({ data, size: SIZE, color: COLOR, highlights });
+    const second = makeFacilityProps({ data, size: SIZE, color: COLOR, highlights });
+    assert.equal(second.updateTriggers.getSize, first.updateTriggers.getSize);
+    assert.equal(
+      facilityInvalidation(
+        { data, size: SIZE, color: COLOR, highlights },
+        { data, size: SIZE, color: COLOR, highlights },
+      ),
+      false,
+      'unchanged renders must not invalidate size/color attributes',
+    );
+  });
+
+  it('changes on highlight add, remove, clear, and timed expiry', () => {
+    const base = getSetSignature(new Set());
+    const added = getSetSignature(new Set(['a']));
+    const removed = getSetSignature(new Set());
+    assert.notEqual(added, base, 'add must change the signature');
+    assert.equal(removed, base, 'remove/clear must restore the empty signature');
+
+    // Timed expiry deletes the id in place — same Set object, new content.
+    const live = new Set(['a']);
+    const beforeExpiry = getSetSignature(live);
+    live.delete('a');
+    assert.notEqual(getSetSignature(live), beforeExpiry, 'expiry must change the signature');
+  });
+
+  it('a Set object reference alone does not invalidate after in-place mutation', () => {
+    const data = [{ id: 'a' }];
+    const highlights = new Set();
+    const mkWithSetRef = (set) =>
+      new IconLayer({
+        id: 'probe-layer',
+        data,
+        getSize: (d) => (set.has(d.id) ? SIZE.highlight : SIZE.base),
+        updateTriggers: { getSize: set, getColor: set },
+      }).props;
+    const before = mkWithSetRef(highlights);
+    highlights.add('a'); // in-place mutation: same reference, new content
+    const after = mkWithSetRef(highlights);
+    assert.equal(
+      diffProps(after, before).updateTriggersChanged,
+      false,
+      'passing the Set itself as a trigger value cannot detect in-place mutation',
+    );
+  });
+
+  it('invalidates size and color when the signature changes', () => {
+    const data = [{ id: 'a' }];
+    const changed = facilityInvalidation(
+      { data, size: SIZE, color: COLOR, highlights: new Set() },
+      { data, size: SIZE, color: COLOR, highlights: new Set(['a']) },
+    );
+    assert.deepEqual(changed, { getSize: true, getColor: true });
+  });
+
+  it('the new accessor values read highlighted after the signature change', () => {
+    const highlights = new Set(['a']);
+    const props = makeFacilityProps({ data: [], size: SIZE, color: COLOR, highlights });
+    assert.equal(props.getSize({ id: 'a' }), SIZE.highlight);
+    assert.deepEqual(props.getColor({ id: 'a' }), COLOR.highlight);
+    assert.equal(props.getSize({ id: 'b' }), SIZE.base);
+  });
+});
+
+// ---------- builder source contract ----------
+
+function methodSource(name) {
+  const start = deckGlMapSrc.indexOf(name);
+  assert.ok(start >= 0, `${name} must exist in DeckGLMap.ts`);
+  const braceStart = deckGlMapSrc.indexOf('{', start);
+  let depth = 0;
+  for (let i = braceStart; i < deckGlMapSrc.length; i++) {
+    if (deckGlMapSrc[i] === '{') depth++;
+    else if (deckGlMapSrc[i] === '}') {
+      depth--;
+      if (depth === 0) return deckGlMapSrc.slice(start, i + 1);
+    }
+  }
+  assert.fail(`${name} must have balanced braces`);
+}
+
+describe('facility layer builders (#7777)', () => {
+  for (const [method, getter, catalog] of [
+    ['private createNuclearLayer', 'getActiveNuclearFacilities', 'NUCLEAR_FACILITIES'],
+    ['private createDatacentersLayer', 'getActiveDatacenters', 'AI_DATA_CENTERS'],
+  ]) {
+    it(`${method} reuses a stable filtered catalog array`, () => {
+      const src = methodSource(method);
+      assert.doesNotMatch(
+        src,
+        /\.filter\(/,
+        `${method} must not allocate a fresh filtered array on every render`,
+      );
+      assert.match(
+        src,
+        new RegExp(`const data = this\\.${getter}\\(\\);`),
+        `${method} must read the cached catalog array via ${getter}()`,
+      );
+      const getterSrc = methodSource(`private ${getter}`);
+      assert.match(
+        getterSrc,
+        new RegExp(`${catalog}\\.filter\\([^)]*status !== 'decommissioned'`),
+        `${getter} must keep the decommissioned-status filter`,
+      );
+      assert.match(
+        getterSrc,
+        /\?\?=/,
+        `${getter} must cache the filtered array so the reference stays stable`,
+      );
+    });
+
+    it(`${method} invalidates size and color from the highlight signature`, () => {
+      const src = methodSource(method);
+      assert.match(
+        src,
+        /const highlightSignature = this\.getSetSignature\(highlighted\w+\);/,
+        `${method} must derive the sorted-content signature from the highlight Set`,
+      );
+      assert.match(
+        src,
+        /updateTriggers:\s*{\s*getSize:\s*highlightSignature,\s*getColor:\s*highlightSignature\s*}/,
+        `${method} must pass the signature into updateTriggers.getSize/getColor`,
+      );
+    });
+  }
+
+  it('highlight mutations (add/remove/clear/expiry) flow through highlightAssets/flashAssets', () => {
+    assert.match(deckGlMapSrc, /public highlightAssets\(assets/);
+    assert.match(deckGlMapSrc, /public flashAssets\(assetType/);
+    // flashAssets timed expiry mutates the same Set in place — the signature
+    // derived at build time is what lets deck.gl see it.
+    assert.match(deckGlMapSrc, /setTimeout\(\(\) => \{\s*ids\.forEach\(id => this\.highlightedAssets/);
+  });
+});


### PR DESCRIPTION
Repeated renders with the nuclear and data-center layers enabled no longer hand deck.gl a fresh filtered array each time, so unchanged frames skip instance-attribute rebuilds; highlight add, remove, clear, and timed expiry now invalidate size and color through a sorted-content signature instead of going stale. Before, both builders filtered their catalogs on every render (new data container, full attribute rebuild each frame) and passed no updateTriggers, so in-place highlight Set mutations were invisible to the renderer — highlighted nuclear icons kept size 11 instead of 15 and data centers 10 instead of 14, with stale colors. The fix caches the filtered catalog per map instance (shared with the cluster path so leaf indexes resolve the same records tooltips identify) and derives `updateTriggers.getSize/getColor` from the existing `getSetSignature()` helper; sizes, colors, picking, and tooltips are unchanged.

Fixes #7777.

Validation: new `tests/deckgl-facility-highlight-triggers.test.mjs` (10 tests) exercises the real `IconLayer` + `diffProps` invalidation path — unchanged renders invalidate nothing, signature changes invalidate size and color, and a Set reference alone cannot — plus a builder source contract pinning the stable-array and trigger wiring. `node --test` on the four issue-listed files: 41/41 pass. `npm run typecheck`, `lint:boundaries`, and `git diff --check` are clean, and the pre-push gates passed. Before/after on an identical 563-record fixture via `diffProps`: old reported `dataChanged` on every unchanged render and no trigger change on highlight add; new reports no change on unchanged renders and `{getSize, getColor}` on highlight add. Software diff evidence only — no GPU timing claimed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-000000)
