### PR TITLE
fix(agent-readiness): start auth guide with its heading

### DIFF
--- a/public/auth.md
+++ b/public/auth.md
@@ -1,12 +1,7 @@
----
-title: "World Monitor agent authentication"
-description: "API key and OAuth authentication."
-canonical: "https://www.worldmonitor.app/auth.md"
----
-
 # WorldMonitor — Agent Authentication (auth.md)
 
-Authentication follows the WorkOS **auth.md** spec: <https://workos.com/auth-md>.
+Use API keys or OAuth 2.1 to authenticate with the WorldMonitor API and MCP server.
+This walkthrough follows the WorkOS **auth.md** spec: <https://workos.com/auth-md>.
 
 Discovery is open. `get_sources` alone is credential- and daily-quota-free
 (10 anonymous calls/minute/IP, fail closed). Other MCP data tools need

--- a/scripts/verify-agent-readiness.mjs
+++ b/scripts/verify-agent-readiness.mjs
@@ -19,12 +19,22 @@ async function check(name, path, headers, verify) {
   }
 }
 
-function markdown(response, body) {
+function assertMarkdownResponse(response, body) {
   assert.equal(response.status, 200);
   assert.match(response.headers.get('content-type') ?? '', /text\/markdown/);
+  assert.doesNotMatch(body.slice(0, 1000), /<!doctype html|<html/i);
+}
+
+function markdown(response, body) {
+  assertMarkdownResponse(response, body);
   assert.match(body, /^---\n[\s\S]*?\btitle:[\s\S]*?\n---\n/);
   assert.match(body, /^canonical: /m);
-  assert.doesNotMatch(body.slice(0, 1000), /<!doctype html|<html/i);
+}
+
+function authMarkdown(response, body) {
+  assertMarkdownResponse(response, body);
+  assert.match(body, /^# WorldMonitor — Agent Authentication \(auth\.md\)\n/);
+  assert.match(response.headers.get('link') ?? '', /<https:\/\/www\.worldmonitor\.app\/auth\.md>;\s*rel="canonical"/);
 }
 
 await check('JSON agent mode', '/?mode=agent', { Accept: 'application/json' }, (response, body) => {
@@ -35,9 +45,12 @@ await check('JSON agent mode', '/?mode=agent', { Accept: 'application/json' }, (
   assert.ok(view.endpoints.rest.openapi && view.authentication.apiKey && view.capabilities.length);
 });
 
-const docs = readdirSync(new URL('../public/', import.meta.url)).filter((name) => name.endsWith('.md'));
+const docs = readdirSync(new URL('../public/', import.meta.url)).filter(
+  (name) => name.endsWith('.md') && name !== 'auth.md',
+);
 docs.push('api/download.md', 'countries.md', 'sources.md', 'contact.md');
 for (const document of docs) await check(document, `/${document}`, {}, markdown);
+await check('auth.md', '/auth.md', {}, authMarkdown);
 for (const ua of policy.userAgents) {
   await check(`${ua} homepage`, '/', { 'User-Agent': `${ua}/1.0`, Accept: 'text/html' }, markdown);
 }

--- a/tests/agent-readiness.test.mts
+++ b/tests/agent-readiness.test.mts
@@ -6,7 +6,11 @@ import middleware from '../middleware';
 import agentRequestPolicy from '../shared/agent-request-policy.json';
 
 describe('public agent documents', () => {
-  const files = readdirSync(new URL('../public/', import.meta.url)).filter((file) => file.endsWith('.md'));
+  // auth.md is intentionally heading-led for scanner compatibility. Its title,
+  // description, and canonical identity are guarded in the dedicated auth suite.
+  const files = readdirSync(new URL('../public/', import.meta.url)).filter(
+    (file) => file.endsWith('.md') && file !== 'auth.md',
+  );
   files.push('api/download.md');
   for (const file of files) {
     it(`${file} opens with document metadata`, () => {

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -3579,6 +3579,15 @@ describe('agent readiness: MCP/OAuth origin alignment', () => {
 describe('agent readiness: auth.md walkthrough', () => {
   const authMd = readFileSync(resolve(__dirname, '../public/auth.md'), 'utf-8');
 
+  it('opens with its title and describes API key and OAuth authentication', () => {
+    assert.match(
+      authMd,
+      /^# WorldMonitor — Agent Authentication \(auth\.md\)\n/,
+      'auth.md must open directly with its H1 for scanner compatibility'
+    );
+    assert.match(authMd, /API keys?.*OAuth|OAuth.*API keys?/i);
+  });
+
   it('publishes /auth.md with the WorkOS-prescribed sections', () => {
     for (const heading of ['Discover', 'Pick a method', 'Register', 'Claim', 'Use the credential', 'Errors', 'Revocation']) {
       assert.match(


### PR DESCRIPTION
## Summary

`/auth.md` now starts with its H1, so heading-first scanners can identify the authentication guide instead of stopping at YAML metadata. The guide keeps its API-key and OAuth description, WorkOS guidance, discovery links, and canonical identity through the existing HTTP `Link` header. The live readiness sweep validates that heading-led contract separately, while other public Markdown documents still require YAML title, description, and canonical metadata.

Related: #7825

## Verification

- Regression proof: the new leading-H1 assertion failed against the previous YAML-first document, then passed after the document change.
- Focused data tests: 314 tests, 308 passed, 6 intentional skips, 0 failed.
- Contract-test type check, Biome lint, Markdown lint, and `git diff --check`: passed.
- Full data suite: 30,883 passed and 41 skipped; three unrelated load-sensitive process-control tests did not pass under full concurrency. Their isolated rerun passed all 99 tests.
- Pre-push gates: passed, including the changed-file suite with all 314 tests passing.
- Vercel preview live sweep: unavailable because preview access protection returned `401`/HTML for agent routes; production acceptance remains a post-deploy gate.

## Post-Deploy Monitoring & Validation

After an authorized merge and deployment, the PR owner should record fresh `ora-agent` GET and HEAD probes for both the apex URL (following redirects) and direct `https://www.worldmonitor.app/auth.md`. Record UTC time, status chain, final MIME type, canonical `Link` header, and the first document lines.

Accept when both paths finish with `200`, serve `text/markdown`, advertise the `www` canonical URL, and start with `# WorldMonitor — Agent Authentication (auth.md)` without YAML. Treat an Ora scan as secondary evidence only. If the contract fails, inspect deployment and CDN propagation, redeploy the same verified head when appropriate, or revert only if the deployment caused a broader regression; deployment actions require separate authorization.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
