### PR TITLE
perf(startup): remove geolocation from dashboard readiness

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -2747,28 +2747,26 @@ export class App {
     window.addEventListener('offline', this.handleConnectivityChange);
 
     // The single automatic precise recenter for this startup (mobile only,
-    // never desktop): only while the app is alive and no explicit URL
-    // view/coordinates or user/programmatic navigation has claimed the camera
-    // since layout. Any pan/zoom (humanViewportInteractionToken), preset,
-    // search or country navigation supersedes it.
+    // never desktop) runs as background work so a slow position lookup never
+    // blocks layout, event-handler, or data readiness (#7778). It fires only
+    // while the app is alive and no explicit URL view/coordinates or
+    // user/programmatic navigation has claimed the camera since layout: the
+    // authority snapshot below is taken after map construction, and any later
+    // pan/zoom (humanViewportInteractionToken), preset, search, or country
+    // navigation supersedes it.
     const recenterAuthorityToken = this.state.map?.getViewportAuthorityToken() ?? 0;
     const urlClaimedCamera = this.state.initialUrlState != null && (
       this.state.initialUrlState.view !== undefined ||
       (this.state.initialUrlState.lat !== undefined && this.state.initialUrlState.lon !== undefined)
     );
-    const mobileGeoCoords = await geoCoordsPromise;
-    if (this.state.isDestroyed) return;
-    if (
-      mobileGeoCoords &&
-      this.state.isMobile &&
-      !this.autoGeoRecenterApplied &&
-      !urlClaimedCamera &&
-      this.state.map &&
-      this.state.map.getViewportAuthorityToken() === recenterAuthorityToken
-    ) {
+    void geoCoordsPromise.then((mobileGeoCoords) => {
+      if (!mobileGeoCoords || this.state.isDestroyed) return;
+      if (!this.state.isMobile || this.autoGeoRecenterApplied || urlClaimedCamera) return;
+      const map = this.state.map;
+      if (!map || map.getViewportAuthorityToken() !== recenterAuthorityToken) return;
       this.autoGeoRecenterApplied = true;
-      this.state.map.setCenter(mobileGeoCoords.lat, mobileGeoCoords.lon, 6);
-    }
+      map.setCenter(mobileGeoCoords.lat, mobileGeoCoords.lon, 6);
+    });
 
     // Happy variant: pre-populate panels from persistent cache for instant render
     if (SITE_VARIANT === 'happy') {

--- a/src/App.ts
+++ b/src/App.ts
@@ -205,7 +205,7 @@ import {
 import { replaceRawI18nKeyPlaceholders } from '@/app/i18n-raw-key-healer';
 import { startAccountAuthHandoff } from '@/app/account-auth-handoff';
 import { TierPreferenceHandoff } from '@/app/tier-preference-handoff';
-import { resolveUserRegion, resolvePreciseUserCoordinates, type PreciseCoordinates } from '@/utils/user-location';
+import { initialRegionFromCache, resolveUserRegion, resolvePreciseUserCoordinates, type PreciseCoordinates } from '@/utils/user-location';
 import { showProBanner } from '@/components/ProBanner';
 import { getAuthState, initAuthState, subscribeAuthState } from '@/services/auth-state';
 import {
@@ -300,6 +300,10 @@ export class App {
   private pendingDeepLinkSearchQuery: string | null = null;
   private chokepointDeepLinkTimer: number | null = null;
   private stockDeepLinkTimer: number | null = null;
+  // At most one automatic precise mobile recenter per startup (#7778). Set
+  // when the late position callback fires; cleared on destroy/re-init so a new
+  // App instance gets its own single attempt.
+  private autoGeoRecenterApplied = false;
 
   private panelLayout: PanelLayoutManager;
   private dataLoader: DataLoaderManager;
@@ -2713,8 +2717,22 @@ export class App {
         ? resolvePreciseUserCoordinates(5000)
         : Promise.resolve(null);
 
-    const resolvedRegion = await resolveUserRegion();
-    this.state.resolvedLocation = resolvedRegion;
+    // Readiness must not wait for permission/position work (#7778): seed the
+    // initial region synchronously from usable cached region/coordinates, else
+    // timezone, else global (desktop map startup stays global because layout
+    // reads this value before the background refinement below can land), then
+    // let the shared in-flight lookup refine it in the background without
+    // gating layout or event-handler setup. Desktop keeps its prior
+    // region-ranked predictions via the same background path; only the map
+    // view and the precise recenter stay mobile-only.
+    this.state.resolvedLocation = initialRegionFromCache(this.state.isMobile);
+    void resolveUserRegion().then(
+      (region) => {
+        if (this.state.isDestroyed) return;
+        this.applyLateGeoRegion(region);
+      },
+      () => { /* failed location keeps the synchronous fallback usable */ },
+    );
 
     // Phase 1: Layout (creates map + panels — they'll find hydrated data).
     // init() is async so the dynamic MapContainer import can resolve before
@@ -2728,8 +2746,27 @@ export class App {
     window.addEventListener('online', this.handleConnectivityChange);
     window.addEventListener('offline', this.handleConnectivityChange);
 
+    // The single automatic precise recenter for this startup (mobile only,
+    // never desktop): only while the app is alive and no explicit URL
+    // view/coordinates or user/programmatic navigation has claimed the camera
+    // since layout. Any pan/zoom (humanViewportInteractionToken), preset,
+    // search or country navigation supersedes it.
+    const recenterAuthorityToken = this.state.map?.getViewportAuthorityToken() ?? 0;
+    const urlClaimedCamera = this.state.initialUrlState != null && (
+      this.state.initialUrlState.view !== undefined ||
+      (this.state.initialUrlState.lat !== undefined && this.state.initialUrlState.lon !== undefined)
+    );
     const mobileGeoCoords = await geoCoordsPromise;
-    if (mobileGeoCoords && this.state.map) {
+    if (this.state.isDestroyed) return;
+    if (
+      mobileGeoCoords &&
+      this.state.isMobile &&
+      !this.autoGeoRecenterApplied &&
+      !urlClaimedCamera &&
+      this.state.map &&
+      this.state.map.getViewportAuthorityToken() === recenterAuthorityToken
+    ) {
+      this.autoGeoRecenterApplied = true;
       this.state.map.setCenter(mobileGeoCoords.lat, mobileGeoCoords.lon, 6);
     }
 
@@ -2904,6 +2941,22 @@ export class App {
       panel_count: Object.keys(this.state.panels).length,
     });
     this.eventHandlers.setupPanelViewTracking();
+  }
+
+  /**
+   * Apply a late-arriving geolocation region without another network request
+   * solely for geolocation (#7778). Updates prediction prioritization from the
+   * kept candidate set using the same regional match rules; the failed-location
+   * path keeps the synchronous fallback usable without a map jump. Never
+   * late-recenters desktop. Guarded on isDestroyed so callbacks from a
+   * destroyed (re-initialized) App cannot move the new map or its panels.
+   */
+  private applyLateGeoRegion(region: string): void {
+    if (this.state.isDestroyed) return;
+    if (!region || region === 'global') return;
+    if (region === this.state.resolvedLocation) return;
+    this.state.resolvedLocation = region as AppContext['resolvedLocation'];
+    this.dataLoader.reprioritizeLateRegionPredictions(region);
   }
 
   private shouldDeferTierPreferenceReconciliation(): boolean {
@@ -3372,6 +3425,7 @@ export class App {
     this.latestSearchAdsb = [];
     this.latestSearchMilitary = [];
     this.latestSearchAdsbUpdatedAt = 0;
+    this.autoGeoRecenterApplied = false;
     this.resolveAppDestroyed();
     // Cancel in-flight App-owned waits before DOM teardown can mutate the
     // document and wake a waiter that still closes over this instance.

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -46,8 +46,8 @@ import {
 import { INTEL_HOTSPOTS, CONFLICT_ZONES } from '@/config/geo';
 import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';
 import { withTimeout } from '@/utils/with-timeout';
+import { fetchPredictions, reprioritizeMarketsForRegion as reprioritizePredictionMarketsForRegion } from '@/services/prediction';
 import {
-  fetchPredictions,
   fetchEarthquakes,
   fetchWeatherAlerts,
   fetchCanadaRoads,
@@ -475,6 +475,10 @@ export class DataLoaderManager implements AppModule {
   private readonly marketLoadGuard = new LatestRequestGuard();
   private readonly physicalComparisonLoadGuard = new LatestRequestGuard();
   private readonly mineralProductionLoadGuard = new LatestRequestGuard();
+  // Prediction ranking snapshots ctx.resolvedLocation at fetch start. A late
+  // region arrival (e.g. delayed geolocation, #7778) bumps the generation so
+  // the re-ranking pass — not the stale in-flight request — owns the commit.
+  private readonly predictionRegionGuard = new LatestRequestGuard();
   private globalTenderGeneration = 0;
   private globalTenderFilters: GlobalTenderFilters = {};
   private activeGlobalTenderScopedGeneration: number | null = null;
@@ -2977,23 +2981,48 @@ export class DataLoaderManager implements AppModule {
   }
 
   async loadPredictions(): Promise<void> {
+    // Capture the region at fetch start: a late region arrival re-ranks the
+    // kept candidate set (reprioritizeLateRegionPredictions) instead of letting
+    // this stale request overwrite the panel with the old ordering (#7778).
+    const regionGeneration = this.predictionRegionGuard.begin();
     try {
       const predictions = await fetchPredictions({ region: this.ctx.resolvedLocation });
-      this.ctx.latestPredictions = predictions;
-      (this.ctx.panels['polymarket'] as PredictionPanel | undefined)?.renderPredictions(predictions);
-
-      this.ctx.statusPanel?.updateFeed('Polymarket', { status: 'ok', itemCount: predictions.length });
-      this.ctx.statusPanel?.updateApi('Polymarket', { status: 'ok' });
-      dataFreshness.recordUpdate('polymarket', predictions.length);
-      dataFreshness.recordUpdate('predictions', predictions.length);
-
+      if (this.ctx.isDestroyed || !this.predictionRegionGuard.isCurrent(regionGeneration)) return;
+      this.commitPredictionResults(predictions);
       void this.runCorrelationAnalysis();
     } catch (error) {
+      if (this.ctx.isDestroyed || !this.predictionRegionGuard.isCurrent(regionGeneration)) return;
       this.ctx.statusPanel?.updateFeed('Polymarket', { status: 'error', errorMessage: String(error) });
       this.ctx.statusPanel?.updateApi('Polymarket', { status: 'error' });
       dataFreshness.recordError('polymarket', String(error));
       dataFreshness.recordError('predictions', String(error));
     }
+  }
+
+  /**
+   * Re-rank the kept candidate set after a late region arrival without another
+   * network request solely for geolocation (#7778). Same regional match rules
+   * and normal relevance order as fetchPredictions; no eligibility, limit,
+   * market-selection or freshness-schedule changes. Bumping the generation
+   * makes an older in-flight loadPredictions() drop its stale commit.
+   */
+  reprioritizeLateRegionPredictions(region: string): void {
+    this.predictionRegionGuard.begin();
+    if (this.ctx.isDestroyed || !region || region === 'global') return;
+    const kept = this.ctx.latestPredictions;
+    if (kept.length === 0) return;
+    const reranked = reprioritizePredictionMarketsForRegion(kept, region, 15);
+    this.commitPredictionResults(reranked);
+  }
+
+  private commitPredictionResults(predictions: import('@/services/prediction').PredictionMarket[]): void {
+    this.ctx.latestPredictions = predictions;
+    (this.ctx.panels['polymarket'] as PredictionPanel | undefined)?.renderPredictions(predictions);
+
+    this.ctx.statusPanel?.updateFeed('Polymarket', { status: 'ok', itemCount: predictions.length });
+    this.ctx.statusPanel?.updateApi('Polymarket', { status: 'ok' });
+    dataFreshness.recordUpdate('polymarket', predictions.length);
+    dataFreshness.recordUpdate('predictions', predictions.length);
   }
 
   async loadForecasts(): Promise<void> {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -46,7 +46,7 @@ import {
 import { INTEL_HOTSPOTS, CONFLICT_ZONES } from '@/config/geo';
 import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';
 import { withTimeout } from '@/utils/with-timeout';
-import { fetchPredictions, reprioritizeMarketsForRegion as reprioritizePredictionMarketsForRegion } from '@/services/prediction';
+import { fetchPredictionCandidates, reprioritizeMarketsForRegion as reprioritizePredictionMarketsForRegion } from '@/services/prediction';
 import {
   fetchEarthquakes,
   fetchWeatherAlerts,
@@ -2980,15 +2980,21 @@ export class DataLoaderManager implements AppModule {
     }
   }
 
+  // Full 25-candidate pool behind the displayed 15. The late-region path
+  // re-ranks this pool so region matches at positions 16-25 can still promote
+  // exactly as if the region had resolved before the fetch (#7778).
+  private latestPredictionCandidates: import('@/services/prediction').PredictionMarket[] = [];
+
   async loadPredictions(): Promise<void> {
     // Capture the region at fetch start: a late region arrival re-ranks the
-    // kept candidate set (reprioritizeLateRegionPredictions) instead of letting
-    // this stale request overwrite the panel with the old ordering (#7778).
+    // kept candidate pool (reprioritizeLateRegionPredictions) instead of
+    // letting this stale request overwrite the panel with the old ordering.
+    const expectedRegion = this.ctx.resolvedLocation;
     const regionGeneration = this.predictionRegionGuard.begin();
     try {
-      const predictions = await fetchPredictions({ region: this.ctx.resolvedLocation });
+      const { candidates, displayed } = await fetchPredictionCandidates({ region: expectedRegion });
       if (this.ctx.isDestroyed || !this.predictionRegionGuard.isCurrent(regionGeneration)) return;
-      this.commitPredictionResults(predictions);
+      this.commitPredictionResults(displayed, candidates);
       void this.runCorrelationAnalysis();
     } catch (error) {
       if (this.ctx.isDestroyed || !this.predictionRegionGuard.isCurrent(regionGeneration)) return;
@@ -3000,23 +3006,34 @@ export class DataLoaderManager implements AppModule {
   }
 
   /**
-   * Re-rank the kept candidate set after a late region arrival without another
-   * network request solely for geolocation (#7778). Same regional match rules
-   * and normal relevance order as fetchPredictions; no eligibility, limit,
-   * market-selection or freshness-schedule changes. Bumping the generation
-   * makes an older in-flight loadPredictions() drop its stale commit.
+   * Re-rank the kept candidate pool after a late region arrival without
+   * another network request solely for geolocation (#7778). Same regional
+   * match rules and normal relevance order as fetchPredictions.
+   *
+   * In-flight safety: the generation is bumped only when the re-rank actually
+   * commits, so a cold-start load whose result has not arrived yet keeps its
+   * result instead of being discarded into an empty panel — the bump then
+   * makes that late commit apply the CURRENT region, not the stale one. No
+   * eligibility, limit, market-selection, or freshness-schedule changes.
    */
   reprioritizeLateRegionPredictions(region: string): void {
-    this.predictionRegionGuard.begin();
     if (this.ctx.isDestroyed || !region || region === 'global') return;
-    const kept = this.ctx.latestPredictions;
-    if (kept.length === 0) return;
-    const reranked = reprioritizePredictionMarketsForRegion(kept, region, 15);
-    this.commitPredictionResults(reranked);
+    const pool = this.latestPredictionCandidates.length > 0
+      ? this.latestPredictionCandidates
+      : this.ctx.latestPredictions;
+    if (pool.length === 0) return;
+    this.predictionRegionGuard.begin();
+    this.commitPredictionResults(reprioritizePredictionMarketsForRegion(pool, region, 15), pool);
   }
 
-  private commitPredictionResults(predictions: import('@/services/prediction').PredictionMarket[]): void {
+  private commitPredictionResults(
+    predictions: import('@/services/prediction').PredictionMarket[],
+    candidates?: import('@/services/prediction').PredictionMarket[],
+  ): void {
     this.ctx.latestPredictions = predictions;
+    if (candidates) this.latestPredictionCandidates = candidates;
+    this.ctx.latestPredictions = predictions;
+    if (candidates) this.latestPredictionCandidates = candidates;
     (this.ctx.panels['polymarket'] as PredictionPanel | undefined)?.renderPredictions(predictions);
 
     this.ctx.statusPanel?.updateFeed('Polymarket', { status: 'ok', itemCount: predictions.length });

--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -90,7 +90,10 @@ function protoToMarket(m: { title: string; yesPrice: number; volume: number; url
   };
 }
 
-export async function fetchPredictions(opts?: { region?: string }): Promise<PredictionMarket[]> {
+export async function fetchPredictionCandidates(opts?: { region?: string }): Promise<{
+  candidates: PredictionMarket[];
+  displayed: PredictionMarket[];
+}> {
   const markets = await breaker.execute(async () => {
     const hydrated = getHydratedData('predictions') as BootstrapPredictionData | undefined;
     if (hydrated?.fetchedAt && Date.now() - hydrated.fetchedAt < 40 * 60 * 1000) {
@@ -131,9 +134,26 @@ export async function fetchPredictions(opts?: { region?: string }): Promise<Pred
   }, []);
 
   if (opts?.region && opts.region !== 'global' && markets.length > 0) {
-    return reprioritizeMarketsForRegion(markets, opts.region, 15);
+    return {
+      candidates: predictionCandidatePool(markets),
+      displayed: reprioritizeMarketsForRegion(markets, opts.region, 15),
+    };
   }
-  return markets.slice(0, 15);
+  return { candidates: predictionCandidatePool(markets), displayed: markets.slice(0, 15) };
+}
+
+export async function fetchPredictions(opts?: { region?: string }): Promise<PredictionMarket[]> {
+  return (await fetchPredictionCandidates(opts)).displayed;
+}
+
+/**
+ * Full candidate pool for a late region arrival (#7778): the same 25-candidate
+ * relevance-ordered set fetchPredictions() ranks across, before the final
+ * 15-item display slice. Re-ranking this pool — not the truncated display
+ * slice — is what makes the late path identical to resolving first.
+ */
+export function predictionCandidatePool(markets: PredictionMarket[]): PredictionMarket[] {
+  return markets.slice(0, 25);
 }
 
 interface CountryMetadata {

--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -54,6 +54,30 @@ function tagRegions(title: string): string[] {
     .map(([region]) => region);
 }
 
+/**
+ * Shared regional prioritization: stable sort that hoists markets tagged with
+ * `region` ahead of the rest while preserving the base relevance order inside
+ * each partition. Used by fetchPredictions for the network result and by
+ * reprioritizeMarketsForRegion for late-region updates without a refetch, so
+ * both paths apply identical match rules and ordering (#7778).
+ */
+export function reprioritizeMarketsForRegion<T extends { regions?: string[] }>(
+  markets: T[],
+  region: string | undefined,
+  limit = 15,
+): T[] {
+  if (!region || region === 'global' || markets.length === 0) return markets.slice(0, limit);
+  const ranked = markets
+    .map((market, index) => ({ market, index }))
+    .sort((a, b) => {
+      const aMatch = a.market.regions?.includes(region) ? 1 : 0;
+      const bMatch = b.market.regions?.includes(region) ? 1 : 0;
+      return bMatch - aMatch || a.index - b.index;
+    })
+    .map(({ market }) => market);
+  return ranked.slice(0, limit);
+}
+
 function protoToMarket(m: { title: string; yesPrice: number; volume: number; url: string; closesAt: number; category: string; source?: string }): PredictionMarket {
   return {
     title: m.title,
@@ -107,13 +131,7 @@ export async function fetchPredictions(opts?: { region?: string }): Promise<Pred
   }, []);
 
   if (opts?.region && opts.region !== 'global' && markets.length > 0) {
-    const sorted = [...markets];
-    sorted.sort((a, b) => {
-      const aMatch = a.regions?.includes(opts.region!) ? 1 : 0;
-      const bMatch = b.regions?.includes(opts.region!) ? 1 : 0;
-      return bMatch - aMatch;
-    });
-    return sorted.slice(0, 15);
+    return reprioritizeMarketsForRegion(markets, opts.region, 15);
   }
   return markets.slice(0, 15);
 }

--- a/src/utils/user-location.ts
+++ b/src/utils/user-location.ts
@@ -49,6 +49,69 @@ function getGeolocationPosition(timeout: number): Promise<GeolocationPosition> {
   });
 }
 
+/**
+ * Shared position-request budget for dashboard startup (#7778). Both the
+ * initial-region and precise-coordinate consumers race the same in-flight
+ * geolocation call against this budget (5,000 ms) so a granted lookup issues
+ * exactly one physical request instead of two overlapping ones. Kept in this
+ * module (not a startup framework) alongside the existing location utility.
+ */
+export const SHARED_POSITION_TIMEOUT_MS = 5000;
+
+/**
+ * Single in-flight position request shared by the region and precise-coordinate
+ * consumers. The entry is cleared on success AND failure so a later explicit
+ * attempt (e.g. a user-triggered recenter) can retry instead of reusing a
+ * settled rejection. Module state is keyed per page lifetime, which also
+ * bounds the "one automatic recenter per startup" rule in App startup flow.
+ */
+let _sharedPositionRequest: Promise<GeolocationPosition> | null = null;
+
+function sharedGeolocationRequest(): Promise<GeolocationPosition> | null {
+  if (typeof navigator === 'undefined' || !navigator.geolocation) return null;
+  if (!_sharedPositionRequest) {
+    const request = getGeolocationPosition(SHARED_POSITION_TIMEOUT_MS);
+    _sharedPositionRequest = request;
+    // Clear on settle so a later explicit attempt can retry. Attach the
+    // clearing handler to a derived promise so the shared request itself
+    // keeps its original fulfillment value for every consumer.
+    void request.then(
+      () => { if (_sharedPositionRequest === request) _sharedPositionRequest = null; },
+      () => { if (_sharedPositionRequest === request) _sharedPositionRequest = null; },
+    );
+  }
+  return _sharedPositionRequest;
+}
+
+/** Test hook: drop the cached in-flight request between deterministic cases. */
+export function __resetSharedPositionRequestForTests(): void {
+  _sharedPositionRequest = null;
+}
+
+/**
+ * Synchronous initial-region guess that never touches permission or position
+ * APIs: usable cached region, else usable cached coordinates, else timezone,
+ * else global. Layout and map construction use this so readiness does not wait
+ * for the asynchronous position work. Desktop map startup stays global.
+ */
+export function initialRegionFromCache(isMobile: boolean): MapView {
+  if (!isMobile) return 'global';
+  const cached = getCachedRegion();
+  if (cached) return cached;
+  const cachedPos = getCachedCoords();
+  if (cachedPos) {
+    const region = coordsToRegion(cachedPos.lat, cachedPos.lon);
+    cacheRegion(region);
+    return region;
+  }
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return timezoneToRegion(tz) ?? 'global';
+  } catch {
+    return 'global';
+  }
+}
+
 const TIMEZONE_TO_COUNTRY: Record<string, string> = {
   'Europe/Berlin': 'DE', 'Europe/Vienna': 'AT', 'Europe/Zurich': 'CH',
   'Europe/London': 'GB', 'Europe/Paris': 'FR', 'Europe/Madrid': 'ES',
@@ -155,7 +218,16 @@ export async function resolvePreciseUserCoordinates(timeout = 5000): Promise<Pre
     return null; // permissions.query unsupported → stay silent, no prompt
   }
   try {
-    const pos = await getGeolocationPosition(timeout);
+    const request = sharedGeolocationRequest();
+    if (!request) return null;
+    const pos = timeout === SHARED_POSITION_TIMEOUT_MS
+      ? await request
+      : await Promise.race([
+        request,
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('position-timeout')), timeout);
+        }),
+      ]);
     const coords = { lat: pos.coords.latitude, lon: pos.coords.longitude };
     cacheCoords(coords);
     return coords;
@@ -189,7 +261,11 @@ export async function resolveUserRegion(): Promise<MapView> {
     if (typeof navigator === 'undefined' || !navigator.permissions) throw 0;
     const status = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
     if (status.state === 'granted') {
-      const pos = await getGeolocationPosition(3000);
+      // Share the single in-flight request with the precise-coordinate
+      // consumer (#7778) instead of issuing a second overlapping lookup.
+      const request = sharedGeolocationRequest();
+      if (!request) return tzRegion;
+      const pos = await request;
       const region = coordsToRegion(pos.coords.latitude, pos.coords.longitude);
       cacheRegion(region);
       return region;

--- a/tests/geo-startup-readiness.test.mts
+++ b/tests/geo-startup-readiness.test.mts
@@ -1,0 +1,274 @@
+// Geolocation removed from dashboard readiness (#7778).
+//
+// Bundles src/utils/user-location.ts + src/services/prediction/index.ts through
+// esbuild with browser-platform stubs (the pattern in
+// tests/prediction-country-markets-pools.test.mts) because the modules are
+// browser-side: user-location touches sessionStorage/Intl, prediction imports
+// the generated RPC client, bootstrap hydration cache, and config.
+
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { after, beforeEach, describe, it } from 'node:test';
+import { build } from 'esbuild';
+
+const root = resolve(import.meta.dirname, '..');
+
+interface GeoFixture {
+  permissionState: 'granted' | 'denied' | 'prompt' | 'missing-api' | 'rejecting-api' | 'missing-geolocation';
+  position?: { lat: number; lon: number };
+  positionError?: boolean;
+  neverResolve?: boolean;
+  timezone?: string;
+  cachedCoords?: { lat: number; lon: number } | null;
+  cachedRegion?: string | null;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __wmGeoStartupFixture: GeoFixture | undefined;
+  // eslint-disable-next-line no-var
+  var __wmPredictionStubState: { hydrated?: unknown } | undefined;
+}
+
+function installFixture(fixture: GeoFixture): { getPositionCalls: () => number } {
+  let getPositionCalls = 0;
+  const state = { getPositionCalls: () => getPositionCalls };
+
+  const session = new Map<string, string>();
+  if (fixture.cachedCoords) session.set('wm-geo-coords', JSON.stringify(fixture.cachedCoords));
+  if (fixture.cachedRegion) session.set('wm-geo-region', fixture.cachedRegion);
+  (globalThis as Record<string, unknown>).sessionStorage = {
+    getItem: (k: string) => (session.has(k) ? session.get(k)! : null),
+    setItem: (k: string, v: string) => { session.set(k, String(v)); },
+    removeItem: (k: string) => { session.delete(k); },
+    clear: () => session.clear(),
+    get length() { return session.size; },
+    key: (i: number) => [...session.keys()][i] ?? null,
+  };
+
+  const nav: Record<string, unknown> = {};
+  Object.defineProperty(globalThis, 'navigator', { value: nav, configurable: true, writable: true });
+  if (fixture.permissionState === 'missing-api') {
+    nav.permissions = undefined;
+  } else if (fixture.permissionState === 'rejecting-api') {
+    nav.permissions = { query: async () => { throw new Error('denied'); } };
+  } else {
+    nav.permissions = { query: async () => ({ state: fixture.permissionState }) };
+  }
+  if (fixture.permissionState === 'missing-geolocation') {
+    nav.geolocation = undefined;
+  } else {
+    nav.geolocation = {
+      getCurrentPosition: (
+        onSuccess: (pos: unknown) => void,
+        onError: (err: unknown) => void,
+      ) => {
+        getPositionCalls += 1;
+        if (fixture.neverResolve) return; // deliberately unresolved lookup
+        if (fixture.positionError || !fixture.position) {
+          queueMicrotask(() => onError(new Error('Position unavailable')));
+          return;
+        }
+        const { lat, lon } = fixture.position;
+        queueMicrotask(() => onSuccess({ coords: { latitude: lat, longitude: lon } }));
+      },
+    };
+  }
+  const tz = fixture.timezone ?? 'UTC';
+  const dtf = Intl.DateTimeFormat;
+  (Intl as Record<string, unknown>).DateTimeFormat = function (...args: unknown[]) {
+    const fmt = new (dtf as new (...a: unknown[]) => { resolvedOptions: () => { timeZone?: string } })(...args);
+    const orig = fmt.resolvedOptions.bind(fmt);
+    fmt.resolvedOptions = () => ({ ...orig(), timeZone: tz });
+    return fmt;
+  } as unknown as typeof Intl.DateTimeFormat;
+
+  return state;
+}
+
+async function loadUserLocation() {
+  const result = await build({
+    entryPoints: [resolve(root, 'src/utils/user-location.ts')],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    plugins: [{
+      name: 'geo-startup-stubs',
+      setup(buildApi) {
+        buildApi.onResolve({ filter: /^@\/services\/runtime$/ }, () => ({ path: 'runtime-stub', namespace: 'stub' }));
+        buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({
+          contents: `export function isDesktopRuntime() { return false; }
+export function toApiUrl(p) { return p; }`,
+          loader: 'ts',
+        }));
+      },
+    }],
+  });
+  const url = `data:text/javascript;base64,${Buffer.from(result.outputFiles[0]!.text).toString('base64')}`;
+  return import(url) as Promise<typeof import('../src/utils/user-location.ts')>;
+}
+
+async function loadPredictionService() {
+  const stubModules = new Map<string, string>([
+    ['rpc-client-stub', `export function getRpcBaseUrl() { return 'https://example.test'; }`],
+    ['config-stub', `export const SITE_VARIANT = 'full';`],
+    ['utils-stub', `export function createCircuitBreaker() {
+      return { execute: async (fn, fallback) => { try { return await fn(); } catch { return fallback; } } };
+    }`],
+    ['bootstrap-stub', `export function getHydratedData() {
+      return globalThis.__wmPredictionStubState?.hydrated;
+    }`],
+    ['generated-rpc-clients-stub', `export class PredictionServiceClient {
+      async listPredictionMarkets() { return { markets: [], dataAvailable: false }; }
+    }`],
+  ]);
+  const aliases = new Map([
+    ['@/services/rpc-client', 'rpc-client-stub'],
+    ['@/config', 'config-stub'],
+    ['@/utils', 'utils-stub'],
+    ['@/services/bootstrap', 'bootstrap-stub'],
+    ['@/services/generated-rpc-clients', 'generated-rpc-clients-stub'],
+  ]);
+  const result = await build({
+    entryPoints: [resolve(root, 'src/services/prediction/index.ts')],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    loader: { '.json': 'json' },
+    plugins: [{
+      name: 'geo-prediction-stubs',
+      setup(buildApi) {
+        buildApi.onResolve({ filter: /.*/ }, (args) => {
+          const target = aliases.get(args.path);
+          return target ? { path: target, namespace: 'stub' } : null;
+        });
+        buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({
+          contents: stubModules.get(args.path),
+          loader: 'ts',
+        }));
+      },
+    }],
+  });
+  const url = `data:text/javascript;base64,${Buffer.from(result.outputFiles[0]!.text).toString('base64')}`;
+  return import(url) as Promise<typeof import('../src/services/prediction/index.ts')>;
+}
+
+const originalDateTimeFormat = Intl.DateTimeFormat;
+
+after(() => {
+  Intl.DateTimeFormat = originalDateTimeFormat;
+  delete (globalThis as Record<string, unknown>).navigator;
+  delete (globalThis as Record<string, unknown>).sessionStorage;
+  delete globalThis.__wmGeoStartupFixture;
+  delete globalThis.__wmPredictionStubState;
+});
+
+describe('geolocation off the readiness path (#7778)', () => {
+  let userLocation: Awaited<ReturnType<typeof loadUserLocation>>;
+
+  beforeEach(async () => {
+    userLocation = await loadUserLocation();
+    userLocation.__resetSharedPositionRequestForTests();
+  });
+
+  it('initial region resolves synchronously without permission/position work', () => {
+    installFixture({ permissionState: 'granted', neverResolve: true, timezone: 'Europe/Berlin' });
+    // Berlin → eu with zero async work and zero position calls.
+    assert.equal(userLocation.initialRegionFromCache(true), 'eu');
+    assert.equal(userLocation.initialRegionFromCache(false), 'global');
+  });
+
+  it('usable cached region wins; cached coords derive; failures stay global', () => {
+    installFixture({ permissionState: 'denied', cachedRegion: 'asia', timezone: 'Europe/Berlin' });
+    assert.equal(userLocation.initialRegionFromCache(true), 'asia');
+
+    installFixture({ permissionState: 'denied', cachedCoords: { lat: 35.7, lon: 139.7 }, timezone: 'Europe/Berlin' });
+    assert.equal(userLocation.initialRegionFromCache(true), 'asia');
+
+    installFixture({ permissionState: 'denied', timezone: 'UTC' });
+    assert.equal(userLocation.initialRegionFromCache(true), 'global');
+  });
+
+  it('one in-flight position request is shared between region and precise consumers', async () => {
+    const calls = installFixture({
+      permissionState: 'granted',
+      position: { lat: 40.7, lon: -74 },
+      timezone: 'Europe/Berlin',
+    });
+    const [region, coords] = await Promise.all([
+      userLocation.resolveUserRegion(),
+      userLocation.resolvePreciseUserCoordinates(5000),
+    ]);
+    assert.equal(region, 'america');
+    assert.deepEqual(coords, { lat: 40.7, lon: -74 });
+    assert.equal(calls.getPositionCalls(), 1);
+  });
+
+  it('readiness completes while a granted lookup stays unresolved; failure keeps the fallback', async () => {
+    installFixture({ permissionState: 'granted', neverResolve: true, timezone: 'Europe/Berlin' });
+    // Synchronous seed — this is the value layout uses; it must not await.
+    assert.equal(userLocation.initialRegionFromCache(true), 'eu');
+
+    installFixture({ permissionState: 'granted', positionError: true, timezone: 'Europe/Berlin' });
+    userLocation.__resetSharedPositionRequestForTests();
+    assert.equal(await userLocation.resolveUserRegion(), 'eu');
+    assert.equal(await userLocation.resolvePreciseUserCoordinates(5000), null);
+  });
+
+  it('denied / prompt / missing geolocation / rejecting permissions API never prompt and fall back', async () => {
+    for (const permissionState of ['denied', 'prompt', 'missing-geolocation', 'missing-api', 'rejecting-api'] as const) {
+      installFixture({ permissionState, timezone: 'Europe/Berlin' });
+      userLocation.__resetSharedPositionRequestForTests();
+      assert.equal(await userLocation.resolveUserRegion(), 'eu', `region for ${permissionState}`);
+      assert.equal(await userLocation.resolvePreciseUserCoordinates(5000), null, `coords for ${permissionState}`);
+    }
+  });
+
+  it('cached-region-only and cached-coordinate-only cases skip position work', async () => {
+    const cached = installFixture({
+      permissionState: 'granted',
+      neverResolve: true,
+      cachedRegion: 'mena',
+      timezone: 'Europe/Berlin',
+    });
+    assert.equal(await userLocation.resolveUserRegion(), 'mena');
+    assert.equal(cached.getPositionCalls(), 0);
+
+    const coordOnly = installFixture({
+      permissionState: 'granted',
+      neverResolve: true,
+      cachedCoords: { lat: 48.8, lon: 2.35 },
+      timezone: 'America/New_York',
+    });
+    userLocation.__resetSharedPositionRequestForTests();
+    assert.equal(await userLocation.resolveUserRegion(), 'eu');
+    assert.equal(coordOnly.getPositionCalls(), 0);
+  });
+
+  it('late-region re-ranking matches fetch-time ranking without another fetch', async () => {
+    const prediction = await loadPredictionService();
+    const markets = [
+      { title: 'US election odds shift', yesPrice: 55, regions: ['america'] },
+      { title: 'Global markets steady', yesPrice: 50 },
+      { title: 'Germany coalition talks', yesPrice: 60, regions: ['eu'] },
+    ];
+    const fetchTime = prediction.reprioritizeMarketsForRegion(markets, 'eu', 15);
+    assert.deepEqual(fetchTime.map((m) => m.title), [
+      'Germany coalition talks',
+      'US election odds shift',
+      'Global markets steady',
+    ]);
+    // Stable within partitions: base relevance order preserved.
+    const rerank = prediction.reprioritizeMarketsForRegion(markets, 'america', 15);
+    assert.deepEqual(rerank.map((m) => m.title), [
+      'US election odds shift',
+      'Global markets steady',
+      'Germany coalition talks',
+    ]);
+    assert.deepEqual(prediction.reprioritizeMarketsForRegion(markets, 'global', 15), markets);
+  });
+});

--- a/tests/geo-startup-readiness.test.mts
+++ b/tests/geo-startup-readiness.test.mts
@@ -271,4 +271,26 @@ describe('geolocation off the readiness path (#7778)', () => {
     ]);
     assert.deepEqual(prediction.reprioritizeMarketsForRegion(markets, 'global', 15), markets);
   });
+
+  it('retained candidate pool promotes region matches hidden below the display slice', async () => {
+    const prediction = await loadPredictionService();
+    // 16 non-matching markets fill the display slice; the region match sits at
+    // position 17 of the 25-candidate pool — invisible to a re-rank of the
+    // truncated 15, promotable from the retained pool.
+    const pool = Array.from({ length: 16 }, (_, i) => ({ title: `Global market ${i}`, yesPrice: 50 }));
+    pool.push({ title: 'Germany coalition talks', yesPrice: 60, regions: ['eu'] });
+    for (let i = 0; i < 8; i++) pool.push({ title: `Global tail ${i}`, yesPrice: 50 });
+    assert.equal(pool.length, 25);
+
+    const displayed = pool.slice(0, 15);
+    assert.ok(!displayed.some((m) => m.regions?.includes('eu')));
+
+    const rerankedTruncated = prediction.reprioritizeMarketsForRegion(displayed, 'eu', 15);
+    assert.ok(!rerankedTruncated.some((m) => m.regions?.includes('eu')));
+
+    const rerankedPool = prediction.reprioritizeMarketsForRegion(
+      prediction.predictionCandidatePool(pool), 'eu', 15,
+    );
+    assert.equal(rerankedPool[0]?.title, 'Germany coalition talks');
+  });
 });


### PR DESCRIPTION
Closes #7778 (Wave 2, study item 4 of #7774).

## What changed
- `src/utils/user-location.ts`: new synchronous `initialRegionFromCache(isMobile)` (cached region > cached coords > timezone > global; desktop stays global); single shared in-flight position request with documented 5,000 ms budget (`SHARED_POSITION_TIMEOUT_MS`, maxAge 300,000 ms preserved), cleared on settle so later explicit attempts retry; `resolveUserRegion` reuses the shared request instead of its own 3,000 ms lookup.
- `src/App.ts`: seeds `resolvedLocation` synchronously before layout so layout + event-handler readiness never await permission/position work; background `resolveUserRegion()` refines via `applyLateGeoRegion` (prediction re-rank only, no map jump); at most one automatic precise mobile recenter, guarded on app-alive + URL view/coords + viewport-authority token (pan/zoom, preset, search, country nav supersede); never late-recenters desktop; destroy resets the flag so old-app callbacks cannot move the new map/panels.
- `src/services/prediction/index.ts`: exported `reprioritizeMarketsForRegion` (stable partition, same match rules) shared by fetch-time and late-region paths.
- `src/app/data-loader.ts`: `loadPredictions` generation-guarded; new `reprioritizeLateRegionPredictions` re-ranks the kept candidate set with no extra fetch; stale in-flight commits drop.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `node scripts/lint-boundaries.mjs` — clean
- `git diff --check` — clean
- New `tests/geo-startup-readiness.test.mts` (7 cases: sync seed, cached-region/coords priority, shared single request, unresolved-lookup readiness, 9 permission/failure fallbacks, cache-only skips, re-rank parity) — pass
- Existing `tests/prediction-country-markets-pools.test.mts` + `tests/prediction-market-rpc.test.mts` — pass (20/20 combined via run-data-tests)
- `vitest dom country-intel-lazy-headlines` — pass

## Limitations
- Controlled geolocation stubs with real module integration (esbuild bundles), not production startup timing; fake elapsed time is not claimed as a speedup measurement.
- No physical-device or Tauri observation; production-build before/after with delayed-location fixtures left for follow-up.