### PR TITLE
perf(ci): scope doc anchors to docs inputs

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    - cron: '17 6 * * 1'
 
 permissions:
   contents: read
@@ -19,18 +21,55 @@ jobs:
     outputs:
       code: ${{ steps.diff.outputs.code }}
       markdown: ${{ steps.diff.outputs.markdown }}
+      docs: ${{ steps.diff.outputs.docs }}
     steps:
       - id: diff
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          set -euo pipefail
+
+          emit_all_true() {
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "markdown=true" >> "$GITHUB_OUTPUT"
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+          }
+          if [ "${{ github.event_name }}" = "push" ]; then
+            emit_all_true
             exit 0
           fi
-          FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
-            --paginate --jq '.[].filename')
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "markdown=false" >> "$GITHUB_OUTPUT"
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}") ||
+             ! FILES_JSON=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
+               --paginate --slurp | jq -ce 'add | arrays'); then
+            echo "PR file lookup failed; running every gated Lint Code job."
+            emit_all_true
+            exit 0
+          fi
+          FILE_COUNT=$(jq 'length' <<< "$FILES_JSON")
+          if ! jq -e --arg head "${{ github.event.pull_request.head.sha }}" \
+            --arg base "${{ github.event.pull_request.base.sha }}" --argjson count "$FILE_COUNT" \
+            '.head.sha == $head and .base.sha == $base and .changed_files == $count and $count < 3000' <<< "$PR_JSON" >/dev/null; then
+            echo "PR metadata moved or its file list is incomplete; running every gated Lint Code job."
+            emit_all_true
+            exit 0
+          fi
+          # Include both sides of renames. A deleted file remains at filename.
+          if ! FILES=$(jq -er '
+            [.[] | .filename, (.previous_filename // empty)] as $paths
+            | if ($paths | length > 0) and all($paths[]; type == "string" and length > 0 and (explode | all(. != 0 and . != 10 and . != 13)))
+              then $paths[] else error("invalid path listing") end
+          ' <<< "$FILES_JSON"); then
+            echo "Unusable PR file list; running every gated Lint Code job."
+            emit_all_true
+            exit 0
+          fi
           CODE=$(echo "$FILES" | grep -vcE '\.md$|^docs/|^src-tauri/|^CHANGELOG\.md$|^LICENSE$|\.github/workflows/(build-desktop|docker-publish)\.yml$' || echo 0)
           echo "code=$( [ "$CODE" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
           # markdown job: only the lint:md inputs (the markdown, its config, and
@@ -38,6 +77,8 @@ jobs:
           # a code-only PR skips it. LINT_MD_INPUTS in .husky/pre-push plus the lockfile.
           MARKDOWN=$(printf '%s\n' "$FILES" | grep -cE '\.md$|^\.markdownlint|^package(-lock)?\.json$' || true)
           echo "markdown=$( [ "$MARKDOWN" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          DOCS=$(printf '%s\n' "$FILES" | grep -cE '^docs/|^scripts/check-doc-anchors\.mjs$|^scripts/_html-entities\.mjs$|^\.github/workflows/lint-code\.yml$' || true)
+          echo "docs=$( [ "$DOCS" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
 
   biome:
     needs: changes
@@ -101,6 +142,8 @@ jobs:
   doc-anchors:
     # Why this gate exists, and how Mintlify slugs a heading, is documented
     # once in scripts/check-doc-anchors.mjs. Keep it there, not in both.
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -40,9 +40,7 @@ jobs:
             exit 0
           fi
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "code=false" >> "$GITHUB_OUTPUT"
-            echo "markdown=false" >> "$GITHUB_OUTPUT"
-            echo "docs=true" >> "$GITHUB_OUTPUT"
+            emit_all_true
             exit 0
           fi
           if ! PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}") ||

--- a/tests/ci-lint-code-selection.test.mjs
+++ b/tests/ci-lint-code-selection.test.mjs
@@ -1,0 +1,176 @@
+// The Lint Code workflow owns an expensive rendered-doc anchor check. These
+// tests execute its real path classifier so code-only changes can skip the
+// export without losing docs changes, renames, deletions, or renderer canaries.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { test } from 'node:test';
+import { parse } from 'yaml';
+
+const root = resolve(import.meta.dirname, '..');
+const workflow = parse(readFileSync(join(root, '.github/workflows/lint-code.yml'), 'utf8'));
+
+function classify(files, {
+  event = 'pull_request',
+  pages,
+  changedFiles,
+  eventHead = 'event-head',
+  eventBase = 'event-base',
+  prHead = eventHead,
+  prBase = eventBase,
+  filePayload,
+  ghMode = 'success',
+} = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'wm-lint-code-selection-'));
+  try {
+    const normalize = (file) => typeof file === 'string' ? { filename: file } : file;
+    const filePages = (pages ?? [files]).map((page) => page.map(normalize));
+    const listedCount = filePages.reduce((count, page) => count + page.length, 0);
+    writeFileSync(join(dir, 'pr.json'), JSON.stringify({
+      changed_files: changedFiles ?? listedCount,
+      head: { sha: prHead },
+      base: { sha: prBase },
+    }));
+    writeFileSync(join(dir, 'files.json'), filePayload ?? JSON.stringify(filePages));
+    writeFileSync(join(dir, 'output'), '');
+    writeFileSync(join(dir, 'gh'), `#!/bin/sh
+if [ "$GH_MODE" = "fail" ]; then
+  exit 1
+fi
+case "$2" in
+  */files)
+    cat "$FIXTURE/files.json"
+    if [ "$GH_MODE" = "partial-files-failure" ]; then
+      exit 1
+    fi
+    ;;
+  *)
+    cat "$FIXTURE/pr.json"
+    ;;
+esac
+`, { mode: 0o755 });
+
+    const values = {
+      'github.event_name': event,
+      'github.repository': 'owner/repo',
+      'github.event.number': '1',
+      'github.event.pull_request.head.sha': eventHead,
+      'github.event.pull_request.base.sha': eventBase,
+    };
+    const script = workflow.jobs.changes.steps.find((step) => step.id === 'diff').run.replace(
+      /\$\{\{ ([^}]+) \}\}/g,
+      (_, name) => {
+        assert.ok(Object.hasOwn(values, name), `unknown workflow expression ${name}`);
+        return values[name];
+      },
+    );
+    const result = spawnSync('bash', ['-euo', 'pipefail', '-c', script], {
+      cwd: root,
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: {
+        ...process.env,
+        FIXTURE: dir,
+        GH_MODE: ghMode,
+        PATH: `${dir}:${process.env.PATH}`,
+        GITHUB_OUTPUT: join(dir, 'output'),
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return Object.fromEntries(
+      readFileSync(join(dir, 'output'), 'utf8').trim().split('\n').map((line) => line.split('=')),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function assertFailsOpen(result) {
+  assert.deepEqual(result, { code: 'true', markdown: 'true', docs: 'true' });
+}
+
+test('doc-anchors runs for every repository input that can change rendered anchors', () => {
+  const docsOnly = classify(['docs/about.mdx']);
+  assert.equal(docsOnly.code, 'false');
+  assert.equal(docsOnly.markdown, 'false');
+  assert.equal(docsOnly.docs, 'true');
+  for (const file of [
+    'scripts/check-doc-anchors.mjs',
+    'scripts/_html-entities.mjs',
+    '.github/workflows/lint-code.yml',
+  ]) {
+    assert.equal(classify([file]).docs, 'true', file);
+  }
+});
+
+test('doc-anchors skips code-only changes and runs for mixed changes', () => {
+  assert.equal(classify(['src/app/App.ts']).docs, 'false');
+  const mixed = classify([], { pages: [['src/app/App.ts'], ['docs/about.mdx']] });
+  assert.equal(mixed.code, 'true');
+  assert.equal(mixed.docs, 'true');
+});
+
+test('doc-anchors counts both sides of renames and deleted docs', () => {
+  assert.equal(classify([{
+    filename: 'archive/about.mdx',
+    previous_filename: 'docs/about.mdx',
+    status: 'renamed',
+  }]).docs, 'true');
+  assert.equal(classify([{ filename: 'docs/deleted.mdx', status: 'removed' }]).docs, 'true');
+});
+
+test('an unreadable PR file list fails open', () => {
+  assertFailsOpen(classify(['src/app/App.ts'], { ghMode: 'fail' }));
+});
+
+test('a partial pagination failure fails open even after valid page JSON', () => {
+  assertFailsOpen(classify([], {
+    pages: [['src/app/App.ts'], ['docs/about.mdx']],
+    ghMode: 'partial-files-failure',
+  }));
+});
+
+test('malformed or unusable successful file listings fail open', () => {
+  assertFailsOpen(classify(['src/app/App.ts'], { filePayload: 'not json' }));
+  assertFailsOpen(classify([{ filename: '' }]));
+});
+
+test('an incomplete file list fails open when changed_files is larger', () => {
+  assertFailsOpen(classify(['src/app/App.ts'], { changedFiles: 2 }));
+});
+
+test('stale PR head or base metadata fails open', () => {
+  assertFailsOpen(classify(['src/app/App.ts'], { prHead: 'stale-head' }));
+  assertFailsOpen(classify(['src/app/App.ts'], { prBase: 'stale-base' }));
+});
+
+test('the GitHub 3000-file cap fails open', () => {
+  const files = Array.from({ length: 3000 }, (_, index) => `src/file-${index}.ts`);
+  assertFailsOpen(classify(files));
+});
+
+test('the weekly renderer canary enables docs without gated lint work', () => {
+  assert.deepEqual(workflow.on.schedule, [{ cron: '17 6 * * 1' }]);
+  const result = classify([], { event: 'schedule' });
+  assert.equal(result.code, 'false');
+  assert.equal(result.markdown, 'false');
+  assert.equal(result.docs, 'true');
+});
+
+test('pushes to main keep every gated lint classifier enabled', () => {
+  const result = classify([], { event: 'push' });
+  assert.equal(result.code, 'true');
+  assert.equal(result.markdown, 'true');
+  assert.equal(result.docs, 'true');
+});
+
+test('doc-anchors is gated by the docs classifier', () => {
+  const diffStep = workflow.jobs.changes.steps.find((step) => step.id === 'diff');
+  assert.equal(diffStep.shell, 'bash');
+  assert.match(diffStep.run, /^\s*set -euo pipefail$/m);
+  assert.equal(workflow.jobs['doc-anchors'].needs, 'changes');
+  assert.equal(workflow.jobs['doc-anchors'].if, "needs.changes.outputs.docs == 'true'");
+});

--- a/tests/ci-lint-code-selection.test.mjs
+++ b/tests/ci-lint-code-selection.test.mjs
@@ -152,11 +152,11 @@ test('the GitHub 3000-file cap fails open', () => {
   assertFailsOpen(classify(files));
 });
 
-test('the weekly renderer canary enables docs without gated lint work', () => {
+test('the weekly renderer canary keeps every required lint classifier enabled', () => {
   assert.deepEqual(workflow.on.schedule, [{ cron: '17 6 * * 1' }]);
   const result = classify([], { event: 'schedule' });
-  assert.equal(result.code, 'false');
-  assert.equal(result.markdown, 'false');
+  assert.equal(result.code, 'true');
+  assert.equal(result.markdown, 'true');
   assert.equal(result.docs, 'true');
 });
 


### PR DESCRIPTION
## Summary

- Classify the exact documentation and anchor-check inputs in the shared `changes` job, including both names for renames and deleted paths.
- Skip the costly `doc-anchors` Mintlify export for code-only pull requests while keeping its required check visible as a successful skip.
- Run the full required Lint Code set every Monday at 06:17 UTC, including the real renderer drift canary, so scheduled skips cannot replace failed push evidence. Keep the existing renderer version output unchanged.
- Fail open when pull-request metadata, pagination, paths, or GitHub's 3,000-file limit make the classifier uncertain.

## Verification

- `node scripts/run-data-tests.mjs tests/ci-lint-code-selection.test.mjs tests/ci-test-selection.test.mjs tests/ci-workflow-coverage.test.mts tests/deploy-gate-status-description.test.mjs` — 100 tests passed across 6 suites.
- `npm run typecheck && npm run lint` — passed; lint reported only existing advisory warnings outside this change.
- `./node_modules/.bin/biome lint tests/ci-lint-code-selection.test.mjs` — passed.
- `git diff --check` — passed.
- Repository pre-push gate — passed, including TypeScript, Unicode safety, version sync, and the 12 changed classifier tests.

## Post-Deploy Monitoring & Validation

- Logs and searches: inspect the `Lint Code` workflow, especially `lint-changes` and `doc-anchors`; confirm the anchor log still includes `renderer:`. Treat `PR file lookup failed`, `PR metadata moved`, or `Unusable PR file list` as fail-open classifier events.
- Metrics: compare `Lint Code` workflow duration and `doc-anchors` conclusions before and after merge.
- Healthy result: a code-only PR publishes `doc-anchors` as skipped while the deploy gate stays green; a docs-input PR runs and passes `doc-anchors`; the first Monday 06:17 UTC scheduled run logs the renderer version and passes.
- Failure signal: a docs-input PR skips `doc-anchors`, a code-only PR still performs the export, the deploy gate rejects an expected skip, or the scheduled canary fails.
- Rollback or mitigation: revert this commit. If GitHub metadata is unreliable, temporarily emit `docs=true` so every pull request runs the anchor check.
- Validation window and owner: repository maintainers should check the first code-only PR, the first docs-input PR, and the first scheduled run after merge.

Fixes #7783

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
