### PR TITLE
fix(earthquakes): retain provider coverage through transient misses

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -612,7 +612,14 @@ const SEED_META = {
   // Always-on loop publishes every few seconds. Five minutes tolerates deploy
   // churn while still detecting a stopped worker well before leases age out.
   companyMonitoringWorker: { key: 'seed-meta:company-monitoring:worker', maxStaleMin: 5, workerControl: true },
-  earthquakes:      { key: 'seed-meta:seismology:earthquakes',  maxStaleMin: 30 },
+  earthquakes: {
+    key: 'seed-meta:seismology:earthquakes', maxStaleMin: 30,
+    sourceFailure: {
+      warnAfterConsecutive: 2, maxPendingMin: 10,
+      successAtField: 'lastSourceSuccessAt',
+      failureCodePattern: /^EARTHQUAKE_UPSTREAM_INCOMPLETE$/,
+    },
+  },
   wildfires:        {
     key: 'seed-meta:wildfire:fires',
     maxStaleMin: 360,
@@ -2249,7 +2256,8 @@ function projectSourceFailure(meta, policy, now, maxStaleMin) {
   if (policy.maxPendingMin != null) {
     const first = meta.firstSourceFailureAt;
     const attempt = meta.lastSourceAttemptAt;
-    const success = meta.fetchedAt;
+    // A mixed-source publication may be new while one retained provider is older.
+    const success = meta[policy.successAtField || 'fetchedAt'];
     const validEpisode = [first, attempt, success].every((value) => Number.isSafeInteger(value) && value > 0)
       && success <= first && first <= attempt && attempt <= now;
     const deadline = validEpisode

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -515,6 +515,10 @@ degraded.
 
 ### Staleness Thresholds (maxStaleMin)
 
+Earthquake ingestion retries transient USGS or NRCan failures once. The internal `seismology:earthquakes:providers:v1` snapshot keeps each provider's parsed observations and original success clock separately. A failed provider can contribute last-good coverage for less than 30 minutes, provided its content is still within the existing 48-hour budget. Fresh events from the other provider continue to publish.
+
+The first exhausted transient failure remains visible as pending only with usable coverage from both providers. Its deadline is the earlier of 10 minutes after the first failed run or 30 minutes after the oldest provider success. A second failed run for that provider warns immediately. Missing, malformed, expired, or permanently failed coverage earns no pending period. Polling health cannot reset the deadline, and a successful provider fetch resets only that provider's failure streak. The five-minute cron and existing freshness thresholds are unchanged.
+
 Selected thresholds from `SEED_META`:
 
 | Domain | Max Stale (min) | Notes |

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -111,14 +111,15 @@ export function isStaleContentGraceProblem(problem, now = Date.now()) {
 }
 
 export function isSourceFailurePendingProblem(problem, now = Date.now()) {
+  const earthquake = problem?.errorCode === 'EARTHQUAKE_UPSTREAM_INCOMPLETE';
   return problem?.status === 'SEED_ERROR'
     && Number.isFinite(problem.records) && problem.records > 0
     && Number.isFinite(problem.seedAgeMin) && problem.seedAgeMin >= 0
     && Number.isFinite(problem.maxStaleMin) && problem.seedAgeMin <= problem.maxStaleMin
     && problem.consecutiveSourceFailures === 1
-    && typeof problem.errorCode === 'string' && /^MND_[A-Z0-9_]{1,60}$/.test(problem.errorCode)
+    && typeof problem.errorCode === 'string' && (earthquake || /^MND_[A-Z0-9_]{1,60}$/.test(problem.errorCode))
     && problem.errorCode === problem.lastSourceFailureCode
-    && hasActiveBoundedDeadline(problem.sourceFailurePendingUntil, now, 215 * 60_000);
+    && hasActiveBoundedDeadline(problem.sourceFailurePendingUntil, now, (earthquake ? 15 : 215) * 60_000);
 }
 
 export function findPendingDiagnostics(payload, now = Date.now()) {

--- a/scripts/seed-earthquakes.mjs
+++ b/scripts/seed-earthquakes.mjs
@@ -7,9 +7,10 @@
 //   - startCommand: node seed-earthquakes.mjs
 //   - Cron schedule: "*/5 * * * *" (every 5min UTC)
 
-import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, httpRetryError, readSeedSnapshot, runSeed, writeExtraKey } from './_seed-utils.mjs';
 import {
   EARTHQUAKES_MAX_CONTENT_AGE_MIN,
+  EARTHQUAKE_PROVIDERS_KEY,
   NRCAN_ATOM_URL,
   earthquakesAfterPublish,
   earthquakesContentMeta,
@@ -23,7 +24,7 @@ loadEnvFile(import.meta.url);
 
 const USGS_FEED_URL = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_week.geojson';
 const CANONICAL_KEY = 'seismology:earthquakes:v1';
-const CACHE_TTL = 21600; // 6h — 6x the 1h cron interval (was 2x = survived only 1 missed run)
+const CACHE_TTL = 21600; // 6h storage; provider reuse and health remain bounded to 30 minutes.
 
 // Seismic scoring intentionally uses only high-signal nuclear-test centroids.
 // Broader registry entries such as missile ranges, exercises, or one-off low-signal
@@ -85,13 +86,18 @@ async function fetchUsgs(fetchFn) {
     headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
     signal: AbortSignal.timeout(15_000),
   });
-  if (!resp.ok) throw new Error(`USGS API error: ${resp.status}`);
+  if (!resp.ok) {
+    await resp.body?.cancel?.();
+    throw httpRetryError(resp, { remainingBudgetMs: 2_000 });
+  }
   return parseUsgsGeojson(await resp.json());
 }
 
 async function fetchEarthquakes() {
   const cache = new Map();
+  const previousSources = await readSeedSnapshot(EARTHQUAKE_PROVIDERS_KEY);
   const merged = await fetchMergedEarthquakes({
+    previousSources,
     fetchUsgs: () => fetchUsgs(globalThis.fetch),
     fetchNrcan: () => fetchNrcanAtom({ fetchFn: globalThis.fetch, cache, url: NRCAN_ATOM_URL }),
   });
@@ -120,6 +126,11 @@ runSeed('seismology', 'earthquakes', CANONICAL_KEY, fetchEarthquakes, {
   contentMeta: earthquakesContentMeta,
   maxContentAgeMin: EARTHQUAKES_MAX_CONTENT_AGE_MIN,
   publishTransform: earthquakesPublishTransform,
+  // Persist recovery state before replacing the canonical payload. A failed
+  // state write must not leave a partial publication under old success metadata.
+  beforePublish: async (data) => {
+    await writeExtraKey(EARTHQUAKE_PROVIDERS_KEY, data._providerSnapshots, CACHE_TTL);
+  },
   afterPublish: earthquakesAfterPublish,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seismology/nrcan-atom.mjs
+++ b/scripts/seismology/nrcan-atom.mjs
@@ -1,7 +1,7 @@
 // Pure Earthquakes Canada (NRCan) Atom parser + USGS merge/dedup helpers.
 // Tests import this module, not the seeder entrypoint.
 
-import { CHROME_UA, roundGeoCoordinate } from '../_seed-utils.mjs';
+import { CHROME_UA, httpRetryError, roundGeoCoordinate, withRetry } from '../_seed-utils.mjs';
 import { decodeHtmlEntities } from '../_html-entities.mjs';
 
 export const NRCAN_ATOM_HOST = 'www.earthquakescanada.nrcan.gc.ca';
@@ -10,6 +10,8 @@ export const NRCAN_OFFICIAL_PAGE = 'https://www.earthquakescanada.nrcan.gc.ca/in
 // Live canada-en.atom was 343771 bytes on 2026-08-13; 342KB is below that, so raise.
 export const MAX_NRCAN_ATOM_BYTES = 1024 * 1024;
 export const EARTHQUAKES_MAX_CONTENT_AGE_MIN = 2 * 24 * 60; // 48h — min() of successful upstream newest
+export const EARTHQUAKE_PROVIDERS_KEY = 'seismology:earthquakes:providers:v1';
+const PROVIDER_MAX_AGE_MS = 30 * 60_000;
 // Align NRCan's 30-day national bulletin with the USGS M4.5+ week layer.
 export const USGS_MIN_MAGNITUDE = 4.5;
 export const EARTHQUAKES_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -27,6 +29,7 @@ export class NrcanAtomParseError extends Error {
     super(message);
     this.name = 'NrcanAtomParseError';
     this.code = 'SEED_ERROR';
+    this.nonRetryable = true;
   }
 }
 
@@ -172,12 +175,12 @@ export function parseNrcanAtom(xml) {
 async function readBoundedText(response, maxBytes) {
   const advertisedLength = Number(response.headers?.get?.('content-length'));
   if (Number.isFinite(advertisedLength) && advertisedLength > maxBytes) {
-    throw new Error('RESPONSE_TOO_LARGE');
+    throw Object.assign(new Error('RESPONSE_TOO_LARGE'), { nonRetryable: true });
   }
   const reader = response.body?.getReader?.();
   if (!reader) {
     const text = await response.text();
-    if (Buffer.byteLength(text, 'utf8') > maxBytes) throw new Error('RESPONSE_TOO_LARGE');
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) throw Object.assign(new Error('RESPONSE_TOO_LARGE'), { nonRetryable: true });
     return text;
   }
   const chunks = [];
@@ -189,7 +192,7 @@ async function readBoundedText(response, maxBytes) {
       total += value.byteLength;
       if (total > maxBytes) {
         await reader.cancel().catch(() => {});
-        throw new Error('RESPONSE_TOO_LARGE');
+        throw Object.assign(new Error('RESPONSE_TOO_LARGE'), { nonRetryable: true });
       }
       chunks.push(value);
     }
@@ -208,7 +211,7 @@ export async function fetchApprovedAtom(url, {
   const parsed = new URL(url);
   const allowed = new Set((allowedHosts || []).map((host) => String(host).toLowerCase()));
   if (parsed.protocol !== 'https:' || !allowed.has(parsed.hostname.toLowerCase())) {
-    throw new Error('UNTRUSTED_SOURCE_HOST');
+    throw Object.assign(new Error('UNTRUSTED_SOURCE_HOST'), { nonRetryable: true });
   }
   const cacheKey = nrcanAtomCacheKey(parsed.toString());
   if (cache?.has(cacheKey)) return cache.get(cacheKey);
@@ -221,7 +224,10 @@ export async function fetchApprovedAtom(url, {
     redirect: 'error',
     signal: AbortSignal.timeout(15_000),
   });
-  if (!response.ok) throw Object.assign(new Error(`HTTP_${response.status}`), { status: response.status });
+  if (!response.ok) {
+    await response.body?.cancel?.();
+    throw httpRetryError(response, { remainingBudgetMs: 2_000 });
+  }
   const xml = await readBoundedText(response, maxBytes);
   cache?.set(cacheKey, xml);
   return xml;
@@ -249,7 +255,7 @@ export async function fetchNrcanAtom({
 
 export function parseUsgsGeojson(geojson) {
   if (!geojson || typeof geojson !== 'object' || !Array.isArray(geojson.features)) {
-    throw new Error('SEED_ERROR');
+    throw Object.assign(new Error('SEED_ERROR'), { nonRetryable: true });
   }
   const earthquakes = [];
   let newestAt = null;
@@ -388,52 +394,80 @@ export function mergeEarthquakeFeeds(usgsEvents = [], nrcanEvents = [], nowMs = 
   ];
 }
 
-export async function fetchMergedEarthquakes({ fetchUsgs, fetchNrcan, nowMs = Date.now() }) {
-  const [usgsResult, nrcanResult] = await Promise.allSettled([
-    fetchUsgs(),
-    fetchNrcan(),
-  ]);
-  const usgsOk = usgsResult.status === 'fulfilled';
-  const nrcanOk = nrcanResult.status === 'fulfilled';
-  if (!usgsOk && !nrcanOk) {
-    const usgsErr = usgsResult.reason?.message || usgsResult.reason;
-    const nrcanErr = nrcanResult.reason?.message || nrcanResult.reason;
-    throw new Error(`All earthquake upstreams failed (usgs: ${usgsErr}; nrcan: ${nrcanErr})`);
-  }
-  if (!usgsOk) console.warn(`[earthquakes] USGS failed: ${usgsResult.reason?.message || usgsResult.reason}`);
-  if (!nrcanOk) console.warn(`[earthquakes] NRCan failed: ${nrcanResult.reason?.message || nrcanResult.reason}`);
+function usableProvider(snapshot, source, nowMs) {
+  return snapshot && Number.isSafeInteger(snapshot.fetchedAt)
+    && snapshot.fetchedAt > 0 && snapshot.fetchedAt <= nowMs
+    && nowMs - snapshot.fetchedAt < PROVIDER_MAX_AGE_MS
+    && Number.isSafeInteger(snapshot.newestAt) && snapshot.newestAt > 0
+    && snapshot.newestAt <= nowMs + CLOCK_SKEW_MS
+    && nowMs - snapshot.newestAt <= EARTHQUAKES_MAX_CONTENT_AGE_MIN * 60_000
+    && Array.isArray(snapshot.earthquakes)
+    && snapshot.earthquakes.every(eq => eq?.source === source && typeof eq.id === 'string'
+      && eq.id.length > 0 && Number.isFinite(eq.magnitude) && Number.isFinite(eq.occurredAt)
+      && Number.isFinite(eq.location?.latitude) && Number.isFinite(eq.location?.longitude));
+}
 
-  const usgsEvents = usgsOk ? (usgsResult.value.earthquakes || []) : [];
-  const nrcanEvents = nrcanOk ? (nrcanResult.value.earthquakes || []) : [];
-  // A failed upstream must be REPORTED, not merely omitted. earthquakesContentMeta
-  // takes min() over the upstreams that answered, which catches a FROZEN NRCan —
-  // its stale newestAt drags the minimum down — but not a FAILED one, whose null
-  // is filtered out and leaves USGS's fresh timestamp as the answer. An NRCan
-  // outage therefore published a fresh, healthy, USGS-only result with every
-  // Canadian event silently absent. Callers use _failedSources to degrade.
+export async function fetchMergedEarthquakes({ fetchUsgs, fetchNrcan, previousSources, nowMs = Date.now() }) {
+  const sources = ['usgs', 'nrcan'];
+  const results = await Promise.allSettled([fetchUsgs, fetchNrcan].map(fetchSource => withRetry(async () => {
+    try { return await fetchSource(); }
+    catch (error) {
+      if (error instanceof SyntaxError) error.nonRetryable = true;
+      throw error;
+    }
+  }, 1, 500)));
+  const snapshots = {};
+  const available = {};
   const failedSources = [];
-  if (!usgsOk) failedSources.push('usgs');
-  if (!nrcanOk) failedSources.push('nrcan');
+  const failureDetails = [];
+  for (const [index, source] of sources.entries()) {
+    const result = results[index];
+    if (result.status === 'fulfilled') {
+      snapshots[source] = { ...result.value, fetchedAt: nowMs, consecutiveFailures: 0, firstFailureAt: null };
+      available[source] = snapshots[source];
+      continue;
+    }
+    const previous = previousSources?.[source];
+    const usable = usableProvider(previous, source, nowMs);
+    const priorCount = previous?.consecutiveFailures;
+    const knownStreak = Number.isInteger(priorCount) && priorCount >= 0 && priorCount <= 100;
+    const firstFailureAt = knownStreak && priorCount > 0
+      && Number.isSafeInteger(previous.firstFailureAt) && previous.firstFailureAt >= previous.fetchedAt
+      && previous.firstFailureAt <= nowMs ? previous.firstFailureAt : nowMs;
+    // Unknown predecessors, unusable coverage, and permanent failures earn no grace.
+    const nextCount = knownStreak ? Math.min(priorCount + 1, 100) : 2;
+    const consecutiveFailures = usable && !result.reason?.nonRetryable ? nextCount : Math.max(2, nextCount);
+    snapshots[source] = { ...(usable ? previous : {}), consecutiveFailures, firstFailureAt };
+    if (usable) available[source] = snapshots[source];
+    failedSources.push(source);
+    const cause = result.reason?.cause?.code || result.reason?.cause?.message;
+    failureDetails.push(`${source}: ${result.reason?.message || result.reason}${cause ? ` (${cause})` : ''}`);
+  }
+  const failureDetail = failureDetails.join('; ');
+  if (failureDetail) console.warn(`[earthquakes] upstream failure: ${failureDetail}`);
+  if (!available.usgs && !available.nrcan) {
+    // Per-provider retries are already exhausted; runSeed must not multiply them.
+    throw Object.assign(new Error(`All earthquake upstreams failed (${failureDetail})`), { nonRetryable: true });
+  }
   return {
-    earthquakes: mergeEarthquakeFeeds(usgsEvents, nrcanEvents, nowMs),
+    earthquakes: mergeEarthquakeFeeds(available.usgs?.earthquakes, available.nrcan?.earthquakes, nowMs),
+    _providerSnapshots: snapshots,
     _failedSources: failedSources,
-    _failureDetail: failedSources.length
-      ? [
-        usgsOk ? null : `usgs: ${usgsResult.reason?.message || usgsResult.reason}`,
-        nrcanOk ? null : `nrcan: ${nrcanResult.reason?.message || nrcanResult.reason}`,
-      ].filter(Boolean).join('; ')
-      : '',
-    _usgsNewestAt: usgsOk ? (usgsResult.value.newestAt ?? null) : null,
-    _usgsOldestAt: usgsOk ? (usgsResult.value.oldestAt ?? null) : null,
-    _nrcanNewestAt: nrcanOk ? (nrcanResult.value.newestAt ?? null) : null,
-    _nrcanOldestAt: nrcanOk ? (nrcanResult.value.oldestAt ?? null) : null,
+    _failureDetail: failureDetail,
+    _lastSourceSuccessAt: sources.every(source => usableProvider(available[source], source, nowMs))
+      ? Math.min(...sources.map(source => available[source].fetchedAt)) : null,
+    _sourceAttemptAt: nowMs,
+    _usgsNewestAt: available.usgs?.newestAt ?? null,
+    _usgsOldestAt: available.usgs?.oldestAt ?? null,
+    _nrcanNewestAt: available.nrcan?.newestAt ?? null,
+    _nrcanOldestAt: available.nrcan?.oldestAt ?? null,
   };
 }
 
 /**
- * Content-age is min() of successful upstream newest timestamps so USGS
- * freshness cannot hide an NRCan freeze. Failed upstreams are omitted —
- * never substituted with Date.now().
+ * Content-age is min() of live or retained provider timestamps so USGS
+ * freshness cannot hide an NRCan freeze. Missing coverage is reported separately;
+ * a retained provider keeps its original clock, never Date.now().
  */
 export function earthquakesContentMeta(data, nowMs = Date.now()) {
   const newestParts = [];
@@ -482,24 +516,10 @@ export function earthquakesPublishTransform(data) {
 }
 
 /**
- * Publishing a single-upstream result is right — one feed beats none — but it
- * must not read OK.
- *
- * earthquakesContentMeta above takes min() over the upstreams that ANSWERED.
- * That catches a FROZEN NRCan, whose stale newestAt drags the minimum down, but
- * not a FAILED one: its null is filtered out and USGS's fresh timestamp becomes
- * the answer. An NRCan outage therefore passed the staleness gate AND the
- * content-age gate while every Canadian event was missing — indistinguishable
- * from a quiet week in Canada.
- *
- * Lives here rather than in the seeder for two reasons: it is pure, and
- * importing seed-earthquakes.mjs executes runSeed() at module scope, so a test
- * could not reach it there.
- *
- * Must be wired as runSeed's `afterPublish`. That is the only path into
- * seed-meta — runSeed writes the metadata itself and merges only
- * `freshnessMetaPatch`. Returning these fields from the fetch function is inert:
- * publishTransform strips them and nothing reads them.
+ * Preserve the source diagnosis even when retained coverage earns bounded pending.
+ * Without complete coverage, content-age alone cannot detect a missing provider.
+ * Must be wired to runSeed's afterPublish: publishTransform strips diagnostics,
+ * and only freshnessMetaPatch reaches the health reader.
  */
 export function earthquakesAfterPublish(data) {
   const failed = Array.isArray(data?._failedSources) ? data._failedSources : [];
@@ -508,10 +528,16 @@ export function earthquakesAfterPublish(data) {
     `[earthquakes] DEGRADED — upstream(s) failed: ${data?._failureDetail || failed.join(', ')}`,
   );
   return {
+    completionState: 'DEGRADED',
     freshnessMetaPatch: {
       sourceState: 'degraded',
       errorCode: 'EARTHQUAKE_UPSTREAM_INCOMPLETE',
       skipReason: `upstream-failed:${failed.join('+')}`,
+      lastSourceSuccessAt: data._lastSourceSuccessAt ?? null,
+      lastSourceAttemptAt: data._sourceAttemptAt,
+      firstSourceFailureAt: Math.min(...failed.map(source => data._providerSnapshots?.[source]?.firstFailureAt ?? Infinity)),
+      consecutiveSourceFailures: Math.max(...failed.map(source => data._providerSnapshots?.[source]?.consecutiveFailures ?? 2)),
+      lastSourceFailureCode: 'EARTHQUAKE_UPSTREAM_INCOMPLETE',
     },
   };
 }

--- a/tests/earthquake-provider-recovery.test.mjs
+++ b/tests/earthquake-provider-recovery.test.mjs
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { __testing__ as health } from '../api/health.js';
+import { isSourceFailurePendingProblem } from '../scripts/check-seed-freshness.mjs';
+import {
+  fetchMergedEarthquakes, earthquakesAfterPublish, earthquakesContentMeta, fetchNrcanAtom, NRCAN_ATOM_URL,
+} from '../scripts/seismology/nrcan-atom.mjs';
+
+const NOW = Date.parse('2026-09-06T10:00:00Z');
+const MIN = 60_000;
+process.env.WM_SEED_RETRY_DELAY_MS = '1';
+const event = (source, now = NOW) => ({
+  id: `${source}:event`, source, magnitude: 5, depthKm: 10,
+  location: { latitude: source === 'usgs' ? 0 : 50, longitude: 0 },
+  occurredAt: now - MIN, place: source, sourceUrl: 'https://example.test/event',
+});
+const feed = (source, now = NOW) => ({ earthquakes: [event(source, now)], newestAt: now, oldestAt: now - MIN });
+const fail = async () => { throw new TypeError('fetch failed', { cause: new Error('ECONNRESET') }); };
+const firstRun = () => fetchMergedEarthquakes({ fetchUsgs: async () => feed('usgs'), fetchNrcan: async () => feed('nrcan'), nowMs: NOW });
+
+function verdict(data, now, overrides = {}, bytes = 1024) {
+  const meta = {
+    fetchedAt: now, recordCount: data.earthquakes.length,
+    ...earthquakesContentMeta(data, now), maxContentAgeMin: 2880,
+    ...earthquakesAfterPublish(data)?.freshnessMetaPatch, ...overrides,
+  };
+  const key = health.BOOTSTRAP_KEYS.earthquakes;
+  return health.classifyKey('earthquakes', key, { allowOnDemand: false }, {
+    keyStrens: new Map([[key, bytes]]), keyErrors: new Map(), keyMetaErrors: new Map(),
+    keyMetaValues: new Map([['seed-meta:seismology:earthquakes', JSON.stringify(meta)]]), now,
+  });
+}
+
+test('retries a transient provider once before recording a failed run', async () => {
+  let calls = 0;
+  const data = await fetchMergedEarthquakes({
+    fetchUsgs: async () => feed('usgs'),
+    fetchNrcan: async () => { if (++calls === 1) return fail(); return feed('nrcan'); },
+    nowMs: NOW,
+  });
+  assert.equal(calls, 2);
+  assert.deepEqual(data._failedSources, []);
+  assert.equal(data.earthquakes.length, 2);
+});
+
+test('first transient miss retains provider events and clock; second run warns; recovery clears', async () => {
+  const good = await firstRun();
+  let calls = 0;
+  const run = (previousSources, nowMs) => fetchMergedEarthquakes({
+    fetchUsgs: async () => feed('usgs', nowMs),
+    fetchNrcan: async () => { calls++; return fail(); }, previousSources, nowMs,
+  });
+  const first = await run(good._providerSnapshots, NOW + 5 * MIN);
+  assert.equal(calls, 2);
+  assert.deepEqual(first.earthquakes.map(e => e.source), ['usgs', 'nrcan']);
+  assert.equal(first._nrcanNewestAt, NOW);
+  assert.equal(first._providerSnapshots.nrcan.fetchedAt, NOW);
+  assert.equal(earthquakesContentMeta(first).newestItemAt, NOW);
+  const pending = verdict(first, NOW + 5 * MIN);
+  assert.equal(pending.status, 'SEED_ERROR', 'diagnosis remains visible');
+  assert.equal(health.healthStatusBucket(pending, NOW + 5 * MIN), 'ok');
+  assert.equal(pending.sourceFailurePendingUntil, new Date(NOW + 15 * MIN).toISOString());
+  assert.equal(isSourceFailurePendingProblem(pending, NOW + 5 * MIN), true);
+  const compact = health.healthResponseBody({ status: 'HEALTHY', summary: { pending: 1 }, checkedAt: new Date(NOW + 5 * MIN).toISOString(), checks: { earthquakes: pending } }, true);
+  assert.deepEqual(compact.pending, { earthquakes: pending });
+  assert.equal(health.snapshotTtlSeconds(compact, NOW + 15 * MIN - 20_000), 20);
+  assert.equal(health.hasExpiredActivationGrace(compact, NOW + 15 * MIN), true);
+  assert.equal(health.healthStatusBucket(pending, NOW + 15 * MIN), 'warn', 'expires without another run');
+  assert.equal(health.healthStatusBucket(verdict(first, NOW + 5 * MIN, {}, 0), NOW + 5 * MIN), 'crit');
+
+  const second = await run(first._providerSnapshots, NOW + 10 * MIN);
+  assert.equal(second._providerSnapshots.nrcan.fetchedAt, NOW);
+  assert.equal(health.healthStatusBucket(verdict(second, NOW + 10 * MIN), NOW + 10 * MIN), 'warn');
+  const recovered = await fetchMergedEarthquakes({
+    fetchUsgs: async () => feed('usgs', NOW + 15 * MIN), fetchNrcan: async () => feed('nrcan', NOW + 15 * MIN),
+    previousSources: second._providerSnapshots, nowMs: NOW + 15 * MIN,
+  });
+  assert.deepEqual(recovered._failedSources, []);
+  assert.equal(recovered._providerSnapshots.nrcan.consecutiveFailures, 0);
+  assert.equal(verdict(recovered, NOW + 15 * MIN).status, 'OK');
+});
+
+test('missing, malformed, future, or expired provider coverage never gets pending', async () => {
+  const good = await firstRun();
+  for (const previousSources of [
+    undefined,
+    { ...good._providerSnapshots, nrcan: null },
+    { ...good._providerSnapshots, nrcan: { ...good._providerSnapshots?.nrcan, fetchedAt: NOW + 6 * MIN } },
+    { ...good._providerSnapshots, nrcan: { ...good._providerSnapshots?.nrcan, fetchedAt: NOW - 25 * MIN } },
+    { ...good._providerSnapshots, nrcan: { ...good._providerSnapshots?.nrcan, newestAt: NOW - 3 * 1440 * MIN } },
+    { ...good._providerSnapshots, nrcan: { ...good._providerSnapshots?.nrcan, earthquakes: [{}] } },
+  ]) {
+    const data = await fetchMergedEarthquakes({ fetchUsgs: async () => feed('usgs'), fetchNrcan: fail, previousSources, nowMs: NOW + 5 * MIN });
+    assert.equal(data.earthquakes.length, 1);
+    const failed = verdict(data, NOW + 5 * MIN);
+    assert.equal(health.healthStatusBucket(failed, NOW + 5 * MIN), 'warn');
+    assert.equal(failed.sourceFailurePendingUntil, undefined);
+  }
+});
+
+test('verified quiet NRCan coverage is retained and different provider failures do not combine streaks', async () => {
+  const good = await fetchMergedEarthquakes({ fetchUsgs: async () => feed('usgs'), fetchNrcan: async () => ({ ...feed('nrcan'), earthquakes: [] }), nowMs: NOW });
+  const first = await fetchMergedEarthquakes({ fetchUsgs: async () => feed('usgs'), fetchNrcan: fail, previousSources: good._providerSnapshots, nowMs: NOW + 5 * MIN });
+  assert.equal(first.earthquakes.length, 1);
+  assert.equal(health.healthStatusBucket(verdict(first, NOW + 5 * MIN), NOW + 5 * MIN), 'ok');
+  const different = await fetchMergedEarthquakes({ fetchUsgs: fail, fetchNrcan: async () => feed('nrcan', NOW + 10 * MIN), previousSources: first._providerSnapshots, nowMs: NOW + 10 * MIN });
+  assert.equal(different._providerSnapshots.usgs.consecutiveFailures, 1);
+  assert.equal(different._providerSnapshots.nrcan.consecutiveFailures, 0);
+  assert.equal(health.healthStatusBucket(verdict(different, NOW + 10 * MIN), NOW + 10 * MIN), 'ok');
+});
+
+test('both exhausted providers do not trigger outer runSeed retries when there is no retained data', async () => {
+  let calls = 0;
+  const failing = async () => { calls++; return fail(); };
+  await assert.rejects(fetchMergedEarthquakes({ fetchUsgs: failing, fetchNrcan: failing, nowMs: NOW }), err => err.nonRetryable === true);
+  assert.equal(calls, 4);
+});
+
+test('both provider failures retain bounded coverage, not an unlimited fallback', async () => {
+  const good = await firstRun();
+  const first = await fetchMergedEarthquakes({ fetchUsgs: fail, fetchNrcan: fail, previousSources: good._providerSnapshots, nowMs: NOW + 5 * MIN });
+  assert.equal(first.earthquakes.length, 2);
+  assert.equal(health.healthStatusBucket(verdict(first, NOW + 5 * MIN), NOW + 5 * MIN), 'ok');
+  const second = await fetchMergedEarthquakes({ fetchUsgs: fail, fetchNrcan: fail, previousSources: first._providerSnapshots, nowMs: NOW + 10 * MIN });
+  assert.equal(health.healthStatusBucket(verdict(second, NOW + 10 * MIN), NOW + 10 * MIN), 'warn');
+  await assert.rejects(fetchMergedEarthquakes({ fetchUsgs: fail, fetchNrcan: fail, previousSources: second._providerSnapshots, nowMs: NOW + 30 * MIN }), /All earthquake upstreams failed/);
+});
+
+test('real NRCan transport retries 503 but not permanent HTTP, unsafe hosts, oversized or malformed pages', async () => {
+  const good = await firstRun();
+  for (const scenario of ['503', '403', '429-long', 'oversized', 'malformed', 'host']) {
+    let calls = 0;
+    const data = await fetchMergedEarthquakes({
+      fetchUsgs: async () => feed('usgs'),
+      fetchNrcan: () => fetchNrcanAtom({
+        url: scenario === 'host' ? 'https://untrusted.test/feed' : NRCAN_ATOM_URL,
+        fetchFn: async (_url, init) => {
+          calls++;
+          assert.equal(init.redirect, 'error');
+          assert.ok(init.signal instanceof AbortSignal);
+          assert.ok(init.headers['User-Agent']);
+          if (scenario === '503' && calls === 1) return new Response('', { status: 503 });
+          if (scenario === '403') return new Response('', { status: 403 });
+          if (scenario === '429-long') return new Response('', { status: 429, headers: { 'Retry-After': '60' } });
+          if (scenario === 'oversized') return new Response('x', { headers: { 'content-length': '2000000' } });
+          if (scenario === 'malformed') return new Response('<html>bad gateway</html>');
+          return new Response(`<feed><updated>${new Date(NOW).toISOString()}</updated></feed>`);
+        },
+      }),
+      previousSources: good._providerSnapshots, nowMs: NOW + 5 * MIN,
+    });
+    assert.equal(calls, scenario === 'host' ? 0 : scenario === '503' ? 2 : 1, scenario);
+    assert.equal(health.healthStatusBucket(verdict(data, NOW + 5 * MIN), NOW + 5 * MIN), scenario === '503' ? 'ok' : 'warn', scenario);
+  }
+});
+
+test('pending ends at the provider deadline and cannot hide absent clocks, stale content, or missing data', async () => {
+  const good = await firstRun();
+  const first = await fetchMergedEarthquakes({ fetchUsgs: async () => feed('usgs', NOW + 29 * MIN), fetchNrcan: fail, previousSources: good._providerSnapshots, nowMs: NOW + 29 * MIN });
+  const entry = verdict(first, NOW + 29 * MIN);
+  assert.equal(entry.sourceFailurePendingUntil, new Date(NOW + 30 * MIN).toISOString());
+  for (const overrides of [
+    { lastSourceSuccessAt: null }, { lastSourceSuccessAt: NOW + 30 * MIN },
+    { firstSourceFailureAt: null }, { lastSourceAttemptAt: null },
+    { newestItemAt: NOW - 3 * 1440 * MIN }, { consecutiveSourceFailures: 2 },
+  ]) {
+    assert.notEqual(health.healthStatusBucket(verdict(first, NOW + 29 * MIN, overrides), NOW + 29 * MIN), 'ok');
+  }
+  assert.equal(isSourceFailurePendingProblem({ ...entry, sourceFailurePendingUntil: new Date(NOW + 60 * MIN).toISOString() }, NOW + 29 * MIN), false);
+});
+
+// Exercise the actual entrypoint and runSeed writes in separate cron processes.
+// Every fetch is intercepted; unknown requests fail rather than reaching a network.
+async function seedProcess(initial, now, nrcanMode, failStateWrite = false) {
+  Date.now = () => now;
+  const store = new Map(initial);
+  const calls = { usgs: 0, nrcan: 0 };
+  const redis = command => {
+    const [name, key, value] = command;
+    if (name === 'SET') { store.set(key, value); return 'OK'; }
+    if (name === 'GET') return store.get(key) ?? null;
+    if (name === 'DEL') return Number(store.delete(key));
+    if (name === 'EXPIRE' || name === 'EVAL') return 1;
+    throw new Error(`unexpected Redis command ${name}`);
+  };
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://redis.earthquake.test/get/')) return Response.json({ result: store.get(decodeURIComponent(url.split('/get/')[1])) ?? null });
+    if (url === 'https://redis.earthquake.test' || url === 'https://redis.earthquake.test/pipeline') {
+      const body = JSON.parse(init.body);
+      if (failStateWrite && body[0] === 'SET' && body[1] === 'seismology:earthquakes:providers:v1') return new Response('', { status: 403 });
+      return Response.json(Array.isArray(body[0]) ? body.map(command => ({ result: redis(command) })) : { result: redis(body) });
+    }
+    if (url === 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_week.geojson') {
+      calls.usgs++;
+      // Verify that the real USGS path also gets the bounded transient retry.
+      if (calls.usgs === 1) return new Response('', { status: 503 });
+      return Response.json({ metadata: { generated: now }, features: [{ id: 'usgs-event', properties: { mag: 5, time: now - 60000, place: 'USGS' }, geometry: { coordinates: [0, 0, 10] } }] });
+    }
+    if (url === 'https://www.earthquakescanada.nrcan.gc.ca/cache/earthquakes/canada-en.atom') {
+      calls.nrcan++;
+      if (nrcanMode === 'fail') return new Response('', { status: 503 });
+      const date = new Date(now - 60000).toISOString().replace('T', ' ').replace('.000Z', '');
+      return new Response(`<feed><updated>${new Date(now).toISOString()}</updated><entry><title>${date} UTC: M5.0 Canada</title><id>https://www.earthquakescanada.nrcan.gc.ca/?eventid=fixture</id><georss:point>50 -120</georss:point></entry></feed>`);
+    }
+    throw new Error(`unexpected network request ${url}`);
+  };
+  process.on('exit', () => console.log('FIXTURE_RESULT=' + JSON.stringify({ store: [...store], calls })));
+  await import(new URL('../scripts/seed-earthquakes.mjs', process.env.TEST_MODULE_URL));
+}
+
+test('real seeder persists provider history across cron processes and publishes matching health metadata', () => {
+  let previous = [];
+  for (const [index, mode] of ['ok', 'fail', 'fail', 'ok', 'state-write-fail'].entries()) {
+    const now = NOW + index * 5 * MIN;
+    const result = spawnSync(process.execPath, ['--input-type=module', '--eval', `(${seedProcess.toString()})(${JSON.stringify(previous)}, ${now}, ${JSON.stringify(mode === 'state-write-fail' ? 'fail' : mode)}, ${mode === 'state-write-fail'})`], {
+      encoding: 'utf8', timeout: 10_000,
+      env: {
+        PATH: process.env.PATH, NODE_TEST_CONTEXT: 'child', WM_SEED_RETRY_DELAY_MS: '1',
+        WM_SEED_ENV_FILE: '/dev/null', TEST_MODULE_URL: import.meta.url,
+        UPSTASH_REDIS_REST_URL: 'https://redis.earthquake.test', UPSTASH_REDIS_REST_TOKEN: 'fixture-only',
+      },
+    });
+    assert.equal(result.status, mode === 'state-write-fail' ? 1 : 0, result.stdout + result.stderr);
+    const captured = JSON.parse(result.stdout.split('FIXTURE_RESULT=')[1].trim());
+    if (mode === 'state-write-fail') {
+      for (const key of ['seismology:earthquakes:v1', 'seed-meta:seismology:earthquakes', 'seismology:earthquakes:providers:v1']) {
+        assert.equal(new Map(captured.store).get(key), new Map(previous).get(key), `${key} must remain unchanged when recovery-state persistence fails`);
+      }
+      continue;
+    }
+    previous = captured.store;
+    const store = new Map(previous);
+    const canonical = JSON.parse(store.get('seismology:earthquakes:v1'));
+    const meta = JSON.parse(store.get('seed-meta:seismology:earthquakes'));
+    const providers = JSON.parse(store.get('seismology:earthquakes:providers:v1'));
+    assert.equal(canonical.data.earthquakes.length, 2);
+    assert.deepEqual(Object.keys(canonical.data), ['earthquakes'], 'internal provider records stay out of the API');
+    assert.equal(captured.calls.usgs, 2);
+    assert.equal(captured.calls.nrcan, mode === 'ok' ? 1 : 2);
+    assert.match(result.stdout, mode === 'ok' ? /"state":"OK"/ : /"state":"DEGRADED"/);
+    assert.equal(providers.nrcan.fetchedAt, mode === 'ok' ? now : NOW);
+    assert.equal(meta.newestItemAt, mode === 'ok' ? now : NOW);
+    const key = health.BOOTSTRAP_KEYS.earthquakes;
+    const entry = health.classifyKey('earthquakes', key, { allowOnDemand: false }, {
+      keyStrens: new Map([[key, store.get(key).length]]), keyErrors: new Map(), keyMetaErrors: new Map(),
+      keyMetaValues: new Map([['seed-meta:seismology:earthquakes', JSON.stringify(meta)]]), now,
+    });
+    assert.equal(health.healthStatusBucket(entry, now), index === 2 ? 'warn' : 'ok');
+  }
+});


### PR DESCRIPTION
## Summary

Prevent a short USGS or NRCan transport failure from immediately dropping provider coverage and flipping production health. The September 6 10:05 UTC NRCan fetch failed once; the next five-minute run recovered. The old merged seeder had no provider retry or persisted provider fallback, and marked the incomplete result degraded immediately.

- Retry each transient provider request once, with the existing 15-second attempt timeout and bounded backoff. Permanent HTTP, malformed/oversized Atom, and untrusted hosts do not consume repeated attempts. Do not multiply exhausted provider retries through the outer seeder loop.
- Keep one internal provider snapshot with separate observations, success clocks, and failure streaks. New USGS events can publish together with retained Canadian events, and vice versa.
- Retain provider coverage for less than the existing 30-minute seed budget, subject to the existing 48-hour content budget. Never advance a failed provider's clock.
- Opt into the existing health pending policy: first exhausted transient miss with usable coverage stays visible in `pending`; second failed run warns. The deadline is the earlier of 10 minutes after the first failure or 30 minutes after the oldest provider success. Missing/expired coverage and permanent failures warn immediately.
- Match the scheduled monitor to that bounded policy. Save provider state before replacing the canonical payload, and label degraded completion logs accurately.

No schedule, source URL, API response schema, or freshness-threshold change. The five-minute cron remains unchanged. This PR is independent of the cable fix #7797 and targets `main`.

## Verification

- Four new regressions failed against the old implementation before the fix.
- 355 focused producer, health, monitor, shared retry, and metadata tests passed. Nine final provider regressions also passed, including the real seeder in separate fixture-only cron processes.
- Tested healthy -> first miss pending -> repeated miss warning -> recovery; distinct provider streaks; expiry without another poll; valid quiet NRCan; missing/malformed/future/expired state; missing canonical data; permanent HTTP/malformed/oversized/unsafe sources; retry bounds; and recovery-state write failure preserving prior canonical data and metadata.
- `npm run typecheck`, `npm run typecheck:api`, `npm run lint:boundaries`, full lint and changed-file lint passed. Full lint has existing unrelated warnings.
- `ce-code-review` lenses completed sequentially under the repository tool mapping. Repaired the publication-order finding and verified it with a subprocess regression. No unresolved actionable findings; optional external reviewer was unavailable.

## Post-deploy validation

- Let the provider snapshot initialize on a natural run. Cold/missing state deliberately receives no grace.
- Observe natural five-minute runs and persisted health incidents for 24 hours. Require both provider timestamps to advance on successful fetches.
- On a transient failure, require retained provider events and the original provider/content clocks. A retry recovery must not create a failure streak; an exhausted first miss may be pending only within its fixed deadline. The second failed run or expired coverage must warn, even without a new health observation.
- Confirm recovery clears only the recovered provider's failure streak, and the public payload has no internal provider-state fields.
- Roll back if partial coverage reads healthy without valid retained data, provider clocks advance on failures, retry counts exceed two per provider, or the pending deadline can reset.

No production seeder, deployment, Redis mutation, or configuration change was performed for this PR. Local checks and CI do not establish production acceptance.

---
Created with Compound Engineering and Codex.
