### PR TITLE
fix(ci): bound deploy gate recovery for blocked commits

### DIFF
--- a/.github/scripts/deploy-gate.sh
+++ b/.github/scripts/deploy-gate.sh
@@ -27,6 +27,12 @@ gate_description() {
 name_count() {
   printf '%s\n' "$1" | tr ',' '\n' | wc -l | tr -d ' '
 }
+report_blocked_head() {
+  echo "::notice::$1"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf -- '- %s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
 # Retry a primary-rate-limit response once at GitHub's published
 # reset time. The rate_limit endpoint does not spend primary budget;
 # keeping this bounded avoids turning an outage into an infinite job.
@@ -98,11 +104,19 @@ post_gate_status() {
   else
     result=$?
   fi
-  cat "$error_file" >&2
   if grep -qi 'This SHA and context has reached the maximum number of statuses' "$error_file"; then
     gate_status_exhausted=1
+    # An immutable pending/failure/error still blocks this commit. A stale
+    # success or an unreadable status cannot be treated as safely blocked.
+    if [ "$read_failed" -eq 0 ] && printf '%s\n' "$previous" |
+      jq -e '.state == "pending" or .state == "failure" or .state == "error"' >/dev/null; then
+      report_blocked_head "$SHA remains blocked: gate status capacity exhausted. Update the branch with a new commit before retrying."
+      rm -f "$error_file"
+      return 0
+    fi
     echo "::error::Gate status capacity exhausted for $SHA; this head needs a new commit before its status can change."
   fi
+  cat "$error_file" >&2
   rm -f "$error_file"
   return "$result"
 }
@@ -209,7 +223,7 @@ emit_matrix() {
 }
 
 discover() {
-  local discovery matrix
+  local discovery matrix pending_states recovery_cutoff
   if [ -n "$SHA" ]; then
     SHA=$(printf '%s' "$SHA" | tr 'A-F' 'a-f')
     validate_sha
@@ -226,7 +240,7 @@ discover() {
               commits(last: 1) {
                 nodes {
                   commit {
-                    status { context(name: "gate") { state description } }
+                    status { context(name: "gate") { state description createdAt } }
                   }
                 }
               }
@@ -241,43 +255,55 @@ discover() {
         .commits.nodes[0].commit.status.context as $gate |
         select(
           $gate != null and
-          $gate.state != "PENDING" and
+          $gate.state == "SUCCESS" and
           (($gate.description // "") | endswith($gate_stamp) | not)
         ) |
         .headRefOid
       ' |
       awk '!seen[$0]++')
-    pending_shas=$(printf '%s\n' "$pr_gate_states" |
-      jq -r '
+    # Only recover recent pending publications. An unchanged blocked commit
+    # cannot gain missing CI jobs through polling. workflow_run and exact-SHA
+    # dispatch still evaluate it regardless of age when work resumes.
+    recovery_cutoff=$(($(date +%s) - 86400))
+    pending_states=$(printf '%s\n' "$pr_gate_states" |
+      jq -c --argjson cutoff "$recovery_cutoff" '[
         .[].data.repository.pullRequests.nodes[] |
         select(.commits.nodes[0].commit.status.context.state == "PENDING") |
-        .headRefOid
-      ' |
-      awk '!seen[$0]++')
+        {sha: .headRefOid, expired: ((.commits.nodes[0].commit.status.context.createdAt | fromdateiso8601) <= $cutoff)}
+      ]')
+    pending_shas=$(printf '%s\n' "$pending_states" | jq -r '.[] | select(.expired | not) | .sha')
+    deferred_shas=$(printf '%s\n' "$pending_states" | jq -r '.[] | select(.expired) | .sha')
     missing_shas=$(printf '%s\n' "$pr_gate_states" | jq -r '
       .[].data.repository.pullRequests.nodes[] |
       select(.commits.nodes[0].commit.status.context == null) |
       .headRefOid
     ')
 
-    discovery=$(jq -nc --arg stale "$stale_terminal_shas" --arg pending "$pending_shas" --arg missing "$missing_shas" '
+    discovery=$(jq -nc --arg stale "$stale_terminal_shas" --arg pending "$pending_shas" --arg missing "$missing_shas" --arg deferred "$deferred_shas" '
       def shas: split("\n") | map(select(length > 0)) | reduce .[] as $sha ([]; if index($sha) then . else . + [$sha] end);
-      {kind:"sweep", stale:($stale|shas), pending:($pending|shas), missing:($missing|shas)}')
+      {kind:"sweep", stale:($stale|shas), pending:($pending|shas), missing:($missing|shas), deferred:($deferred|shas)}')
   fi
   printf '%s\n' "$discovery" | jq -e '
-    [.stale[], .pending[], .missing[]] as $shas |
+    [.stale[], .pending[], .missing[], .deferred[]?] as $shas |
     all($shas[]; test("^[0-9a-f]{40}$")) and ($shas|length) == ($shas|unique|length)
   ' >/dev/null
   matrix=$(printf '%s\n' "$discovery" | jq -c '{include:[.stale[]|{sha:.}]}')
   emit_matrix "$matrix"
   emit_output discovery "$discovery"
+  printf '%s\n' "$discovery" | jq -r '.deferred[]?' | while read -r deferred_sha; do
+    report_blocked_head "$deferred_sha remains blocked: pending status unchanged for at least 24 hours; scheduled recovery stopped. Update the branch or dispatch Deploy Gate with this exact SHA after resolving its checks."
+  done
 }
 
 finish_invalidation() {
   local result=$?
   post_pending_on_exit "$result"
   if [ "${gate_status_exhausted:-0}" -eq 1 ]; then
-    invalidation_outcome=exhausted
+    if [ "$result" -eq 0 ]; then
+      invalidation_outcome=blocked
+    else
+      invalidation_outcome=exhausted
+    fi
   fi
   jq -nc --arg sha "$SHA" --arg outcome "${invalidation_outcome:-failed}" \
     '{version:1,sha:$sha,outcome:$outcome}' > "$RESULT_PATH"
@@ -327,7 +353,7 @@ for directory in sorted(root.iterdir()) if root.exists() else []:
         if not directory.is_dir() or list(directory.iterdir()) != [path]:
             raise ValueError("Invalid invalidation artifact contents")
         row = json.loads(path.read_text())
-        if not isinstance(row, dict) or set(row) != {"version", "sha", "outcome"} or row["version"] != 1 or row["sha"] != sha or row["outcome"] not in ("invalidated", "failed", "exhausted"):
+        if not isinstance(row, dict) or set(row) != {"version", "sha", "outcome"} or row["version"] != 1 or row["sha"] != sha or row["outcome"] not in ("invalidated", "failed", "exhausted", "blocked"):
             raise ValueError("Invalid invalidation result")
         results[sha] = row["outcome"]
     except (ValueError, KeyError, TypeError, OSError) as error:
@@ -341,7 +367,7 @@ if unknown:
     protocol_failed = True
 print(json.dumps({
     "stale": [sha for sha in discovery["stale"] if results.get(sha) in {"invalidated", "failed"}],
-    "invalidation_failed": any(value != "invalidated" for value in results.values()),
+    "invalidation_failed": any(value not in {"invalidated", "blocked"} for value in results.values()),
     "protocol_failed": protocol_failed
 }, separators=(",", ":")))
 ')

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -8,10 +8,11 @@ run-name: Deploy Gate ${{ github.event.workflow_run.head_sha || github.event.inp
 # (#5479): event-driven evaluation alone can strand a PR — the check-runs API
 # can serve stale reads (~1 min normally, longer during GitHub degradation),
 # and the last workflow_run event for a SHA is the last time anything
-# re-evaluates. The sweep finds open-PR head SHAs whose gate status is pending
-# or whose required-check contract stamp is stale, then re-evaluates them. A
-# stranded PR heals within 30 minutes, and a success from an older gate cannot
-# stay mergeable after the required set changes (#5851).
+# re-evaluates. For 24 hours after a pending status is published, the sweep
+# re-evaluates it. Older pending heads remain blocked and are listed in the
+# run summary for a branch update or exact-SHA dispatch. Failed gates stay
+# blocked until a workflow event or dispatch evaluates them again. Successes
+# with an old required-check contract are always invalidated (#5851).
 
 on:
   workflow_run:

--- a/docs/solutions/conventions/a-gate-required-check-must-be-an-if-gated-job-not-a-path-filtered-workflow.md
+++ b/docs/solutions/conventions/a-gate-required-check-must-be-an-if-gated-job-not-a-path-filtered-workflow.md
@@ -53,7 +53,7 @@ latest[name] = 'pending'                                    # deploy-gate.sh:424
 print('failed=' + ','.join(... latest[name] not in ('success', 'skipped')))  # deploy-gate.sh:428
 ```
 
-A required name with no check run on the SHA is `pending`, so the gate waits and the 30-minute sweep (`.github/workflows/deploy-gate.yml:21`) keeps retrying forever. A `skipped` conclusion is accepted as passing. A workflow with a top-level `paths:` filter publishes no check run at all on a PR that does not match it, so any of its jobs in `required` strands every non-matching PR. An `if:`-gated job inside an always-triggered workflow publishes `skipped` instead, which the gate accepts. `desktop-rust` and `umami-postgres` in `.github/workflows/test.yml` already worked this way; the new `markdown` job in `.github/workflows/lint-code.yml:69` now does too.
+A required name with no check run on the SHA is `pending`. The 30-minute sweep retries for 24 hours after the latest pending status publication, then leaves the commit blocked and lists it in the run summary. A `skipped` conclusion is accepted as passing. A workflow with a top-level `paths:` filter publishes no check run at all on a PR that does not match it, so any of its jobs in `required` strands every non-matching PR. An `if:`-gated job inside an always-triggered workflow publishes `skipped` instead, which the gate accepts. `desktop-rust` and `umami-postgres` in `.github/workflows/test.yml` already worked this way; the new `markdown` job in `.github/workflows/lint-code.yml:69` now does too.
 
 ```yaml
   markdown:
@@ -73,7 +73,11 @@ MARKDOWN=$(printf '%s\n' "$FILES" | grep -cE '\.md$|^\.markdownlint|^package(-lo
 
 That set is `LINT_MD_INPUTS` from `.husky/pre-push:428` plus the lockfile, which the local pre-push gate omits, so CI treats a strict superset of what the local gate treats as a markdown change. Per this session's conclusion, the `.md`-only version of this filter passed the author's own review and was caught only by a multi-reviewer pass that included a cross-model Codex review. The same principle already existed in the workflow: the `VALIDATION` filter counts `package.json` and `package-lock.json` at `.github/workflows/test.yml:184`, and the `CODE` filter carves `src-tauri` node suites back in at `.github/workflows/test.yml:144` because `sidecar` and `unit` both run them and both are gated on `code`.
 
-**4. Expect a transitional pending on every open PR after you edit `required`.** The list is hashed into a gate contract stamp (`.github/scripts/deploy-gate.sh:141`), and the sweep uses that stamp to tell current evidence from a success posted against an older list, posting `Required PR gate contract changed; re-evaluation scheduled` (`.github/scripts/deploy-gate.sh:293`). Open PRs will show the new check pending until they push again. That is designed behaviour from #5851, not a regression.
+**4. Expect a transitional pending on previously green PRs after you edit `required`.** The list is hashed into a gate contract stamp, and the sweep uses that stamp to tell current evidence from a success posted against an older list, posting `Required PR gate contract changed; re-evaluation scheduled`. A PR missing the new check stays pending until it runs current CI. This preserves the stale-success protection from #5851.
+
+Scheduled recovery expires when a pending status has been unchanged for 24 hours. Update the branch to run current checks, or use **Deploy Gate → Run workflow → sha** to evaluate that exact commit after resolving its checks. Workflow completion events also evaluate their SHA regardless of this cutoff. Failed or errored gates are already blocked and are not reopened by a contract change; stale successes must still be invalidated at any age.
+
+GitHub can exhaust commit-status capacity on a SHA. If the latest gate is verified as pending, failure, or error, the commit remains blocked and the run reports the required branch update without failing independent recovery. An exhausted success or an unreadable previous gate still fails the run because the gate cannot prove that the commit is blocked. A new commit is required to restore status publication on an exhausted SHA; dispatch alone cannot do that.
 
 ## Why This Matters
 

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -1126,9 +1126,9 @@ describe('CI workflow coverage', () => {
     assert.match(deployGateJob, /pullRequests\(first: 100, states: \[OPEN\], after: \$endCursor\)/);
     assert.match(deployGateJob, /pageInfo \{ hasNextPage endCursor \}/);
     assert.match(deployGateJob, /contexts\(first: 100, after: \$endCursor\)/);
-    assert.match(deployGateJob, /status \{ context\(name: "gate"\) \{ state description \} \}/);
+    assert.match(deployGateJob, /status \{ context\(name: "gate"\) \{ state description createdAt \} \}/);
     assert.match(deployGateJob, /stale_terminal_shas=/);
-    assert.match(deployGateJob, /\$gate\.state != "PENDING"/);
+    assert.match(deployGateJob, /\$gate\.state == "SUCCESS"/);
     assert.match(deployGateJob, /context\.state == "PENDING"/);
     assert.match(deployGateJob, /endswith\(\$gate_stamp\) \| not/);
     assert.match(deployGateJob, /awk '!seen\[\$0\]\+\+'/);

--- a/tests/deploy-gate-status-description.test.mjs
+++ b/tests/deploy-gate-status-description.test.mjs
@@ -113,13 +113,13 @@ describe('deploy gate phase results', () => {
   });
 
   it('keeps ordinary failures eligible and excludes exhausted heads', () => {
-    for (const outcome of ['invalidated', 'failed', 'exhausted']) {
+    for (const outcome of ['invalidated', 'failed', 'exhausted', 'blocked']) {
       const result = recoverPlan(plan, { [artifact]: { version: 1, sha: stale, outcome } });
       assert.deepEqual(result.matrix.include, [
-        ...(outcome === 'exhausted' ? [] : [{ sha: stale, check_attempts: 1 }]),
+        ...(['exhausted', 'blocked'].includes(outcome) ? [] : [{ sha: stale, check_attempts: 1 }]),
         { sha: pending, check_attempts: 2 },
       ]);
-      assert.equal(result.invalidation_failed, outcome !== 'invalidated');
+      assert.equal(result.invalidation_failed, !['invalidated', 'blocked'].includes(outcome));
       assert.equal(result.protocol_failed, false);
     }
   });
@@ -151,6 +151,7 @@ describe('deploy gate phase results', () => {
  * cannot be masked by its predecessor.
  */
 function runGate(conclusions, {
+  now = '2026-08-12T12:30:00Z',
   failedRunCreatedAt = '2026-08-12T12:15:00Z',
   failedRunSha = SHA,
   graphQlFailures = 0,
@@ -184,6 +185,7 @@ function runGate(conclusions, {
   const callsFile = join(tempDir, 'calls');
   const currentStatusesFile = join(tempDir, 'current-statuses.json');
   const statusReadFailuresFile = join(tempDir, 'status-read-failures');
+  const summaryFile = join(tempDir, 'summary');
 
   try {
     mkdirSync(fakeBin);
@@ -197,6 +199,7 @@ function runGate(conclusions, {
     writeFileSync(postTargetsFile, '');
     writeFileSync(rejectedFile, '');
     writeFileSync(callsFile, '');
+    writeFileSync(summaryFile, '');
     writeFileSync(statusReadFailuresFile, String(statusReadFailures));
     writeFileSync(currentStatusesFile, JSON.stringify(Object.fromEntries(
       (sweepStatuses ?? [{ sha: SHA, status: previousStatus ?? sweepStatus }])
@@ -277,7 +280,7 @@ function runGate(conclusions, {
         nodes: [{
           commit: {
             status: {
-              context: status,
+              context: status ? { createdAt: now, ...status } : null,
             },
           },
         }],
@@ -511,7 +514,7 @@ function runGate(conclusions, {
           FAKE_POSTED: postedFile,
           FAKE_POST_TARGETS: postTargetsFile,
           FAKE_REJECTED: rejectedFile,
-          FAKE_NOW: String(Date.parse('2026-08-12T12:30:00Z') / 1000),
+          FAKE_NOW: String(Date.parse(now) / 1000),
           FAKE_RESET_AT: String(Date.parse('2026-08-12T12:30:10Z') / 1000),
           FAKE_RESET_AVAILABLE: resetAvailable ? '1' : '0',
           FAKE_STATUS_FAILURE_KIND: statusFailureKind,
@@ -520,6 +523,7 @@ function runGate(conclusions, {
           FAKE_SWEEP_RESPONSES: sweepFile,
           FAKE_SHA: SHA,
           GH_TOKEN: 'test-token',
+          GITHUB_STEP_SUMMARY: summaryFile,
           PATH: `${fakeBin}:${process.env.PATH}`,
           REPO: 'koala73/worldmonitor',
           RUNNER_TEMP: tempDir,
@@ -545,6 +549,7 @@ function runGate(conclusions, {
       postTargets: readFileSync(postTargetsFile, 'utf8').split('\n').filter(Boolean),
       posted: parse(postedFile),
       rejected: parse(rejectedFile),
+      summary: readFileSync(summaryFile, 'utf8'),
     };
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
@@ -572,7 +577,7 @@ describe('deploy gate commit-status description', () => {
     assert.equal(result.posted[0].state, 'pending');
   });
 
-  it('continues a sweep after an exhausted head without repeating its rejected write', () => {
+  it('keeps an exhausted pending head blocked without failing independent recovery', () => {
     const secondSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     const result = runGate(conclusionsFor('success'), {
       exhaustedSha: SHA,
@@ -580,9 +585,100 @@ describe('deploy gate commit-status description', () => {
         sha, status: { state: 'PENDING', description: stamped('Waiting for checks') },
       })),
     });
-    assert.notEqual(result.status, 0);
+    assert.equal(result.status, 0, result.stderr);
     assert.deepEqual(result.postTargets, [secondSha], result.stderr);
     assert.equal(result.calls.filter((call) => call.startsWith('status:')).length, 2);
+    assert.match(result.summary, /status capacity exhausted/);
+    assert.match(result.summary, /remains blocked/);
+    assert.doesNotMatch(result.stdout + result.stderr, /::error::/);
+  });
+
+  it('stops polling the unchanged exhausted PR from run 34041600634', () => {
+    const exhausted = '6a6648de9e94cc739866b1c2523aca15ab9e1932';
+    const result = runGate({}, {
+      now: '2026-09-06T15:12:57Z',
+      exhaustedSha: exhausted,
+      repetitions: 2,
+      sweepStatuses: [{
+        sha: exhausted,
+        status: {
+          state: 'PENDING',
+          createdAt: '2026-09-05T06:25:21Z',
+          description: 'Waiting for required PR gates (18): typecheck-changes,lint-changes,consumer-prices,umami-postgres,dom-tests,... [gate-contract:5c196f971bc8]',
+        },
+      }],
+    });
+    assert.deepEqual(result.exitCodes, [0, 0], result.stderr);
+    assert.deepEqual(result.posted, []);
+    assert.equal(result.statusReads, 0);
+    assert.deepEqual(result.calls, Array(2).fill(['graphql-sweep-page', 'graphql-sweep-page']).flat());
+    assert.match(result.summary, new RegExp(exhausted));
+    assert.match(result.summary, /remains blocked/);
+    assert.match(result.summary, /Update the branch/);
+  });
+
+  it('recovers only pending statuses newer than the 24-hour cutoff', () => {
+    const shas = ['a', 'b', 'c'].map((letter) => letter.repeat(40));
+    const publications = ['2026-08-11T12:29:59Z', '2026-08-11T12:30:00Z', '2026-08-11T12:30:01Z'];
+    const result = runGate(conclusionsFor('success'), {
+      sweepStatuses: shas.map((sha, index) => ({
+        sha,
+        status: {
+          state: 'PENDING',
+          createdAt: publications[index],
+          description: stamped('Waiting for checks'),
+        },
+      })),
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.postTargets, [shas[2]]);
+    assert.match(result.summary, new RegExp(shas[0]));
+    assert.match(result.summary, new RegExp(shas[1]));
+    assert.doesNotMatch(result.summary, new RegExp(shas[2]));
+  });
+
+  it('allows an exact-SHA evaluation after scheduled recovery expires', () => {
+    const result = runGate(conclusionsFor('success'), {
+      previousStatus: {
+        state: 'pending',
+        createdAt: '2026-06-02T19:27:26Z',
+        description: 'Waiting for old checks',
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.posted.at(-1).state, 'success');
+  });
+
+  it('does not reopen failed gates when the required contract changes', () => {
+    const result = runGate(conclusionsFor('success'), {
+      sweepStatuses: ['FAILURE', 'ERROR'].map((state, index) => ({
+        sha: String(index + 1).repeat(40),
+        status: { state, description: 'Blocked under an older contract' },
+      })),
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.calls, ['graphql-sweep-page', 'graphql-sweep-page']);
+    assert.deepEqual(result.posted, []);
+  });
+
+  it('still fails on exhaustion when the previous gate cannot be verified as blocked', () => {
+    for (const statusReadFailures of [0, 10]) {
+      const result = runGate(conclusionsFor('success'), { exhaustedSha: SHA, statusReadFailures });
+      assert.notEqual(result.status, 0);
+      assert.match(result.stdout + result.stderr, /::error::Gate status capacity exhausted/);
+    }
+  });
+
+  it('accepts an exhausted gate already blocked by another writer after discovery', () => {
+    const result = runGate(conclusionsFor('success'), {
+      exhaustedSha: SHA,
+      sweepStatus: { state: 'SUCCESS', description: 'Old contract' },
+      previousStatus: { state: 'pending', description: stamped('Waiting for checks') },
+    });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.deepEqual(result.posted, []);
+    assert.deepEqual(result.calls, ['graphql-sweep-page', 'graphql-sweep-page', 'status:pending']);
+    assert.match(result.summary, /remains blocked/);
   });
 
   it('keeps evaluating other heads when a stale green cannot be invalidated', () => {
@@ -590,7 +686,7 @@ describe('deploy gate commit-status description', () => {
     const result = runGate(conclusionsFor('success'), {
       exhaustedSha: SHA,
       sweepStatuses: [
-        { sha: SHA, status: { state: 'SUCCESS', description: 'Old contract' } },
+        { sha: SHA, status: { state: 'SUCCESS', createdAt: '2026-06-02T19:27:26Z', description: 'Old contract' } },
         { sha: secondSha, status: { state: 'PENDING', description: stamped('Waiting for checks') } },
       ],
     });


### PR DESCRIPTION
## Summary

An unchanged, already-blocked PR can no longer make Deploy Gate schedule runs fail indefinitely. Scheduled recovery stops 24 hours after the latest pending status publication and lists the blocked commit with a branch-update or exact-SHA dispatch instruction. Workflow completion events and explicit dispatch still evaluate any SHA regardless of age.

Status-capacity exhaustion is a notice only when the latest gate was successfully read as pending, failure, or error. Stale successes are still invalidated at any age; exhaustion or unknown state that prevents proving the commit is blocked still fails the run. Failed gates are not reopened just because the required-check list changes.

Related: [failed schedule run 34041600634](https://github.com/koala73/worldmonitor/actions/runs/34041600634).

## Validation

- Regression replay uses the affected commit and its observed pending timestamp. Before the fix, two sweeps fail; after it, both succeed without polling or attempting a status write for that commit.
- Read-only discovery against live GitHub data deferred `6a6648de9e94cc739866b1c2523aca15ab9e1932` and kept 27 recent pending heads eligible. No live status writes or workflow dispatches were performed.
- 39 gate tests and 41 workflow checks pass, including the 24-hour boundary, explicit recovery, stale-green exhaustion, unreadable previous status, and a writer blocking the commit between discovery and invalidation.
- Typecheck, lint, Bash syntax, changed-document Markdown lint, and `git diff --check` pass. Full lint reports existing warnings; the changed tests have no lint diagnostics.

## Post-Deploy Monitoring & Validation

After merge, the maintainer should inspect the next two scheduled Deploy Gate runs. The affected commit should appear under `scheduled recovery stopped` in the run summary and have no evaluation job, while recent pending heads still recover. Its commit gate must remain blocked. A stale success that cannot be invalidated must still fail visibly. Investigate or revert if a blocked commit receives an unsupported success or the same exhausted head continues to fail the schedule. Natural scheduled-run acceptance remains unverified until this change reaches main.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
