### PR TITLE
perf(news): offload initial hybrid clustering

### DIFF
--- a/docs/perf/news-hybrid-clustering-7782-dashboard.after.json
+++ b/docs/perf/news-hybrid-clustering-7782-dashboard.after.json
@@ -1,0 +1,838 @@
+{
+  "issue": 7782,
+  "generatedAt": "2026-09-06T16:18:48.763Z",
+  "surface": "production-minified full dashboard with local ML available",
+  "host": {
+    "node": "v24.20.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"
+  },
+  "build": {
+    "productionMinify": true,
+    "viteE2EInstrumentation": true,
+    "graphics": "SwiftShader (headless capability support; clustering is CPU-attributed)",
+    "assetScripts": [
+      "/assets/main-BYcrR7En.js",
+      "https://abacus.worldmonitor.app/script.js",
+      "/_vercel/insights/script.js"
+    ]
+  },
+  "fixture": {
+    "path": "docs/perf/news-hybrid-clustering-7782.fixture.json",
+    "capturedAt": "2026-09-06T12:01:48.463288+00:00",
+    "generatedAt": "2026-09-06T11:50:08.529Z",
+    "source": "https://www.worldmonitor.app/api/news/v1/list-feed-digest?variant=full&lang=en&public=1"
+  },
+  "budgets": {
+    "frameMs": 16.7,
+    "longTaskMs": 50
+  },
+  "samplesPerCaseAndPath": 3,
+  "cpuThrottleRates": [
+    1,
+    6
+  ],
+  "cases": [
+    {
+      "cpuThrottleRate": 1,
+      "name": "representative",
+      "path": "hybrid",
+      "sampleCount": 3,
+      "itemCount": 289,
+      "clusterCount": 249,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 2115.3,
+        "median": 2175.5,
+        "p90": 7299.2,
+        "max": 7299.2,
+        "mean": 3863.333
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 54.2,
+        "median": 75.058,
+        "p90": 451.481,
+        "max": 451.481,
+        "mean": 193.58
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 4.6,
+        "median": 4.9,
+        "p90": 14.6,
+        "max": 14.6,
+        "mean": 8.033
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": {
+        "generation": 3,
+        "selectedPath": "hybrid",
+        "mlAvailableAtSelection": true,
+        "itemCount": 289,
+        "clusterCount": 249,
+        "totalLatencyMs": 7299.199999988079,
+        "coreMs": 14.600000023841858,
+        "pathFrameIntervalsMs": [],
+        "coreFrameIntervalsMs": [
+          8.300000000000068,
+          8.299999999999955,
+          8.399999999999977
+        ],
+        "coreLongTasksMs": [],
+        "pathFrameBudgetExceeded": false,
+        "coreFrameBudgetExceeded": false,
+        "coldStart": true,
+        "mainThreadTaskMs": 451.481
+      },
+      "raw": [
+        {
+          "generation": 3,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 7299.199999988079,
+          "coreMs": 14.600000023841858,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.300000000000068,
+            8.299999999999955,
+            8.399999999999977
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": true,
+          "mainThreadTaskMs": 451.481
+        },
+        {
+          "generation": 4,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2175.5,
+          "coreMs": 4.899999976158142,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            7.900000000000546
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 75.058
+        },
+        {
+          "generation": 5,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2115.300000011921,
+          "coreMs": 4.600000023841858,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.299999999999272
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 54.2
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 1,
+      "name": "representative",
+      "path": "analysis-worker",
+      "sampleCount": 3,
+      "itemCount": 289,
+      "clusterCount": 261,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 3.8,
+        "median": 4,
+        "p90": 4.5,
+        "max": 4.5,
+        "mean": 4.1
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 7.244,
+        "median": 8.214,
+        "p90": 10.286,
+        "max": 10.286,
+        "mean": 8.581
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 0,
+        "median": 0,
+        "p90": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": {
+        "generation": 6,
+        "selectedPath": "analysis-worker",
+        "mlAvailableAtSelection": true,
+        "itemCount": 289,
+        "clusterCount": 261,
+        "totalLatencyMs": 4.5,
+        "coreMs": 0,
+        "pathFrameIntervalsMs": [],
+        "coreFrameIntervalsMs": [],
+        "coreLongTasksMs": [],
+        "pathFrameBudgetExceeded": false,
+        "coreFrameBudgetExceeded": false,
+        "coldStart": true,
+        "mainThreadTaskMs": 10.286
+      },
+      "raw": [
+        {
+          "generation": 6,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 4.5,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": true,
+          "mainThreadTaskMs": 10.286
+        },
+        {
+          "generation": 7,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 4,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 8.214
+        },
+        {
+          "generation": 8,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 3.800000011920929,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 7.244
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 1,
+      "name": "highDiversity1500",
+      "path": "hybrid",
+      "sampleCount": 3,
+      "itemCount": 1500,
+      "clusterCount": 753,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 2084.3,
+        "median": 2098.6,
+        "p90": 2105.1,
+        "max": 2105.1,
+        "mean": 2096
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 66.526,
+        "median": 68.237,
+        "p90": 79.782,
+        "max": 79.782,
+        "mean": 71.515
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 5.7,
+        "median": 6,
+        "p90": 6.5,
+        "max": 6.5,
+        "mean": 6.067
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 9,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2105.099999964237,
+          "coreMs": 6.5,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.399999999999636
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 79.782
+        },
+        {
+          "generation": 10,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2098.600000023842,
+          "coreMs": 6,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            7.899999999999636
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 68.237
+        },
+        {
+          "generation": 11,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2084.300000011921,
+          "coreMs": 5.699999988079071,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.299999999999272
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 66.526
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 1,
+      "name": "highDiversity1500",
+      "path": "analysis-worker",
+      "sampleCount": 3,
+      "itemCount": 1500,
+      "clusterCount": 1000,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 5,
+        "median": 5.5,
+        "p90": 6.7,
+        "max": 6.7,
+        "mean": 5.733
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 9.111,
+        "median": 9.328,
+        "p90": 13.188,
+        "max": 13.188,
+        "mean": 10.542
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 0,
+        "median": 0,
+        "p90": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 12,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 6.699999988079071,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 13.188
+        },
+        {
+          "generation": 13,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 5,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 9.111
+        },
+        {
+          "generation": 14,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 5.5,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 9.328
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 6,
+      "name": "representative",
+      "path": "hybrid",
+      "sampleCount": 3,
+      "itemCount": 289,
+      "clusterCount": 249,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 2201.7,
+        "median": 2211.6,
+        "p90": 2221,
+        "max": 2221,
+        "mean": 2211.433
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 305.53,
+        "median": 323.188,
+        "p90": 335.317,
+        "max": 335.317,
+        "mean": 321.345
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 7.8,
+        "median": 7.9,
+        "p90": 9.6,
+        "max": 9.6,
+        "mean": 8.433
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 15,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2211.600000023842,
+          "coreMs": 7.800000011920929,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.299999999999272
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 323.188
+        },
+        {
+          "generation": 16,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2201.699999988079,
+          "coreMs": 7.899999976158142,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.200000000000728,
+            9
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 305.53
+        },
+        {
+          "generation": 17,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2221,
+          "coreMs": 9.600000023841858,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            9.200000000000728,
+            8.299999999999272
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 335.317
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 6,
+      "name": "representative",
+      "path": "analysis-worker",
+      "sampleCount": 3,
+      "itemCount": 289,
+      "clusterCount": 261,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 7.1,
+        "median": 7.3,
+        "p90": 9.4,
+        "max": 9.4,
+        "mean": 7.933
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 43.646,
+        "median": 44.739,
+        "p90": 47.518,
+        "max": 47.518,
+        "mean": 45.301
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 0,
+        "median": 0,
+        "p90": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 18,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 9.400000035762787,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 47.518
+        },
+        {
+          "generation": 19,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 7.300000011920929,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 43.646
+        },
+        {
+          "generation": 20,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 7.100000023841858,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 44.739
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 6,
+      "name": "highDiversity1500",
+      "path": "hybrid",
+      "sampleCount": 3,
+      "itemCount": 1500,
+      "clusterCount": 753,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 2090.9,
+        "median": 2112.7,
+        "p90": 2145.2,
+        "max": 2145.2,
+        "mean": 2116.267
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 268.911,
+        "median": 290.081,
+        "p90": 384.25,
+        "max": 384.25,
+        "mean": 314.414
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 13.6,
+        "median": 14.1,
+        "p90": 14.4,
+        "max": 14.4,
+        "mean": 14.033
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 21,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2112.699999988079,
+          "coreMs": 14.399999976158142,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.299999999999272,
+            7.80000000000291,
+            8.599999999998545
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 290.081
+        },
+        {
+          "generation": 22,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2145.2000000476837,
+          "coreMs": 14.100000023841858,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            7.400000000001455,
+            8.19999999999709,
+            8.80000000000291
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 384.25
+        },
+        {
+          "generation": 23,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2090.900000035763,
+          "coreMs": 13.600000023841858,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.200000000000728,
+            8.799999999999272,
+            8.5
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 268.911
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 6,
+      "name": "highDiversity1500",
+      "path": "analysis-worker",
+      "sampleCount": 3,
+      "itemCount": 1500,
+      "clusterCount": 1000,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 13.4,
+        "median": 14.7,
+        "p90": 16.3,
+        "max": 16.3,
+        "mean": 14.8
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 57.605,
+        "median": 62.66,
+        "p90": 64.021,
+        "max": 64.021,
+        "mean": 61.429
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 0,
+        "median": 0,
+        "p90": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 24,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 13.400000035762787,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 57.605
+        },
+        {
+          "generation": 25,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 16.30000001192093,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 62.66
+        },
+        {
+          "generation": 26,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 14.700000047683716,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 64.021
+        }
+      ]
+    }
+  ],
+  "gate": {
+    "decision": "no-change",
+    "reason": "No representative dashboard frame miss or 16.7 ms core overrun repeated across samples."
+  }
+}

--- a/docs/perf/news-hybrid-clustering-7782-dashboard.before.json
+++ b/docs/perf/news-hybrid-clustering-7782-dashboard.before.json
@@ -1,0 +1,837 @@
+{
+  "issue": 7782,
+  "generatedAt": "2026-09-06T16:13:26.927Z",
+  "surface": "production-minified full dashboard with local ML available",
+  "host": {
+    "node": "v24.20.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"
+  },
+  "build": {
+    "productionMinify": true,
+    "viteE2EInstrumentation": true,
+    "graphics": "SwiftShader (headless capability support; clustering is CPU-attributed)",
+    "assetScripts": [
+      "/assets/main-BVQwrOTI.js",
+      "https://abacus.worldmonitor.app/script.js",
+      "/_vercel/insights/script.js"
+    ]
+  },
+  "fixture": {
+    "path": "docs/perf/news-hybrid-clustering-7782.fixture.json",
+    "capturedAt": "2026-09-06T12:01:48.463288+00:00",
+    "generatedAt": "2026-09-06T11:50:08.529Z",
+    "source": "https://www.worldmonitor.app/api/news/v1/list-feed-digest?variant=full&lang=en&public=1"
+  },
+  "budgets": {
+    "frameMs": 16.7,
+    "longTaskMs": 50
+  },
+  "samplesPerCaseAndPath": 3,
+  "cpuThrottleRates": [
+    1,
+    6
+  ],
+  "cases": [
+    {
+      "cpuThrottleRate": 1,
+      "name": "representative",
+      "path": "hybrid",
+      "sampleCount": 3,
+      "itemCount": 289,
+      "clusterCount": 249,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 2104.3,
+        "median": 2126.4,
+        "p90": 6762.9,
+        "max": 6762.9,
+        "mean": 3664.533
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 63.294,
+        "median": 69.006,
+        "p90": 370.831,
+        "max": 370.831,
+        "mean": 167.71
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 2.7,
+        "median": 3.3,
+        "p90": 3.9,
+        "max": 3.9,
+        "mean": 3.3
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": {
+        "generation": 3,
+        "selectedPath": "hybrid",
+        "mlAvailableAtSelection": true,
+        "itemCount": 289,
+        "clusterCount": 249,
+        "totalLatencyMs": 6762.899999976158,
+        "coreMs": 3.899999976158142,
+        "pathFrameIntervalsMs": [],
+        "coreFrameIntervalsMs": [
+          9
+        ],
+        "coreLongTasksMs": [],
+        "pathFrameBudgetExceeded": false,
+        "coreFrameBudgetExceeded": false,
+        "coldStart": true,
+        "mainThreadTaskMs": 370.831
+      },
+      "raw": [
+        {
+          "generation": 3,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 6762.899999976158,
+          "coreMs": 3.899999976158142,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            9
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": true,
+          "mainThreadTaskMs": 370.831
+        },
+        {
+          "generation": 4,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2126.399999976158,
+          "coreMs": 2.699999988079071,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.400000000000546
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 69.006
+        },
+        {
+          "generation": 5,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2104.300000011921,
+          "coreMs": 3.300000011920929,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.399999999999636
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 63.294
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 1,
+      "name": "representative",
+      "path": "analysis-worker",
+      "sampleCount": 3,
+      "itemCount": 289,
+      "clusterCount": 261,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 4.8,
+        "median": 5,
+        "p90": 16.1,
+        "max": 16.1,
+        "mean": 8.633
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 8.675,
+        "median": 8.876,
+        "p90": 11.91,
+        "max": 11.91,
+        "mean": 9.82
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 0,
+        "median": 0,
+        "p90": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": {
+        "generation": 6,
+        "selectedPath": "analysis-worker",
+        "mlAvailableAtSelection": true,
+        "itemCount": 289,
+        "clusterCount": 261,
+        "totalLatencyMs": 16.099999964237213,
+        "coreMs": 0,
+        "pathFrameIntervalsMs": [],
+        "coreFrameIntervalsMs": [],
+        "coreLongTasksMs": [],
+        "pathFrameBudgetExceeded": false,
+        "coreFrameBudgetExceeded": false,
+        "coldStart": true,
+        "mainThreadTaskMs": 11.91
+      },
+      "raw": [
+        {
+          "generation": 6,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 16.099999964237213,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": true,
+          "mainThreadTaskMs": 11.91
+        },
+        {
+          "generation": 7,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 5,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 8.876
+        },
+        {
+          "generation": 8,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 4.799999952316284,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 8.675
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 1,
+      "name": "highDiversity1500",
+      "path": "hybrid",
+      "sampleCount": 3,
+      "itemCount": 1500,
+      "clusterCount": 753,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 2055.8,
+        "median": 2085,
+        "p90": 2140,
+        "max": 2140,
+        "mean": 2093.6
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 67.568,
+        "median": 79.7,
+        "p90": 79.77,
+        "max": 79.77,
+        "mean": 75.679
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 2.3,
+        "median": 2.6,
+        "p90": 3.3,
+        "max": 3.3,
+        "mean": 2.733
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 9,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2055.800000011921,
+          "coreMs": 3.300000011920929,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.300000000001091
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 67.568
+        },
+        {
+          "generation": 10,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2140,
+          "coreMs": 2.600000023841858,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.400000000001455
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 79.77
+        },
+        {
+          "generation": 11,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2085,
+          "coreMs": 2.300000011920929,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            8.200000000000728
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 79.7
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 1,
+      "name": "highDiversity1500",
+      "path": "analysis-worker",
+      "sampleCount": 3,
+      "itemCount": 1500,
+      "clusterCount": 1000,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 5.2,
+        "median": 5.6,
+        "p90": 13,
+        "max": 13,
+        "mean": 7.933
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 8.49,
+        "median": 9.525,
+        "p90": 13.448,
+        "max": 13.448,
+        "mean": 10.488
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 0,
+        "median": 0,
+        "p90": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 12,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 13,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 13.448
+        },
+        {
+          "generation": 13,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 5.599999964237213,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 9.525
+        },
+        {
+          "generation": 14,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 5.199999988079071,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 8.49
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 6,
+      "name": "representative",
+      "path": "hybrid",
+      "sampleCount": 3,
+      "itemCount": 289,
+      "clusterCount": 249,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 2136.2,
+        "median": 2136.4,
+        "p90": 2148,
+        "max": 2148,
+        "mean": 2140.2
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 207.664,
+        "median": 211.799,
+        "p90": 241.724,
+        "max": 241.724,
+        "mean": 220.396
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 15.9,
+        "median": 16.1,
+        "p90": 16.9,
+        "max": 16.9,
+        "mean": 16.3
+      },
+      "coreFrameBudgetMissCount": 3,
+      "pathFrameBudgetMissCount": 2,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": true,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 15,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2136.400000035763,
+          "coreMs": 15.900000035762787,
+          "pathFrameIntervalsMs": [
+            17.400000000001455
+          ],
+          "coreFrameIntervalsMs": [
+            17.400000000001455,
+            8.5
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": true,
+          "coreFrameBudgetExceeded": true,
+          "coldStart": false,
+          "mainThreadTaskMs": 211.799
+        },
+        {
+          "generation": 16,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2148,
+          "coreMs": 16.100000023841858,
+          "pathFrameIntervalsMs": [
+            24.799999999999272
+          ],
+          "coreFrameIntervalsMs": [
+            24.799999999999272
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": true,
+          "coreFrameBudgetExceeded": true,
+          "coldStart": false,
+          "mainThreadTaskMs": 241.724
+        },
+        {
+          "generation": 17,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 249,
+          "totalLatencyMs": 2136.199999988079,
+          "coreMs": 16.899999976158142,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            16.599999999998545,
+            8.200000000000728
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": true,
+          "coldStart": false,
+          "mainThreadTaskMs": 207.664
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 6,
+      "name": "representative",
+      "path": "analysis-worker",
+      "sampleCount": 3,
+      "itemCount": 289,
+      "clusterCount": 261,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 6.5,
+        "median": 7.2,
+        "p90": 8.2,
+        "max": 8.2,
+        "mean": 7.3
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 43.565,
+        "median": 44.123,
+        "p90": 45.268,
+        "max": 45.268,
+        "mean": 44.319
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 0,
+        "median": 0,
+        "p90": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 18,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 7.199999988079071,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 43.565
+        },
+        {
+          "generation": 19,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 8.199999988079071,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 44.123
+        },
+        {
+          "generation": 20,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 289,
+          "clusterCount": 261,
+          "totalLatencyMs": 6.5,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 45.268
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 6,
+      "name": "highDiversity1500",
+      "path": "hybrid",
+      "sampleCount": 3,
+      "itemCount": 1500,
+      "clusterCount": 753,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 2056.7,
+        "median": 2059.8,
+        "p90": 2069.9,
+        "max": 2069.9,
+        "mean": 2062.133
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 193.556,
+        "median": 199.959,
+        "p90": 212.49,
+        "max": 212.49,
+        "mean": 202.002
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 15.7,
+        "median": 16.4,
+        "p90": 17,
+        "max": 17,
+        "mean": 16.367
+      },
+      "coreFrameBudgetMissCount": 2,
+      "pathFrameBudgetMissCount": 2,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": true,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 21,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2069.899999976158,
+          "coreMs": 17,
+          "pathFrameIntervalsMs": [
+            25.100000000002183
+          ],
+          "coreFrameIntervalsMs": [
+            25.100000000002183
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": true,
+          "coreFrameBudgetExceeded": true,
+          "coldStart": false,
+          "mainThreadTaskMs": 212.49
+        },
+        {
+          "generation": 22,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2059.800000011921,
+          "coreMs": 15.699999988079071,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [
+            16.5,
+            8.399999999997817
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 193.556
+        },
+        {
+          "generation": 23,
+          "selectedPath": "hybrid",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 753,
+          "totalLatencyMs": 2056.699999988079,
+          "coreMs": 16.399999976158142,
+          "pathFrameIntervalsMs": [
+            24.099999999998545
+          ],
+          "coreFrameIntervalsMs": [
+            24.099999999998545
+          ],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": true,
+          "coreFrameBudgetExceeded": true,
+          "coldStart": false,
+          "mainThreadTaskMs": 199.959
+        }
+      ]
+    },
+    {
+      "cpuThrottleRate": 6,
+      "name": "highDiversity1500",
+      "path": "analysis-worker",
+      "sampleCount": 3,
+      "itemCount": 1500,
+      "clusterCount": 1000,
+      "pathProof": {
+        "selectedEverySample": true,
+        "mlAvailableEverySample": true
+      },
+      "totalLatencyMs": {
+        "n": 3,
+        "min": 12.3,
+        "median": 12.8,
+        "p90": 13.8,
+        "max": 13.8,
+        "mean": 12.967
+      },
+      "mainThreadTaskMs": {
+        "n": 3,
+        "min": 56.414,
+        "median": 57.511,
+        "p90": 59.791,
+        "max": 59.791,
+        "mean": 57.905
+      },
+      "coreMs": {
+        "n": 3,
+        "min": 0,
+        "median": 0,
+        "p90": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "coreFrameBudgetMissCount": 0,
+      "pathFrameBudgetMissCount": 0,
+      "coreLongTaskCount": 0,
+      "repeatableCoreFrameMiss": false,
+      "coldStart": null,
+      "raw": [
+        {
+          "generation": 24,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 12.300000011920929,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 59.791
+        },
+        {
+          "generation": 25,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 13.800000011920929,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 56.414
+        },
+        {
+          "generation": 26,
+          "selectedPath": "analysis-worker",
+          "mlAvailableAtSelection": true,
+          "itemCount": 1500,
+          "clusterCount": 1000,
+          "totalLatencyMs": 12.800000011920929,
+          "coreMs": 0,
+          "pathFrameIntervalsMs": [],
+          "coreFrameIntervalsMs": [],
+          "coreLongTasksMs": [],
+          "pathFrameBudgetExceeded": false,
+          "coreFrameBudgetExceeded": false,
+          "coldStart": false,
+          "mainThreadTaskMs": 57.511
+        }
+      ]
+    }
+  ],
+  "gate": {
+    "decision": "implement",
+    "reason": "The existing analysis worker removed a repeatable representative frame-budget miss with lower renderer task occupancy."
+  }
+}

--- a/docs/perf/news-hybrid-clustering-7782.md
+++ b/docs/perf/news-hybrid-clustering-7782.md
@@ -1,15 +1,15 @@
-# Hybrid clustering profiling correction — 2026-09-06 (#7782)
+# Hybrid clustering profiling and worker offload — 2026-09-06 (#7782)
 
-**Status: measurement gate remains open.** The complete production input is
-more expensive than the reduced input in PR #7802. Repeated 6× measurements
-also cross the frame budget in the deterministic high-diversity case. The old
-blanket statement that both cases stay below 16.7 ms is withdrawn.
+**Status: implementation gate met and offload verified.** A production-built
+dashboard selected `clusterNewsHybrid` with local ML available. At 6× CPU
+throttle, its synchronous initial core caused repeatable frame-budget misses on
+both committed inputs. The existing analysis worker removed those misses on the
+same surface, so the hybrid path now uses that worker for its initial stage.
 
-This report establishes isolated execution cost and exact worker output parity.
-It does not yet establish a dashboard interaction improvement or justify a
-production worker migration. Keep #7782 open for that attribution and the
-conditional implementation checks in its issue body. The production algorithm,
-limits, semantic refinement, and worker lifecycle remain unchanged.
+The earlier sections preserve the corrected isolated evidence from PR #7811.
+The dashboard section records the later attribution, implementation decision,
+and same-command before/after results. Limits, source tiers, clustering
+semantics, semantic thresholds, and semantic candidate selection are unchanged.
 
 ## Corrections to the review findings
 
@@ -35,6 +35,8 @@ Its old “warm worker” metric actually spawned a fresh process for each reque
 and returned only a count. It is removed; browser measurements own worker costs.
 
 ## Reproduction
+
+Run the isolated core and exact worker-parity profile:
 
 ```sh
 node scripts/profile-news-hybrid-clustering-7782-browser.mjs \
@@ -93,26 +95,89 @@ long task was observed. Exact full-output parity passed for every measured
 cold and warm request. Faster worker round trips under CDP are not proof of a
 real-device end-to-end speedup.
 
-## Remaining acceptance
+## Production-dashboard attribution
+
+Run the complete dashboard profile:
+
+```sh
+node scripts/profile-news-hybrid-clustering-7782-dashboard.mjs \
+  docs/perf/news-hybrid-clustering-7782.fixture.json \
+  --samples 3 --cpu 1,6
+```
+
+The harness builds the full dashboard with production minification and test-only
+timing marks. It enables the browser model, waits for local ML, verifies the
+actual selected path for every generation, and uses the source-extracted proto
+conversion. Fixture conversion is completed before the measured frame so it
+cannot be attributed to the initial clustering stage. The matching direct path
+uses the production `analysisWorker.clusterNews` lifecycle, not a synthetic
+worker. The two complete reports contain every raw sample:
+
+- [before offload](./news-hybrid-clustering-7782-dashboard.before.json)
+- [after offload](./news-hybrid-clustering-7782-dashboard.after.json)
+
+The 6× results below are warm samples. “Initial” is the synchronous core before
+the change and the full worker result round trip after it. An initial crossing
+has a stage duration or overlapping request-animation-frame interval at or above
+16.7 ms. A path miss requires the overlapping frame interval.
+
+| Input | Build | Initial median | Initial crossings | Full hybrid path misses | Final clusters |
+|---|---|---:|---:|---:|---:|
+| representative, 289 items | before | 16.1 ms | 3/3 | 2/3 | 249 |
+| representative, 289 items | after | 7.9 ms | 0/3 | 0/3 | 249 |
+| high diversity, 1,500 items | before | 16.4 ms | 2/3 | 2/3 | 753 |
+| high diversity, 1,500 items | after | 14.1 ms | 0/3 | 0/3 | 753 |
+
+At 1×, neither build missed a frame. The worker adds a small warm round-trip
+cost there: the representative initial median changed from 3.3 ms to 4.9 ms,
+and the high-diversity median changed from 2.6 ms to 6.0 ms. The dashboard boot
+can warm the shared analysis worker before the explicit samples, so its first
+sample is not a cold-start measure. The isolated real-worker runs record cold
+readiness and result latency separately: at 6×, representative cold readiness
+was 7.1 ms and its first result was 8.7 ms; high diversity was 7.0 ms and
+16.5 ms. The hybrid total includes about 2.1 seconds of semantic model work in
+both builds.
+
+The direct analysis-worker comparison at 6× returned the representative result
+in a 7.2 ms median before the change and 7.3 ms after it. The high-diversity
+medians were 12.8 ms and 14.7 ms. Its renderer `TaskDuration` medians were
+44.1/44.7 ms and 57.5/62.7 ms, respectively. The full hybrid path's broad
+`TaskDuration` counter moved upward in the second run while semantic work was in
+flight, so this report does not claim that noisy whole-path counter improved.
+The verified improvement is narrower: the attributed initial-stage frame misses
+dropped from repeated to zero on both inputs.
+
+## Implementation contracts
 
 DataLoader selects `clusterNewsHybrid` only when local ML is already available
 for that news generation. Otherwise it already uses `analysisWorker.clusterNews`.
-The remaining dashboard probe must enable and verify the local-ML/hybrid path;
-measuring ordinary boot with ML unavailable would exercise a different path.
+The hybrid path now sends the unchanged complete input to that same worker, then
+runs the existing semantic ranking, 250-candidate refinement, overflow merge,
+and final ordering.
 
-Use these same complete inputs in a production-built dashboard. Attribute
-interaction/frame delay to the synchronous initial clustering call, then compare
-main-thread occupancy and result latency with the existing worker under matching
-load. If no repeatable user-facing miss is attributable to clustering, record
-that stop decision. Otherwise, implement the existing issue's bounded fallback,
-supersession/teardown and semantic-parity checks before closing it. Do not treat
-an unavailable worker's empty result as authoritative news data.
+For nonempty input, an unavailable worker's empty result and construction,
+readiness, request, reset, or runtime errors run the local shared core once. A
+superseded generation or app teardown cancels the continuation before fallback
+or semantic work, so worker termination cannot start a fresh main-thread core.
+Genuine empty input remains an authoritative empty result. Tests cover no-merge
+and multi-source semantic results, more than 250 candidates, more than 1,000
+inputs, known and unknown tiers, fallback, supersession, and teardown.
 
 ## Verification
 
 ```sh
-node --test tests/profile-news-hybrid-clustering-7782.test.mjs
+node --test \
+  tests/profile-news-hybrid-clustering-7782.test.mjs \
+  tests/profile-news-hybrid-clustering-7782-dashboard.test.mjs \
+  tests/clustering-cap.test.mjs
+npx vitest run --config vitest.dom.config.mts \
+  tests/dom/news-hybrid-worker-offload.test.mts
+npm run typecheck
+npm run lint:boundaries
+git diff --check
 ```
 
-The browser runs additionally execute the real analysis worker and assert exact
-output parity. No production clustering change or production speedup is claimed.
+The isolated browser runs execute the real analysis worker and assert exact
+full-output parity. The production-dashboard run verifies the local-ML hybrid
+selection and the final semantic cluster counts on both inputs before and after
+the implementation.

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -375,7 +375,7 @@ This generated inventory covers **761 active source hosts** representing **748 a
 | lnc-abc-news.tubi.video (lnc-abc-news.tubi.video) | feed — src/components/LiveNewsPanel.ts |
 | lobste.rs (lobste.rs) | feed+structured — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts, src/config/variants/tech.ts |
 | Local development transport (localhost) | feed+structured — scripts/ais-relay.cjs, server/worldmonitor/research/v1/list-tech-events.ts, src/components/LiveNewsPanel.ts, src/services/desktop-runtime.ts, +1 more |
-| Local loopback transport (127.0.0.1) | feed+structured — scripts/measure-trade-animation-rebuild.mjs, src/components/LiveNewsPanel.ts, src/services/runtime.ts |
+| Local loopback transport (127.0.0.1) | feed+structured — scripts/measure-trade-animation-rebuild.mjs, scripts/profile-news-hybrid-clustering-7782-dashboard.mjs, src/components/LiveNewsPanel.ts, src/services/runtime.ts |
 | lowyinstitute.org (lowyinstitute.org) | feed — src/config/feeds.ts |
 | macleans.ca (macleans.ca) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | Mada Masr (madamasr.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |

--- a/scripts/profile-news-hybrid-clustering-7782-dashboard.mjs
+++ b/scripts/profile-news-hybrid-clustering-7782-dashboard.mjs
@@ -1,0 +1,487 @@
+#!/usr/bin/env node
+/**
+ * Production-dashboard attribution for issue #7782.
+ *
+ * The harness builds the real full dashboard with production minification and
+ * VITE_E2E instrumentation, waits for the local-ML worker to become available,
+ * then runs the dashboard's own per-generation path selector with the committed
+ * representative input and the deterministic high-diversity input. The same
+ * page and inputs exercise the existing analysis worker for comparison.
+ *
+ * Usage:
+ *   node scripts/profile-news-hybrid-clustering-7782-dashboard.mjs \
+ *     docs/perf/news-hybrid-clustering-7782.fixture.json [--samples 3] [--cpu 1,6]
+ */
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+export const FRAME_BUDGET_MS = 16.7;
+export const LONG_TASK_MS = 50;
+const DEFAULT_SAMPLES = 3;
+const DEFAULT_CPU_RATES = [1, 6];
+
+function round(value) {
+  return Math.round((Number(value) || 0) * 1000) / 1000;
+}
+
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[index];
+}
+
+function summarize(values) {
+  const sorted = values.map(Number).filter(Number.isFinite).sort((a, b) => a - b);
+  const total = sorted.reduce((sum, value) => sum + value, 0);
+  return {
+    n: sorted.length,
+    min: round(sorted[0] ?? 0),
+    median: round(percentile(sorted, 50)),
+    p90: round(percentile(sorted, 90)),
+    max: round(sorted.at(-1) ?? 0),
+    mean: round(total / Math.max(1, sorted.length)),
+  };
+}
+
+function pathFrameIntervals(sample, path) {
+  if (Array.isArray(sample.pathFrameIntervalsMs)) return sample.pathFrameIntervalsMs;
+  return path === 'hybrid' && Array.isArray(sample.coreFrameIntervalsMs)
+    ? sample.coreFrameIntervalsMs
+    : [];
+}
+
+export function buildDashboardCaseSummary(name, path, samples) {
+  const coreDurations = samples.map((sample) => sample.coreMs).filter(Number.isFinite);
+  const coreFrameBudgetMissCount = samples.filter((sample) =>
+    Number(sample.coreMs) >= FRAME_BUDGET_MS
+    || (sample.coreFrameIntervalsMs ?? []).some((duration) => Number(duration) >= FRAME_BUDGET_MS),
+  ).length;
+  const pathFrameBudgetMissCount = samples.filter((sample) =>
+    pathFrameIntervals(sample, path).some((duration) => Number(duration) >= FRAME_BUDGET_MS),
+  ).length;
+  const coreLongTaskCount = samples.reduce(
+    (count, sample) => count + (sample.coreLongTasksMs ?? []).filter((duration) => Number(duration) >= LONG_TASK_MS).length,
+    0,
+  );
+
+  return {
+    name,
+    path,
+    sampleCount: samples.length,
+    itemCount: samples[0]?.itemCount ?? 0,
+    clusterCount: samples[0]?.clusterCount ?? 0,
+    pathProof: {
+      selectedEverySample: samples.length > 0 && samples.every((sample) => sample.selectedPath === path),
+      mlAvailableEverySample: samples.length > 0 && samples.every((sample) => sample.mlAvailableAtSelection === true),
+    },
+    totalLatencyMs: summarize(samples.map((sample) => sample.totalLatencyMs)),
+    mainThreadTaskMs: summarize(samples.map((sample) => sample.mainThreadTaskMs)),
+    coreMs: summarize(coreDurations),
+    coreFrameBudgetMissCount,
+    pathFrameBudgetMissCount,
+    coreLongTaskCount,
+    repeatableCoreFrameMiss: coreFrameBudgetMissCount >= 2,
+    coldStart: samples.find((sample) => sample.coldStart) ?? null,
+    raw: samples,
+  };
+}
+
+export function decideDashboardAttribution(summaries) {
+  const hybrid = summaries.find((summary) => summary.name === 'representative' && summary.path === 'hybrid');
+  const worker = summaries.find((summary) => summary.name === 'representative' && summary.path === 'analysis-worker');
+
+  if (!hybrid || !worker) {
+    return {
+      decision: 'unmet',
+      reason: 'Representative hybrid and analysis-worker dashboard samples are both required.',
+    };
+  }
+  if (!hybrid.pathProof.selectedEverySample || !hybrid.pathProof.mlAvailableEverySample) {
+    return {
+      decision: 'unmet',
+      reason: 'The representative hybrid generation was not selected with local ML available for every sample.',
+    };
+  }
+  if (!worker.pathProof.selectedEverySample || hybrid.itemCount !== worker.itemCount) {
+    return {
+      decision: 'unmet',
+      reason: 'The analysis worker did not run on the same representative dashboard input.',
+    };
+  }
+
+  const repeatableMiss = hybrid.repeatableCoreFrameMiss || hybrid.coreLongTaskCount >= 2;
+  if (!repeatableMiss) {
+    return {
+      decision: 'no-change',
+      reason: `No representative dashboard frame miss or ${FRAME_BUDGET_MS} ms core overrun repeated across samples.`,
+    };
+  }
+
+  const workerReducedOccupancy = worker.mainThreadTaskMs.median < hybrid.mainThreadTaskMs.median;
+  const workerRemovedMiss = worker.pathFrameBudgetMissCount < 2
+    && worker.pathFrameBudgetMissCount < hybrid.coreFrameBudgetMissCount;
+  if (workerReducedOccupancy && workerRemovedMiss) {
+    return {
+      decision: 'implement',
+      reason: 'The existing analysis worker removed a repeatable representative frame-budget miss with lower renderer task occupancy.',
+    };
+  }
+
+  return {
+    decision: 'no-change',
+    reason: 'A repeated representative miss was observed, but the existing worker did not improve both frame delivery and renderer task occupancy.',
+  };
+}
+
+function makeHighDiversity(count) {
+  return Array.from({ length: count }, (_, index) => ({
+    source: `Outlet${String(index % 47).padStart(2, '0')}`,
+    title: `UniqueTopic${index} DistinctEvent${index} Country${index % 173} Marker${index}`,
+    link: `https://fixture.test/high-diversity/${index}`,
+    publishedAt: Date.UTC(2026, 8, 6, 12, 0, 0) - index * 60_000,
+    isAlert: index % 17 === 0,
+  }));
+}
+
+function parseArgs(argv) {
+  const args = {
+    fixturePath: 'docs/perf/news-hybrid-clustering-7782.fixture.json',
+    samples: DEFAULT_SAMPLES,
+    cpuRates: [...DEFAULT_CPU_RATES],
+  };
+  const rest = argv.slice(2);
+  for (let index = 0; index < rest.length; index += 1) {
+    const value = rest[index];
+    if (value === '--samples') {
+      args.samples = Math.max(1, Number(rest[++index]) || DEFAULT_SAMPLES);
+    } else if (value === '--cpu') {
+      args.cpuRates = String(rest[++index] ?? '')
+        .split(',')
+        .map(Number)
+        .filter((rate) => Number.isFinite(rate) && rate >= 1);
+    } else if (!value.startsWith('--')) {
+      args.fixturePath = value;
+    }
+  }
+  if (args.cpuRates.length === 0) throw new Error('At least one positive --cpu rate is required');
+  return args;
+}
+
+function freePort() {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close((error) => error ? reject(error) : resolvePort(port));
+    });
+  });
+}
+
+async function waitForUrl(url, timeoutMs = 120_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url, { redirect: 'manual' });
+      if (response.ok || response.status === 304) return;
+    } catch {
+      // Preview is still starting.
+    }
+    await delay(250);
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function startProductionDashboard() {
+  const { build, preview } = await import('vite');
+  const port = await freePort();
+  process.env.SENTRY_AUTH_TOKEN = '';
+  process.env.VITE_SENTRY_DSN = '';
+  process.env.VITE_E2E = '1';
+  process.env.VITE_VARIANT = 'full';
+  const outDir = resolve(ROOT, 'tmp/news-hybrid-dashboard-production');
+  const config = {
+    mode: 'production',
+    customLogger: {
+      info: () => {},
+      warn: (message) => console.error(message),
+      warnOnce: (message) => console.error(message),
+      error: (message) => console.error(message),
+      clearScreen: () => {},
+      hasErrorLogged: () => false,
+      hasWarned: false,
+    },
+    build: { outDir },
+  };
+  const originalWrite = process.stdout.write;
+  try {
+    process.stdout.write = process.stderr.write.bind(process.stderr);
+    await build(config);
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  const server = await preview({
+    ...config,
+    preview: { host: '127.0.0.1', port, strictPort: true },
+  });
+  const url = `http://127.0.0.1:${port}/dashboard`;
+  try {
+    await waitForUrl(url);
+    return { server, url };
+  } catch (error) {
+    await new Promise((resolveClose) => server.httpServer.close(resolveClose));
+    throw error;
+  }
+}
+
+async function rendererTaskDurationMs(client) {
+  const { metrics } = await client.send('Performance.getMetrics');
+  const taskDuration = metrics.find((metric) => metric.name === 'TaskDuration')?.value ?? 0;
+  return taskDuration * 1000;
+}
+
+async function runPageSample(page, client, path, items, coldStart) {
+  await page.evaluate(() => {
+    performance.clearMeasures('wm:news-clustering:hybrid-core');
+    performance.clearMeasures('wm:news-clustering:path:hybrid');
+    performance.clearMeasures('wm:news-clustering:path:analysis-worker');
+  });
+  const taskBefore = await rendererTaskDurationMs(client);
+  const raw = await page.evaluate(async ({ selectedPath, fixtureItems, frameBudgetMs, longTaskMs }) => {
+    const hook = window.__wmNewsClusteringProfile;
+    if (!hook) throw new Error('Dashboard news-clustering profile hook is unavailable');
+
+    const frames = [];
+    let active = true;
+    let previousFrame = performance.now();
+    const onFrame = (timestamp) => {
+      frames.push({ start: previousFrame, end: timestamp, duration: timestamp - previousFrame });
+      previousFrame = timestamp;
+      if (active) requestAnimationFrame(onFrame);
+    };
+    requestAnimationFrame(onFrame);
+    const longTasks = [];
+    let observer = null;
+    try {
+      observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          longTasks.push({ start: entry.startTime, end: entry.startTime + entry.duration, duration: entry.duration });
+        }
+      });
+      observer.observe({ type: 'longtask', buffered: true });
+    } catch {
+      // Long Task API is optional; exact core and frame windows remain valid.
+    }
+
+    await new Promise((resolveFrame) => requestAnimationFrame(() => resolveFrame()));
+    const startedAt = performance.now();
+    const result = await hook.run(selectedPath, fixtureItems);
+    const endedAt = performance.now();
+    await new Promise((resolveFrame) => requestAnimationFrame(() => requestAnimationFrame(resolveFrame)));
+    active = false;
+    observer?.disconnect();
+
+    const lastMeasure = (name) => performance.getEntriesByName(name).at(-1);
+    const pathMeasure = lastMeasure(`wm:news-clustering:path:${selectedPath}`);
+    const coreMeasure = selectedPath === 'hybrid'
+      ? lastMeasure('wm:news-clustering:hybrid-core')
+      : null;
+    if (!pathMeasure) throw new Error(`No performance measure recorded for ${selectedPath}`);
+
+    const overlaps = (entry, start, end) => entry.start < end && entry.end > start;
+    const pathStart = pathMeasure.startTime;
+    const pathEnd = pathStart + pathMeasure.duration;
+    const coreStart = coreMeasure?.startTime ?? 0;
+    const coreEnd = coreStart + (coreMeasure?.duration ?? 0);
+    const pathFrames = frames.filter((entry) => overlaps(entry, pathStart, pathEnd));
+    const coreFrames = coreMeasure ? frames.filter((entry) => overlaps(entry, coreStart, coreEnd)) : [];
+    const coreLongTasks = coreMeasure ? longTasks.filter((entry) => overlaps(entry, coreStart, coreEnd)) : [];
+
+    return {
+      ...result,
+      totalLatencyMs: pathMeasure.duration || endedAt - startedAt,
+      coreMs: coreMeasure?.duration ?? 0,
+      pathFrameIntervalsMs: pathFrames
+        .map((entry) => entry.duration)
+        .filter((duration) => duration >= frameBudgetMs),
+      coreFrameIntervalsMs: coreFrames.map((entry) => entry.duration),
+      coreLongTasksMs: coreLongTasks.filter((entry) => entry.duration >= longTaskMs).map((entry) => entry.duration),
+      pathFrameBudgetExceeded: pathFrames.some((entry) => entry.duration >= frameBudgetMs),
+      coreFrameBudgetExceeded: Boolean(coreMeasure) && (
+        coreMeasure.duration >= frameBudgetMs
+        || coreFrames.some((entry) => entry.duration >= frameBudgetMs)
+      ),
+    };
+  }, {
+    selectedPath: path,
+    fixtureItems: items,
+    frameBudgetMs: FRAME_BUDGET_MS,
+    longTaskMs: LONG_TASK_MS,
+  });
+  const taskAfter = await rendererTaskDurationMs(client);
+  return {
+    ...raw,
+    coldStart,
+    mainThreadTaskMs: round(Math.max(0, taskAfter - taskBefore)),
+  };
+}
+
+async function installDashboardEnvironment(page) {
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem('worldmonitor-variant', 'full');
+    localStorage.setItem('wm-ai-flow-browser-model', 'true');
+    localStorage.setItem('wm-layer-warning-dismissed', 'true');
+    localStorage.setItem('wm-pro-banner-launched-dismissed', String(Date.now()));
+    localStorage.setItem('worldmonitor-mission-preset-dismissed-v1', '1');
+  });
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname.endsWith('/api/news/v1/list-feed-digest')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ categories: {}, feedStatuses: {}, generatedAt: new Date(0).toISOString() }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const fixturePath = resolve(ROOT, args.fixturePath);
+  const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+  if (!Array.isArray(fixture.items) || fixture.items.length === 0) {
+    throw new Error('A nonempty representative fixture is required');
+  }
+  const cases = {
+    representative: fixture.items,
+    highDiversity1500: makeHighDiversity(1500),
+  };
+
+  mkdirSync(resolve(ROOT, 'tmp'), { recursive: true });
+  const { server, url } = await startProductionDashboard();
+  const { chromium } = await import('@playwright/test');
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--use-angle=swiftshader', '--use-gl=swiftshader'],
+  });
+  const reports = [];
+  try {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    const page = await context.newPage();
+    const consoleMessages = [];
+    page.on('console', (message) => {
+      const text = message.text();
+      if (text.includes('[MLWorker]') || text.includes('[App] Initialization failed')) {
+        consoleMessages.push(text);
+      }
+    });
+    page.on('pageerror', (error) => consoleMessages.push(`pageerror: ${error.message}`));
+    await installDashboardEnvironment(page);
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await page.waitForFunction(() => Boolean(window.__wmNewsClusteringProfile), null, { timeout: 60_000 });
+    await page.waitForFunction(
+      () => document.documentElement.dataset.wmInitialDataReady === 'true',
+      null,
+      { timeout: 120_000 },
+    );
+    try {
+      await page.waitForFunction(
+        () => window.__wmNewsClusteringProfile?.getState().mlAvailable === true,
+        null,
+        { timeout: 60_000 },
+      );
+    } catch (error) {
+      const state = await page.evaluate(() => window.__wmNewsClusteringProfile?.getState() ?? null);
+      throw new Error(
+        `Local ML did not become available: ${JSON.stringify({ state, consoleMessages })}`,
+        { cause: error },
+      );
+    }
+
+    const assetScripts = await page.locator('script[src]').evaluateAll((scripts) =>
+      scripts.map((script) => script.getAttribute('src')),
+    );
+    if (assetScripts.some((src) => src?.includes('/@vite/')) || !assetScripts.some((src) => src?.startsWith('/assets/'))) {
+      throw new Error('Profile did not load production-built dashboard assets');
+    }
+
+    const client = await context.newCDPSession(page);
+    await client.send('Performance.enable');
+    const firstByPath = new Set();
+    for (const cpuThrottleRate of args.cpuRates) {
+      await client.send('Emulation.setCPUThrottlingRate', { rate: cpuThrottleRate });
+      for (const [name, items] of Object.entries(cases)) {
+        for (const path of ['hybrid', 'analysis-worker']) {
+          const samples = [];
+          for (let index = 0; index < args.samples; index += 1) {
+            const coldStart = !firstByPath.has(path);
+            samples.push(await runPageSample(page, client, path, items, coldStart));
+            firstByPath.add(path);
+            await delay(100);
+          }
+          reports.push({
+            cpuThrottleRate,
+            ...buildDashboardCaseSummary(name, path, samples),
+          });
+        }
+      }
+    }
+
+    const decisionAtSlowCpu = decideDashboardAttribution(
+      reports.filter((report) => report.cpuThrottleRate === Math.max(...args.cpuRates)),
+    );
+    const report = {
+      issue: 7782,
+      generatedAt: new Date().toISOString(),
+      surface: 'production-minified full dashboard with local ML available',
+      host: {
+        node: process.version,
+        platform: process.platform,
+        arch: process.arch,
+        userAgent: await page.evaluate(() => navigator.userAgent),
+      },
+      build: {
+        productionMinify: true,
+        viteE2EInstrumentation: true,
+        graphics: 'SwiftShader (headless capability support; clustering is CPU-attributed)',
+        assetScripts,
+      },
+      fixture: {
+        path: args.fixturePath,
+        capturedAt: fixture.capturedAt ?? null,
+        generatedAt: fixture.generatedAt ?? null,
+        source: fixture.source ?? null,
+      },
+      budgets: { frameMs: FRAME_BUDGET_MS, longTaskMs: LONG_TASK_MS },
+      samplesPerCaseAndPath: args.samples,
+      cpuThrottleRates: args.cpuRates,
+      cases: reports,
+      gate: decisionAtSlowCpu,
+    };
+    const outputPath = resolve(ROOT, 'tmp/news-hybrid-clustering-7782-dashboard.json');
+    writeFileSync(outputPath, JSON.stringify(report, null, 2));
+    console.log(JSON.stringify(report, null, 2));
+  } finally {
+    await browser.close();
+    await new Promise((resolveClose) => server.httpServer.close(resolveClose));
+  }
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -14,6 +14,9 @@
           "path": "scripts/measure-trade-animation-rebuild.mjs"
         },
         {
+          "path": "scripts/profile-news-hybrid-clustering-7782-dashboard.mjs"
+        },
+        {
           "path": "src/components/LiveNewsPanel.ts"
         },
         {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -6,7 +6,7 @@ import { runHydrationTier, type HydrationTask } from '@/app/hydration-scheduler'
 import { yieldToMain } from '@/utils/after-paint';
 import { getSignalAggregator, type SignalAggregator } from '@/app/lazy-services';
 import { getMilitaryVesselsModule, isVesselRuntimeStoppedError } from '@/services/military-vessels-lazy';
-import type { NewsItem, MapLayers, SocialUnrestEvent, MilitaryFlight } from '@/types';
+import type { ClusteredEvent, NewsItem, MapLayers, SocialUnrestEvent, MilitaryFlight } from '@/types';
 import type { MarketData } from '@/types';
 import type { TimeRange } from '@/components/MapContainer';
 import {
@@ -438,6 +438,29 @@ const HYDRATION_TIER_FOUR = new Set([
 ]);
 const HYDRATION_TIERS: HydrationTier[] = [1, 2, 3, 4];
 
+type NewsClusteringProfilePath = 'hybrid' | 'analysis-worker';
+
+interface NewsClusteringProfileResult {
+  generation: number;
+  selectedPath: NewsClusteringProfilePath;
+  mlAvailableAtSelection: boolean;
+  itemCount: number;
+  clusterCount: number;
+}
+
+interface NewsClusteringProfileHook {
+  getState(): {
+    mlAvailable: boolean;
+    capabilities: typeof mlWorker.mlCapabilities;
+    loadedModelIds: string[];
+  };
+  run(path: NewsClusteringProfilePath, items: ProtoNewsItem[]): Promise<NewsClusteringProfileResult>;
+}
+
+type NewsClusteringProfileWindow = Window & {
+  __wmNewsClusteringProfile?: NewsClusteringProfileHook;
+};
+
 export class DataLoaderManager implements AppModule {
   private ctx: AppContext;
   private callbacks: DataLoaderCallbacks;
@@ -551,6 +574,16 @@ export class DataLoaderManager implements AppModule {
   constructor(ctx: AppContext, callbacks: DataLoaderCallbacks) {
     this.ctx = ctx;
     this.callbacks = callbacks;
+    if (import.meta.env.VITE_E2E === '1') {
+      (window as NewsClusteringProfileWindow).__wmNewsClusteringProfile = {
+        getState: () => ({
+          mlAvailable: mlWorker.isAvailable,
+          capabilities: mlWorker.mlCapabilities,
+          loadedModelIds: mlWorker.loadedModelIds,
+        }),
+        run: (path, items) => this.runNewsClusteringProfile(path, items),
+      };
+    }
   }
 
   private getHydrationTier(name: string): HydrationTier {
@@ -620,6 +653,11 @@ export class DataLoaderManager implements AppModule {
   }
 
   destroy(): void {
+    this.newsLoadGeneration += 1;
+    if (import.meta.env.VITE_E2E === '1') {
+      const profileWindow = window as NewsClusteringProfileWindow;
+      delete profileWindow.__wmNewsClusteringProfile;
+    }
     this.globalTenderGeneration += 1;
     this.activeGlobalTenderScopedGeneration = null;
     this.stopSatellitePropagation();
@@ -2011,6 +2049,72 @@ export class DataLoaderManager implements AppModule {
     return generation === this.newsLoadGeneration;
   }
 
+  private async clusterNewsForGeneration(
+    items: NewsItem[],
+    generation: number,
+    forcedPath?: NewsClusteringProfilePath,
+  ): Promise<NewsClusteringProfileResult & { clusters: ClusteredEvent[] }> {
+    const mlAvailableAtSelection = mlWorker.isAvailable;
+    const selectedPath = forcedPath ?? (mlAvailableAtSelection ? 'hybrid' : 'analysis-worker');
+    if (selectedPath === 'hybrid' && !mlAvailableAtSelection) {
+      throw new Error('Hybrid clustering profile requested before local ML became available');
+    }
+
+    const startedAt = import.meta.env.VITE_E2E === '1' ? performance.now() : 0;
+    const clusters = selectedPath === 'hybrid'
+      ? await clusterNewsHybrid(items, { shouldContinue: () => this.isCurrentNewsLoad(generation) })
+      : await analysisWorker.clusterNews(items);
+    if (import.meta.env.VITE_E2E === '1') {
+      performance.measure(`wm:news-clustering:path:${selectedPath}`, {
+        start: startedAt,
+        end: performance.now(),
+        detail: {
+          generation,
+          selectedPath,
+          mlAvailableAtSelection,
+          itemCount: items.length,
+          clusterCount: clusters.length,
+        },
+      });
+    }
+
+    return {
+      generation,
+      selectedPath,
+      mlAvailableAtSelection,
+      itemCount: items.length,
+      clusterCount: clusters.length,
+      clusters,
+    };
+  }
+
+  private async runNewsClusteringProfile(
+    path: NewsClusteringProfilePath,
+    protoItems: ProtoNewsItem[],
+  ): Promise<NewsClusteringProfileResult> {
+    if (path === 'hybrid' && !mlWorker.isAvailable) {
+      throw new Error('Hybrid clustering profile requested before local ML became available');
+    }
+
+    const generation = this.beginNewsLoad();
+    const items = protoItems.map(protoItemToNewsItem);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    if (!this.isCurrentNewsLoad(generation)) {
+      throw new Error('News clustering profile generation was superseded');
+    }
+    const profiled = await this.clusterNewsForGeneration(items, generation, path);
+    if (!this.isCurrentNewsLoad(generation)) {
+      throw new Error('News clustering profile generation was superseded');
+    }
+    return {
+      generation: profiled.generation,
+      selectedPath: profiled.selectedPath,
+      mlAvailableAtSelection: profiled.mlAvailableAtSelection,
+      itemCount: profiled.itemCount,
+      clusterCount: profiled.clusterCount,
+    };
+  }
+
   private commitNewsFreshness(generation: number, servedStale: boolean): boolean {
     if (!this.isCurrentNewsLoad(generation)) return false;
     this.committedNewsGeneration = generation;
@@ -2160,9 +2264,7 @@ export class DataLoaderManager implements AppModule {
       // path. Worker readiness alone must never force a news reload or
       // retroactively regroup committed first-load results — a later normal
       // refresh re-reads availability and may use newly available ML.
-      const clusters = mlWorker.isAvailable
-        ? await clusterNewsHybrid(this.ctx.allNews)
-        : await analysisWorker.clusterNews(this.ctx.allNews);
+      const { clusters } = await this.clusterNewsForGeneration(this.ctx.allNews, generation);
       if (!this.isCurrentNewsLoad(generation)) return;
       this.ctx.latestClusters = clusters;
       // Only now is an empty cluster set a real answer. Set inside the try, after
@@ -4513,9 +4615,8 @@ export class DataLoaderManager implements AppModule {
       // the clustering path with THIS call's news body, never with a later
       // worker-ready event that would regroup already-committed clusters.
       if (this.ctx.latestClusters.length === 0 && this.ctx.allNews.length > 0) {
-        this.ctx.latestClusters = mlWorker.isAvailable
-          ? await clusterNewsHybrid(this.ctx.allNews)
-          : await analysisWorker.clusterNews(this.ctx.allNews);
+        const { clusters } = await this.clusterNewsForGeneration(this.ctx.allNews, newsGeneration);
+        this.ctx.latestClusters = clusters;
         this.ctx.clustersSettled = true;
       }
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -109,7 +109,7 @@ import {
 import { checkBatchForBreakingAlerts, dispatchOrefBreakingAlert } from '@/services/breaking-news-alerts';
 import { displayPubDateMs, effectivePubDateMs } from '@/services/feed-date';
 import { mlWorker } from '@/services/ml-worker';
-import { clusterNewsHybrid } from '@/services/clustering';
+import { clusterNewsHybrid, clusterNewsWithWorkerFallback } from '@/services/clustering';
 import { ingestProtests, ingestFlights, ingestVessels, ingestEarthquakes, detectGeoConvergence, geoConvergenceToSignal } from '@/services/geo-convergence';
 import { consumeServerAnomalies, fetchLiveAnomalies } from '@/services/temporal-baseline';
 import { fetchAllFires, flattenFires, computeRegionStats, toMapFires } from '@/services/wildfires';
@@ -2063,7 +2063,9 @@ export class DataLoaderManager implements AppModule {
     const startedAt = import.meta.env.VITE_E2E === '1' ? performance.now() : 0;
     const clusters = selectedPath === 'hybrid'
       ? await clusterNewsHybrid(items, { shouldContinue: () => this.isCurrentNewsLoad(generation) })
-      : await analysisWorker.clusterNews(items);
+      : await clusterNewsWithWorkerFallback(items, {
+        shouldContinue: () => this.isCurrentNewsLoad(generation),
+      });
     if (import.meta.env.VITE_E2E === '1') {
       performance.measure(`wm:news-clustering:path:${selectedPath}`, {
         start: startedAt,

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -4616,6 +4616,7 @@ export class DataLoaderManager implements AppModule {
       // worker-ready event that would regroup already-committed clusters.
       if (this.ctx.latestClusters.length === 0 && this.ctx.allNews.length > 0) {
         const { clusters } = await this.clusterNewsForGeneration(this.ctx.allNews, newsGeneration);
+        if (!this.isCurrentNewsLoad(newsGeneration)) return;
         this.ctx.latestClusters = clusters;
         this.ctx.clustersSettled = true;
       }

--- a/src/services/clustering.ts
+++ b/src/services/clustering.ts
@@ -7,11 +7,16 @@
 import type { NewsItem, ClusteredEvent } from '@/types';
 import { getSourceTier } from '@/config';
 import { countPublisherFamilies } from '../../shared/publisher-families.js';
+import { analysisWorker } from './analysis-worker';
 import { clusterNewsCore } from './analysis-core';
 import { mlWorker } from './ml-worker';
 import { ML_THRESHOLDS } from '@/config/ml-config';
 
 export const MAX_SEMANTIC_CLUSTER_INPUT = 250;
+
+interface HybridClusteringOptions {
+  shouldContinue?: () => boolean;
+}
 
 export function clusterNews(items: NewsItem[]): ClusteredEvent[] {
   return clusterNewsCore(items, getSourceTier) as ClusteredEvent[];
@@ -31,12 +36,47 @@ function compareClustersForSemanticCandidate(a: ClusteredEvent, b: ClusteredEven
     || a.id.localeCompare(b.id);
 }
 
+async function clusterInitialStage(
+  items: NewsItem[],
+  shouldContinue: () => boolean,
+): Promise<ClusteredEvent[] | null> {
+  if (items.length === 0) return [];
+
+  try {
+    const clusters = await analysisWorker.clusterNews(items);
+    if (!shouldContinue()) return null;
+    if (clusters.length > 0) return clusters;
+    console.warn('[Clustering] Analysis worker returned no clusters, using local fallback');
+  } catch (error) {
+    if (!shouldContinue()) return null;
+    console.warn('[Clustering] Analysis worker failed, using local fallback:', error);
+  }
+
+  if (!shouldContinue()) return null;
+  return clusterNews(items);
+}
+
 /**
  * Hybrid clustering: Jaccard first, then semantic refinement if ML available
  */
-export async function clusterNewsHybrid(items: NewsItem[]): Promise<ClusteredEvent[]> {
-  // Step 1: Fast Jaccard clustering
-  const jaccardClusters = clusterNewsCore(items, getSourceTier) as ClusteredEvent[];
+export async function clusterNewsHybrid(
+  items: NewsItem[],
+  options: HybridClusteringOptions = {},
+): Promise<ClusteredEvent[]> {
+  const shouldContinue = options.shouldContinue ?? (() => true);
+  const coreStartedAt = import.meta.env.VITE_E2E === '1' ? performance.now() : 0;
+  const jaccardClusters = await clusterInitialStage(items, shouldContinue);
+  if (import.meta.env.VITE_E2E === '1') {
+    performance.measure('wm:news-clustering:hybrid-core', {
+      start: coreStartedAt,
+      end: performance.now(),
+      detail: {
+        itemCount: items.length,
+        clusterCount: jaccardClusters?.length ?? 0,
+      },
+    });
+  }
+  if (jaccardClusters === null || !shouldContinue()) return [];
 
   // Step 2: If ML unavailable or too few clusters, return Jaccard results
   if (!mlWorker.isAvailable || jaccardClusters.length < ML_THRESHOLDS.minClustersForML) {
@@ -59,12 +99,14 @@ export async function clusterNewsHybrid(items: NewsItem[]): Promise<ClusteredEve
       clusterTexts,
       ML_THRESHOLDS.semanticClusterThreshold
     );
+    if (!shouldContinue()) return [];
 
     // Merge semantically similar clusters
     const mergedSemanticClusters = mergeSemanticallySimilarClusters(semanticCandidates, semanticGroups);
     return [...mergedSemanticClusters, ...overflowClusters]
       .sort((a, b) => b.lastUpdated.getTime() - a.lastUpdated.getTime());
   } catch (error) {
+    if (!shouldContinue()) return [];
     console.warn('[Clustering] Semantic clustering failed, using Jaccard only:', error);
     return jaccardClusters;
   }

--- a/src/services/clustering.ts
+++ b/src/services/clustering.ts
@@ -36,23 +36,24 @@ function compareClustersForSemanticCandidate(a: ClusteredEvent, b: ClusteredEven
     || a.id.localeCompare(b.id);
 }
 
-async function clusterInitialStage(
+export async function clusterNewsWithWorkerFallback(
   items: NewsItem[],
-  shouldContinue: () => boolean,
-): Promise<ClusteredEvent[] | null> {
+  options: HybridClusteringOptions = {},
+): Promise<ClusteredEvent[]> {
+  const shouldContinue = options.shouldContinue ?? (() => true);
   if (items.length === 0) return [];
 
   try {
     const clusters = await analysisWorker.clusterNews(items);
-    if (!shouldContinue()) return null;
+    if (!shouldContinue()) return [];
     if (clusters.length > 0) return clusters;
     console.warn('[Clustering] Analysis worker returned no clusters, using local fallback');
   } catch (error) {
-    if (!shouldContinue()) return null;
+    if (!shouldContinue()) return [];
     console.warn('[Clustering] Analysis worker failed, using local fallback:', error);
   }
 
-  if (!shouldContinue()) return null;
+  if (!shouldContinue()) return [];
   return clusterNews(items);
 }
 
@@ -65,18 +66,18 @@ export async function clusterNewsHybrid(
 ): Promise<ClusteredEvent[]> {
   const shouldContinue = options.shouldContinue ?? (() => true);
   const coreStartedAt = import.meta.env.VITE_E2E === '1' ? performance.now() : 0;
-  const jaccardClusters = await clusterInitialStage(items, shouldContinue);
+  const jaccardClusters = await clusterNewsWithWorkerFallback(items, { shouldContinue });
   if (import.meta.env.VITE_E2E === '1') {
     performance.measure('wm:news-clustering:hybrid-core', {
       start: coreStartedAt,
       end: performance.now(),
       detail: {
         itemCount: items.length,
-        clusterCount: jaccardClusters?.length ?? 0,
+        clusterCount: jaccardClusters.length,
       },
     });
   }
-  if (jaccardClusters === null || !shouldContinue()) return [];
+  if (!shouldContinue()) return [];
 
   // Step 2: If ML unavailable or too few clusters, return Jaccard results
   if (!mlWorker.isAvailable || jaccardClusters.length < ML_THRESHOLDS.minClustersForML) {

--- a/tests/dom/data-loader-digest-coverage.test.mts
+++ b/tests/dom/data-loader-digest-coverage.test.mts
@@ -329,6 +329,34 @@ describe('digest coverage follows the selected browser response', () => {
     expect(mocks.analyzeCorrelations).not.toHaveBeenCalled();
   });
 
+  it('keeps local clusters when the ML-off analysis worker is unavailable (#7782)', async () => {
+    const { loader, internal } = await makeLoader();
+    const ctx = (loader as unknown as { ctx: AppContext }).ctx;
+    ctx.allNews = [{
+      source: 'Reuters',
+      title: 'Fixture event',
+      link: 'https://fixture.test/event',
+      pubDate: new Date('2026-09-06T12:00:00.000Z'),
+      isAlert: false,
+    }];
+
+    const generation = internal.beginNewsLoad();
+    expect(internal.commitNewsFreshness(generation, false)).toBe(true);
+    mocks.clusterNews.mockResolvedValueOnce([]);
+    mocks.analyzeCorrelations.mockResolvedValueOnce([]);
+
+    await internal.runCorrelationAnalysis();
+
+    expect(ctx.latestClusters).toHaveLength(1);
+    expect(ctx.latestClusters[0]?.primaryTitle).toBe('Fixture event');
+    expect(ctx.clustersSettled).toBe(true);
+    expect(mocks.analyzeCorrelations).toHaveBeenCalledWith(
+      ctx.latestClusters,
+      ctx.latestPredictions,
+      ctx.latestMarkets,
+    );
+  });
+
   it.each(['retained', 'persisted'] as const)(
     'a %s fallback cannot run direct breaking-alert checks (#7084)',
     async (fallbackKind) => {

--- a/tests/dom/data-loader-digest-coverage.test.mts
+++ b/tests/dom/data-loader-digest-coverage.test.mts
@@ -2,14 +2,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AppContext } from '@/app/app-context';
 import type { ListFeedDigestResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
+import type { ClusteredEvent } from '@/types';
 
 const mocks = vi.hoisted(() => ({
   checkBatchForBreakingAlerts: vi.fn(),
+  clusterNews: vi.fn(),
+  analyzeCorrelations: vi.fn(),
 }));
 
 vi.mock('@/services/breaking-news-alerts', async (importOriginal) => ({
   ...await importOriginal<typeof import('@/services/breaking-news-alerts')>(),
   checkBatchForBreakingAlerts: mocks.checkBatchForBreakingAlerts,
+}));
+
+vi.mock('@/services/analysis-worker', () => ({
+  analysisWorker: {
+    clusterNews: mocks.clusterNews,
+    analyzeCorrelations: mocks.analyzeCorrelations,
+  },
 }));
 
 await import('@/app/data-loader');
@@ -33,6 +43,7 @@ interface DigestLoaderInternals {
   beginNewsLoad(): number;
   commitNewsFreshness(generation: number, servedStale: boolean): boolean;
   canNotifyForCommittedNews(generation: number, servedStale: boolean): boolean;
+  runCorrelationAnalysis(): Promise<void>;
   loadNewsCategory(
     category: string,
     feeds: Array<{ name: string }>,
@@ -93,6 +104,11 @@ async function makeLoader() {
     newsByCategory: {},
     currentTimeRange: 'all',
     initialLoadComplete: false,
+    allNews: [],
+    latestClusters: [],
+    latestPredictions: [],
+    latestMarkets: [],
+    clustersSettled: false,
   } as unknown as AppContext;
   const { DataLoaderManager } = await import('@/app/data-loader');
   const loader = new DataLoaderManager(ctx, {
@@ -108,6 +124,8 @@ async function makeLoader() {
 describe('digest coverage follows the selected browser response', () => {
   beforeEach(() => {
     mocks.checkBatchForBreakingAlerts.mockReset();
+    mocks.clusterNews.mockReset();
+    mocks.analyzeCorrelations.mockReset();
     vi.stubGlobal('fetch', vi.fn());
   });
 
@@ -268,6 +286,47 @@ describe('digest coverage follows the selected browser response', () => {
     expect(selected?.servedStale).toBe(true);
     expect(internal.commitNewsFreshness(obsoleteGeneration, selected?.servedStale ?? false)).toBe(false);
     expect(internal.canNotifyForCommittedNews(freshGeneration, false)).toBe(true);
+  });
+
+  it('a superseded correlation clustering pass cannot replace current clusters (#7782)', async () => {
+    const { loader, internal } = await makeLoader();
+    const ctx = (loader as unknown as { ctx: AppContext }).ctx;
+    ctx.allNews = [{
+      source: 'Reuters',
+      title: 'Fixture event',
+      link: 'https://fixture.test/event',
+      pubDate: new Date('2026-09-06T12:00:00.000Z'),
+      isAlert: false,
+    }];
+
+    const committedGeneration = internal.beginNewsLoad();
+    expect(internal.commitNewsFreshness(committedGeneration, false)).toBe(true);
+    const staleCluster: ClusteredEvent = {
+      id: 'stale-cluster',
+      primaryTitle: 'Fixture event',
+      primarySource: 'Reuters',
+      primaryLink: 'https://fixture.test/event',
+      sourceCount: 1,
+      uniquePublisherCount: 1,
+      topSources: [{ name: 'Reuters', tier: 1, url: 'https://fixture.test/event' }],
+      allItems: ctx.allNews,
+      firstSeen: ctx.allNews[0]!.pubDate,
+      lastUpdated: ctx.allNews[0]!.pubDate,
+      isAlert: false,
+    };
+    let resolveClusters!: (clusters: ClusteredEvent[]) => void;
+    mocks.clusterNews.mockImplementationOnce(() => new Promise<ClusteredEvent[]>((resolve) => {
+      resolveClusters = resolve;
+    }));
+
+    const pending = internal.runCorrelationAnalysis();
+    internal.beginNewsLoad();
+    resolveClusters([staleCluster]);
+    await pending;
+
+    expect(ctx.latestClusters).toEqual([]);
+    expect(ctx.clustersSettled).toBe(false);
+    expect(mocks.analyzeCorrelations).not.toHaveBeenCalled();
   });
 
   it.each(['retained', 'persisted'] as const)(

--- a/tests/dom/news-hybrid-worker-offload.test.mts
+++ b/tests/dom/news-hybrid-worker-offload.test.mts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ClusteredEvent, NewsItem } from '@/types';
+
+const workerMocks = vi.hoisted(() => ({
+  clusterNews: vi.fn(),
+}));
+const mlMocks = vi.hoisted(() => ({
+  available: false,
+  clusterBySemanticSimilarity: vi.fn(),
+}));
+
+vi.mock('@/services/analysis-worker', () => ({
+  analysisWorker: { clusterNews: workerMocks.clusterNews },
+}));
+vi.mock('@/services/ml-worker', () => ({
+  mlWorker: {
+    get isAvailable() { return mlMocks.available; },
+    clusterBySemanticSimilarity: mlMocks.clusterBySemanticSimilarity,
+  },
+}));
+
+import { clusterNews, clusterNewsHybrid, MAX_SEMANTIC_CLUSTER_INPUT } from '@/services/clustering';
+
+function item(index: number, source = 'Reuters', title = `Distinct event ${index}`): NewsItem {
+  return {
+    source,
+    title,
+    link: `https://fixture.test/${index}`,
+    pubDate: new Date(Date.UTC(2026, 8, 6, 12, 0) - index * 60_000),
+    isAlert: false,
+  };
+}
+
+function cluster(index: number, overrides: Partial<ClusteredEvent> = {}): ClusteredEvent {
+  const primary = item(index, `Source ${index}`, `Cluster ${index}`);
+  return {
+    id: `cluster-${index}`,
+    primaryTitle: primary.title,
+    primarySource: primary.source,
+    primaryLink: primary.link,
+    sourceCount: 1,
+    uniquePublisherCount: 1,
+    topSources: [{ name: primary.source, tier: 4, url: primary.link }],
+    allItems: [primary],
+    firstSeen: primary.pubDate,
+    lastUpdated: primary.pubDate,
+    isAlert: false,
+    ...overrides,
+  };
+}
+
+describe('hybrid clustering initial worker stage (#7782)', () => {
+  beforeEach(() => {
+    workerMocks.clusterNews.mockReset();
+    mlMocks.clusterBySemanticSimilarity.mockReset();
+    mlMocks.available = false;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the existing analysis worker result for the initial stage', async () => {
+    const items = [item(1), item(2)];
+    const expected = clusterNews(items);
+    workerMocks.clusterNews.mockResolvedValue(expected);
+
+    await expect(clusterNewsHybrid(items)).resolves.toEqual(expected);
+    expect(workerMocks.clusterNews).toHaveBeenCalledOnce();
+    expect(workerMocks.clusterNews).toHaveBeenCalledWith(items);
+  });
+
+  it('falls back once for an unavailable empty result or worker error, but accepts genuine empty input', async () => {
+    const items = [item(1), item(2)];
+    const expected = clusterNews(items);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    workerMocks.clusterNews.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error('Worker reset'));
+    await expect(clusterNewsHybrid(items)).resolves.toEqual(expected);
+    await expect(clusterNewsHybrid(items)).resolves.toEqual(expected);
+    await expect(clusterNewsHybrid([])).resolves.toEqual([]);
+
+    expect(workerMocks.clusterNews).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not start semantic work after a generation is superseded', async () => {
+    let resolveWorker!: (clusters: ClusteredEvent[]) => void;
+    const pending = new Promise<ClusteredEvent[]>((resolve) => { resolveWorker = resolve; });
+    workerMocks.clusterNews.mockReturnValue(pending);
+    mlMocks.available = true;
+    let current = true;
+
+    const result = clusterNewsHybrid([item(1)], { shouldContinue: () => current });
+    current = false;
+    resolveWorker([cluster(1)]);
+
+    await expect(result).resolves.toEqual([]);
+    expect(mlMocks.clusterBySemanticSimilarity).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back or start semantic work when teardown terminates the worker', async () => {
+    let rejectWorker!: (error: Error) => void;
+    const pending = new Promise<ClusteredEvent[]>((_resolve, reject) => { rejectWorker = reject; });
+    workerMocks.clusterNews.mockReturnValue(pending);
+    mlMocks.available = true;
+    let current = true;
+
+    const result = clusterNewsHybrid([item(1)], { shouldContinue: () => current });
+    current = false;
+    rejectWorker(new Error('Worker terminated'));
+
+    await expect(result).resolves.toEqual([]);
+    expect(mlMocks.clusterBySemanticSimilarity).not.toHaveBeenCalled();
+  });
+
+  it('preserves no-merge and multi-source semantic refinement', async () => {
+    const newest = cluster(1, {
+      primarySource: 'Unknown fixture publisher',
+      topSources: [{ name: 'Unknown fixture publisher', tier: 4, url: 'https://fixture.test/unknown' }],
+    });
+    const trusted = cluster(2, {
+      primarySource: 'Reuters',
+      topSources: [{ name: 'Reuters', tier: 1, url: 'https://fixture.test/reuters' }],
+    });
+    const otherClusters = [cluster(3), cluster(4), cluster(5)];
+    const workerClusters = [newest, trusted, ...otherClusters];
+    workerMocks.clusterNews.mockResolvedValue(workerClusters);
+    mlMocks.available = true;
+
+    mlMocks.clusterBySemanticSimilarity.mockResolvedValueOnce(workerClusters.map(({ id }) => [id]));
+    const unmerged = await clusterNewsHybrid(Array.from({ length: 5 }, (_, index) => item(index)));
+    expect(unmerged.map(({ id }) => id)).toEqual(workerClusters.map(({ id }) => id));
+
+    mlMocks.clusterBySemanticSimilarity.mockResolvedValueOnce([
+      [newest.id, trusted.id],
+      ...otherClusters.map(({ id }) => [id]),
+    ]);
+    const mergedResult = await clusterNewsHybrid(Array.from({ length: 5 }, (_, index) => item(index)));
+    const merged = mergedResult.find(({ allItems }) => allItems.length === 2);
+    expect(merged?.primarySource).toBe('Reuters');
+    expect(merged?.sourceCount).toBe(2);
+    expect(merged?.uniquePublisherCount).toBe(2);
+    expect(merged?.allItems).toHaveLength(2);
+    expect(merged?.firstSeen).toBeInstanceOf(Date);
+    expect(merged?.lastUpdated).toBeInstanceOf(Date);
+  });
+
+  it('keeps the 250 semantic cap and all overflow clusters', async () => {
+    const clusters = Array.from({ length: MAX_SEMANTIC_CLUSTER_INPUT + 10 }, (_, index) => cluster(index));
+    workerMocks.clusterNews.mockResolvedValue(clusters);
+    mlMocks.available = true;
+    mlMocks.clusterBySemanticSimilarity.mockImplementation(async (candidates: Array<{ id: string }>) => (
+      candidates.map(({ id }) => [id])
+    ));
+
+    const result = await clusterNewsHybrid(Array.from({ length: 260 }, (_, index) => item(index)));
+
+    expect(mlMocks.clusterBySemanticSimilarity.mock.calls[0]?.[0]).toHaveLength(MAX_SEMANTIC_CLUSTER_INPUT);
+    expect(result).toHaveLength(260);
+  });
+
+  it('passes more than 1,000 inputs to the shared worker core without changing tier semantics', async () => {
+    const items = Array.from({ length: 1_001 }, (_, index) => item(index, 'Unknown fixture publisher'));
+    items[0] = item(0, 'Reuters', items[1]!.title);
+    const expected = clusterNews(items);
+    workerMocks.clusterNews.mockResolvedValue(expected);
+
+    const result = await clusterNewsHybrid(items);
+
+    expect(workerMocks.clusterNews.mock.calls[0]?.[0]).toHaveLength(1_001);
+    expect(result).toEqual(expected);
+    expect(result[0]?.primarySource).toBe('Reuters');
+  });
+});

--- a/tests/dom/news-hybrid-worker-offload.test.mts
+++ b/tests/dom/news-hybrid-worker-offload.test.mts
@@ -92,9 +92,12 @@ describe('hybrid clustering initial worker stage (#7782)', () => {
     mlMocks.available = true;
     let current = true;
 
-    const result = clusterNewsHybrid([item(1)], { shouldContinue: () => current });
+    const result = clusterNewsHybrid(
+      Array.from({ length: 5 }, (_, index) => item(index)),
+      { shouldContinue: () => current },
+    );
     current = false;
-    resolveWorker([cluster(1)]);
+    resolveWorker(Array.from({ length: 5 }, (_, index) => cluster(index)));
 
     await expect(result).resolves.toEqual([]);
     expect(mlMocks.clusterBySemanticSimilarity).not.toHaveBeenCalled();
@@ -107,7 +110,10 @@ describe('hybrid clustering initial worker stage (#7782)', () => {
     mlMocks.available = true;
     let current = true;
 
-    const result = clusterNewsHybrid([item(1)], { shouldContinue: () => current });
+    const result = clusterNewsHybrid(
+      Array.from({ length: 5 }, (_, index) => item(index)),
+      { shouldContinue: () => current },
+    );
     current = false;
     rejectWorker(new Error('Worker terminated'));
 

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -102,7 +102,7 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/services/clustering.ts',
-    line: 139,
+    line: 182,
     reason: 'allDates aggregation for cluster firstSeen/lastUpdated metadata; not a per-item ranking comparator.',
   },
   {

--- a/tests/hub-activity-hydration.test.mts
+++ b/tests/hub-activity-hydration.test.mts
@@ -156,12 +156,12 @@ describe('late-mounted hub activity wiring', () => {
 
     assert.match(
       source,
-      /this\.ctx\.latestClusters = mlWorker\.isAvailable\n\s*\? await clusterNewsHybrid\(this\.ctx\.allNews\)\n\s*: await analysisWorker\.clusterNews\(this\.ctx\.allNews\);\n(?:\s*\/\/[^\n]*\n)*\s*this\.ctx\.clustersSettled = true;/,
+      /const \{ clusters \} = await this\.clusterNewsForGeneration\(this\.ctx\.allNews, generation\);\n\s*if \(!this\.isCurrentNewsLoad\(generation\)\) return;\n\s*this\.ctx\.latestClusters = clusters;\n(?:\s*\/\/[^\n]*\n)*\s*this\.ctx\.clustersSettled = true;/,
       'clustersSettled must be set immediately after the clustering assignment, never before it',
     );
     assert.doesNotMatch(
       source,
-      /this\.ctx\.clustersSettled = true;[\s\S]{0,200}?this\.ctx\.latestClusters = mlWorker\.isAvailable/,
+      /this\.ctx\.clustersSettled = true;[\s\S]{0,200}?clusterNewsForGeneration/,
       'clustersSettled must not be set ahead of the clustering pass it describes',
     );
   });

--- a/tests/profile-news-hybrid-clustering-7782-dashboard.test.mjs
+++ b/tests/profile-news-hybrid-clustering-7782-dashboard.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  FRAME_BUDGET_MS,
+  buildDashboardCaseSummary,
+  decideDashboardAttribution,
+} from '../scripts/profile-news-hybrid-clustering-7782-dashboard.mjs';
+
+function sample(overrides = {}) {
+  return {
+    selectedPath: 'hybrid',
+    mlAvailableAtSelection: true,
+    itemCount: 289,
+    clusterCount: 261,
+    totalLatencyMs: 20,
+    mainThreadTaskMs: 10,
+    coreMs: 18,
+    coreFrameIntervalsMs: [20],
+    coreLongTasksMs: [],
+    ...overrides,
+  };
+}
+
+describe('dashboard hybrid-clustering attribution gate (#7782)', () => {
+  it('summarizes exact path proof and frame misses for one dashboard case', () => {
+    const summary = buildDashboardCaseSummary('representative', 'hybrid', [
+      sample({ coreMs: 18, coreFrameIntervalsMs: [20] }),
+      sample({ coreMs: 17, coreFrameIntervalsMs: [19] }),
+      sample({ coreMs: 15, coreFrameIntervalsMs: [16] }),
+    ]);
+
+    assert.equal(summary.pathProof.selectedEverySample, true);
+    assert.equal(summary.pathProof.mlAvailableEverySample, true);
+    assert.equal(summary.itemCount, 289);
+    assert.equal(summary.coreMs.median, 17);
+    assert.equal(summary.coreFrameBudgetMissCount, 2);
+    assert.equal(summary.repeatableCoreFrameMiss, true);
+    assert.equal(summary.coreLongTaskCount, 0);
+  });
+
+  it('requires the production dashboard to select hybrid with local ML available', () => {
+    const hybrid = buildDashboardCaseSummary('representative', 'hybrid', [
+      sample({ selectedPath: 'analysis-worker', mlAvailableAtSelection: false }),
+    ]);
+    const worker = buildDashboardCaseSummary('representative', 'analysis-worker', [
+      sample({ selectedPath: 'analysis-worker', coreMs: 0, mainThreadTaskMs: 2 }),
+    ]);
+
+    assert.deepEqual(decideDashboardAttribution([hybrid, worker]), {
+      decision: 'unmet',
+      reason: 'The representative hybrid generation was not selected with local ML available for every sample.',
+    });
+  });
+
+  it('stops without production movement when the synchronous core does not repeatably miss a frame budget', () => {
+    const hybrid = buildDashboardCaseSummary('representative', 'hybrid', [
+      sample({ coreMs: 12, coreFrameIntervalsMs: [16] }),
+      sample({ coreMs: 14, coreFrameIntervalsMs: [16.5] }),
+      sample({ coreMs: 15, coreFrameIntervalsMs: [16.6] }),
+    ]);
+    const worker = buildDashboardCaseSummary('representative', 'analysis-worker', [
+      sample({ selectedPath: 'analysis-worker', coreMs: 0, mainThreadTaskMs: 2 }),
+    ]);
+
+    assert.deepEqual(decideDashboardAttribution([hybrid, worker]), {
+      decision: 'no-change',
+      reason: `No representative dashboard frame miss or ${FRAME_BUDGET_MS} ms core overrun repeated across samples.`,
+    });
+  });
+
+  it('permits offload only when the existing worker removes an attributed repeated miss', () => {
+    const hybrid = buildDashboardCaseSummary('representative', 'hybrid', [
+      sample({ coreMs: 18, coreFrameIntervalsMs: [20], mainThreadTaskMs: 12 }),
+      sample({ coreMs: 19, coreFrameIntervalsMs: [22], mainThreadTaskMs: 13 }),
+      sample({ coreMs: 17, coreFrameIntervalsMs: [21], mainThreadTaskMs: 11 }),
+    ]);
+    const worker = buildDashboardCaseSummary('representative', 'analysis-worker', [
+      sample({ selectedPath: 'analysis-worker', coreMs: 0, coreFrameIntervalsMs: [], mainThreadTaskMs: 2 }),
+      sample({ selectedPath: 'analysis-worker', coreMs: 0, coreFrameIntervalsMs: [], mainThreadTaskMs: 3 }),
+      sample({ selectedPath: 'analysis-worker', coreMs: 0, coreFrameIntervalsMs: [], mainThreadTaskMs: 2 }),
+    ]);
+
+    assert.deepEqual(decideDashboardAttribution([hybrid, worker]), {
+      decision: 'implement',
+      reason: 'The existing analysis worker removed a repeatable representative frame-budget miss with lower renderer task occupancy.',
+    });
+  });
+
+  it('does not claim the worker removed the miss when its own path repeats it', () => {
+    const hybrid = buildDashboardCaseSummary('representative', 'hybrid', [
+      sample({ coreMs: 18, coreFrameIntervalsMs: [20], mainThreadTaskMs: 12 }),
+      sample({ coreMs: 19, coreFrameIntervalsMs: [22], mainThreadTaskMs: 13 }),
+      sample({ coreMs: 17, coreFrameIntervalsMs: [21], mainThreadTaskMs: 11 }),
+    ]);
+    const worker = buildDashboardCaseSummary('representative', 'analysis-worker', [
+      sample({ selectedPath: 'analysis-worker', coreMs: 0, pathFrameIntervalsMs: [20], mainThreadTaskMs: 2 }),
+      sample({ selectedPath: 'analysis-worker', coreMs: 0, pathFrameIntervalsMs: [21], mainThreadTaskMs: 3 }),
+      sample({ selectedPath: 'analysis-worker', coreMs: 0, pathFrameIntervalsMs: [], mainThreadTaskMs: 2 }),
+    ]);
+
+    assert.deepEqual(decideDashboardAttribution([hybrid, worker]), {
+      decision: 'no-change',
+      reason: 'A repeated representative miss was observed, but the existing worker did not improve both frame delivery and renderer task occupancy.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Hybrid news clustering no longer runs its initial Jaccard pass synchronously on the renderer when local ML is ready. The existing analysis worker now runs the unchanged shared core, after which the existing semantic ranking, 250-candidate cap, overflow handling, thresholds, merge behavior, and final ordering continue unchanged.

The controlled production-dashboard reports show that the representative 289-item initial stage improved from a 16.1 ms median with 3/3 frame-budget crossings to 7.9 ms with 0/3 crossings. The final semantic result stayed at 249 clusters. The 1,500-item high-diversity case improved from 16.4 ms and 2/3 crossings to 14.1 ms and 0/3 crossings, with the final result fixed at 753 clusters.

| 6× CPU case | Before initial median | After initial median | Before crossings | After crossings | Final clusters |
|---|---:|---:|---:|---:|---:|
| Representative, 289 items | 16.1 ms | 7.9 ms | 3/3 | 0/3 | 249 |
| High diversity, 1,500 items | 16.4 ms | 14.1 ms | 2/3 | 0/3 | 753 |

The final exact-head rerun measured 7.3 ms and 0/3 crossings for the representative case, and 14.7 ms with one non-repeatable crossing for the high-diversity case. Two high-diversity full-path frame misses occurred during the roughly 2.1-second semantic phase, so this PR claims only the measured improvement to the initial stage, not a device-wide interaction or total-latency improvement.

For non-empty input, worker absence, empty output, construction or readiness failure, request timeout, runtime error, reset, and termination use one bounded local-core fallback. Generation and teardown checks prevent stale results from committing or starting fallback or semantic work. Genuine empty input remains authoritative. The same fallback now protects the ML-off analysis-worker path.

The committed profiler builds the production-minified full dashboard, waits for local ML, exercises the real DataLoader selector and source conversion, records all raw samples, and compares the real analysis-worker lifecycle on identical inputs. Its window hook and timing marks exist only in `VITE_E2E=1` builds.

## Verification

- Production-dashboard profile: representative final count 249; high-diversity final count 753; no repeatable initial-stage crossing after offload.
- `node --test tests/profile-news-hybrid-clustering-7782.test.mjs tests/profile-news-hybrid-clustering-7782-dashboard.test.mjs tests/clustering-cap.test.mjs` — 12 passed.
- `npx vitest run --config vitest.dom.config.mts tests/dom/news-hybrid-worker-offload.test.mts tests/dom/data-loader-digest-coverage.test.mts` — 19 passed.
- `node --import tsx --test tests/hub-activity-hydration.test.mts` — 8 passed.
- `npm run typecheck`, `npm run typecheck:api`, `npm run lint:boundaries`, `npm run sources:check`, and `git diff --check` passed.
- `node --test tests/source-attribution.test.mjs` — 47 passed.
- `npm run lint` passed with 25 existing warnings and 14 infos in unrelated files; no changed-file finding was reported.
- The pre-push gate passed 112 DOM files / 911 tests, 277 Edge tests, Markdown lint, MDX lint, version checks, and repository safety checks.

## Monitoring and rollback

After an authorized deployment, watch browser error telemetry and logs for analysis-worker initialization or timeout errors and the `[Clustering] Analysis worker returned no clusters` / `failed` fallback warnings for 24 hours. Healthy behavior is populated news clusters and hub panels with no new worker-error trend. Repeated fallbacks, empty hub data, or a dashboard responsiveness regression are rollback triggers; revert this PR to restore the synchronous hybrid initial stage.

Fixes #7782

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
