### PR TITLE
test(energy): bind copied suites to production paths

### DIFF
--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -507,7 +507,7 @@ export function parseEiaSprRow(row) {
   return { barrels: +barrels.toFixed(3), period };
 }
 
-async function fetchSprLevels() {
+export async function fetchSprLevels() {
   const apiKey = process.env.EIA_API_KEY;
   if (!apiKey) throw new Error('Missing EIA_API_KEY');
 

--- a/scripts/seed-ember-electricity.mjs
+++ b/scripts/seed-ember-electricity.mjs
@@ -27,6 +27,19 @@ const LOCK_TTL_MS = 20 * 60 * 1000; // 20 min
 const MIN_COUNTRIES = 60;
 const MIN_COUNT_RATIO = 0.75; // abort if new count < 75% of previous
 
+export function isEmberCountDrop(newCount, previousMeta) {
+  return Boolean(
+    previousMeta
+    && typeof previousMeta === 'object'
+    && previousMeta.recordCount > 0
+    && newCount < previousMeta.recordCount * MIN_COUNT_RATIO
+  );
+}
+
+export function getPipelineFailures(results) {
+  return results.filter((result) => result?.error || result?.result === 'ERR');
+}
+
 function parseDelimitedRow(line, delimiter) {
   const cells = [];
   let current = '';
@@ -248,7 +261,7 @@ async function redisGet(key) {
   return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
-async function preservePreviousSnapshot(errorMsg, stashedAllMap = null, newCountryKeys = null, dataWritten = false) {
+export async function preservePreviousSnapshot(errorMsg, stashedAllMap = null, newCountryKeys = null, dataWritten = false) {
   console.error('[EmberElectricity] Preserving previous snapshot:', errorMsg);
 
   const existingMeta = await redisGet(EMBER_META_KEY).catch(() => null);
@@ -337,12 +350,10 @@ export async function main() {
 
     // Count-drop guard: abort if new count < 75% of previous
     const prevMeta = await redisGet(EMBER_META_KEY).catch(() => null);
-    if (prevMeta && typeof prevMeta === 'object' && prevMeta.recordCount > 0) {
-      if (countries.size < prevMeta.recordCount * MIN_COUNT_RATIO) {
-        throw new Error(
-          `Ember: country count dropped from ${prevMeta.recordCount} to ${countries.size} (<75% threshold) — aborting`,
-        );
-      }
+    if (isEmberCountDrop(countries.size, prevMeta)) {
+      throw new Error(
+        `Ember: country count dropped from ${prevMeta.recordCount} to ${countries.size} (<75% threshold) — aborting`,
+      );
     }
 
     newCountryKeys = new Set(countries.keys());
@@ -386,7 +397,7 @@ export async function main() {
     }
 
     const dataResults = await redisPipeline(dataCommands);
-    const dataFailures = dataResults.filter((r) => r?.error || r?.result === 'ERR');
+    const dataFailures = getPipelineFailures(dataResults);
     if (dataFailures.length > 0) {
       throw new Error(
         `Redis pipeline: ${dataFailures.length}/${dataCommands.length} data commands failed`,

--- a/scripts/seed-energy-intelligence.mjs
+++ b/scripts/seed-energy-intelligence.mjs
@@ -154,7 +154,7 @@ async function fetchFeed(feed) {
   }
 }
 
-async function fetchEnergyIntelligence() {
+export async function fetchEnergyIntelligence() {
   const settled = await Promise.allSettled(FEEDS.map(fetchFeed));
   const allItems = [];
   for (const result of settled) {

--- a/scripts/seed-energy-spine.mjs
+++ b/scripts/seed-energy-spine.mjs
@@ -40,6 +40,14 @@ const LOCK_DOMAIN = 'energy:spine';
 const LOCK_TTL_MS = 20 * 60 * 1000; // 20 min (pipeline write of 200+ countries)
 const MIN_COVERAGE_RATIO = 0.80; // abort if new spine < 80% of previous country count
 
+export function areCoreSourcesEmpty(jodiCount, owidCount) {
+  return jodiCount === 0 && owidCount === 0;
+}
+
+export function isSpineCountDrop(newCount, previousCount) {
+  return previousCount > 0 && newCount / previousCount < MIN_COVERAGE_RATIO;
+}
+
 const ISO2_TO_UN = Object.fromEntries(Object.entries(UN_TO_ISO2).map(([unCode, iso2]) => [iso2, unCode]));
 
 // Only these reporters are seeded in comtrade:flows for spine shock inputs.
@@ -395,7 +403,7 @@ export async function main() {
       return;
     }
 
-    if (jodiCount === 0 && owidCount === 0) {
+    if (areCoreSourcesEmpty(jodiCount, owidCount)) {
       console.error('[energy-spine] Both JODI oil and OWID mix returned zero countries — aborting to preserve snapshot');
       const prevCountries = await redisGet(SPINE_COUNTRIES_KEY).catch(() => null);
       if (Array.isArray(prevCountries) && prevCountries.length > 0) {
@@ -411,22 +419,20 @@ export async function main() {
     // Step 2: Count-drop guard — check against previous _countries count
     const prevCountries = await redisGet(SPINE_COUNTRIES_KEY).catch(() => null);
     const prevCount = Array.isArray(prevCountries) ? prevCountries.length : 0;
-    if (prevCount > 0) {
+    if (isSpineCountDrop(countries.length, prevCount)) {
       const coverageRatio = countries.length / prevCount;
-      if (coverageRatio < MIN_COVERAGE_RATIO) {
-        console.error(
-          `[energy-spine] Count-drop guard triggered: ${countries.length} countries = ` +
-          `${(coverageRatio * 100).toFixed(1)}% of previous ${prevCount} — aborting to preserve snapshot`,
-        );
-        // Extend TTL on existing spine keys
-        const prevKeys = prevCountries.map(iso2 => `${SPINE_KEY_PREFIX}${iso2}`);
-        await extendExistingTtl(
-          [...prevKeys, SPINE_COUNTRIES_KEY, SPINE_META_KEY],
-          SPINE_TTL_SECONDS,
-        );
-        await writeMeta(0, 'count_drop_guard');
-        return;
-      }
+      console.error(
+        `[energy-spine] Count-drop guard triggered: ${countries.length} countries = ` +
+        `${(coverageRatio * 100).toFixed(1)}% of previous ${prevCount} — aborting to preserve snapshot`,
+      );
+      // Extend TTL on existing spine keys
+      const prevKeys = prevCountries.map(iso2 => `${SPINE_KEY_PREFIX}${iso2}`);
+      await extendExistingTtl(
+        [...prevKeys, SPINE_COUNTRIES_KEY, SPINE_META_KEY],
+        SPINE_TTL_SECONDS,
+      );
+      await writeMeta(0, 'count_drop_guard');
+      return;
     }
 
     // Read SPR policy registry once (global key, not per-country)

--- a/tests/economy-eia-spr-seed.test.mjs
+++ b/tests/economy-eia-spr-seed.test.mjs
@@ -1,6 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseEiaSprRow, parseEiaRefineryRow, SPR_TTL, REFINERY_INPUTS_TTL } from '../scripts/seed-economy.mjs';
+import {
+  fetchSprLevels,
+  parseEiaSprRow,
+  parseEiaRefineryRow,
+  SPR_TTL,
+  REFINERY_INPUTS_TTL,
+} from '../scripts/seed-economy.mjs';
 
 // ─── Key constants (imported from cache-keys pattern) ───
 // These tests intentionally cross-check the seed's internal strings against
@@ -86,27 +92,63 @@ describe('parseEiaSprRow', () => {
   });
 });
 
-// ─── computeSprWoW (inline logic mirroring fetchSprLevels) ───
+// ─── SPR weekly changes ───
 
-describe('computeSprWoW', () => {
-  it('computes correct WoW delta', () => {
-    const latest = { barrels: 370.2 };
-    const prev = { barrels: 371.6 };
-    const changeWoW = +(latest.barrels - prev.barrels).toFixed(3);
-    assert.equal(changeWoW, -1.4);
+describe('fetchSprLevels', () => {
+  it('computes weekly and four-week changes from EIA rows', async (t) => {
+    const previousApiKey = process.env.EIA_API_KEY;
+    process.env.EIA_API_KEY = 'test-eia-key';
+    t.after(() => {
+      if (previousApiKey === undefined) delete process.env.EIA_API_KEY;
+      else process.env.EIA_API_KEY = previousApiKey;
+    });
+
+    const rows = [
+      { value: '370.2', period: '2026-03-28' },
+      { value: '371.6', period: '2026-03-21' },
+      { value: '372.0', period: '2026-03-14' },
+      { value: '373.0', period: '2026-03-07' },
+      { value: '375.4', period: '2026-02-28' },
+    ];
+    t.mock.method(globalThis, 'fetch', async (input) => {
+      const url = new URL(String(input));
+      assert.equal(url.pathname, '/v2/petroleum/stoc/wstk/data/');
+      assert.equal(url.searchParams.get('facets[series][]'), 'WCSSTUS1');
+      return Response.json({ response: { data: rows } });
+    });
+
+    const result = await fetchSprLevels();
+
+    assert.equal(result.changeWoW, -1.4);
+    assert.equal(result.changeWoW4, -5.2);
+    assert.deepEqual(result.weeks, rows.map((row) => ({
+      period: row.period,
+      barrels: Number(row.value),
+    })));
   });
 
-  it('returns null when prev is null', () => {
-    const prev = null;
-    const changeWoW = prev ? +(370.2 - prev.barrels).toFixed(3) : null;
-    assert.equal(changeWoW, null);
-  });
+  it('returns no four-week change when a fifth valid week is unavailable', async (t) => {
+    const previousApiKey = process.env.EIA_API_KEY;
+    process.env.EIA_API_KEY = 'test-eia-key';
+    t.after(() => {
+      if (previousApiKey === undefined) delete process.env.EIA_API_KEY;
+      else process.env.EIA_API_KEY = previousApiKey;
+    });
 
-  it('computes correct 4-week change', () => {
-    const latest = { barrels: 370.2 };
-    const prev4 = { barrels: 375.4 };
-    const changeWoW4 = +(latest.barrels - prev4.barrels).toFixed(3);
-    assert.equal(changeWoW4, -5.2);
+    t.mock.method(globalThis, 'fetch', async () => Response.json({
+      response: {
+        data: [
+          { value: '370.2', period: '2026-03-28' },
+          { value: '371.6', period: '2026-03-21' },
+          { value: '372.0', period: '2026-03-14' },
+          { value: '373.4', period: '2026-03-07' },
+        ],
+      },
+    }));
+
+    const result = await fetchSprLevels();
+
+    assert.equal(result.changeWoW4, null);
   });
 });
 

--- a/tests/energy-ember-seed.test.mjs
+++ b/tests/energy-ember-seed.test.mjs
@@ -6,11 +6,15 @@ import { fileURLToPath } from 'node:url';
 import {
   parseEmberCsv,
   buildAllCountriesMap,
+  getPipelineFailures,
+  isEmberCountDrop,
+  preservePreviousSnapshot,
   EMBER_KEY_PREFIX,
   EMBER_ALL_KEY,
   EMBER_META_KEY,
   EMBER_TTL_SECONDS,
 } from '../scripts/seed-ember-electricity.mjs';
+import { createRedisFetch } from './helpers/fake-upstash-redis.mts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = resolve(__dirname, 'fixtures');
@@ -77,6 +81,26 @@ function threeCountryFixture() {
     makeRow({ [ISO3_COL]: 'FRA', [DATE_COL]: '2024-01-01', [SERIES_COL]: 'Total Generation', [VALUE_COL]: '550' }),
   ];
   return buildCsv(rows);
+}
+
+function mockEmberRedis(t, existingMeta) {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.ember.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  const { fetchImpl } = createRedisFetch(existingMeta == null ? {} : {
+    [EMBER_META_KEY]: existingMeta,
+  });
+  const pipelines = [];
+
+  t.mock.method(console, 'error', () => {});
+  t.mock.method(globalThis, 'fetch', async (input, init = {}) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (new URL(url).pathname === '/pipeline') {
+      pipelines.push(JSON.parse(String(init.body)));
+    }
+    return fetchImpl(input, init);
+  });
+
+  return pipelines;
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────
@@ -310,36 +334,30 @@ describe('exported constants', () => {
 
 describe('count-drop guard math', () => {
   it('45/60 is acceptable (75% threshold)', () => {
-    const prevCount = 60;
-    const newCount = 45;
-    const ratio = newCount / prevCount;
-    assert.ok(ratio >= 0.75, '45/60 = 75% should pass the guard');
+    assert.equal(isEmberCountDrop(45, { recordCount: 60 }), false);
   });
 
   it('44/60 triggers the guard (below 75%)', () => {
-    const prevCount = 60;
-    const newCount = 44;
-    const ratio = newCount / prevCount;
-    assert.ok(ratio < 0.75, '44/60 ≈ 73.3% should trigger the guard');
+    assert.equal(isEmberCountDrop(44, { recordCount: 60 }), true);
   });
 });
 
 describe('pipeline failure detection logic (non-transactional, e.g. Phase B meta write)', () => {
   it('detects a partial pipeline failure when one command errors', () => {
     const results = [{ result: 'OK' }, { result: 'OK' }, { error: 'NOSCRIPT' }, { result: 'OK' }];
-    const failures = results.filter((r) => r?.error || r?.result === 'ERR');
+    const failures = getPipelineFailures(results);
     assert.equal(failures.length, 1, 'should detect 1 failed command');
   });
 
   it('treats all-OK results as no failures', () => {
     const results = [{ result: 'OK' }, { result: 'OK' }, { result: 'OK' }];
-    const failures = results.filter((r) => r?.error || r?.result === 'ERR');
+    const failures = getPipelineFailures(results);
     assert.equal(failures.length, 0, 'all-OK pipeline should have 0 failures');
   });
 
   it('detects ERR-result commands as failures', () => {
     const results = [{ result: 'OK' }, { result: 'ERR' }];
-    const failures = results.filter((r) => r?.error || r?.result === 'ERR');
+    const failures = getPipelineFailures(results);
     assert.equal(failures.length, 1, 'ERR result should count as failure');
   });
 });
@@ -541,79 +559,63 @@ describe('health cascade: seedError priority over hasData', () => {
   });
 });
 
-describe('health endpoint status agreement for error meta', () => {
-  it('seed-health.js logic emits "error" for meta.status="error"', () => {
-    // Simulates seed-health.js lines 131-148 logic
-    const meta = { fetchedAt: Date.now(), recordCount: 100, status: 'error', error: 'test failure' };
-    const isError = meta.status === 'error';
-    const ageMs = Date.now() - (meta.fetchedAt || 0);
-    const maxStalenessMs = 1440 * 2 * 60 * 1000;
-    const stale = ageMs > maxStalenessMs || isError;
-    const status = stale ? (isError ? 'error' : 'stale') : 'ok';
-    assert.equal(status, 'error', 'seed-health.js should report "error" for meta.status=error');
-  });
-
-  it('health.js SEED_ERROR is the correct status for meta.status="error" (not STALE_SEED)', () => {
-    // Verifies the expected contract: meta.status=error → SEED_ERROR (not STALE_SEED)
-    // This test documents the intended behavior after the fix
-    const meta = { fetchedAt: Date.now(), recordCount: 100, status: 'error', error: 'test failure' };
-    const seedError = meta?.status === 'error';
-    const seedStale = seedError; // error implies stale
-
-    let status;
-    if (seedError) {
-      status = 'SEED_ERROR';
-    } else if (seedStale) {
-      status = 'STALE_SEED';
-    } else {
-      status = 'OK';
-    }
-    assert.equal(status, 'SEED_ERROR', 'explicit error meta should yield SEED_ERROR, not STALE_SEED');
-  });
-});
-
 describe('preservePreviousSnapshot recordCount fallback', () => {
-  it('uses null (not 0) when existingMeta is unavailable', () => {
-    const existingMeta = null;
-    const recordCount = existingMeta?.recordCount ?? null;
-    assert.equal(recordCount, null, 'should be null, not 0');
-    const serialized = JSON.stringify({ recordCount });
-    assert.ok(serialized.includes('"recordCount":null'), 'null should be serialized');
+  it('uses null (not 0) when existingMeta is unavailable', async (t) => {
+    const pipelines = mockEmberRedis(t, null);
+
+    await preservePreviousSnapshot('test failure', null, null, true);
+
+    const [[metaCommand]] = pipelines;
+    const meta = JSON.parse(metaCommand[2]);
+    assert.equal(meta.recordCount, null, 'should publish null, not 0');
   });
 
-  it('preserves existing recordCount when meta is readable', () => {
-    const existingMeta = { recordCount: 180, fetchedAt: Date.now() };
-    const recordCount = existingMeta?.recordCount ?? null;
-    assert.equal(recordCount, 180);
+  it('preserves existing recordCount when meta is readable', async (t) => {
+    const pipelines = mockEmberRedis(t, { recordCount: 180, fetchedAt: Date.now() });
+
+    await preservePreviousSnapshot('test failure', null, null, true);
+
+    const [[metaCommand]] = pipelines;
+    const meta = JSON.parse(metaCommand[2]);
+    assert.equal(meta.recordCount, 180);
   });
 
   it('null recordCount does not enable count-drop guard', () => {
-    const prevMeta = { recordCount: null, status: 'error' };
-    const guardActive = prevMeta && typeof prevMeta === 'object' && prevMeta.recordCount > 0;
-    assert.equal(guardActive, false, 'null recordCount should not activate guard');
+    assert.equal(
+      isEmberCountDrop(44, { recordCount: null, status: 'error' }),
+      false,
+      'null recordCount should not activate guard',
+    );
   });
 });
 
 describe('dataWritten flag prevents stash restore after successful pipeline', () => {
-  it('skips restore when dataWritten=true (data is correct, only meta failed)', () => {
+  it('skips restore when dataWritten=true (data is correct, only meta failed)', async (t) => {
     const stashedAllMap = { US: {}, DE: {} };
-    const dataWritten = true;
-    const shouldRestore = stashedAllMap && typeof stashedAllMap === 'object' && !dataWritten;
-    assert.equal(shouldRestore, false, 'should not restore stash when data was written successfully');
+    const pipelines = mockEmberRedis(t, { recordCount: 180 });
+
+    await preservePreviousSnapshot('metadata failed', stashedAllMap, new Set(['US', 'DE']), true);
+
+    assert.equal(pipelines.length, 1, 'only the error metadata pipeline should run');
+    assert.equal(pipelines[0][0][1], EMBER_META_KEY);
   });
 
-  it('allows restore when dataWritten=false (pipeline failed or never ran)', () => {
+  it('allows restore when dataWritten=false (pipeline failed or never ran)', async (t) => {
     const stashedAllMap = { US: {}, DE: {} };
-    const dataWritten = false;
-    const shouldRestore = stashedAllMap && typeof stashedAllMap === 'object' && !dataWritten;
-    assert.ok(shouldRestore, 'should restore stash when data was not written');
-  });
+    const pipelines = mockEmberRedis(t, { recordCount: 180 });
 
-  it('skips TTL extension when dataWritten=true and no stash', () => {
-    const stashedAllMap = null;
-    const dataWritten = true;
-    const shouldExtendTtl = !dataWritten;
-    assert.equal(shouldExtendTtl, false, 'should not extend TTL when data is already correct');
+    await preservePreviousSnapshot('data pipeline failed', stashedAllMap, new Set(['US', 'DE', 'XX']), false);
+
+    assert.equal(pipelines.length, 2, 'restore and error metadata pipelines should run');
+    assert.deepEqual(
+      pipelines[0].map((command) => command.slice(0, 2)),
+      [
+        ['SET', `${EMBER_KEY_PREFIX}US`],
+        ['SET', `${EMBER_KEY_PREFIX}DE`],
+        ['SET', EMBER_ALL_KEY],
+        ['DEL', `${EMBER_KEY_PREFIX}XX`],
+      ],
+    );
   });
 });
 

--- a/tests/energy-intelligence-seed.test.mjs
+++ b/tests/energy-intelligence-seed.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   parseRssItems,
+  fetchEnergyIntelligence,
   filterEnergyRelevant,
   deduplicateByUrl,
   validate,
@@ -135,19 +136,33 @@ describe('deduplicateByUrl', () => {
 // ---------------------------------------------------------------------------
 
 describe('age filter', () => {
-  it('item older than 30 days is excluded via AGE_LIMIT_MS threshold', () => {
-    const now = Date.now();
-    const oldTs = now - (31 * 24 * 3600 * 1000);
-    const AGE_LIMIT_MS = 30 * 24 * 3600 * 1000;
+  it('fetchEnergyIntelligence excludes feed items older than 30 days', async (t) => {
+    const now = Date.parse('2026-04-05T10:00:00Z');
+    t.mock.method(Date, 'now', () => now);
 
-    const items = [
-      { id: 'old', title: 'Old oil report', url: 'https://example.com/old', source: 'IEA', publishedAt: oldTs, summary: '' },
-      { id: 'new', title: 'New gas update', url: 'https://example.com/new', source: 'IEA', publishedAt: now, summary: '' },
-    ];
+    const ageFixture = `<rss version="1.0"><channel>
+      <item>
+        <title>Old oil report</title>
+        <link>https://example.com/old</link>
+        <pubDate>${new Date(now - 31 * 24 * 3600 * 1000).toUTCString()}</pubDate>
+      </item>
+      <item>
+        <title>New gas update</title>
+        <link>https://example.com/new</link>
+        <pubDate>${new Date(now).toUTCString()}</pubDate>
+      </item>
+    </channel></rss>`;
+    const emptyFixture = '<rss version="1.0"><channel></channel></rss>';
 
-    const recent = items.filter((item) => item.publishedAt >= now - AGE_LIMIT_MS);
-    assert.equal(recent.length, 1);
-    assert.equal(recent[0].id, 'new');
+    t.mock.method(globalThis, 'fetch', async (input) => new Response(
+      String(input).includes('oilprice.com') ? ageFixture : emptyFixture,
+      { status: 200, headers: { 'Content-Type': 'application/rss+xml' } },
+    ));
+
+    const result = await fetchEnergyIntelligence();
+
+    assert.deepEqual(result.items.map((item) => item.title), ['New gas update']);
+    assert.equal(result.fetchedAt, now);
   });
 });
 

--- a/tests/energy-shock-v2.test.mjs
+++ b/tests/energy-shock-v2.test.mjs
@@ -23,8 +23,82 @@ import {
   REFINERY_YIELD,
   REFINERY_YIELD_BASIS,
 } from '../server/worldmonitor/intelligence/v1/_shock-compute.js';
+import { computeEnergyShockScenario } from '../server/worldmonitor/intelligence/v1/compute-energy-shock.ts';
+import { installRedis } from './helpers/fake-upstash-redis.mts';
 
 import { ISO2_TO_COMTRADE } from '../server/worldmonitor/intelligence/v1/_comtrade-reporters.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_REDIS_ENV = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+  vercelEnv: process.env.VERCEL_ENV,
+  localApiMode: process.env.LOCAL_API_MODE,
+};
+function restoreEnergyShockEnvironment() {
+  globalThis.fetch = ORIGINAL_FETCH;
+  for (const [name, value] of [
+    ['UPSTASH_REDIS_REST_URL', ORIGINAL_REDIS_ENV.url],
+    ['UPSTASH_REDIS_REST_TOKEN', ORIGINAL_REDIS_ENV.token],
+    ['VERCEL_ENV', ORIGINAL_REDIS_ENV.vercelEnv],
+    ['LOCAL_API_MODE', ORIGINAL_REDIS_ENV.localApiMode],
+  ]) {
+    if (value == null) delete process.env[name];
+    else process.env[name] = value;
+  }
+}
+
+function installEnergyShockRedis(seed = {}) {
+  const { redis } = installRedis(seed);
+  delete process.env.LOCAL_API_MODE;
+
+  return {
+    set(key, value) {
+      redis.set(key, JSON.stringify(value));
+    },
+    delete(key) {
+      redis.delete(key);
+    },
+  };
+}
+
+function liveChokepointSeed(flowRatio = 1) {
+  return {
+    'energy:chokepoint-flows:v1': {
+      hormuz_strait: { flowRatio },
+      malacca_strait: { flowRatio },
+    },
+  };
+}
+
+const US_OIL_SEED = {
+  'energy:jodi-oil:v1:US': {
+    crude: { importsKbd: 100 },
+    gasoline: { demandKbd: 80 },
+    diesel: { demandKbd: 60 },
+  },
+  'energy:iea-oil-stocks:v1:US': {
+    daysOfCover: 90,
+    netExporter: false,
+    anomaly: false,
+  },
+  'comtrade:flows:842:2709': [
+    { reporterCode: '842', partnerCode: '682', cmdCode: '2709', tradeValueUsd: 100, year: 2025 },
+  ],
+};
+
+const US_GAS_SEED = {
+  'energy:jodi-gas:v1:US': {
+    lngImportsTj: 1_000,
+    pipeImportsTj: 200,
+    totalDemandTj: 5_000,
+    lngShareOfImports: 0.8,
+  },
+};
+
+async function computeShock(request) {
+  return computeEnergyShockScenario({}, request);
+}
 
 // ---------------------------------------------------------------------------
 // deriveCoverageLevel
@@ -333,27 +407,55 @@ describe('deriveCoverageLevel accounts for IEA and degraded state', () => {
 });
 
 // ---------------------------------------------------------------------------
-// live_flow_ratio absent when portwatchCoverage=false
+// Production response construction
 // ---------------------------------------------------------------------------
 
-describe('liveFlowRatio is absent (undefined) when PortWatch unavailable', () => {
-  it('liveFlowRatio should be undefined, not 0, when portwatch is absent', () => {
-    // This tests the response contract: callers must check portwatchCoverage,
-    // not rely on liveFlowRatio===0 to detect missing data.
-    const liveFlowRatioFromServer = null; // PortWatch unavailable
-    const fieldOnWire = liveFlowRatioFromServer !== null
-      ? Math.round(liveFlowRatioFromServer * 1000) / 1000
-      : undefined;
-    assert.equal(fieldOnWire, undefined, 'field should be absent on wire when portwatch unavailable');
+describe('computeEnergyShockScenario response construction', () => {
+  it('distinguishes a missing PortWatch ratio from a real zero-flow ratio', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    const redis = installEnergyShockRedis();
+
+    const missing = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 40, fuelMode: 'oil',
+    });
+    assert.equal(missing.portwatchCoverage, false);
+    assert.equal(missing.liveFlowRatio, undefined, 'missing PortWatch data must omit liveFlowRatio');
+
+    redis.set('energy:chokepoint-flows:v1', { hormuz_strait: { flowRatio: 0 } });
+    const zero = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 41, fuelMode: 'oil',
+    });
+    assert.equal(zero.portwatchCoverage, true);
+    assert.equal(zero.liveFlowRatio, 0, 'a real zero-flow ratio must remain distinct from missing data');
   });
 
-  it('liveFlowRatio=0 is valid and distinct from "unavailable" when portwatchCoverage=true', () => {
-    // True zero flow (chokepoint collapse) is a real and distinct signal
-    const liveFlowRatioFromServer = 0; // portwatchCoverage=true, chokepoint collapsed
-    const fieldOnWire = liveFlowRatioFromServer !== null
-      ? Math.round(liveFlowRatioFromServer * 1000) / 1000
-      : undefined;
-    assert.equal(fieldOnWire, 0, 'true 0 flow should serialize as 0, not undefined');
+  it('derives IEA stock coverage from the production response path', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    const redis = installEnergyShockRedis({ ...liveChokepointSeed(), ...US_OIL_SEED });
+
+    redis.set('energy:iea-oil-stocks:v1:US', { daysOfCover: null, netExporter: false, anomaly: false });
+    const missing = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 20, fuelMode: 'oil',
+    });
+    assert.equal(missing.ieaStocksCoverage, false, 'a non-exporter needs finite, non-negative cover days');
+
+    redis.set('energy:iea-oil-stocks:v1:US', { daysOfCover: 0, netExporter: false, anomaly: false });
+    const exhausted = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 21, fuelMode: 'oil',
+    });
+    assert.equal(exhausted.ieaStocksCoverage, true, 'zero cover days is valid observed data');
+
+    redis.set('energy:iea-oil-stocks:v1:US', { daysOfCover: -1, netExporter: false, anomaly: false });
+    const invalid = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 22, fuelMode: 'oil',
+    });
+    assert.equal(invalid.ieaStocksCoverage, false, 'negative cover days must not count as coverage');
+
+    redis.set('energy:iea-oil-stocks:v1:US', { daysOfCover: null, netExporter: true, anomaly: false });
+    const exporter = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 23, fuelMode: 'oil',
+    });
+    assert.equal(exporter.ieaStocksCoverage, true, 'net exporters do not require cover days');
   });
 });
 
@@ -434,141 +536,40 @@ describe('buildAssessment proxy text is tied to comtradeCoverage, not coverageLe
 });
 
 // ---------------------------------------------------------------------------
-// ieaStocksCoverage requires daysOfCover for non-exporters
-// ---------------------------------------------------------------------------
-
-describe('ieaStocksCoverage requires daysOfCover for non-exporters', () => {
-  it('ieaStocksCoverage is false when daysOfCover is null and not a net exporter', () => {
-    const ieaStocks = { anomaly: false, daysOfCover: null, netExporter: false };
-    const coverage = ieaStocks != null && ieaStocks.anomaly !== true
-      && (ieaStocks.netExporter === true || typeof ieaStocks.daysOfCover === 'number');
-    assert.equal(coverage, false, 'null daysOfCover for non-exporter should be false');
-  });
-
-  it('ieaStocksCoverage is true when daysOfCover is 0 (genuinely exhausted)', () => {
-    const ieaStocks = { anomaly: false, daysOfCover: 0, netExporter: false };
-    const coverage = ieaStocks != null && ieaStocks.anomaly !== true
-      && (ieaStocks.netExporter === true || typeof ieaStocks.daysOfCover === 'number');
-    assert.equal(coverage, true, 'daysOfCover=0 is real data, should be true');
-  });
-
-  it('ieaStocksCoverage is true for net exporter even without daysOfCover', () => {
-    const ieaStocks = { anomaly: false, daysOfCover: null, netExporter: true };
-    const coverage = ieaStocks != null && ieaStocks.anomaly !== true
-      && (ieaStocks.netExporter === true || typeof ieaStocks.daysOfCover === 'number');
-    assert.equal(coverage, true, 'net exporters do not need daysOfCover');
-  });
-
-  it('ieaStocksCoverage is false when anomaly is true', () => {
-    const ieaStocks = { anomaly: true, daysOfCover: 90, netExporter: false };
-    const coverage = ieaStocks != null && ieaStocks.anomaly !== true
-      && (ieaStocks.netExporter === true || typeof ieaStocks.daysOfCover === 'number');
-    assert.equal(coverage, false, 'anomaly should override');
-  });
-
-  it('ieaStocksCoverage is false when ieaStocks is null', () => {
-    const ieaStocks = null;
-    const coverage = ieaStocks != null && ieaStocks.anomaly !== true
-      && (ieaStocks.netExporter === true || typeof ieaStocks.daysOfCover === 'number');
-    assert.equal(coverage, false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// ieaStocksCoverage rejects non-finite and negative daysOfCover
-// ---------------------------------------------------------------------------
-
-describe('ieaStocksCoverage rejects non-finite and negative daysOfCover', () => {
-  function checkCoverage(ieaStocks) {
-    return ieaStocks != null && ieaStocks.anomaly !== true
-      && (ieaStocks.netExporter === true || (Number.isFinite(ieaStocks.daysOfCover) && ieaStocks.daysOfCover >= 0));
-  }
-
-  it('rejects NaN daysOfCover', () => {
-    assert.equal(checkCoverage({ anomaly: false, daysOfCover: NaN, netExporter: false }), false);
-  });
-
-  it('rejects Infinity daysOfCover', () => {
-    assert.equal(checkCoverage({ anomaly: false, daysOfCover: Infinity, netExporter: false }), false);
-  });
-
-  it('rejects negative daysOfCover', () => {
-    assert.equal(checkCoverage({ anomaly: false, daysOfCover: -1, netExporter: false }), false);
-  });
-
-  it('accepts zero daysOfCover (genuinely exhausted)', () => {
-    assert.equal(checkCoverage({ anomaly: false, daysOfCover: 0, netExporter: false }), true);
-  });
-
-  it('accepts positive finite daysOfCover', () => {
-    assert.equal(checkCoverage({ anomaly: false, daysOfCover: 90, netExporter: false }), true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// liveFlowRatio clamped to 0..1.5
-// ---------------------------------------------------------------------------
-
-describe('liveFlowRatio clamped to 0..1.5', () => {
-  it('clamps negative flowRatio to 0', () => {
-    const raw = -0.5;
-    const clamped = Math.max(0, Math.min(1.5, raw));
-    assert.equal(clamped, 0);
-  });
-
-  it('clamps oversized flowRatio to 1.5', () => {
-    const raw = 3.0;
-    const clamped = Math.max(0, Math.min(1.5, raw));
-    assert.equal(clamped, 1.5);
-  });
-
-  it('passes through valid flowRatio unchanged', () => {
-    const raw = 0.85;
-    const clamped = Math.max(0, Math.min(1.5, raw));
-    assert.equal(clamped, 0.85);
-  });
-
-  it('passes through zero flowRatio (chokepoint collapsed)', () => {
-    const raw = 0;
-    const clamped = Math.max(0, Math.min(1.5, raw));
-    assert.equal(clamped, 0);
-  });
-
-  it('passes through 1.5 (max valid ratio)', () => {
-    const raw = 1.5;
-    const clamped = Math.max(0, Math.min(1.5, raw));
-    assert.equal(clamped, 1.5);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // cache key includes degraded state
 // ---------------------------------------------------------------------------
 
 describe('cache key includes degraded state and fuelMode', () => {
-  it('degraded and non-degraded produce different cache keys', () => {
-    const code = 'US';
-    const chokepointId = 'hormuz';
-    const disruptionPct = 50;
-    const fuelMode = 'oil';
+  it('does not reuse a live response after PortWatch degrades', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    const redis = installEnergyShockRedis({ ...liveChokepointSeed(), ...US_OIL_SEED });
 
-    const keyDegraded = `energy:shock:v2:${code}:${chokepointId}:${disruptionPct}:d:${fuelMode}`;
-    const keyLive = `energy:shock:v2:${code}:${chokepointId}:${disruptionPct}:l:${fuelMode}`;
+    const live = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 50, fuelMode: 'oil',
+    });
+    assert.equal(live.degraded, false);
 
-    assert.notEqual(keyDegraded, keyLive, 'cache keys must differ by degraded state');
-    assert.ok(keyDegraded.endsWith(':d:oil'));
-    assert.ok(keyLive.endsWith(':l:oil'));
+    redis.delete('energy:chokepoint-flows:v1');
+    const degraded = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 50, fuelMode: 'oil',
+    });
+    assert.equal(degraded.degraded, true, 'degraded and live requests must not share a cached response');
   });
 
-  it('different fuelMode values produce different cache keys', () => {
-    const base = 'energy:shock:v2:US:hormuz:50:l';
-    const keyOil = `${base}:oil`;
-    const keyGas = `${base}:gas`;
-    const keyBoth = `${base}:both`;
+  it('does not reuse an oil response for gas-only mode', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    installEnergyShockRedis({ ...liveChokepointSeed(), ...US_OIL_SEED, ...US_GAS_SEED });
 
-    assert.notEqual(keyOil, keyGas);
-    assert.notEqual(keyOil, keyBoth);
-    assert.notEqual(keyGas, keyBoth);
+    const oil = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 60, fuelMode: 'oil',
+    });
+    assert.ok(oil.products.length > 0);
+
+    const gas = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 60, fuelMode: 'gas',
+    });
+    assert.equal(gas.products.length, 0, 'gas-only mode must not receive the oil cache entry');
+    assert.equal(gas.gasImpact?.dataAvailable, true);
   });
 });
 
@@ -721,16 +722,31 @@ describe('exposureMult composes baseExposure with liveFlowRatio', () => {
 // ---------------------------------------------------------------------------
 
 describe('gasDataAvailable distinguishes zero-LNG from missing data', () => {
-  it('pipeline-only country (lngImportsTj=0) has dataAvailable=true', () => {
-    const jodiGas = { lngImportsTj: 0, totalDemandTj: 5000, lngShareOfImports: 0 };
-    const gasDataAvailable = jodiGas != null;
-    assert.equal(gasDataAvailable, true, 'JODI gas exists, so data is available');
+  it('reports pipeline-only JODI gas as available through the production response', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    installEnergyShockRedis({
+      ...liveChokepointSeed(),
+      'energy:jodi-gas:v1:US': { lngImportsTj: 0, totalDemandTj: 5_000, lngShareOfImports: 0 },
+    });
+
+    const response = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 50, fuelMode: 'gas',
+    });
+    assert.equal(response.dataAvailable, true, 'an existing JODI gas record is available even with zero LNG');
+    assert.equal(response.gasImpact?.dataAvailable, true);
+    assert.match(response.assessment, /pipeline only/i);
   });
 
-  it('missing JODI gas (null) has dataAvailable=false', () => {
-    const jodiGas = null;
-    const gasDataAvailable = jodiGas != null;
-    assert.equal(gasDataAvailable, false);
+  it('reports missing JODI gas as unavailable through the production response', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    installEnergyShockRedis(liveChokepointSeed());
+
+    const response = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 50, fuelMode: 'gas',
+    });
+    assert.equal(response.dataAvailable, false);
+    assert.equal(response.gasImpact, undefined);
+    assert.equal(response.coverageLevel, 'unsupported');
   });
 });
 
@@ -774,32 +790,32 @@ describe('buildGasAssessment pipeline-only branch', () => {
 // ---------------------------------------------------------------------------
 
 describe('grid-tightness limitation from Ember fossilShare', () => {
-  it('appends limitation when fossilShare > 70', () => {
-    const limitations = [];
-    const fossilShare = 75.3;
-    if (fossilShare !== null && fossilShare > 70) {
-      limitations.push('high fossil grid dependency: limited electricity substitution capacity');
-    }
-    assert.equal(limitations.length, 1);
-    assert.ok(limitations[0].includes('fossil grid dependency'));
+  it('appends the limitation from a high-fossil Ember record', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    installEnergyShockRedis({
+      ...liveChokepointSeed(),
+      ...US_OIL_SEED,
+      'energy:ember:v1:US': { fossilShare: 75.3 },
+    });
+
+    const response = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 70, fuelMode: 'oil',
+    });
+    assert.ok(response.limitations.some((limitation) => limitation.includes('fossil grid dependency')));
   });
 
-  it('does not append when fossilShare <= 70', () => {
-    const limitations = [];
-    const fossilShare = 55.0;
-    if (fossilShare !== null && fossilShare > 70) {
-      limitations.push('high fossil grid dependency: limited electricity substitution capacity');
-    }
-    assert.equal(limitations.length, 0);
-  });
+  it('does not append the limitation for a lower-fossil Ember record', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    installEnergyShockRedis({
+      ...liveChokepointSeed(),
+      ...US_OIL_SEED,
+      'energy:ember:v1:US': { fossilShare: 55 },
+    });
 
-  it('does not append when fossilShare is null (no Ember data)', () => {
-    const limitations = [];
-    const fossilShare = null;
-    if (fossilShare !== null && fossilShare > 70) {
-      limitations.push('high fossil grid dependency: limited electricity substitution capacity');
-    }
-    assert.equal(limitations.length, 0);
+    const response = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 71, fuelMode: 'oil',
+    });
+    assert.ok(!response.limitations.some((limitation) => limitation.includes('fossil grid dependency')));
   });
 });
 
@@ -828,110 +844,40 @@ describe('computeGasDisruption uses liveFlowRatio when available', () => {
 // gas-only mode coverage override
 // ---------------------------------------------------------------------------
 
-describe('gas-only mode coverage override', () => {
-  it('gas-only with valid gas data (not degraded) should be full', () => {
-    const needsOil = false;
-    const gasImpact = { dataAvailable: true };
-    const degraded = false;
-    let coverageLevel = 'unsupported';
-    if (!needsOil && gasImpact?.dataAvailable) {
-      coverageLevel = degraded ? 'partial' : 'full';
-    }
-    assert.equal(coverageLevel, 'full');
-  });
+describe('gas-only mode response', () => {
+  it('uses gas coverage and removes all oil-only response data', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    installEnergyShockRedis({ ...liveChokepointSeed(), ...US_OIL_SEED, ...US_GAS_SEED });
 
-  it('gas-only with valid gas data (degraded) should be partial', () => {
-    const needsOil = false;
-    const gasImpact = { dataAvailable: true };
-    const degraded = true;
-    let coverageLevel = 'unsupported';
-    if (!needsOil && gasImpact?.dataAvailable) {
-      coverageLevel = degraded ? 'partial' : 'full';
-    }
-    assert.equal(coverageLevel, 'partial');
-  });
+    const response = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 80, fuelMode: 'gas',
+    });
 
-  it('gas-only limitations exclude oil-specific strings', () => {
-    const limitations = [
-      REFINERY_YIELD_BASIS,
-      'Gulf crude share proxied at 40% (no Comtrade data)',
-      'IEA strategic stock data unavailable',
-      'LNG chokepoint exposure estimates based on global trade route shares',
-    ];
-    const filtered = limitations.filter(l =>
-      !l.includes('refinery yield') &&
-      !l.includes('Gulf crude share') &&
-      !l.includes('IEA strategic stock')
-    );
-    assert.equal(filtered.length, 1);
-    assert.ok(filtered[0].includes('LNG'));
-  });
-});
-
-describe('gas-only coverageLevel respects degraded state', () => {
-  it('gas-only with degraded=true should be partial, not full', () => {
-    const gasImpact = { dataAvailable: true };
-    const degraded = true;
-    const needsOil = false;
-    let coverageLevel = 'unsupported';
-    if (!needsOil && gasImpact?.dataAvailable) {
-      coverageLevel = degraded ? 'partial' : 'full';
-    }
-    assert.equal(coverageLevel, 'partial');
-  });
-
-  it('gas-only with degraded=false should be full', () => {
-    const gasImpact = { dataAvailable: true };
-    const degraded = false;
-    const needsOil = false;
-    let coverageLevel = 'unsupported';
-    if (!needsOil && gasImpact?.dataAvailable) {
-      coverageLevel = degraded ? 'partial' : 'full';
-    }
-    assert.equal(coverageLevel, 'full');
-  });
-
-  it('gas-only with no gas data should be unsupported', () => {
-    const gasImpact = { dataAvailable: false };
-    const degraded = false;
-    const needsOil = false;
-    let coverageLevel = 'unsupported';
-    if (!needsOil && gasImpact?.dataAvailable) {
-      coverageLevel = degraded ? 'partial' : 'full';
-    }
-    assert.equal(coverageLevel, 'unsupported');
-  });
-});
-
-describe('gas-only mode zeros oil fields', () => {
-  it('products should be empty array in gas-only mode', () => {
-    const needsOil = false;
-    const gasImpact = { dataAvailable: true };
-    const response = {
-      products: [{ product: 'Diesel', outputLossKbd: 5, demandKbd: 100, deficitPct: 4 }],
-      gulfCrudeShare: 0.35,
-      crudeLossKbd: 50,
-      effectiveCoverDays: 90,
-      jodiOilCoverage: true,
-      comtradeCoverage: true,
-      ieaStocksCoverage: true,
-    };
-    if (!needsOil && gasImpact) {
-      response.products = [];
-      response.gulfCrudeShare = 0;
-      response.crudeLossKbd = 0;
-      response.effectiveCoverDays = 0;
-      response.jodiOilCoverage = false;
-      response.comtradeCoverage = false;
-      response.ieaStocksCoverage = false;
-    }
-    assert.equal(response.products.length, 0);
+    assert.equal(response.coverageLevel, 'full');
+    assert.equal(response.dataAvailable, true);
+    assert.equal(response.gasImpact?.dataAvailable, true);
+    assert.deepEqual(response.products, []);
     assert.equal(response.gulfCrudeShare, 0);
     assert.equal(response.crudeLossKbd, 0);
     assert.equal(response.effectiveCoverDays, 0);
     assert.equal(response.jodiOilCoverage, false);
     assert.equal(response.comtradeCoverage, false);
     assert.equal(response.ieaStocksCoverage, false);
+    assert.ok(response.limitations.some((limitation) => limitation.includes('LNG chokepoint exposure')));
+    assert.ok(!response.limitations.some((limitation) => limitation.includes('refinery yield')));
+    assert.ok(!response.limitations.some((limitation) => limitation.includes('Gulf crude share')));
+    assert.ok(!response.limitations.some((limitation) => limitation.includes('IEA strategic stock')));
+  });
+
+  it('marks a valid degraded gas-only response as partial', async (t) => {
+    t.after(restoreEnergyShockEnvironment);
+    installEnergyShockRedis(US_GAS_SEED);
+
+    const response = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 80, fuelMode: 'gas',
+    });
+    assert.equal(response.degraded, true);
+    assert.equal(response.coverageLevel, 'partial');
   });
 });
 

--- a/tests/energy-shock-v2.test.mjs
+++ b/tests/energy-shock-v2.test.mjs
@@ -427,6 +427,18 @@ describe('computeEnergyShockScenario response construction', () => {
     });
     assert.equal(zero.portwatchCoverage, true);
     assert.equal(zero.liveFlowRatio, 0, 'a real zero-flow ratio must remain distinct from missing data');
+
+    redis.set('energy:chokepoint-flows:v1', { hormuz_strait: { flowRatio: -0.5 } });
+    const clampedLow = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 42, fuelMode: 'oil',
+    });
+    assert.equal(clampedLow.liveFlowRatio, 0, 'negative ratios must clamp to zero');
+
+    redis.set('energy:chokepoint-flows:v1', { hormuz_strait: { flowRatio: 3 } });
+    const clampedHigh = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 43, fuelMode: 'oil',
+    });
+    assert.equal(clampedHigh.liveFlowRatio, 1.5, 'oversized ratios must clamp to 1.5');
   });
 
   it('derives IEA stock coverage from the production response path', async (t) => {
@@ -450,6 +462,12 @@ describe('computeEnergyShockScenario response construction', () => {
       countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 22, fuelMode: 'oil',
     });
     assert.equal(invalid.ieaStocksCoverage, false, 'negative cover days must not count as coverage');
+
+    redis.set('energy:iea-oil-stocks:v1:US', { daysOfCover: 90, netExporter: false, anomaly: true });
+    const anomalous = await computeShock({
+      countryCode: 'US', chokepointId: 'hormuz_strait', disruptionPct: 24, fuelMode: 'oil',
+    });
+    assert.equal(anomalous.ieaStocksCoverage, false, 'anomalous positive cover days must not count as coverage');
 
     redis.set('energy:iea-oil-stocks:v1:US', { daysOfCover: null, netExporter: true, anomaly: false });
     const exporter = await computeShock({

--- a/tests/energy-spine-seed.test.mjs
+++ b/tests/energy-spine-seed.test.mjs
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 import {
+  areCoreSourcesEmpty,
   buildDemandChangeEntry,
   buildSpineEntry,
+  isSpineCountDrop,
   SPINE_KEY_PREFIX,
   SPINE_COUNTRIES_KEY,
   SPINE_META_KEY,
@@ -501,24 +503,15 @@ describe('exported key constants', () => {
 
 describe('count-drop guard math', () => {
   it('80% threshold: 160/200 is acceptable', () => {
-    const prevCount = 200;
-    const newCount = 160;
-    const ratio = newCount / prevCount;
-    assert.ok(ratio >= 0.80, `${ratio} should be >= 0.80`);
+    assert.equal(isSpineCountDrop(160, 200), false);
   });
 
   it('80% threshold: 159/200 triggers guard', () => {
-    const prevCount = 200;
-    const newCount = 159;
-    const ratio = newCount / prevCount;
-    assert.ok(ratio < 0.80, `${ratio} should be < 0.80`);
+    assert.equal(isSpineCountDrop(159, 200), true);
   });
 
   it('no guard when prevCount is 0 (first run)', () => {
-    const prevCount = 0;
-    // Guard should not activate on first run (prevCount <= 0)
-    const guardActive = prevCount > 0;
-    assert.equal(guardActive, false);
+    assert.equal(isSpineCountDrop(0, 0), false);
   });
 });
 
@@ -594,17 +587,12 @@ describe('buildSpineEntry with SPR policy data', () => {
 // ---------------------------------------------------------------------------
 
 describe('core-source guard when JODI and OWID are empty', () => {
-  it('assembleCountryList returns jodiCount and owidCount', () => {
-    const jodiCount = 0;
-    const owidCount = 0;
-    const shouldAbort = jodiCount === 0 && owidCount === 0;
-    assert.ok(shouldAbort, 'should abort when both core sources are empty');
+  it('aborts when both core source counts are zero', () => {
+    assert.equal(areCoreSourcesEmpty(0, 0), true);
   });
 
   it('does not abort when at least one core source has data', () => {
-    const jodiCount = 100;
-    const owidCount = 0;
-    const shouldAbort = jodiCount === 0 && owidCount === 0;
-    assert.ok(!shouldAbort, 'should not abort when JODI has data');
+    assert.equal(areCoreSourcesEmpty(100, 0), false);
+    assert.equal(areCoreSourcesEmpty(0, 100), false);
   });
 });


### PR DESCRIPTION
## Summary

Energy coverage tests now fail when production cache partitioning, response guards, or seeder recovery behavior regresses. The five affected suites call `computeEnergyShockScenario` or exported production helpers instead of validating local copies that could drift while runtime code broke.

Redundant copied sections were removed. The runtime seeder branches are unchanged; the new exports and small named predicates expose the existing decisions to direct tests.

## Validation

- `node scripts/run-data-tests.mjs tests/energy-shock-v2.test.mjs tests/energy-ember-seed.test.mjs tests/energy-spine-seed.test.mjs tests/economy-eia-spr-seed.test.mjs tests/energy-intelligence-seed.test.mjs`: 237 passed, 0 failed.
- Pre-push gate: typecheck, API typecheck, seed tests, changed tests, Unicode scan, and version sync passed.
- Independent code review found two lost production-path cases. Clamp bounds and IEA anomaly handling were restored and validated.

Temporary named mutation probes were reverted after each expected failure:

- Collapsing the energy-shock cache key to one constant failed degraded/live isolation and oil/gas isolation (`false !== true`; `2 !== 0`).
- Changing the flow-ratio upper clamp from `1.5` to `2` failed with `2 !== 1.5`.
- Disabling the IEA anomaly guard failed with `true !== false`.
- Ember threshold, pipeline error, record-count fallback, and restore-gate mutants each failed their production-helper assertions.
- Energy-spine threshold and core-source boolean mutants failed at their boundary assertions.
- EIA delta and fifth-week selection mutants failed with incorrect weekly or four-week results.
- Reversing the energy-intelligence age comparison failed by returning the old story instead of the recent story.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. This PR changes test coverage and additive export visibility only; production seeder and response decisions keep the same behavior.

Related: #7771

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
