### PR TITLE
perf(startup): initialize optional local AI independently

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -323,6 +323,13 @@ export class App {
   private unsubAiFlow: (() => void) | null = null;
   private unsubFreeTier: (() => void) | null = null;
   private unsubEntitlementPremiumLoaders: (() => void) | null = null;
+  /**
+   * Boot epoch for optional local-AI continuations (#7779). destroy() bumps
+   * it first so a stale detached continuation from a torn-down App can never
+   * download a model or restart the shared worker a fresh same-document App
+   * reuses. Continuations also check state.isDestroyed directly.
+   */
+  private localAiInitEpoch = 0;
   // Resolves once Phase-4 UI modules have initialised so WebMCP bindings can
   // await readiness before dispatching into UI managers. Avoids the startup
   // race where an agent discovers a tool via early registerTool and invokes it
@@ -2360,28 +2367,64 @@ export class App {
     const srH1 = document.querySelector('body > h1');
     if (srH1) srH1.textContent = t('shell.documentTitle');
     const aiFlow = getAiFlowSettings();
+    // Optional local AI initializes independently of the dashboard critical
+    // path (#7779): boot proceeds to layout, event handlers and basic panels
+    // immediately; the worker settles in the background. The epoch guards
+    // detached continuations: disable/destroy during capability detection,
+    // worker startup or model restoration resolves late continuations as false
+    // instead of downloading models or restarting for a dead app generation.
+    // destroy() bumps the epoch first, so a stale continuation from a
+    // torn-down App can never load a model into the shared worker a fresh
+    // same-document App reuses. The failed/unavailable path leaves the
+    // dashboard usable; explicit AI operations fail visibly through the
+    // manager's readiness promises instead.
+    const localAiEpoch = this.localAiInitEpoch;
+    // Same authority as before: browserModel on web, unconditional on desktop.
+    // Headline Memory needs no extra disjunct — on web its effective gate
+    // already requires browserModel, on desktop the runtime check covers it.
     if (aiFlow.browserModel || isDesktopRuntime()) {
-      await mlWorker.init();
-      if (BETA_MODE) mlWorker.loadModel('summarization-beta').catch(() => { });
+      void (async () => {
+        try {
+          const ready = await mlWorker.init();
+          if (this.localAiInitEpoch !== localAiEpoch || this.state.isDestroyed) return;
+          if (!ready) return;
+          if (!getAiFlowSettings().browserModel && !isDesktopRuntime()) return;
+          if (BETA_MODE) mlWorker.loadModel('summarization-beta').catch(() => { });
+        } catch {
+          // Worker failure must not break boot; explicit AI operations fail
+          // visibly through the manager's readiness promises instead.
+        }
+      })();
     }
 
     // Headline Memory requires Browser Local Model to be ON — `isHeadlineMemoryEnabled()`
     // ANDs both flags. Without this gate, leaving Headline Memory on while turning
     // Browser Local Model off would silently download/run an embeddings model the user
-    // opted out of via the parent toggle.
+    // opted out of via the parent toggle. Joins the detached boot continuation
+    // above (shared in-flight init, no duplicate worker): on slow workers this
+    // waits without blocking layout or panels.
     if (isHeadlineMemoryEnabled()) {
-      mlWorker.init().then(ok => {
-        if (ok) mlWorker.loadModel('embeddings').catch(() => { });
+      void mlWorker.whenReady('app-boot:headline-memory').then((ready) => {
+        if (!ready) return;
+        if (this.localAiInitEpoch !== localAiEpoch || this.state.isDestroyed) return;
+        if (!isHeadlineMemoryEnabled()) return;
+        mlWorker.loadModel('embeddings').catch(() => { });
       }).catch(() => { });
     }
 
     this.unsubAiFlow = subscribeAiFlowChange((key) => {
+      // Detached continuations re-read current settings and the app lifetime
+      // before requesting a model: a toggle that went away while the worker
+      // was starting must not leave a model downloading (#7779).
       if (key === 'browserModel') {
         const s = getAiFlowSettings();
         if (s.browserModel) {
-          mlWorker.init().then(ok => {
+          const epoch = this.localAiInitEpoch;
+          void mlWorker.whenReady('app-settings:browser-model').then((ready) => {
+            if (!ready) return;
+            if (this.localAiInitEpoch !== epoch || this.state.isDestroyed) return;
             // Re-honor Headline Memory's persisted value on parent re-enable.
-            if (ok && isHeadlineMemoryEnabled()) {
+            if (isHeadlineMemoryEnabled()) {
               mlWorker.loadModel('embeddings').catch(() => { });
             }
           }).catch(() => { });
@@ -2394,8 +2437,12 @@ export class App {
       }
       if (key === 'headlineMemory') {
         if (isHeadlineMemoryEnabled()) {
-          mlWorker.init().then(ok => {
-            if (ok) mlWorker.loadModel('embeddings').catch(() => { });
+          const epoch = this.localAiInitEpoch;
+          void mlWorker.whenReady('app-settings:headline-memory').then((ready) => {
+            if (!ready) return;
+            if (this.localAiInitEpoch !== epoch || this.state.isDestroyed) return;
+            if (!isHeadlineMemoryEnabled()) return;
+            mlWorker.loadModel('embeddings').catch(() => { });
           }).catch(() => { });
         } else {
           mlWorker.unloadModel('embeddings').catch(() => { });
@@ -3368,6 +3415,10 @@ export class App {
   }
 
   public destroy(): void {
+    // Invalidate optional local-AI continuations FIRST: any detached
+    // mlWorker.whenReady() callback captured below terminates instead of
+    // downloading models or restarting for a destroyed app (#7779).
+    this.localAiInitEpoch += 1;
     this.state.isDestroyed = true;
     this.latestSearchAdsb = [];
     this.latestSearchMilitary = [];

--- a/src/App.ts
+++ b/src/App.ts
@@ -2419,8 +2419,13 @@ export class App {
       if (key === 'browserModel') {
         const s = getAiFlowSettings();
         if (s.browserModel) {
+          // init(), not whenReady(): cold-boot with the toggle off leaves the
+          // manager disabled, and whenReady() on a disabled manager resolves
+          // false without starting anything — the enable path must START the
+          // worker (#7796 review P1). init() is idempotent over an already
+          // running worker, so a racing boot continuation cannot duplicate it.
           const epoch = this.localAiInitEpoch;
-          void mlWorker.whenReady('app-settings:browser-model').then((ready) => {
+          void mlWorker.init().then((ready) => {
             if (!ready) return;
             if (this.localAiInitEpoch !== epoch || this.state.isDestroyed) return;
             // Re-honor Headline Memory's persisted value on parent re-enable.
@@ -2437,8 +2442,12 @@ export class App {
       }
       if (key === 'headlineMemory') {
         if (isHeadlineMemoryEnabled()) {
+          // init(), not whenReady(): Headline Memory can be toggled on while
+          // the manager was never started (web boot with browserModel off) —
+          // waiting would resolve false without starting anything, and its
+          // effective gate already implies the parent toggle (#7796 review P1).
           const epoch = this.localAiInitEpoch;
-          void mlWorker.whenReady('app-settings:headline-memory').then((ready) => {
+          void mlWorker.init().then((ready) => {
             if (!ready) return;
             if (this.localAiInitEpoch !== epoch || this.state.isDestroyed) return;
             if (!isHeadlineMemoryEnabled()) return;

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2151,6 +2151,11 @@ export class DataLoaderManager implements AppModule {
     this.updateMonitorResults();
 
     try {
+      // Snapshot local-ML availability AT this generation's clustering choice
+      // (#7779): available takes the hybrid path, unavailable the analysis
+      // path. Worker readiness alone must never force a news reload or
+      // retroactively regroup committed first-load results — a later normal
+      // refresh re-reads availability and may use newly available ML.
       const clusters = mlWorker.isAvailable
         ? await clusterNewsHybrid(this.ctx.allNews)
         : await analysisWorker.clusterNews(this.ctx.allNews);
@@ -4458,6 +4463,9 @@ export class DataLoaderManager implements AppModule {
     const newsGeneration = this.committedNewsGeneration;
     const newsServedStale = this.committedNewsServedStale;
     try {
+      // Same per-generation availability snapshot as loadNews (#7779): pair
+      // the clustering path with THIS call's news body, never with a later
+      // worker-ready event that would regroup already-committed clusters.
       if (this.ctx.latestClusters.length === 0 && this.ctx.allNews.length > 0) {
         this.ctx.latestClusters = mlWorker.isAvailable
           ? await clusterNewsHybrid(this.ctx.allNews)

--- a/src/services/ml-worker.ts
+++ b/src/services/ml-worker.ts
@@ -90,6 +90,16 @@ export class MLWorkerManager {
   private desiredModels = new Set<string>();
   private pendingModelUnloads = new Map<string, Promise<boolean>>();
   private modelProgressCallbacks: Map<string, (progress: number) => void> = new Map();
+  /**
+   * Detached readiness continuations, keyed by caller label for debuggability.
+   * Each continuation was registered via {@link whenReady} while the worker was
+   * still initializing; it is resolved in-place when readiness settles rather
+   * than forcing a news reload or re-grouping already-committed results (#7779).
+   */
+  private readyWaiters = new Map<string, {
+    resolve: (ready: boolean) => void;
+    lifecycleGeneration: number;
+  }>();
 
   private readonly readyTimeoutMs: number;
   private readonly recoveryBaseDelayMs: number;
@@ -128,18 +138,81 @@ export class MLWorkerManager {
 
   private async ensureReadyNow(): Promise<boolean> {
     while (this.enabled && !this.recoveryBlocked) {
-      if (this.isReady && this.hasRestoredDesiredModels()) return true;
+      if (this.isReady && this.hasRestoredDesiredModels()) {
+        this.settleReadyWaiters(true);
+        return true;
+      }
 
       const initialization = this.initPromise
         ?? this.initializeAndRestore(this.lifecycleGeneration);
       this.initPromise = initialization;
       try {
-        if (!await initialization) return false;
+        if (!await initialization) {
+          this.settleReadyWaiters(false);
+          return false;
+        }
       } finally {
         if (this.initPromise === initialization) this.initPromise = null;
       }
     }
+    this.settleReadyWaiters(false);
     return false;
+  }
+
+  /**
+   * Wait for the worker to finish its current initialization without forcing
+   * it or queueing inference. Resolves true when the worker becomes available
+   * and false when initialization fails, is disabled, or is superseded by a
+   * later lifecycle (terminate / destroy). Detached continuations MUST recheck
+   * current settings and app lifetime themselves before requesting a model —
+   * a late true does not imply the request is still wanted (#7779 review).
+   *
+   * Multiple waiters share one in-flight initialization; they never duplicate
+   * the startup work.
+   */
+  whenReady(caller = 'anonymous'): Promise<boolean> {
+    if (this.isAvailable) return Promise.resolve(true);
+    if (!this.enabled || this.recoveryBlocked) return Promise.resolve(false);
+    void this.ensureReady();
+    return this.waiterPromise(caller);
+  }
+
+  private waiterPromise(caller: string): Promise<boolean> {
+    // A caller that re-registers while a waiter under its label is still
+    // pending replaces that entry — at most one pending continuation per
+    // label, so repeated toggles cannot accumulate stale waiters. Each entry
+    // pins the lifecycle generation seen at registration; a terminate in the
+    // meantime resolves it false instead of reviving the new lifecycle.
+    return new Promise<boolean>((resolve) => {
+      this.readyWaiters.set(caller, {
+        resolve,
+        lifecycleGeneration: this.lifecycleGeneration,
+      });
+    });
+  }
+
+  private settleReadyWaiters(ready: boolean): void {
+    if (this.readyWaiters.size === 0) return;
+    const waiters = Array.from(this.readyWaiters.entries());
+    this.readyWaiters.clear();
+    for (const [, waiter] of waiters) {
+      if (waiter.lifecycleGeneration !== this.lifecycleGeneration) {
+        waiter.resolve(false);
+      } else {
+        waiter.resolve(ready);
+      }
+    }
+  }
+
+  /**
+   * Snapshot local-ML availability for one news generation's clustering-path
+   * decision. Available takes the hybrid (ML) path; unavailable takes the
+   * analysis (Jaccard) path. The snapshot is taken at the moment the news
+   * generation chooses — worker readiness alone must never trigger a news
+   * reload or retroactively regroup already-committed first-load results.
+   */
+  snapshotAvailableForClustering(): boolean {
+    return this.isAvailable;
   }
 
   private async initializeAndRestore(lifecycleGeneration: number): Promise<boolean> {
@@ -649,6 +722,7 @@ export class MLWorkerManager {
     this.clearRecoveryTimer();
     this.cleanup(true, new Error('ML Worker terminated'));
     this.initPromise = null;
+    this.settleReadyWaiters(false);
     this.recoveryAttempts = 0;
     this.recoveryBlocked = false;
   }

--- a/tests/dom/ml-worker-recovery.test.mts
+++ b/tests/dom/ml-worker-recovery.test.mts
@@ -311,4 +311,53 @@ describe('MLWorkerManager recovery', () => {
     expect(workerHarness.instances).toHaveLength(4);
     expect(manager.isAvailable).toBe(false);
   });
+
+  it('lets detached whenReady waiters share one in-flight init (#7779)', async () => {
+    workerHarness.autoReady = false;
+    const manager = createManager();
+    const bootInit = manager.init();
+    await vi.waitFor(() => expect(workerHarness.instances).toHaveLength(1));
+
+    // Two detached continuations (e.g. boot prefetch + headline-memory gate)
+    // must piggyback the same worker — not spawn duplicate startups.
+    const waiterA = manager.whenReady('app-boot:local-ai');
+    const waiterB = manager.whenReady('app-boot:headline-memory');
+    await new Promise(resolve => setTimeout(resolve, 5));
+    expect(workerHarness.instances).toHaveLength(1);
+
+    workerHarness.instances[0]!.emitReady();
+    await expect(bootInit).resolves.toBe(true);
+    await expect(waiterA).resolves.toBe(true);
+    await expect(waiterB).resolves.toBe(true);
+    // A late waiter after readiness resolves immediately without new work.
+    await expect(manager.whenReady('late-joiner')).resolves.toBe(true);
+    expect(workerHarness.instances).toHaveLength(1);
+  });
+
+  it('fails detached waiters closed when terminate lands mid-startup (#7779)', async () => {
+    workerHarness.autoReady = false;
+    const manager = createManager();
+    const bootInit = manager.init();
+    await vi.waitFor(() => expect(workerHarness.instances).toHaveLength(1));
+
+    const waiter = manager.whenReady('app-boot:headline-memory');
+    manager.terminate();
+
+    await expect(bootInit).resolves.toBe(false);
+    await expect(waiter).resolves.toBe(false);
+    expect(workerHarness.instances).toHaveLength(1);
+  });
+
+  it('snapshots availability per clustering choice without forcing a reload (#7779)', async () => {
+    const manager = createManager();
+    // Cold worker: snapshot is false, so a news generation takes the analysis
+    // (Jaccard) path — readiness alone must not regroup committed results.
+    expect(manager.snapshotAvailableForClustering()).toBe(false);
+
+    expect(await manager.init()).toBe(true);
+    expect(manager.snapshotAvailableForClustering()).toBe(true);
+
+    manager.terminate();
+    expect(manager.snapshotAvailableForClustering()).toBe(false);
+  });
 });

--- a/tests/local-ai-detached-init.test.mts
+++ b/tests/local-ai-detached-init.test.mts
@@ -1,0 +1,105 @@
+/**
+ * Source-text lock for #7779: optional local-AI init must not gate dashboard
+ * startup.
+ *
+ * App.init() is a DOM/bootstrap module that can't be imported under
+ * `tsx --test`, so — per the repo's established pattern (see
+ * tests/business-invite-wiring.test.mts) — this locks the integration with
+ * source-text assertions plus a behavioral delayed-readiness test on the
+ * ml-worker side (the blocking `await mlWorker.init()` used to sit ahead of
+ * layout/panels; now boot continues while the worker settles detached).
+ */
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+const read = (path: string) => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+describe('optional local-AI init stays off the dashboard critical path (#7779)', () => {
+  it('does not block early boot on mlWorker.init()', async () => {
+    const src = await read('src/App.ts');
+    // The only `await mlWorker.init()` lives inside the detached boot
+    // continuation (`void (async () => { ... })()`); boot itself proceeds to
+    // layout/panels first. A bare `await mlWorker.init();` statement at
+    // boot-module statement level or directly in init()'s pre-layout section
+    // would reintroduce the gate.
+    assert.match(
+      src,
+      /void \(async \(\) => \{\s*\n\s*try \{\s*\n\s*const ready = await mlWorker\.init\(\);/,
+      'optional local-AI init must run inside a detached continuation',
+    );
+    assert.doesNotMatch(
+      src,
+      /\n    await mlWorker\.init\(\);/,
+      'boot must never await mlWorker.init() at the init() statement level',
+    );
+  });
+
+  it('starts optional local AI detached and guards the continuation on epoch, lifetime and current settings', async () => {
+    const src = await read('src/App.ts');
+    assert.match(
+      src,
+      /const ready = await mlWorker\.init\(\);/,
+      'the detached boot continuation must still use the manager readiness promise',
+    );
+    assert.match(
+      src,
+      /if \(this\.localAiInitEpoch !== localAiEpoch \|\| this\.state\.isDestroyed\) return;/,
+      'a late boot continuation must bail for a stale epoch or destroyed app',
+    );
+    assert.match(
+      src,
+      /if \(!getAiFlowSettings\(\)\.browserModel && !isDesktopRuntime\(\)\) return;/,
+      'a late boot continuation must recheck the browser-model/desktop authority',
+    );
+  });
+
+  it('keeps the browser-model and headline-memory parent/authority gates on every detached path', async () => {
+    const src = await read('src/App.ts');
+    assert.match(
+      src,
+      /mlWorker\.whenReady\('app-boot:headline-memory'\)/,
+      'headline-memory boot must join the shared init, not spawn its own',
+    );
+    assert.match(
+      src,
+      /mlWorker\.whenReady\('app-settings:browser-model'\)/,
+      'browser-model re-enable must join the shared init, not spawn its own',
+    );
+    assert.match(
+      src,
+      /mlWorker\.whenReady\('app-settings:headline-memory'\)/,
+      'headline-memory re-enable must join the shared init, not spawn its own',
+    );
+    assert.match(
+      src,
+      /if \(!isHeadlineMemoryEnabled\(\)\) return;/,
+      'detached headline-memory continuations must recheck the parent gate',
+    );
+  });
+
+  it('invalidates detached continuations on destroy so they cannot revive a dead app', async () => {
+    const src = await read('src/App.ts');
+    const destroyIndex = src.indexOf('public destroy(): void {');
+    assert.notEqual(destroyIndex, -1, 'could not locate App.destroy');
+    const epochBump = src.indexOf('this.localAiInitEpoch += 1;', destroyIndex);
+    assert.ok(
+      epochBump !== -1 && epochBump - destroyIndex < 600,
+      'destroy() must invalidate detached local-AI continuations before teardown',
+    );
+  });
+
+  it('snapshots clustering availability per news generation instead of reloading on ready', async () => {
+    const src = await read('src/app/data-loader.ts');
+    assert.match(
+      src,
+      /Snapshot local-ML availability AT this generation's clustering choice/,
+      'loadNews must snapshot mlWorker.isAvailable per generation, never reload on worker-ready',
+    );
+    assert.doesNotMatch(
+      src,
+      /whenReady|addEventListener\(['"]ml|onWorkerReady/,
+      'data-loader must not subscribe to worker readiness — readiness alone never regroups committed results',
+    );
+  });
+});

--- a/tests/local-ai-detached-init.test.mts
+++ b/tests/local-ai-detached-init.test.mts
@@ -61,15 +61,19 @@ describe('optional local-AI init stays off the dashboard critical path (#7779)',
       /mlWorker\.whenReady\('app-boot:headline-memory'\)/,
       'headline-memory boot must join the shared init, not spawn its own',
     );
+    // Settings enable-paths use init(), NOT whenReady(): cold-boot with the
+    // toggle off leaves the manager disabled, and whenReady() on a disabled
+    // manager resolves false without starting anything (#7796 review P1).
+    const settingsSection = src.slice(src.indexOf('this.unsubAiFlow = subscribeAiFlowChange'));
     assert.match(
-      src,
-      /mlWorker\.whenReady\('app-settings:browser-model'\)/,
-      'browser-model re-enable must join the shared init, not spawn its own',
+      settingsSection,
+      /void mlWorker\.init\(\)\.then\(\(ready\) => \{/,
+      'settings enable-paths must START the worker via init()',
     );
-    assert.match(
-      src,
-      /mlWorker\.whenReady\('app-settings:headline-memory'\)/,
-      'headline-memory re-enable must join the shared init, not spawn its own',
+    assert.doesNotMatch(
+      settingsSection,
+      /whenReady\('app-settings:/,
+      'settings enable-paths must not use whenReady(), which cannot start a disabled worker',
     );
     assert.match(
       src,


### PR DESCRIPTION
Closes #7779.

## Outcome
Optional local AI (browser model / desktop ML worker) initializes detached from the dashboard critical path. Layout, event handlers and basic panels no longer await capability detection, worker startup or model restoration; a delayed or failed worker leaves the dashboard usable.

## What changed
- `src/services/ml-worker.ts`: new `whenReady(label)` detached-waiter registry sharing one in-flight init (settled true on availability, false on failure/terminate/supersede), plus `snapshotAvailableForClustering()` per-generation clustering-path check.
- `src/App.ts`: removed blocking `await mlWorker.init()`; boot + headline-memory + settings toggles run as detached continuations guarded on epoch, destroy flag and re-read ai-flow settings. `destroy()` invalidates the epoch first. No new model, default, forced download, or clustering change.
- `src/app/data-loader.ts`: `loadNews` / `runCorrelationAnalysis` snapshot `mlWorker.isAvailable` at each generation's clustering choice; readiness alone never reloads news or regroups committed clusters. Later normal refresh may use newly available ML.
- Explicit AI ops still use manager readiness promises and fail visibly (unchanged fail-closed paths in ml-worker/summarization).

## Verification (all in worktree at rebase onto origin/main a24456431)
- `npm run test:dom -- tests/dom/ml-worker-recovery.test.mts`: 10/10 pass (3 new: shared in-flight waiters, terminate-mid-startup fails closed, per-generation snapshot)
- `npx tsx --test tests/local-ai-detached-init.test.mts`: 5/5 pass (new source-text lock: no statement-level await, epoch/lifetime/settings guards, parent gates, destroy invalidation, no ready-subscription in data-loader)
- `npm run test:dom`: 109 files / 883 tests pass
- `npm run typecheck`, `npm run lint:boundaries`, `git diff --check`: clean
- Related contracts still green: spa-lifecycle-recovery, app-destroy-lifecycle, hub-activity-hydration (22/22)

## Evidence limitations
- No production-build browser startup/first-use fixture run and no real Tauri run; desktop semantics covered by source-text authority checks (desktop unconditional init preserved) and unit-level manager tests only. State explicitly: Tauri run NOT performed.
- Before/after timing: this is a correctness/gating change (removes an unbounded await), not a claimed speedup; no benchmark included per issue scope.