### PR TITLE
test(coverage): reconnect brief and widget suites

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -36,6 +36,7 @@ RUN npm ci --prefix scripts --omit=dev --omit=optional --ignore-scripts
 
 # Relay script and shared helpers
 COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs
+COPY scripts/_widget-response-parser.cjs ./scripts/_widget-response-parser.cjs
 COPY scripts/_opensky-account-cooldown.cjs ./scripts/_opensky-account-cooldown.cjs
 # Shared ingestion outcome/cooldown helpers imported by ais-relay.cjs.
 COPY scripts/_ingestion-coverage.cjs ./scripts/_ingestion-coverage.cjs

--- a/scripts/_widget-response-parser.cjs
+++ b/scripts/_widget-response-parser.cjs
@@ -1,0 +1,15 @@
+'use strict';
+
+function parseWidgetAgentResponse(text, maxHtml) {
+  const source = String(text ?? '');
+  const htmlMatch = source.match(/<!--\s*widget-html\s*-->([\s\S]*?)<!--\s*\/widget-html\s*-->/);
+  const titleMatch = source.match(/<!--\s*title:\s*([^\n]+?)\s*-->/);
+
+  return {
+    html: (htmlMatch?.[1] ?? source).slice(0, maxHtml),
+    title: titleMatch?.[1]?.trim() ?? 'Custom Widget',
+    hasHtmlMarkers: Boolean(htmlMatch),
+  };
+}
+
+module.exports = { parseWidgetAgentResponse };

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -25,6 +25,7 @@ const crypto = require('crypto');
 const v8 = require('v8');
 const { WebSocketServer, WebSocket } = require('ws');
 const { parseProxyConfig, resolveProxyString, resolveProxyStringForAttempt } = require('./_proxy-utils.cjs');
+const { parseWidgetAgentResponse } = require('./_widget-response-parser.cjs');
 const {
   cooldownKeyForAccount,
   OPENSKY_LEGACY_COOLDOWN_KEY,
@@ -13690,10 +13691,7 @@ async function handleWidgetAgentRequest(req, res) {
       if (response.stop_reason === 'end_turn') {
         const textBlock = response.content.find(b => b.type === 'text');
         const text = textBlock?.text ?? '';
-        const htmlMatch = text.match(/<!--\s*widget-html\s*-->([\s\S]*?)<!--\s*\/widget-html\s*-->/);
-        const html = (htmlMatch?.[1] ?? text).slice(0, maxHtml);
-        const titleMatch = text.match(/<!--\s*title:\s*([^\n]+?)\s*-->/);
-        const title = titleMatch?.[1]?.trim() ?? 'Custom Widget';
+        const { html, title } = parseWidgetAgentResponse(text, maxHtml);
         sendWidgetSSE(res, 'html_complete', { html });
         sendWidgetSSE(res, 'done', { title });
         completed = true;
@@ -13764,11 +13762,10 @@ async function handleWidgetAgentRequest(req, res) {
         const text = Array.isArray(msg.content)
           ? msg.content.filter(b => b.type === 'text').map(b => b.text).join('')
           : String(msg.content ?? '');
-        const htmlMatch = text.match(/<!--\s*widget-html\s*-->([\s\S]*?)<!--\s*\/widget-html\s*-->/);
-        if (htmlMatch?.[1]?.trim()) {
-          const titleMatch = text.match(/<!--\s*title:\s*([^\n]+?)\s*-->/);
-          sendWidgetSSE(res, 'html_complete', { html: htmlMatch[1].slice(0, maxHtml) });
-          sendWidgetSSE(res, 'done', { title: titleMatch?.[1]?.trim() ?? 'Custom Widget' });
+        const parsed = parseWidgetAgentResponse(text, maxHtml);
+        if (parsed.hasHtmlMarkers && parsed.html.trim()) {
+          sendWidgetSSE(res, 'html_complete', { html: parsed.html });
+          sendWidgetSSE(res, 'done', { title: parsed.title });
           recovered = true;
           break;
         }

--- a/scripts/lib/digest-orchestration-helpers.mjs
+++ b/scripts/lib/digest-orchestration-helpers.mjs
@@ -9,6 +9,31 @@ import { compareRules, MAX_STORIES_PER_USER } from './brief-compose.mjs';
 import { generateDigestProse } from './brief-llm.mjs';
 
 /**
+ * Derive the three Telegram carousel image URLs from a signed magazine URL.
+ * The HMAC token binds the user and issue slot, so the carousel routes reuse
+ * the same token. Invalid magazine URLs return null so delivery can fall back
+ * to text.
+ *
+ * @param {unknown} magazineUrl
+ * @returns {string[] | null}
+ */
+export function carouselUrlsFrom(magazineUrl) {
+  try {
+    const url = new URL(magazineUrl);
+    const match = url.pathname.match(/^\/api\/brief\/([^/]+)\/(\d{4}-\d{2}-\d{2}-\d{4})\/?$/);
+    if (!match) return null;
+    const [, userId, issueSlot] = match;
+    const token = url.searchParams.get('t');
+    if (!token) return null;
+    return [0, 1, 2].map(
+      (page) => `${url.origin}/api/brief/carousel/${userId}/${issueSlot}/${page}?t=${token}`,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Build the email subject string. Extracted so the synthesis-level
  * → subject ternary can be unit-tested without standing up the whole
  * cron loop. (Plan acceptance criterion A6.i.)

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -27,6 +27,7 @@
       "scripts/_seed-utils.mjs",
       "scripts/_wb-tech-readiness-projection.cjs",
       "scripts/_weather-alert-select.mjs",
+      "scripts/_widget-response-parser.cjs",
       "scripts/_yahoo-sector-valuations.cjs",
       "scripts/ais-relay.cjs",
       "scripts/docs-stats.mjs",

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -58,6 +58,7 @@ import {
   shouldExitNonZero as shouldExitOnBriefFailures,
 } from './lib/brief-compose.mjs';
 import {
+  carouselUrlsFrom,
   digestWindowStartMs,
   pickWinningCandidateWithPool,
   readTimeAgeCutoffMs,
@@ -1253,31 +1254,6 @@ function truncateTelegramHtml(html, limit = TELEGRAM_MAX_LEN) {
   const lastNewline = truncated.lastIndexOf('\n');
   const cutPoint = lastNewline > limit * 0.6 ? lastNewline : truncated.length;
   return sanitizeTelegramHtml(truncated.slice(0, cutPoint) + '\n\n[truncated]');
-}
-
-/**
- * Phase 8: derive the 3 carousel image URLs from a signed magazine
- * URL. The HMAC token binds (userId, issueSlot), not the path — so
- * the same token verifies against /api/brief/{u}/{slot}?t=T AND against
- * /api/brief/carousel/{u}/{slot}/{0|1|2}?t=T.
- *
- * Returns null when the magazine URL doesn't match the expected shape
- * — caller falls back to text-only delivery.
- */
-function carouselUrlsFrom(magazineUrl) {
-  try {
-    const u = new URL(magazineUrl);
-    const m = u.pathname.match(/^\/api\/brief\/([^/]+)\/(\d{4}-\d{2}-\d{2}-\d{4})\/?$/);
-    if (!m) return null;
-    const [, userId, issueSlot] = m;
-    const token = u.searchParams.get('t');
-    if (!token) return null;
-    return [0, 1, 2].map(
-      (p) => `${u.origin}/api/brief/carousel/${userId}/${issueSlot}/${p}?t=${token}`,
-    );
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -82,6 +82,7 @@ import {
   PremiumLayerGate,
 } from './premium-layer-gate';
 import { globeAltitudeToMapZoom, mapZoomToGlobeAltitude } from '@/utils/globe-zoom';
+import { headingToCompass } from '@/utils/heading-to-compass';
 
 export interface GlobeMapOptions {
   onInitError?: (error: unknown) => void;
@@ -1478,8 +1479,7 @@ export class GlobeMap {
       html = `<span style="color:${sc};font-weight:bold;">🎯 ${esc(d.name)}</span>` +
              `<br><span style="opacity:.7;">Escalation: ${d.escalationScore}/5</span>`;
     } else if (d._kind === 'flight') {
-      const dirs = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];
-      const compass = dirs[Math.round(((d.heading ?? 0) % 360 + 360) % 360 / 22.5) % 16];
+      const compass = headingToCompass(d.heading);
       html = `<span style="font-weight:bold;">✈ ${esc(d.callsign)}</span>` +
              `<br><span style="opacity:.7;">${esc(d.type)}</span>` +
              `<br><span style="opacity:.5;">Heading: ${compass} (${Math.round(d.heading ?? 0)}°)</span>`;

--- a/src/utils/heading-to-compass.ts
+++ b/src/utils/heading-to-compass.ts
@@ -1,0 +1,23 @@
+const COMPASS_DIRECTIONS = [
+  'N',
+  'NNE',
+  'NE',
+  'ENE',
+  'E',
+  'ESE',
+  'SE',
+  'SSE',
+  'S',
+  'SSW',
+  'SW',
+  'WSW',
+  'W',
+  'WNW',
+  'NW',
+  'NNW',
+] as const;
+
+export function headingToCompass(heading: number | null | undefined): string {
+  const normalized = (((heading ?? 0) % 360) + 360) % 360;
+  return COMPASS_DIRECTIONS[Math.round(normalized / 22.5) % COMPASS_DIRECTIONS.length] ?? 'N';
+}

--- a/tests/brief-carousel.test.mjs
+++ b/tests/brief-carousel.test.mjs
@@ -15,6 +15,7 @@ import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pageFromIndex, renderCarouselImageResponse } from '../server/_shared/brief-carousel-render.ts';
+import { carouselUrlsFrom } from '../scripts/lib/digest-orchestration-helpers.mjs';
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 const RENDERER_SOURCE_PATH = resolve(TEST_DIR, '../server/_shared/brief-carousel-render.ts');
@@ -74,28 +75,6 @@ async function renderCarouselImageResponseForTest(...args) {
   return renderCarouselImageResponse(...args);
 }
 
-// Import the URL helper via dynamic eval of the private function.
-// The digest cron is .mjs; we re-declare the same logic here to lock
-// the behaviour. If the cron's copy drifts, this test stops guarding
-// the contract and should be migrated to shared import.
-//
-// Kept in-sync via a grep assertion at the bottom of this file.
-function carouselUrlsFrom(magazineUrl) {
-  try {
-    const u = new URL(magazineUrl);
-    const m = u.pathname.match(/^\/api\/brief\/([^/]+)\/(\d{4}-\d{2}-\d{2}-\d{4})\/?$/);
-    if (!m) return null;
-    const [, userId, issueSlot] = m;
-    const token = u.searchParams.get('t');
-    if (!token) return null;
-    return [0, 1, 2].map(
-      (p) => `${u.origin}/api/brief/carousel/${userId}/${issueSlot}/${p}?t=${token}`,
-    );
-  } catch {
-    return null;
-  }
-}
-
 describe('pageFromIndex', () => {
   it('maps 0 → cover, 1 → threads, 2 → story', () => {
     assert.equal(pageFromIndex(0), 'cover');
@@ -149,18 +128,6 @@ describe('carouselUrlsFrom', () => {
     assert.equal(carouselUrlsFrom('not a url'), null);
     assert.equal(carouselUrlsFrom(''), null);
     assert.equal(carouselUrlsFrom(null), null);
-  });
-});
-
-describe('carouselUrlsFrom — contract parity with seed-digest-notifications.mjs', () => {
-  it('the cron embeds the same function body (guards drift)', async () => {
-    const { readFileSync } = await import('node:fs');
-    const { fileURLToPath } = await import('node:url');
-    const { dirname, resolve } = await import('node:path');
-    const __d = dirname(fileURLToPath(import.meta.url));
-    const src = readFileSync(resolve(__d, '../scripts/seed-digest-notifications.mjs'), 'utf-8');
-    assert.match(src, /function carouselUrlsFrom\(magazineUrl\)/, 'cron must export carouselUrlsFrom');
-    assert.match(src, /\/api\/brief\/carousel\/\$\{userId\}\/\$\{issueSlot\}\/\$\{p\}\?t=\$\{token\}/, 'cron path template must match test fixture');
   });
 });
 

--- a/tests/brief-composer-rule-dedup.test.mjs
+++ b/tests/brief-composer-rule-dedup.test.mjs
@@ -142,28 +142,11 @@ describe('dedupeRulesByUser', () => {
 });
 
 describe('aiDigestEnabled default parity', () => {
-  // The composer's main loop short-circuits on `rule.aiDigestEnabled
-  // === false`. Exercising the predicate directly so a refactor that
-  // re-inverts it (back to `!rule.aiDigestEnabled`) fails loud.
-
-  function shouldSkipForAiDigest(rule) {
-    return rule.aiDigestEnabled === false;
-  }
-
-  it('includes rules with aiDigestEnabled: true', () => {
-    assert.equal(shouldSkipForAiDigest({ aiDigestEnabled: true }), false);
-  });
-
-  it('includes rules with aiDigestEnabled: undefined (legacy rows)', () => {
-    assert.equal(shouldSkipForAiDigest({ aiDigestEnabled: undefined }), false);
-  });
-
-  it('includes rules with no aiDigestEnabled field at all (legacy rows)', () => {
-    assert.equal(shouldSkipForAiDigest({}), false);
-  });
-
-  it('excludes only when explicitly false', () => {
-    assert.equal(shouldSkipForAiDigest({ aiDigestEnabled: false }), true);
+  it('groupEligibleRulesByUser: legacy rule without aiDigestEnabled remains eligible', () => {
+    const legacyRule = rule();
+    delete legacyRule.aiDigestEnabled;
+    const grouped = groupEligibleRulesByUser([legacyRule]);
+    assert.equal(grouped.get('user_abc')?.[0], legacyRule);
   });
 
   it('groupEligibleRulesByUser: opted-out preferred variant falls back to opted-in sibling', () => {

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -1905,16 +1905,9 @@ describe('Sprint 1 U7 — digest projection invariant: digest.cards ⊆ brief.ca
   // ── Error path companion: missing-clusterId on digest side throws clearly ──
 
   it('error path: digest story with no mergedHashes, hash, or sourceUrl throws a clear diagnostic', () => {
-    // Defends against a producer regression: if a future buildDigest variant
-    // omits `hash` from the per-story shape AND there's no mergedHashes
-    // AND no sourceUrl, projectDigestEmitClusterId throws BEFORE the subset
-    // check runs — the consequence is otherwise a `Set([undefined])`
-    // membership glitch that would fail the subset check with a confusing
-    // "undefined not in set" message rather than naming the producer
-    // regression. (Note: we use `link` not `sourceUrl` here to keep the
-    // story shape clearly absent of all three sources; a future digest
-    // story carrying `sourceUrl` would correctly fall through to the
-    // level-3 url-fallback covered below.)
+    // This expected-side oracle does not execute the live digest producer.
+    // It verifies that a producer-shaped fixture with no cluster identifier
+    // fails before the subset check with a clear diagnostic.
     assert.throws(
       () => projectDigestEmitClusterId({ title: 'no hash here', link: 'https://example.com/x' }),
       /cannot derive clusterId/,

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -47,6 +47,7 @@ async function invokeHandlerWithCachedEnvelope(
   providerCompletion = null,
   primary = 'gemini',
   fallbackProviderCompletion = null,
+  requestOverrides = {},
 ) {
   const previousEnv = Object.fromEntries(HANDLER_ENV_KEYS.map((key) => [key, process.env[key]]));
   const originalFetch = globalThis.fetch;
@@ -97,8 +98,9 @@ async function invokeHandlerWithCachedEnvelope(
       headers: {
         Authorization: 'Bearer test-relay-secret',
         'Content-Type': 'application/json',
+        ...requestOverrides.headers,
       },
-      body: JSON.stringify({ story: story() }),
+      body: requestOverrides.body ?? JSON.stringify({ story: story() }),
     });
     const response = await handler(request);
     return { response, body: await response.json(), fetchCalls };
@@ -700,12 +702,6 @@ describe('endpoint validation contract', () => {
   // test regression on the endpoint flow (see "endpoint end-to-end" below).
   const VALID_THREAT = new Set(['critical', 'high', 'medium', 'low']);
   const CAPS = { headline: 400, source: 120, category: 80, country: 80 };
-  // Must match `api/internal/brief-why-matters.ts:116` — bumped to 8192 in
-  // PR #3269 to accommodate v2 output + description. If this ever drifts
-  // again, the bloated-fixture assertion below silently passes for
-  // payloads in the (OLD_VALUE, NEW_VALUE] range that the real endpoint
-  // now accepts (greptile P2, PR #3281).
-  const MAX_BODY_BYTES = 8192;
 
   function validate(raw) {
     if (!raw || typeof raw !== 'object') return { ok: false, msg: 'body' };
@@ -723,10 +719,6 @@ describe('endpoint validation contract', () => {
       if (s.country.length > CAPS.country) return { ok: false, msg: 'country-length' };
     }
     return { ok: true };
-  }
-
-  function measureBytes(obj) {
-    return new TextEncoder().encode(JSON.stringify(obj)).byteLength;
   }
 
   it('accepts a valid payload', () => {
@@ -767,21 +759,34 @@ describe('endpoint validation contract', () => {
     assert.deepEqual(validate({ story: withoutCountry }), { ok: true });
   });
 
-  it('body cap catches oversize payloads (both Content-Length and post-read)', () => {
-    const bloated = {
+  it('rejects oversize payloads through both endpoint body-cap paths', async () => {
+    const cachedEnvelope = {
+      whyMatters: 'The ruling keeps the 2027 race open while reshaping coalition strategy.',
+      producedBy: 'analyst',
+      at: '2026-07-10T00:00:00.000Z',
+    };
+    const oversizedBody = JSON.stringify({
       story: {
         ...story(),
-        // Artificial oversize payload — would need headline cap bypassed
-        // to reach in practice, but the total body-byte cap must still fire.
-        // Sized well above MAX_BODY_BYTES (8192) so a future bump doesn't
-        // silently invalidate the assertion.
         extra: 'x'.repeat(10_000),
       },
-    };
-    assert.ok(measureBytes(bloated) > MAX_BODY_BYTES, 'fixture is oversize');
-    // Note: body-cap is enforced at the handler level, not the validator.
-    // We assert the invariant about the measure here; the handler path is
-    // covered by the endpoint smoke test below.
+    });
+
+    for (const [path, requestOverrides] of [
+      ['Content-Length', { headers: { 'Content-Length': '10000' } }],
+      ['post-read byte length', { body: oversizedBody }],
+    ]) {
+      const { response, body, fetchCalls } = await invokeHandlerWithCachedEnvelope(
+        cachedEnvelope,
+        null,
+        'gemini',
+        null,
+        requestOverrides,
+      );
+      assert.equal(response.status, 400, path);
+      assert.equal(body.error, 'body exceeds 8192 bytes', path);
+      assert.equal(fetchCalls.length, 0, `${path} must reject before cache access`);
+    }
   });
 });
 

--- a/tests/country-panels-followed-only-filter.test.mjs
+++ b/tests/country-panels-followed-only-filter.test.mjs
@@ -2,33 +2,12 @@
  * Tests for U7 — "Followed only" filter chip integrated with the
  * live `getFollowed()` / `subscribe()` service contract.
  *
- * Mirrors `tests/cii-panel-pin-to-top.test.mjs` — we deliberately do
- * NOT spin up the real `DiseaseOutbreaksPanel` / `DisplacementPanel`
- * here. `Panel.ts` pulls in `import.meta.glob` (i18n) which the
- * node:test runner can't resolve, and the test would devolve into a
- * DOM stub competition.
- *
- * What we test instead:
- *  - The chip's `isActive()` reflects localStorage written by user
- *    toggle.
- *  - When chip is on, applying `isFollowed(row.code)` to a list of
- *    rows produces the expected subset — this IS the filter pass
- *    inside both panels.
- *  - When the user mutates the watchlist via the service
- *    (`addCountry` / external set + dispatch), the next filter pass
- *    sees the new state — proving the panel's
- *    `subscribe(rerender)` wiring will see what the chip sees.
- *  - Empty filtered result + chip on → caller renders the U7 empty
- *    state message.
+ * These tests exercise the real followed-country service and chip.
+ * They do not simulate panel rendering.
  */
 
 import { describe, it, before, beforeEach, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { resolve } from 'node:path';
-
-const ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
 // ---------------------------------------------------------------------------
 // Browser-global stubs
@@ -143,10 +122,6 @@ function makeHost() {
   return host;
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 function setupAnonymousFlagOn() {
   _setDepsForTests({
     getCurrentClerkUser: () => null,
@@ -164,292 +139,55 @@ beforeEach(() => {
   _resetAllPersistedStateForTests();
 });
 
-/**
- * Pure helper that mirrors the inline filter pass in
- * `DiseaseOutbreaksPanel._render` and `DisplacementPanel.renderContent`:
- * when `chipActive` is true, retain only rows whose `code` is in the
- * user's followed list (per the live service); otherwise pass-through.
- */
-function applyFollowedOnlyFilter(rows, chipActive) {
-  if (!chipActive) return rows;
-  return rows.filter((r) => (r.code ? isFollowed(r.code) : false));
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('country-scoped panels — happy paths', () => {
-  it('5 rows from 5 countries; user follows 2; chip on → 2 rows shown', () => {
+describe('followed-only chip and country service', () => {
+  it('activates against the live followed-country state', () => {
     setupAnonymousFlagOn();
     _localStorage.setItem(
       FOLLOWED_COUNTRIES_STORAGE_KEY,
       JSON.stringify({ countries: ['US', 'IR'] }),
     );
-    const rows = [
-      { code: 'US', label: 'us-row' },
-      { code: 'CN', label: 'cn-row' },
-      { code: 'IR', label: 'ir-row' },
-      { code: 'BR', label: 'br-row' },
-      { code: 'IN', label: 'in-row' },
-    ];
     const handle = renderFollowedOnlyChip({ panelId: 'panel-disease' });
     const host = makeHost();
     handle.attach(host);
     host.clickChip();
 
-    const filtered = applyFollowedOnlyFilter(rows, handle.isActive());
-    assert.equal(filtered.length, 2);
-    assert.deepEqual(filtered.map((r) => r.code).sort(), ['IR', 'US']);
+    assert.equal(handle.isActive(), true);
+    assert.equal(isFollowed('US'), true);
+    assert.equal(isFollowed('IR'), true);
+    assert.equal(isFollowed('CN'), false);
   });
 
-  it('chip off → all 5 rows shown', () => {
-    setupAnonymousFlagOn();
-    _localStorage.setItem(
-      FOLLOWED_COUNTRIES_STORAGE_KEY,
-      JSON.stringify({ countries: ['US', 'IR'] }),
-    );
-    const rows = [
-      { code: 'US' },
-      { code: 'CN' },
-      { code: 'IR' },
-      { code: 'BR' },
-      { code: 'IN' },
-    ];
-    const handle = renderFollowedOnlyChip({ panelId: 'panel-disease' });
-    handle.attach(makeHost());
-
-    const filtered = applyFollowedOnlyFilter(rows, handle.isActive());
-    assert.equal(filtered.length, 5);
-  });
-
-  it('rows without a country code are dropped when chip is on', () => {
-    setupAnonymousFlagOn();
-    _localStorage.setItem(
-      FOLLOWED_COUNTRIES_STORAGE_KEY,
-      JSON.stringify({ countries: ['US'] }),
-    );
-    const rows = [
-      { code: 'US' },
-      { code: undefined },
-      { code: '' },
-      { code: 'CN' },
-    ];
-    const handle = renderFollowedOnlyChip({ panelId: 'panel-rowsless' });
-    const host = makeHost();
-    handle.attach(host);
-    host.clickChip();
-
-    const filtered = applyFollowedOnlyFilter(rows, handle.isActive());
-    assert.deepEqual(filtered.map((r) => r.code), ['US']);
-  });
-});
-
-describe('country-scoped panels — edge cases', () => {
-  it('chip on, all rows filtered out → caller renders empty-state copy', () => {
-    setupAnonymousFlagOn();
-    _localStorage.setItem(
-      FOLLOWED_COUNTRIES_STORAGE_KEY,
-      JSON.stringify({ countries: ['JP'] }), // followed code is not in row list
-    );
-    const rows = [{ code: 'US' }, { code: 'CN' }, { code: 'IR' }];
-    const handle = renderFollowedOnlyChip({ panelId: 'panel-empty' });
-    const host = makeHost();
-    handle.attach(host);
-    host.clickChip();
-
-    const filtered = applyFollowedOnlyFilter(rows, handle.isActive());
-    assert.equal(filtered.length, 0);
-
-    // The caller's empty-state branch (used by both panels):
-    const emptyMessage = handle.isActive()
-      ? 'No items in your followed countries. Add countries by tapping the star, or turn off this filter.'
-      : 'No outbreaks match filter';
-    assert.match(emptyMessage, /No items in your followed countries/);
-  });
-
-  it('empty watchlist → chip rendered disabled (panel-side: chip off OR empty-state)', () => {
+  it('renders disabled for an empty watchlist', () => {
     setupAnonymousFlagOn();
     const handle = renderFollowedOnlyChip({ panelId: 'panel-empty-wl' });
     const host = makeHost();
     handle.attach(host);
     assert.match(host.innerHTML, /\bdisabled\b/);
     assert.match(host.innerHTML, /Follow countries to enable this filter/);
-    // isActive defaults to false; panel renders the full list normally.
     assert.equal(handle.isActive(), false);
   });
 });
 
-describe('country-scoped panels — chip placement keeps close button rightmost', () => {
-  // Mirrors the production logic in DiseaseOutbreaksPanel + DisplacementPanel:
-  //
-  //   const closeBtn = this.header.querySelector('.panel-close-btn');
-  //   if (closeBtn) {
-  //     this.header.insertBefore(host, closeBtn);
-  //   } else {
-  //     this.header.appendChild(host);
-  //   }
-  //
-  // The bug: a plain `this.header.appendChild(host)` lands the chip AFTER
-  // the close button (Panel base appends `.panel-close-btn` first), so X
-  // is no longer the rightmost header control. We assert the placement
-  // logic via a minimal fake header DOM — Panel.ts itself can't be
-  // imported under node:test (i18n's `import.meta.glob`).
-
-  function makeFakeHeader() {
-    const children = [];
-    const header = {
-      _children: children,
-      appendChild(node) {
-        children.push(node);
-        return node;
-      },
-      insertBefore(node, ref) {
-        const i = children.indexOf(ref);
-        if (i === -1) {
-          children.push(node);
-        } else {
-          children.splice(i, 0, node);
-        }
-        return node;
-      },
-      querySelector(sel) {
-        if (sel === '.panel-close-btn') {
-          return children.find((c) => c.className === 'panel-close-btn') ?? null;
-        }
-        return null;
-      },
-      get lastChild() {
-        return children[children.length - 1] ?? null;
-      },
-    };
-    return header;
-  }
-
-  /**
-   * Mirrors the ordered Panel-base header construction:
-   *   header-left → status-badge → count → close-btn
-   * The chip is mounted from the panel constructor AFTER the base has
-   * already appended the close button (Panel.ts line 748).
-   */
-  function buildHeaderWithBaseControls() {
-    const header = makeFakeHeader();
-    header.appendChild({ className: 'panel-header-left' });
-    header.appendChild({ className: 'panel-status-badge' });
-    header.appendChild({ className: 'panel-count' });
-    header.appendChild({ className: 'panel-close-btn' });
-    return header;
-  }
-
-  /** The fix's placement logic — used by both panels. */
-  function mountChipBeforeClose(header, host) {
-    const closeBtn = header.querySelector('.panel-close-btn');
-    if (closeBtn) {
-      header.insertBefore(host, closeBtn);
-    } else {
-      header.appendChild(host);
-    }
-  }
-
-  it('DiseaseOutbreaksPanel shape — close button stays as last header child after chip mount', () => {
-    const header = buildHeaderWithBaseControls();
-    const host = { className: 'panel-header-followed-only-host' };
-    mountChipBeforeClose(header, host);
-    assert.equal(
-      header.lastChild?.className,
-      'panel-close-btn',
-      'close button must be the rightmost (last) header child',
-    );
-    // And the chip host is immediately before it.
-    const idxClose = header._children.findIndex((c) => c.className === 'panel-close-btn');
-    const idxHost = header._children.findIndex((c) => c.className === 'panel-header-followed-only-host');
-    assert.equal(idxHost, idxClose - 1, 'chip host sits directly before close');
-  });
-
-  it('DisplacementPanel shape — same placement guarantee (logic is shared)', () => {
-    // Identical to the disease-outbreaks panel; the production logic is
-    // copy-pasted into both panels. We assert again so a regression in
-    // one panel doesn't pass under the other panel's coverage.
-    const header = buildHeaderWithBaseControls();
-    const host = { className: 'panel-header-followed-only-host' };
-    mountChipBeforeClose(header, host);
-    assert.equal(header.lastChild?.className, 'panel-close-btn');
-  });
-
-  it('BUG SHAPE — naive appendChild lands chip AFTER close (regression guard)', () => {
-    // If a future refactor accidentally drops the insertBefore branch,
-    // this test fires the alarm: header.lastChild becomes the chip host.
-    const header = buildHeaderWithBaseControls();
-    const host = { className: 'panel-header-followed-only-host' };
-    header.appendChild(host); // naive — the bug shape
-    assert.equal(
-      header.lastChild?.className,
-      'panel-header-followed-only-host',
-      'sanity: naive appendChild lands chip after close (this is the bug)',
-    );
-  });
-
-  it('no close button present (defensive) → chip falls back to appendChild', () => {
-    // If a Panel subclass disabled the close button entirely, the
-    // querySelector returns null and the fix falls through to appendChild
-    // — the chip still mounts; it just won't have a close to land before.
-    const header = makeFakeHeader();
-    header.appendChild({ className: 'panel-header-left' });
-    const host = { className: 'panel-header-followed-only-host' };
-    mountChipBeforeClose(header, host);
-    assert.equal(header.lastChild?.className, 'panel-header-followed-only-host');
-  });
-
-  it('DisplacementPanel destroy removes the inserted followed-only host', () => {
-    const src = readFileSync(resolve(ROOT, 'src/components/DisplacementPanel.ts'), 'utf8');
-    assert.match(
-      src,
-      /private followedOnlyHost: HTMLElement \| null = null;/,
-      'DisplacementPanel must retain the inserted header host for cleanup',
-    );
-    assert.match(
-      src,
-      /this\.followedOnlyHost = host;/,
-      'DisplacementPanel must store the host when mounting the chip',
-    );
-    assert.match(
-      src,
-      /this\.followedOnlyHost\.parentElement\.removeChild\(this\.followedOnlyHost\)/,
-      'destroy() must remove the chip host from the panel header',
-    );
-    assert.match(
-      src,
-      /this\.followedOnlyHost = null;/,
-      'destroy() must clear the host reference',
-    );
-  });
-});
-
-describe('country-scoped panels — re-filter on watchlist change', () => {
-  it('external watchlist add fires WM_FOLLOWED_COUNTRIES_CHANGED → filter sees new state', () => {
+describe('followed-country notifications', () => {
+  it('external watchlist add notifies subscribers and updates service state', () => {
     setupAnonymousFlagOn();
     _localStorage.setItem(
       FOLLOWED_COUNTRIES_STORAGE_KEY,
       JSON.stringify({ countries: ['US'] }),
     );
-    const rows = [{ code: 'US' }, { code: 'CN' }, { code: 'IR' }];
-
     const handle = renderFollowedOnlyChip({ panelId: 'panel-rerender' });
     const host = makeHost();
     handle.attach(host);
     host.clickChip();
 
-    // Panel-side rerender pass: triggered by subscribe() in production.
     let rerenderCount = 0;
-    const lastFiltered = { rows: [] };
     const unsub = subscribe(() => {
       rerenderCount += 1;
-      lastFiltered.rows = applyFollowedOnlyFilter(rows, handle.isActive());
     });
-
-    // Initial pass — only US.
-    const filtered = applyFollowedOnlyFilter(rows, handle.isActive());
-    assert.deepEqual(filtered.map((r) => r.code), ['US']);
 
     // External add: user follows IR via another tab / surface.
     _localStorage.setItem(
@@ -459,28 +197,27 @@ describe('country-scoped panels — re-filter on watchlist change', () => {
     _window.dispatchEvent(new CustomEvent(WM_FOLLOWED_COUNTRIES_CHANGED));
 
     assert.equal(rerenderCount, 1);
-    assert.deepEqual(lastFiltered.rows.map((r) => r.code).sort(), ['IR', 'US']);
+    assert.equal(isFollowed('IR'), true);
+    assert.equal(handle.isActive(), true);
 
     unsub();
   });
 
-  it('toggling the chip OFF does not break subsequent watchlist-driven re-renders', () => {
+  it('keeps an inactive chip off after an external watchlist change', () => {
     setupAnonymousFlagOn();
     _localStorage.setItem(
       FOLLOWED_COUNTRIES_STORAGE_KEY,
       JSON.stringify({ countries: ['US'] }),
     );
-    const rows = [{ code: 'US' }, { code: 'CN' }];
-
     const handle = renderFollowedOnlyChip({ panelId: 'panel-toggle-off' });
     const host = makeHost();
     handle.attach(host);
     host.clickChip(); // on
     host.clickChip(); // off
 
-    let lastCount = 0;
+    let notificationCount = 0;
     const unsub = subscribe(() => {
-      lastCount = applyFollowedOnlyFilter(rows, handle.isActive()).length;
+      notificationCount += 1;
     });
 
     _localStorage.setItem(
@@ -489,8 +226,8 @@ describe('country-scoped panels — re-filter on watchlist change', () => {
     );
     _window.dispatchEvent(new CustomEvent(WM_FOLLOWED_COUNTRIES_CHANGED));
 
-    // Chip is off so all rows are passed through regardless of watchlist.
-    assert.equal(lastCount, 2);
+    assert.equal(notificationCount, 1);
+    assert.equal(handle.isActive(), false);
     unsub();
   });
 });

--- a/tests/globe-tooltip-enrichment.test.mjs
+++ b/tests/globe-tooltip-enrichment.test.mjs
@@ -14,20 +14,15 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { headingToCompass } from '../src/utils/heading-to-compass.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const readSrc = (relPath) => readFileSync(resolve(root, relPath), 'utf-8');
 
 // ========================================================================
-// 1. Compass heading calculation (pure math, mirrors GlobeMap logic)
+// 1. Compass heading calculation used by GlobeMap
 // ========================================================================
-
-/** Replicates the compass formula from GlobeMap.showMarkerTooltip */
-function headingToCompass(heading) {
-  const dirs = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];
-  return dirs[Math.round(((heading ?? 0) % 360 + 360) % 360 / 22.5) % 16];
-}
 
 describe('headingToCompass', () => {
   it('returns N for heading 0', () => {

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -16,6 +16,9 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
+import widgetResponseParser from '../scripts/_widget-response-parser.cjs';
+
+const { parseWidgetAgentResponse } = widgetResponseParser;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -377,26 +380,17 @@ describe('widget-store — constants and logic', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. Title regex (hyphens-in-titles bug fix)
+// 3. Widget response parsing
 // ---------------------------------------------------------------------------
-describe('widget-agent relay — title extraction regex', () => {
+describe('widget-agent relay — response parsing', () => {
   const relay = src('scripts/ais-relay.cjs');
 
-  it('title regex does NOT exclude hyphens (fixed bug: [^\\n\\-] → [^\\n])', () => {
-    // Extract the title extraction regex from the relay source
-    const match = relay.match(/titleMatch\s*=\s*text\.match\(([^;]+)\)/);
-    assert.ok(match, 'Title extraction line not found (expected: titleMatch = text.match(...))');
-    const regexStr = match[1];
-    // Must NOT have \- inside a character class (the old bug)
-    assert.ok(
-      !regexStr.includes('\\-') && !regexStr.includes('\\\\-'),
-      `Title regex must not exclude hyphens. Found: ${regexStr}`,
-    );
+  it('relay delegates completed and recovered responses to the shared parser', () => {
+    const calls = relay.match(/parseWidgetAgentResponse\(/g) ?? [];
+    assert.equal(calls.length, 2);
   });
 
-  it('title regex correctly parses hyphenated titles', () => {
-    // Simulate the regex from the source
-    const regex = /<!--\s*title:\s*([^\n]+?)\s*-->/;
+  it('parses hyphenated titles through the production parser', () => {
     const cases = [
       { input: '<!-- title: Market-Tracker -->', expected: 'Market-Tracker' },
       { input: '<!-- title: US-China Trade Watch -->', expected: 'US-China Trade Watch' },
@@ -404,34 +398,29 @@ describe('widget-agent relay — title extraction regex', () => {
       { input: '<!-- title:  Leading Spaces -->', expected: 'Leading Spaces' },
     ];
     for (const { input, expected } of cases) {
-      const m = input.match(regex);
-      assert.ok(m, `No match for: ${input}`);
-      assert.equal(m[1].trim(), expected, `Wrong title extracted from: ${input}`);
+      const result = parseWidgetAgentResponse(input, 50_000);
+      assert.equal(result.title, expected, `Wrong title extracted from: ${input}`);
     }
   });
 
-  it('title regex falls back to "Custom Widget" when comment absent', () => {
-    const regex = /<!--\s*title:\s*([^\n]+?)\s*-->/;
+  it('falls back to "Custom Widget" when the title comment is absent', () => {
     const text = 'Some widget HTML without title comment';
-    const m = text.match(regex);
-    const title = m?.[1]?.trim() ?? 'Custom Widget';
-    assert.equal(title, 'Custom Widget');
+    assert.equal(parseWidgetAgentResponse(text, 50_000).title, 'Custom Widget');
   });
 
-  it('html extraction regex handles multiline content', () => {
-    const regex = /<!--\s*widget-html\s*-->([\s\S]*?)<!--\s*\/widget-html\s*-->/;
-    const html = `<!-- widget-html -->\n<div>hello</div>\n<!-- /widget-html -->`;
-    const m = html.match(regex);
-    assert.ok(m, 'HTML extraction must match');
-    assert.ok(m[1].includes('<div>hello</div>'), 'Must capture content between markers');
+  it('extracts multiline HTML between markers', () => {
+    const text = `<!-- widget-html -->\n<div>hello</div>\n<!-- /widget-html -->`;
+    const result = parseWidgetAgentResponse(text, 50_000);
+    assert.equal(result.hasHtmlMarkers, true);
+    assert.ok(result.html.includes('<div>hello</div>'));
+    assert.ok(!result.html.includes('widget-html'));
   });
 
-  it('html extraction falls back to full text when markers missing', () => {
-    const regex = /<!--\s*widget-html\s*-->([\s\S]*?)<!--\s*\/widget-html\s*-->/;
+  it('falls back to full text when HTML markers are missing', () => {
     const text = '<div>fallback</div>';
-    const m = text.match(regex);
-    const html = (m?.[1] ?? text).slice(0, 50000);
-    assert.equal(html, '<div>fallback</div>');
+    const result = parseWidgetAgentResponse(text, 50_000);
+    assert.equal(result.hasHtmlMarkers, false);
+    assert.equal(result.html, text);
   });
 });
 


### PR DESCRIPTION
## Summary

The brief, widget, globe, and followed-country suites now either call production behavior or remove copied assertions that did not protect production code.

- Telegram carousel URL tests call the production helper used by the digest sender.
- Analyst body-limit tests invoke the real Edge handler through both rejection paths.
- Widget response tests call the parser used by both relay completion paths.
- Globe compass tests call the helper used by `GlobeMap`.
- Redundant local copies of AI-digest eligibility, followed-country filtering, empty-state copy, and panel-header placement were removed while the real service and chip tests remain.
- The digest projection comment now describes its expected-side oracle accurately.

Integration review found that the relay's new widget parser also had to be part of the Docker image and Railway watch-path closure. Both deployment contracts now include it, so the production relay will not start with a missing module and changes to the parser will trigger the managed service.

## Validation

- `node scripts/run-data-tests.mjs tests/brief-carousel.test.mjs tests/brief-composer-rule-dedup.test.mjs tests/brief-why-matters-analyst.test.mjs tests/brief-from-digest-stories.test.mjs tests/widget-builder.test.mjs tests/globe-tooltip-enrichment.test.mjs tests/country-panels-followed-only-filter.test.mjs tests/dockerfile-relay-imports.test.mjs tests/railway-watch-path-audit.test.mjs tests/railway-deploy-closure.test.mjs tests/railway-services-registry-coverage.test.mts`: 637 passed, 0 failed.
- `npm run --silent typecheck:all`: passed.
- `npm run --silent lint:boundaries`: passed.
- Targeted Biome check for all changed code and test files: passed.
- CJS syntax checks for the relay and widget parser: passed.
- `git diff --check origin/main...HEAD`: passed.
- Exact-head pre-push gate: typecheck, API typecheck, CJS syntax, architecture and safety lints, changed tests, Unicode scan, Edge isolation, and version sync passed.

Temporary named production mutations were reverted after each expected failure:

- Carousel pages `[0, 1, 2]` to `[0, 1]`: the production-helper test failed with two URLs instead of three.
- Analyst `MAX_BODY_BYTES` from `8192` to `12000`: the Content-Length endpoint case returned `200` instead of the expected `400`.
- Widget title parser `[^\n]` to `[^\n-]`: the hyphenated-title case returned `Custom Widget` instead of `Market-Tracker`.
- Widget missing-marker fallback from the source text to an empty string: the production-parser case returned an empty string instead of `<div>fallback</div>`.
- Globe compass selection from `Math.round` to `Math.floor`: the `-10°` and `11.25°` boundary cases failed.

The other flagged sections were deletion-only because adjacent production-bound tests already prove the retained behavior.

## Post-Deploy Monitoring & Validation

No data migration or manual production action is required. After deployment, confirm that the `ais-relay` service starts without `MODULE_NOT_FOUND` for `_widget-response-parser.cjs`; the Railway watch-path and Docker import-closure tests provide the pre-deploy contract.

Related: #7771

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
