### PR TITLE
perf(military): cap retained and returned vessels at 500

### DIFF
--- a/src/services/military-vessels.ts
+++ b/src/services/military-vessels.ts
@@ -21,6 +21,37 @@ const vesselHistory = new Map<string, { positions: [number, number][]; lastUpdat
 const HISTORY_MAX_POINTS = 30;
 const HISTORY_CLEANUP_INTERVAL = 10 * 60 * 1000; // 10 minutes
 const VESSEL_STALE_TIME = 60 * 60 * 1000; // 1 hour - consider vessel stale
+// Bound live tracking and merged/saved snapshots independently of AIS traffic volume.
+const MAX_MILITARY_VESSELS = 500;
+
+type VesselSnapshot = { vessels: MilitaryVessel[]; clusters: MilitaryVesselCluster[] };
+
+// Carriers first, then dark/unusual vessels, then recency. IDs make ties stable.
+function compareVesselPriority(a: MilitaryVessel, b: MilitaryVessel): number {
+  return Number(b.vesselType === 'carrier') - Number(a.vesselType === 'carrier')
+    || Number(Boolean(b.isDark || b.isInteresting)) - Number(Boolean(a.isDark || a.isInteresting))
+    || (b.lastAisUpdate.getTime() || 0) - (a.lastAisUpdate.getTime() || 0)
+    || a.id.localeCompare(b.id);
+}
+
+function limitVesselSnapshot(data: VesselSnapshot): VesselSnapshot {
+  if (data.vessels.length <= MAX_MILITARY_VESSELS) return data;
+
+  const vessels = [...data.vessels].sort(compareVesselPriority).slice(0, MAX_MILITARY_VESSELS);
+  const retained = new Map(vessels.map(v => [v.id, v]));
+  const clusters = data.clusters.flatMap(cluster => {
+    const members = cluster.vessels.flatMap(v => retained.get(v.id) ?? []);
+    if (members.length < 2) return [];
+    return [{
+      ...cluster,
+      vessels: members,
+      vesselCount: members.length,
+      lat: members.reduce((sum, v) => sum + v.lat, 0) / members.length,
+      lon: members.reduce((sum, v) => sum + v.lon, 0) / members.length,
+    }];
+  });
+  return { vessels, clusters };
+}
 
 // Tracking state
 let isTracking = false;
@@ -28,13 +59,13 @@ let messageCount = 0;
 let historyCleanupIntervalId: ReturnType<typeof setInterval> | null = null;
 
 // Circuit breaker
-const breaker = createCircuitBreaker<{ vessels: MilitaryVessel[]; clusters: MilitaryVesselCluster[] }>({
+const breaker = createCircuitBreaker<VesselSnapshot>({
   name: 'Military Vessel Tracking',
   maxFailures: 3,
   cooldownMs: 5 * 60 * 1000,
   cacheTtlMs: 30 * 1000,
   persistCache: true,
-  revivePersistedData: (data) => ({
+  revivePersistedData: (data) => limitVesselSnapshot({
     ...data,
     vessels: data.vessels.map((v: MilitaryVessel) => ({
       ...v,
@@ -412,6 +443,18 @@ function processAisPosition(data: AisPositionData): void {
 
   const previousSize = trackedVessels.size;
   trackedVessels.set(mmsi, vessel);
+  if (trackedVessels.size > MAX_MILITARY_VESSELS) {
+    cleanup();
+    if (trackedVessels.size > MAX_MILITARY_VESSELS) {
+      // Each callback adds at most one vessel. Evict one without sorting the whole feed.
+      let lowest = vessel;
+      for (const candidate of trackedVessels.values()) {
+        if (compareVesselPriority(candidate, lowest) > 0) lowest = candidate;
+      }
+      trackedVessels.delete(lowest.mmsi);
+      vesselHistory.delete(lowest.mmsi);
+    }
+  }
 
   // Clear the breaker cache when first vessels arrive or when we hit significant milestones.
   // This ensures cached empty results don't block fresh data.
@@ -554,10 +597,7 @@ export function getMilitaryVesselStatus(): { connected: boolean; vessels: number
 /**
  * Main function to get military vessels
  */
-export async function fetchMilitaryVessels(): Promise<{
-  vessels: MilitaryVessel[];
-  clusters: MilitaryVesselCluster[];
-}> {
+export async function fetchMilitaryVessels(): Promise<VesselSnapshot> {
 
   return breaker.execute(async () => {
     // Initialize stream if not running
@@ -578,7 +618,7 @@ export async function fetchMilitaryVessels(): Promise<{
       const usniReport = await fetchUSNIFleetReport();
       if (usniReport && usniReport.vessels.length > 0) {
         const merged = mergeUSNIWithAIS(vessels, usniReport, aisClusters);
-        return merged;
+        return limitVesselSnapshot(merged);
       }
     } catch (e) {
       console.warn('[Military Vessels] USNI merge failed, using AIS only:', (e as Error).message);

--- a/tests/dom/military-vessels-retention.test.mts
+++ b/tests/dom/military-vessels-retention.test.mts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AisPositionData } from '@/services/maritime';
+import type { MilitaryVessel, USNIFleetReport } from '@/types';
+
+const stream = vi.hoisted(() => ({
+  registerAisCallback: vi.fn(),
+  unregisterAisCallback: vi.fn(),
+  isAisConfigured: vi.fn(() => false),
+  initAisStream: vi.fn(),
+}));
+const fetchReport = vi.hoisted(() => vi.fn<() => Promise<USNIFleetReport | null>>());
+
+vi.mock('@/services/maritime', () => stream);
+vi.mock('@/utils', () => import('@/utils/circuit-breaker'));
+vi.mock('@/services/usni-fleet', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/services/usni-fleet')>(),
+  fetchUSNIFleetReport: fetchReport,
+}));
+
+let service: typeof import('@/services/military-vessels');
+let receive: (data: AisPositionData) => void;
+let now: number;
+const LIMIT = 500;
+
+function position(index: number, overrides: Partial<AisPositionData> = {}): AisPositionData {
+  return {
+    mmsi: String(300100000 + index), name: 'TEST PATROL', shipType: 35,
+    lat: -40, lon: -140, ...overrides,
+  };
+}
+
+function send(index: number, overrides: Partial<AisPositionData> = {}): void {
+  now++;
+  receive(position(index, overrides));
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  localStorage.clear();
+  stream.registerAisCallback.mockClear();
+  fetchReport.mockReset().mockResolvedValue(null);
+  now = Date.parse('2026-09-06T12:00:00Z');
+  vi.spyOn(Date, 'now').mockImplementation(() => now);
+  service = await import('@/services/military-vessels');
+  service.initMilitaryVesselStream();
+  receive = stream.registerAisCallback.mock.calls[0][0];
+});
+
+afterEach(() => {
+  service.disconnectMilitaryVesselStream();
+  service.stopVesselHistoryCleanup();
+  localStorage.clear();
+});
+
+describe('military vessel feed retention', () => {
+  it('bounds every insertion in the reported 1,473-vessel case and returns the newest ordinary vessels', async () => {
+    for (let i = 0; i < 1473; i++) {
+      send(i);
+      expect(service.getMilitaryVesselStatus().vessels).toBeLessThanOrEqual(LIMIT);
+    }
+    const data = await service.fetchMilitaryVessels();
+    expect(data.vessels).toHaveLength(LIMIT);
+    expect(new Set(data.vessels.map(v => v.mmsi))).toEqual(
+      new Set(Array.from({ length: LIMIT }, (_, i) => position(973 + i).mmsi)),
+    );
+    expect(service.getVesselByMmsi(position(0).mmsi)).toBeUndefined();
+    expect(service.getVesselsNearLocation(-40, -140)).toHaveLength(LIMIT);
+    expect((await service.fetchMilitaryVessels()).vessels).toHaveLength(LIMIT);
+    expect(fetchReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps carriers, dark returns and unusual positions ahead of newer ordinary vessels', async () => {
+    send(1);
+    now += 61 * 60 * 1000;
+    send(1); // Real AIS gap detection marks this return as dark.
+    send(2, { name: 'USS Nimitz' });
+    send(3, { lat: 26.5, lon: 56.5 });
+    for (let i = 4; i < LIMIT + 20; i++) send(i);
+
+    const data = await service.fetchMilitaryVessels();
+    expect(data.vessels).toHaveLength(LIMIT);
+    expect(service.getVesselByMmsi(position(1).mmsi)?.isDark).toBe(true);
+    expect(service.getDarkVessels().map(v => v.mmsi)).toContain(position(1).mmsi);
+    expect(service.getVesselByMmsi(position(2).mmsi)?.vesselType).toBe('carrier');
+    expect(service.getVesselByMmsi(position(3).mmsi)?.isInteresting).toBe(true);
+    expect(service.getVesselByMmsi(position(4).mmsi)).toBeUndefined();
+  });
+
+  it('uses a stable MMSI tie break when reports arrive at the same time', () => {
+    for (let i = LIMIT; i >= 0; i--) receive(position(i));
+    expect(service.getMilitaryVesselStatus().vessels).toBe(LIMIT);
+    expect(service.getVesselByMmsi(position(0).mmsi)).toBeDefined();
+    expect(service.getVesselByMmsi(position(LIMIT).mmsi)).toBeUndefined();
+  });
+
+  it('rejects lower-priority arrivals when full and still bounds an all-carrier feed', () => {
+    for (let i = 0; i < LIMIT; i++) send(i, { name: 'USS Nimitz' });
+    send(LIMIT, { lat: 26.5, lon: 56.5 });
+    expect(service.getVesselByMmsi(position(LIMIT).mmsi)).toBeUndefined();
+    send(LIMIT + 1, { name: 'USS Carl Vinson' });
+    expect(service.getMilitaryVesselStatus().vessels).toBe(LIMIT);
+    expect(service.getVesselByMmsi(position(0).mmsi)).toBeUndefined();
+    expect(service.getVesselByMmsi(position(LIMIT + 1).mmsi)?.vesselType).toBe('carrier');
+
+    now += 61 * 60 * 1000;
+    send(LIMIT);
+    expect(service.getVesselByMmsi(position(LIMIT).mmsi)?.track).toBeUndefined();
+  });
+
+  it('deletes evicted trails, preserves retained updates and caps each trail at 30 points', () => {
+    send(0);
+    send(0, { lat: -41 });
+    expect(service.getVesselByMmsi(position(0).mmsi)?.track).toHaveLength(2);
+    for (let i = 1; i <= LIMIT; i++) send(i);
+    expect(service.getVesselByMmsi(position(0).mmsi)).toBeUndefined();
+    send(0);
+    expect(service.getVesselByMmsi(position(0).mmsi)?.track).toBeUndefined();
+    for (let i = 0; i < 40; i++) send(0, { lat: -41 });
+    expect(service.getVesselByMmsi(position(0).mmsi)?.track).toHaveLength(30);
+    expect(service.getMilitaryVesselStatus().vessels).toBe(LIMIT);
+  });
+
+  it('expires stale priority vessels before evicting fresh ordinary vessels', async () => {
+    send(0, { name: 'USS Nimitz' });
+    now += 61 * 60 * 1000;
+    for (let i = 1; i <= LIMIT; i++) send(i);
+    expect(service.getVesselByMmsi(position(0).mmsi)).toBeUndefined();
+    expect(service.getMilitaryVesselStatus().vessels).toBe(LIMIT);
+    now += 61 * 60 * 1000;
+    expect((await service.fetchMilitaryVessels()).vessels).toHaveLength(0);
+  });
+
+  it('caps the real USNI merge and keeps cluster membership, counts and centers consistent', async () => {
+    for (let i = 0; i < LIMIT; i++) send(i, { lat: 28 + i / 1000, lon: 125 });
+    const articleDate = new Date(now - 3600_000).toISOString();
+    fetchReport.mockResolvedValue({
+      articleUrl: 'https://news.usni.org/test', articleDate, articleTitle: 'Test fleet report',
+      timestamp: articleDate, strikeGroups: [], regions: ['Western Pacific'], parsingWarnings: [],
+      vessels: ['USS Nimitz', 'USS Carl Vinson'].map((name, i) => ({
+        name, hullNumber: `CVN-${68 + i * 2}`, vesselType: 'carrier', region: 'Western Pacific',
+        regionLat: 28, regionLon: 125, deploymentStatus: 'deployed', strikeGroup: 'Test group',
+        usniArticleUrl: 'https://news.usni.org/test', usniArticleDate: articleDate,
+      })),
+    });
+
+    const data = await service.fetchMilitaryVessels();
+    expect(data.vessels).toHaveLength(LIMIT);
+    expect(data.vessels.filter(v => v.usniSource)).toHaveLength(2);
+    const byId = new Map(data.vessels.map(v => [v.id, v]));
+    expect(data.clusters.length).toBeGreaterThanOrEqual(2);
+    for (const cluster of data.clusters) {
+      expect(cluster.vesselCount).toBe(cluster.vessels.length);
+      expect(cluster.vesselCount).toBeGreaterThanOrEqual(2);
+      expect(cluster.lat).toBeCloseTo(cluster.vessels.reduce((sum, v) => sum + v.lat, 0) / cluster.vesselCount);
+      expect(cluster.lon).toBeCloseTo(cluster.vessels.reduce((sum, v) => sum + v.lon, 0) / cluster.vesselCount);
+      for (const vessel of cluster.vessels) expect(vessel).toBe(byId.get(vessel.id));
+    }
+  });
+
+  it('returns the bounded AIS set when USNI fails and leaves small feeds complete', async () => {
+    send(0);
+    send(1);
+    fetchReport.mockRejectedValue(new Error('USNI unavailable'));
+    expect((await service.fetchMilitaryVessels()).vessels).toHaveLength(2);
+    for (let i = 2; i < 1473; i++) send(i);
+    service.disconnectMilitaryVesselStream();
+    service.initMilitaryVesselStream();
+    expect((await service.fetchMilitaryVessels()).vessels).toHaveLength(LIMIT);
+  });
+
+  it('bounds an older persisted payload and drops clusters with fewer than two retained members', async () => {
+    const vessels = Array.from({ length: 1473 }, (_, i): MilitaryVessel => ({
+      ...position(i), id: `ais-${position(i).mmsi}`, vesselType: 'destroyer',
+      operator: 'other', operatorCountry: 'Unknown', heading: 0, speed: 0,
+      lastAisUpdate: new Date(now + i), confidence: 'low', isInteresting: false,
+    }));
+    const cluster = (id: string, members: MilitaryVessel[]) => ({
+      id, name: id, lat: -40, lon: -140, vesselCount: members.length, vessels: members,
+    });
+    const key = 'breaker:Military Vessel Tracking';
+    localStorage.setItem(`worldmonitor-persistent-cache:${key}`, JSON.stringify({
+      key, updatedAt: now, data: { vessels, clusters: [
+        cluster('retained', vessels),
+        cluster('removed', vessels.slice(0, 2)),
+        cluster('singleton', [vessels[0], vessels[1472]]),
+      ] },
+    }));
+
+    const data = await service.fetchMilitaryVessels();
+    expect(fetchReport).not.toHaveBeenCalled();
+    expect(data.vessels).toHaveLength(LIMIT);
+    expect(data.vessels[0].mmsi).toBe(position(1472).mmsi);
+    expect(data.vessels.every(v => v.lastAisUpdate instanceof Date)).toBe(true);
+    expect(data.clusters.map(c => c.id)).toEqual(['retained']);
+    expect(data.clusters[0].vesselCount).toBe(LIMIT);
+    expect(data.clusters[0].vessels.every(v => data.vessels.includes(v))).toBe(true);
+  });
+});

--- a/tests/dom/military-vessels-retention.test.mts
+++ b/tests/dom/military-vessels-retention.test.mts
@@ -3,7 +3,7 @@ import type { AisPositionData } from '@/services/maritime';
 import type { MilitaryVessel, USNIFleetReport } from '@/types';
 
 const stream = vi.hoisted(() => ({
-  registerAisCallback: vi.fn(),
+  registerAisCallback: vi.fn<(callback: (data: AisPositionData) => void) => void>(),
   unregisterAisCallback: vi.fn(),
   isAisConfigured: vi.fn(() => false),
   initAisStream: vi.fn(),
@@ -43,7 +43,9 @@ beforeEach(async () => {
   vi.spyOn(Date, 'now').mockImplementation(() => now);
   service = await import('@/services/military-vessels');
   service.initMilitaryVesselStream();
-  receive = stream.registerAisCallback.mock.calls[0][0];
+  const callback = stream.registerAisCallback.mock.calls[0]?.[0];
+  if (!callback) throw new Error('Military vessel stream did not register its AIS callback');
+  receive = callback;
 });
 
 afterEach(() => {
@@ -182,17 +184,17 @@ describe('military vessel feed retention', () => {
       key, updatedAt: now, data: { vessels, clusters: [
         cluster('retained', vessels),
         cluster('removed', vessels.slice(0, 2)),
-        cluster('singleton', [vessels[0], vessels[1472]]),
+        cluster('singleton', [...vessels.slice(0, 1), ...vessels.slice(-1)]),
       ] },
     }));
 
     const data = await service.fetchMilitaryVessels();
     expect(fetchReport).not.toHaveBeenCalled();
     expect(data.vessels).toHaveLength(LIMIT);
-    expect(data.vessels[0].mmsi).toBe(position(1472).mmsi);
+    expect(data.vessels[0]?.mmsi).toBe(position(1472).mmsi);
     expect(data.vessels.every(v => v.lastAisUpdate instanceof Date)).toBe(true);
     expect(data.clusters.map(c => c.id)).toEqual(['retained']);
-    expect(data.clusters[0].vesselCount).toBe(LIMIT);
-    expect(data.clusters[0].vessels.every(v => data.vessels.includes(v))).toBe(true);
+    expect(data.clusters[0]?.vesselCount).toBe(LIMIT);
+    expect(data.clusters[0]?.vessels.every(v => data.vessels.includes(v))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Military vessel data can no longer grow with every AIS vessel observed during an hour. Retained AIS tracking and the final feed are capped at 500 vessels, including USNI merges and older saved snapshots. Carriers take priority, then dark or unusual vessels, then recency with a stable ID tie break.

The 500-vessel limit leaves the reported 44-vessel low-volume case intact and reduces the reported 1,473-vessel case by 66%. Evicted vessels lose their trails and gap history; later reports can admit them again. Clusters contain only returned vessels, with matching counts and centers. The existing one-hour stale window and renderer budgets remain in place.

Fixes #5375.

## Validation

Deterministic reports exercise the registered AIS callback, real tracking, clustering, USNI merge, circuit breaker, and saved-cache reader. Only the AIS transport and USNI fetch are controlled.

| Reproduction | Before | After |
| --- | ---: | ---: |
| AIS feed with 1,473 distinct vessels | 1,473 returned | 500 retained and returned |
| 500 AIS vessels plus two USNI carriers | 502 returned | 500, including both carriers |
| Saved snapshot with 1,473 vessels | 1,473 returned | 500, with consistent clusters |

- Nine retention tests pass. Eight original cases failed before implementation; added coverage also checks saturated carrier traffic and rejected arrivals.
- 29 existing globe-budget, vessel-cache, and USNI tests pass. Six data-loader tests pass; that unchanged suite also emits a teardown AbortError when run alone.
- All pre-push gates pass, including 911 DOM tests, 277 selected data tests, type checking, and lint checks. `npm run typecheck:dom-tests` and `git diff --check` pass. Local code review found no blocking issue.
- These are service-level results. Live AIS throughput and browser frame timing were not measured.

## Post-Deploy Monitoring & Validation

Owner: PR author. After an authorized deployment, inspect a desktop globe session with the military layer enabled for at least five minutes, including an AIS-connected session and a reload. Check the vessel service's tracking count and returned snapshot: both must stay at or below 500, carriers must survive ordinary traffic, and cluster counts must match their members. Search the browser console for `[Military Vessels] USNI merge failed` and `Persistent cache hydration failed`. Investigate missing priority vessels or inconsistent clusters; revert this change if either is reproducible. No deployment is included in this PR workflow.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
