### PR TITLE
fix(agent-readiness): detect Cloudflare HTML denials in live sweeps

### DIFF
--- a/.github/workflows/live-api-cache-auth.yml
+++ b/.github/workflows/live-api-cache-auth.yml
@@ -26,6 +26,8 @@ name: Live API Cache/Auth Sweep
 #     cleanly for an anonymous caller, and tools/call is a 401 carrying the
 #     OAuth resource_metadata hint.
 #   - OAuth metadata stays discoverable and cacheable on both hosts.
+#   - denied API User-Agents receive the shared JSON 403 on apex and www;
+#     descriptive clients still receive the origin JSON 404 on missing routes.
 #   - the crawlable corpus is EDGE-cacheable at Cloudflare, not merely at
 #     Vercel: `cf-cache-status` on a corpus document is anything but DYNAMIC
 #     (the fingerprint of a cache rule declaring it ineligible, #7659), while
@@ -41,7 +43,7 @@ name: Live API Cache/Auth Sweep
 # add `WM_LIVE_TEST_KEY: ${{ secrets.WM_LIVE_TEST_KEY }}` to the run step's env
 # and the case self-enables with no other change.
 #
-# No `npm ci`: the suite imports only `node:assert` and `node:test`, so it runs
+# No `npm ci`: the suite uses Node built-ins and the shared JSON policy, so it runs
 # under plain `node --test` on the Node 24 runner. It is invoked directly rather
 # than via `npm run test:data` both to avoid installing the repo's full
 # dependency tree for one file and because test:data would drag in the entire
@@ -105,9 +107,9 @@ jobs:
         # INSIDE the skipped describe.
         #
         # So assert that all mandatory work actually happened. The suite has one
-        # self-check plus nine mandatory production-probe groups; the authenticated
-        # canary is a tenth probe group but remains an explicit skip until
-        # WM_LIVE_TEST_KEY is provisioned. Requiring ten passes means the
+        # self-check plus ten mandatory production-probe groups; the authenticated
+        # canary is an eleventh probe group but remains an explicit skip until
+        # WM_LIVE_TEST_KEY is provisioned. Requiring eleven passes means the
         # documentation-only self-check cannot keep this workflow green if any
         # mandatory production group stops registering or starts skipping. Both
         # numbers below are load-bearing and must be raised together whenever a
@@ -127,11 +129,11 @@ jobs:
           set -o pipefail
           node --test --test-reporter=tap tests/live-api-cache-auth-regression.test.mjs 2>&1 | tee /tmp/sweep.log
           pass_count=$(awk '/^# pass [0-9]+$/ { value = $3 } END { print value + 0 }' /tmp/sweep.log)
-          if [ "$pass_count" -lt 10 ]; then
-            echo "::error::Live sweep completed only $pass_count/10 mandatory checks — one or more production probe groups did not run."
+          if [ "$pass_count" -lt 11 ]; then
+            echo "::error::Live sweep completed only $pass_count/11 mandatory checks — one or more production probe groups did not run."
             exit 1
           fi
-          for probe in bootstrap-auth warm-cache generated-rpc premium-rpc mcp-protocol oauth-metadata corpus-edge-cache document-edge-cache entry-document-edge-cache; do
+          for probe in bootstrap-auth warm-cache generated-rpc premium-rpc mcp-protocol oauth-metadata corpus-edge-cache document-edge-cache entry-document-edge-cache agent-api-errors; do
             if ! grep -qE "^[[:space:]]*# LIVE_SWEEP_PROBE_COMPLETED ${probe}$" /tmp/sweep.log; then
               echo "::error::Live sweep did not complete mandatory production probe group: ${probe}"
               exit 1

--- a/docs/solutions/integration-issues/orank-agent-readiness-edge-routing.md
+++ b/docs/solutions/integration-issues/orank-agent-readiness-edge-routing.md
@@ -55,3 +55,89 @@ curl -sS https://ora.ai/api/score/worldmonitor.app
 The response checker performs public GETs only. A local test pass does not prove Cloudflare activation, Vercel rewrite behavior, or a new orank score. The scan endpoint can return a cached result; compare the response timestamp and cache fields before claiming an improvement.
 
 Cloudflare documents [custom JSON block responses](https://developers.cloudflare.com/waf/custom-rules/create-api/) and [per-rule updates](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update-rule/). The update API requires the full retained rule definition even when only the response body changes.
+
+## Firewall delivery gap observed on September 6
+
+The origin change and the firewall configuration have separate delivery paths.
+PR #7742 merged at `2026-09-05T18:15:08Z`; its delivery notes explicitly said
+Cloudflare had not been changed. The successful Vercel Production deployment
+`6295532865` at `2026-09-06T16:53:52Z` used commit
+`800289c96b2c296893326dd3f54d9ecd6de25e77`, which includes that change.
+The [production sweep](https://github.com/koala73/worldmonitor/actions/runs/34046902572)
+then passed ten checks. Its nine required probe groups did not include API
+User-Agent denials. The standalone readiness checker was not part of that run.
+
+A read at `2026-09-06T16:56:15Z` confirmed zone `worldmonitor.app`
+(`975604917ef222f519dfd394530c3acf`) and custom firewall ruleset
+`99b7a9eb61264b0bb276f835a65aa95d`, version `37`. The ruleset was last updated
+on July 6, before the merged fix. Neither block rule had `action_parameters`.
+The current state therefore supports an unapplied firewall change, rather than
+a subsequent overwrite. The authoritative desired response remains
+`shared/agent-request-policy.json`, applied by `cloudflare-agent-readiness.mjs`.
+
+| Rule | ID | Version / last update | Matching probe evidence |
+| --- | --- | --- | --- |
+| Block API Bots | `e2f695f6f65d48c6b524acea358211ac` | 5 / July 6 | `curl/8.7.1`, ray `a36f0269dfe09244` |
+| Block Scriptlike UAs | `9f0b4d895ea642d99da7f7be6e55917e` | 2 / March 20 | `ora-agent`, rays `a36f02690f1e9244`, `a36f026c19d39244` |
+
+Cloudflare security events matched those exact request rays to `block` actions
+from `firewallCustom`. Thus these are the effective rules, not merely matching
+names. Account audit-log access returned HTTP 403 / code 10000. Historical actor
+identities, external writers and any attempted applies to other targets could
+not be established. Repository inspection found the planner as the explicit
+writer of these responses, with no workflow invoking its apply operation. This
+does not prove that no external writer exists. The document cache rule has a
+separate owner and must not be reapplied as part of this firewall repair.
+
+Redirect-following GETs at `16:56:49–16:56:53 UTC` tested both apex and www,
+both `/api/agent-readiness-missing-endpoint` and `/api/graphql`, and all three
+User-Agents. The eight denied cases returned HTML 403; the four descriptive-UA
+controls returned JSON 404 with `error.code: not_found`, message and hint. Apex
+resolved to www. On the API host, the public China decision signals RPC returned
+JSON 200 and anonymous ACLED remained JSON 401. These are baseline observations,
+not acceptance of the firewall repair.
+
+## Required recurring acceptance
+
+The existing `live-api-cache-auth.yml` sweep now requires `agent-api-errors` in
+addition to its cache/auth probes: eleven passes and every named completion
+marker. The added group performs the twelve GETs above against fixed apex and
+www production targets, follows redirects, checks exact 403/404 statuses, and
+compares denial fields with the shared policy. Each sample logs time, final URL,
+status, Content-Type, edge request identifiers and a bounded body excerpt under
+`LIVE_AGENT_API_RESPONSE`. HTML, an incomplete error or a missing probe fails
+the existing Actions job. No new credentials or alert service are required.
+
+The sweep retains successful Vercel Production deployment events and its
+six-hour schedule (`00:47`, `06:47`, `12:47`, `18:47` UTC, subject to Actions
+scheduling delay). Deployment runs check out the deployed SHA; scheduled runs
+use the scheduled revision. A probe-only merge can be excluded by the Vercel
+build filter. In that case, wait for a successful normal Production deployment
+that includes the probe; do not count a manual checker as a deployment run.
+
+After owner approval, use the existing firewall planner to apply only the two
+response additions. Save the live ruleset, cache ruleset and per-rule plan first.
+Re-read before each write and stop on concurrent drift. Run `--check` afterwards:
+it must report `ready: true` and `changes: []`. Compare retained rule definitions,
+order, authentication exceptions and the cache ruleset with the snapshot.
+
+For rollback, re-read the current rule and confirm its response still equals the
+response this operation installed. Restore only the prior `response` property
+inside the current `action_parameters`, retaining any concurrent unrelated
+parameters. Both inspected rules originally lacked that property; remove the
+installed response (and send an empty parameters object if no parameters remain).
+Patch the full retained current rule definition without server-managed
+`id`, `version` or `last_updated`. Stop for owner review if the response itself
+has changed. Verify the restored response and repeat the same control probes.
+Rollback is a production write and uses the same authorization gate.
+
+Keep the issue open until a real post-deployment sweep and a later scheduled
+sweep both pass the matrix. Record their run URLs, times, deployed revision,
+rule revision and no-drift result in the owner's acceptance checkpoint. Merge,
+configuration activation and production acceptance are separate gates.
+
+After those gates, coordinate one forced Ora scan with the owner of #7818:
+`npx ax audit worldmonitor.app --force --json`. Retain `servedFromCache`,
+`scannedAt`, `generatedAt`, `analysisStatus`, `pendingChecks` and the individual
+JSON-error result. Poll the cached result if analysis is pending; do not spend
+another forced scan. An unavailable scan is unavailable secondary evidence.

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -486,7 +486,7 @@ describe('live cache sweep deployment timing', () => {
     assert.deepEqual(enforced, [
       'bootstrap-auth', 'warm-cache', 'generated-rpc', 'premium-rpc',
       'mcp-protocol', 'oauth-metadata', 'corpus-edge-cache', 'document-edge-cache',
-      'entry-document-edge-cache',
+      'entry-document-edge-cache', 'agent-api-errors',
     ]);
     const suite = read(resolve(root, 'tests/live-api-cache-auth-regression.test.mjs'));
     const emitted = [...suite.matchAll(/markProbeCompleted\('([a-z-]+)'\)/g)].map((m) => m[1]);

--- a/tests/live-agent-api-errors.test.mjs
+++ b/tests/live-agent-api-errors.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { it } from 'node:test';
+import YAML from 'yaml';
+import policy from '../shared/agent-request-policy.json' with { type: 'json' };
+
+const suite = new URL('./live-api-cache-auth-regression.test.mjs', import.meta.url);
+const marker = 'LIVE_SWEEP_PROBE_COMPLETED agent-api-errors';
+const targets = ['https://worldmonitor.app', 'https://www.worldmonitor.app'].flatMap((host) =>
+  ['/api/agent-readiness-missing-endpoint', '/api/graphql'].flatMap((path) =>
+    ['ora-agent', 'curl/8.7.1', 'WorldMonitor-ReadinessCheck/1.0'].map((ua) => ({ url: host + path, ua }))));
+
+// Run the actual production probe, substituting only the network boundary.
+// Any unexpected fetch throws, so this test cannot contact production.
+function runProbe(failure = {}) {
+  const preload = `
+    const targets = ${JSON.stringify(targets)};
+    const failure = ${JSON.stringify(failure)};
+    globalThis.fetch = async (url, init) => {
+      const ua = new Headers(init.headers).get('user-agent');
+      const index = targets.findIndex(t => t.url === String(url) && t.ua === ua);
+      if (index < 0) throw new Error('Unexpected request: ' + url + ' ' + ua);
+      console.info('FIXTURE_REQUEST ' + index);
+      const control = ua === 'WorldMonitor-ReadinessCheck/1.0';
+      let status = control ? 404 : 403;
+      let body = control
+        ? { error: { code: 'not_found', message: 'No API endpoint matches ' + new URL(url).pathname + '.', hint: 'See the API reference.' } }
+        : ${JSON.stringify(policy.blockedResponse)};
+      if (index === failure.index) {
+        if (failure.kind === 'html') return new Response('<html>Blocked</html>', { status, headers: { 'content-type': 'text/html' } });
+        if (failure.kind === 'status') status = control ? 403 : 404;
+        if (failure.kind === 'hint') delete (control ? body.error : body).hint;
+        if (failure.kind === 'code') (control ? body.error : body).code = 'other';
+        if (failure.kind === 'invalid-json') return new Response('{', { status, headers: { 'content-type': 'application/json' } });
+      }
+      const response = Response.json(body, { status, headers: { 'cf-ray': 'fixture-ray' } });
+      Object.defineProperty(response, 'url', { value: String(url).replace('https://worldmonitor.app/', 'https://www.worldmonitor.app/') });
+      return response;
+    };
+  `;
+  return spawnSync(process.execPath, [
+    '--import', `data:text/javascript;base64,${Buffer.from(preload).toString('base64')}`,
+    '--test', '--test-reporter=tap', '--test-name-pattern=API User-Agent denials', suite.pathname,
+  ], { encoding: 'utf8', timeout: 15_000, env: { PATH: process.env.PATH, LIVE_API_CACHE_TESTS: '1' } });
+}
+
+it('the live denial probe executes all twelve host/path/UA cases before marking completion', () => {
+  const result = runProbe();
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, new RegExp(marker));
+  const requests = [...result.stdout.matchAll(/FIXTURE_REQUEST (\d+)/g)].map((match) => Number(match[1]));
+  assert.deepEqual(requests.sort((a, b) => a - b), targets.map((_, index) => index));
+});
+
+it('HTML in any matrix cell fails the actual live probe and withholds its marker', () => {
+  for (let index = 0; index < targets.length; index++) {
+    const result = runProbe({ index, kind: 'html' });
+    assert.equal(result.status, 1, `${JSON.stringify(targets[index])}: ${result.stdout}${result.stderr}`);
+    assert.match(result.stdout, /application\/json/);
+    assert.ok(!result.stdout.includes(marker));
+  }
+});
+
+it('wrong status, malformed JSON, missing hints and changed codes fail denied and origin controls', () => {
+  for (const index of [0, 2]) {
+    for (const kind of ['status', 'invalid-json', 'hint', 'code']) {
+      const result = runProbe({ index, kind });
+      assert.equal(result.status, 1, `${kind}: ${result.stdout}${result.stderr}`);
+      assert.ok(!result.stdout.includes(marker));
+    }
+  }
+});
+
+it('the workflow rejects missing completion even when other tests inflate the pass count', () => {
+  const workflow = YAML.parse(readFileSync(new URL('../.github/workflows/live-api-cache-auth.yml', import.meta.url), 'utf8'));
+  const command = workflow.jobs.sweep.steps.find(step => step.env?.LIVE_API_CACHE_TESTS === '1').run;
+  const guard = command.slice(command.indexOf('pass_count='));
+  const names = command.match(/for probe in ([a-z -]+); do/)[1].split(' ');
+  const directory = mkdtempSync(join(tmpdir(), 'live-agent-guard-'));
+  try {
+    const log = join(directory, 'sweep.log');
+    const run = (count, omitted) => {
+      writeFileSync(log, `# pass ${count}\n` + names.filter(name => name !== omitted)
+        .map(name => `# LIVE_SWEEP_PROBE_COMPLETED ${name}\n`).join(''));
+      return spawnSync('bash', ['-c', guard.replaceAll('/tmp/sweep.log', log)], { encoding: 'utf8' });
+    };
+    assert.equal(run(names.length + 1).status, 0);
+    assert.equal(run(100, 'agent-api-errors').status, 1, 'unrelated passes cannot hide the missing denial probe');
+    assert.equal(run(0).status, 1, 'skipped probes cannot pass');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/tests/live-api-cache-auth-regression.test.mjs
+++ b/tests/live-api-cache-auth-regression.test.mjs
@@ -16,6 +16,7 @@
 
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
+import agentPolicy from '../shared/agent-request-policy.json' with { type: 'json' };
 
 const LIVE = process.env.LIVE_API_CACHE_TESTS === '1';
 const API_BASE = stripTrailingSlash(process.env.WM_LIVE_API_BASE_URL || 'https://api.worldmonitor.app');
@@ -219,6 +220,42 @@ describe(`live API cache/auth regression sweep (${LIVE ? 'ENABLED' : 'SKIPPED - 
       ),
       /shared-cache HIT/,
     );
+  });
+
+  it('API User-Agent denials retain JSON 403s and nonblocked routes retain JSON 404s on both hosts', async () => {
+    // Pin both production entry points: an override must not silently turn this
+    // acceptance matrix into two reads of www or a preview deployment.
+    for (const origin of ['https://worldmonitor.app', 'https://www.worldmonitor.app']) {
+      for (const path of ['/api/agent-readiness-missing-endpoint', '/api/graphql']) {
+        for (const ua of ['ora-agent', 'curl/8.7.1', 'WorldMonitor-ReadinessCheck/1.0']) {
+          const url = `${origin}${path}`;
+          const { resp, bodyText } = await fetchText(url, {
+            redirect: 'follow', headers: { 'User-Agent': ua, Accept: 'application/json' },
+          });
+          const label = `${url} (${ua})`;
+          console.info(`LIVE_AGENT_API_RESPONSE ${JSON.stringify({
+            at: new Date().toISOString(), url, ua, finalUrl: resp.url,
+            status: resp.status, contentType: resp.headers.get('content-type'),
+            ray: resp.headers.get('cf-ray'), vercelId: resp.headers.get('x-vercel-id'),
+            body: bodyText.slice(0, 600),
+          })}`);
+          const control = ua === 'WorldMonitor-ReadinessCheck/1.0';
+          assert.equal(resp.status, control ? 404 : 403, `${label}: preserve access policy and missing-route status`);
+          assert.match(resp.headers.get('content-type') || '', /application\/json/i, `${label}: error must be application/json`);
+          const payload = JSON.parse(bodyText);
+          if (control) {
+            assert.equal(payload.error?.code, 'not_found', `${label}: origin must still report no endpoint`);
+            assert.ok(payload.error.message?.includes(path), `${label}: missing endpoint must be identified`);
+            assert.ok(typeof payload.error.hint === 'string' && payload.error.hint.trim(), `${label}: recovery hint required`);
+          } else {
+            for (const [field, value] of Object.entries(agentPolicy.blockedResponse)) {
+              assert.equal(payload[field], value, `${label}: denial field ${field} must match the shared policy`);
+            }
+          }
+        }
+      }
+    }
+    markProbeCompleted('agent-api-errors');
   });
 
   it('bootstrap rejects fake auth as dynamic no-store while public weather stays cacheable', async () => {


### PR DESCRIPTION
## Summary

The production sweep passed while Cloudflare returned HTML 403s to API agents. Add the missing twelve-case apex/www, route and User-Agent matrix to the existing deployment and six-hour sweep. Require its completion marker and raise the mandatory pass count, so skipped coverage cannot appear green.

Related: #7817

## Evidence and verification

At 2026-09-06 16:56 UTC, eight denied cases returned HTML 403 and four descriptive-client controls returned JSON 404. Cloudflare security events tied our exact request rays to `Block API Bots` and `Block Scriptlike UAs`. Both lack custom responses; firewall ruleset version 37 was last updated July 6, before the earlier fix merged. PR #7742 explicitly recorded no Cloudflare apply. Vercel deployed `800289c96b2c296893326dd3f54d9ecd6de25e77` successfully, and [its sweep passed ten checks without the denial matrix](https://github.com/koala73/worldmonitor/actions/runs/34046902572). Account audit access returned 403, so historical actor identities and external writers remain unverified.

- 105 focused Cloudflare, live-probe and workflow checks pass. The new tests failed before implementation; HTML injected into each matrix cell fails the actual probe, and inflated pass counts cannot hide a missing completion marker.
- Contract-test typecheck, focused Biome lint, Markdown lint and diff checks pass. Inline review found no actionable code defects.
- Before apply, the new probe failed against production with the expected HTML-denial error. After the owner-approved apply at 17:10 UTC, all twelve matrix cells passed: eight shared-policy JSON 403s and four origin JSON 404s. The full live sweep passed 11 mandatory checks; the optional authenticated canary skipped because no test key was supplied. Public China decision signals remain JSON 200; anonymous ACLED remains JSON 401.

The existing firewall planner applied exactly two response additions after explicit owner approval. Firewall ruleset version 39 converged with `ready: true`, `changes: []`; retained policy/order/authentication exceptions and cache rules were unchanged. No origin handler, firewall predicate, cache rule or production configuration changes are included in this PR. The existing solution document records the rule evidence, apply/rollback procedure and acceptance gates.

## Post-Deploy Monitoring & Validation

Owner: this issue's Codex task. The approved Cloudflare apply is complete. Preserve the saved rollback snapshot and re-read rule state before any later write. Continue to verify that `--check` returns no changes and retained policy/order/cache state is unchanged. Use the existing Live API Cache/Auth Sweep; inspect `LIVE_AGENT_API_RESPONSE` and require `LIVE_SWEEP_PROBE_COMPLETED agent-api-errors`.

Healthy means eight shared-policy JSON 403s and four origin JSON 404s across both hosts, with the existing public and protected controls passing. HTML, changed status/body, missing coverage or policy drift blocks acceptance. Restore only the prior response parameters through the same owner authorization gate if controls regress.

Keep the issue open until a real successful Production-deployment run and a subsequent scheduled run both pass. The next scheduled boundary after preparation is 18:47 UTC, subject to Actions delay; it counts only after activation and the required deployment sample. Production configuration is active and the local full live sweep passed. The owner merged this PR at 17:13 UTC. The required Vercel Production-deployment and subsequent scheduled Actions samples remain pending; full acceptance is not yet complete. Run 34047938286 skipped correctly because it was a Railway deployment event, so it does not count. A manual checker alone is insufficient. Coordinate one later forced Ora scan with the request-ID work; do not use a cached score as acceptance.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
