### PR TITLE
test(cleanup): remove vacuous regression cases

### DIFF
--- a/tests/brief-edge-route-smoke.test.mjs
+++ b/tests/brief-edge-route-smoke.test.mjs
@@ -17,6 +17,7 @@ import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 
 const ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
@@ -211,10 +212,63 @@ describe('infrastructure-error vs miss (both routes must not collapse)', () => {
     }
   });
 
-  it('api/latest-brief returns 503 when Upstash fails (not 200 "composing")', async () => {
-    // Skipped when Clerk is not mockable in unit tests. We exercise
-    // the infra-error branch at the helper level above; the route
-    // wiring is covered by the 403/404 smoke tests.
+  it('api/latest-brief returns 503 when Upstash fails (not 200 "composing")', async (t) => {
+    const saved = {
+      issuer: process.env.CLERK_JWT_ISSUER_DOMAIN,
+      secret: process.env.BRIEF_URL_SIGNING_SECRET,
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    };
+    const issuer = 'https://clerk.test';
+    const kid = 'latest-brief-test-key';
+    const { privateKey, publicKey } = await generateKeyPair('RS256');
+    const jwk = { ...(await exportJWK(publicKey)), alg: 'RS256', kid, use: 'sig' };
+    const jwt = await new SignJWT({ plan: 'pro' })
+      .setProtectedHeader({ alg: 'RS256', kid })
+      .setIssuer(issuer)
+      .setSubject('user_test')
+      .setAudience('convex')
+      .setExpirationTime('5m')
+      .sign(privateKey);
+
+    process.env.CLERK_JWT_ISSUER_DOMAIN = issuer;
+    process.env.BRIEF_URL_SIGNING_SECRET = 'test-secret-infra-err-path';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.invalid';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'tok';
+    t.mock.method(globalThis, 'fetch', async (input) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url === `${issuer}/.well-known/jwks.json`) {
+        return Response.json({ keys: [jwk] });
+      }
+      return new Response('oops', { status: 500 });
+    });
+
+    const { __resetJwksForTests } = await import('../server/auth-session.ts');
+    __resetJwksForTests();
+    try {
+      const { default: handler } = await import('../api/latest-brief.ts');
+      const req = new Request('https://worldmonitor.app/api/latest-brief', {
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${jwt}`,
+          origin: 'https://worldmonitor.app',
+        },
+      });
+      const res = await handler(req);
+      assert.equal(res.status, 503, 'Upstash outage must surface as 503, not composing');
+      assert.deepEqual(await res.json(), { error: 'service_unavailable' });
+    } finally {
+      __resetJwksForTests();
+      for (const [key, value] of [
+        ['CLERK_JWT_ISSUER_DOMAIN', saved.issuer],
+        ['BRIEF_URL_SIGNING_SECRET', saved.secret],
+        ['UPSTASH_REDIS_REST_URL', saved.url],
+        ['UPSTASH_REDIS_REST_TOKEN', saved.token],
+      ]) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 });
 

--- a/tests/brief-share-url.test.mts
+++ b/tests/brief-share-url.test.mts
@@ -198,13 +198,6 @@ describe('pointer wire format (P1 regression — write ↔ read must round-trip)
     assert.deepEqual(pointer, { userId: 'user_abc', issueDate: '2026-04-18-0800' });
   });
 
-  it('a raw colon-delimited string (the P1 bug) fails JSON.parse', () => {
-    // This is the format the earlier buggy code wrote. If we ever
-    // revert to it, readRawJsonFromUpstash's parse will throw and
-    // the public route will 503. Locking the failure so anyone
-    // who reintroduces the bug gets a red test.
-    assert.throws(() => JSON.parse('user_abc:2026-04-18-0800'), SyntaxError);
-  });
 });
 
 describe('preview share route reachability', () => {

--- a/tests/follow-button.test.mjs
+++ b/tests/follow-button.test.mjs
@@ -18,6 +18,7 @@
 
 import { describe, it, before, beforeEach, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 // ---------------------------------------------------------------------------
 // Browser-global stubs
@@ -597,41 +598,28 @@ describe('renderFollowButton — entitlement-loading window', () => {
   });
 });
 
-describe('renderFollowButton — P2 #16 assertNever exhaustiveness on unknown reason', () => {
-  it('hypothetical new reason → click handler logs/throws via assertNever runtime guard', async () => {
-    // The compile-time exhaustiveness guard fires at typecheck if a
-    // new variant is added to FollowMutationResult. The runtime branch
-    // catches a malformed test fake. Here we monkey-patch addCountry
-    // to return a not-yet-known reason and assert that the unhandled-
-    // discriminant path runs (we observe the console.error path via a
-    // captured originalError stub).
+describe('renderFollowButton — P2 #16 INVALID_INPUT and assertNever exhaustiveness', () => {
+  it('keeps the compile-time guard and logs an invalid mounted country code', async (t) => {
+    const source = readFileSync(new URL('../src/utils/follow-button.ts', import.meta.url), 'utf8');
+    assert.match(
+      source,
+      /^[ \t]+assertNever\(result\);[ \t]*$/m,
+      'the switch must pass its fully narrowed result to the exhaustiveness guard',
+    );
+
     setupAnonymousFree();
-    const originalError = console.error;
-    let captured = null;
-    console.error = (...args) => { captured = args; };
-    // Stub addCountry on the module — node's ESM bindings are
-    // read-only, so we can't simply reassign. Instead, drive the
-    // service via a fake that returns INVALID_INPUT for an unknown
-    // code (the existing INVALID_INPUT branch fires, NOT assertNever).
-    // We assert the typecheck guard exists by inspecting the source
-    // file for the `assertNever(result.reason)` call.
-    try {
-      const { renderFollowButton: rfb } = await import('../src/utils/follow-button.ts');
-      const handle = rfb({ countryCode: 'NotAValidCode' });
-      const host = makeHost();
-      const teardown = handle.attach(host);
-      host.clickButton();
-      await flushMicrotasks();
-      teardown();
-      // The `INVALID_INPUT` reason is handled (not assertNever-fall-through).
-      // The presence of `assertNever(result.reason)` in the source is
-      // what the typecheck enforces; here we just verify the test
-      // didn't throw and the existing branches still fire correctly.
-      assert.ok(true, 'INVALID_INPUT branch executed without assertNever fallthrough');
-    } finally {
-      console.error = originalError;
-      void captured;
-    }
+    const warn = t.mock.method(console, 'warn', () => {});
+    const handle = renderFollowButton({ countryCode: 'NotAValidCode' });
+    const host = makeHost();
+    const teardown = handle.attach(host);
+    host.clickButton();
+    await flushMicrotasks();
+    teardown();
+    assert.equal(warn.mock.callCount(), 1);
+    assert.deepEqual(warn.mock.calls[0].arguments, [
+      '[follow-button] invalid country code at mount site:',
+      'NotAValidCode',
+    ]);
   });
 });
 

--- a/tests/geo-keyword-matching.test.mts
+++ b/tests/geo-keyword-matching.test.mts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { tokenizeForMatch, matchKeyword, matchesAnyKeyword, findMatchingKeywords } from '../src/utils/keyword-match.ts';
+import { getGeoHubById } from '../src/services/geo-hub-index.ts';
 
 // --- Tokenizer tests ---
 
@@ -275,27 +276,22 @@ describe('multi-word phrase matching', () => {
 // --- DC keywords cleanup ---
 
 describe('DC keywords (cleaned)', () => {
-  const dcKeywords = ['pentagon', 'white house', 'congress', 'cia', 'nsa', 'washington', 'biden', 'trump', 'senate', 'supreme court', 'vance', 'elon'];
-
-  it('does NOT contain "house" as standalone keyword', () => {
-    assert.ok(!dcKeywords.includes('house'));
-  });
-
-  it('does NOT contain "us " trailing-space hack', () => {
-    assert.ok(!dcKeywords.includes('us '));
-  });
+  const dcKeywords = getGeoHubById('washington')?.keywords;
 
   it('"Housing market crashes" does NOT match any DC keyword', () => {
+    assert.ok(dcKeywords);
     const t = tokenizeForMatch('Housing market crashes nationwide');
     assert.ok(!matchesAnyKeyword(t, dcKeywords));
   });
 
   it('"White House announces budget" DOES match DC', () => {
+    assert.ok(dcKeywords);
     const t = tokenizeForMatch('White House announces budget cuts');
     assert.ok(matchesAnyKeyword(t, dcKeywords));
   });
 
   it('"Congress passes bill" DOES match DC', () => {
+    assert.ok(dcKeywords);
     const t = tokenizeForMatch('Congress passes new spending bill');
     assert.ok(matchesAnyKeyword(t, dcKeywords));
   });

--- a/tests/pro-welcome-teaser-links.test.mts
+++ b/tests/pro-welcome-teaser-links.test.mts
@@ -217,26 +217,6 @@ describe('third-party headline text survives the prerender splice', () => {
     assert.match(source, /mounted && h\.publishedAt \? ` · \$\{timeAgo\(h\.publishedAt\)\}`/);
   });
 
-  // Positive control for the hazard itself. Without this, the assertion below
-  // reads as style preference rather than a defect being held closed.
-  it('a STRING replacement expands $-patterns in the injected markup', () => {
-    const page = '<html><body><div id="root"></div></body></html>';
-    const marker = '<div id="root"></div>';
-    // React escapes `'` to `&#x27;`, so a headline containing `$'` arrives at
-    // the splice as a literal `$&` -- the "insert the matched substring" pattern.
-    const ssr = '<li>Oil at $&#x27;record&#x27; highs</li>';
-    const corrupted = page.replace(marker, `<div id="root">${ssr}</div>`);
-    assert.equal(
-      (corrupted.match(/id="root"/g) ?? []).length,
-      2,
-      'premise: a string replacement splices a second #root into the page',
-    );
-    // A backtick, which React does not escape, is worse: it inserts everything
-    // before the match -- the whole preceding document.
-    const withBacktick = page.replace(marker, '<div id="root"><li>a $` b</li></div>');
-    assert.match(withBacktick, /<html><body><div id="root"><li>a <html>/);
-  });
-
   it('prerender.mjs splices with function replacements, not replacement strings', () => {
     const source = readFileSync(resolve(repoRoot, 'pro-test/prerender.mjs'), 'utf8');
     for (const call of [
@@ -275,12 +255,4 @@ describe('third-party headline text survives the prerender splice', () => {
     );
   });
 
-  it('the function form leaves the same headline verbatim', () => {
-    const page = '<html><body><div id="root"></div></body></html>';
-    const marker = '<div id="root"></div>';
-    const ssr = '<li>Oil at $&#x27;record&#x27; highs</li>';
-    const safe = page.replace(marker, () => `<div id="root">${ssr}</div>`);
-    assert.equal((safe.match(/id="root"/g) ?? []).length, 1);
-    assert.match(safe, /Oil at \$&#x27;record&#x27; highs/);
-  });
 });

--- a/tests/resilience-displacement-field-mapping.test.mts
+++ b/tests/resilience-displacement-field-mapping.test.mts
@@ -205,20 +205,6 @@ describe('UNHCR displacement — scorer reads + labor-migrant-cohort invariant',
       `undefined-hostTotal must fall back to totalDisplaced=5M; score should be <80, got ${score.score}`);
   });
 
-  it('safeNum gotcha: safeNum(null) returns 0, not null (documents the root cause of the `??` short-circuit)', () => {
-    // Not testing the scorer directly — this pins the numeric-coercion
-    // quirk that makes the `hostTotal ?? totalDisplaced` fallback
-    // effectively dead code for any payload where hostTotal is null or 0.
-    // JavaScript's Number(null) === 0 (while Number(undefined) === NaN),
-    // so `safeNum` correctly classifies null as the finite number 0.
-    // The only way the `??` at _dimension-scorers.ts:1412 falls back
-    // today is if hostTotal is UNDEFINED — which the seeder never emits.
-    assert.equal(Number(null), 0, 'JS coerces null → 0 numerically');
-    assert.equal(Number.isFinite(Number(null)), true, 'and 0 is finite');
-    assert.equal(Number(undefined), Number(undefined), 'Number(undefined) is NaN');
-    assert.equal(Number.isFinite(Number(undefined)), false, 'NaN is not finite');
-  });
-
   it('scoreBorderSecurity imputes with `stable-absence` when the country is absent entirely from UNHCR', async () => {
     // Country not in payload at all (neither origin nor host).
     const payload = buildDisplacementPayload([

--- a/tests/resilience-energy-v2.test.mts
+++ b/tests/resilience-energy-v2.test.mts
@@ -82,10 +82,6 @@ describe('scoreEnergy — RESILIENCE_ENERGY_V2_ENABLED=false (default)', () => {
     delete process.env.RESILIENCE_ENERGY_V2_ENABLED;
   });
 
-  it('repo default remains legacy until production v2 seed health is verified', () => {
-    assert.equal(process.env.RESILIENCE_ENERGY_V2_ENABLED, undefined);
-  });
-
   it('reads legacy inputs — higher renewShare raises score', async () => {
     const low = await scoreEnergy(TEST_ISO2, makeEnergyReader(TEST_ISO2, { mix: { gasShare: 30, coalShare: 20, renewShare: 5 } }));
     const high = await scoreEnergy(TEST_ISO2, makeEnergyReader(TEST_ISO2, { mix: { gasShare: 30, coalShare: 20, renewShare: 70 } }));
@@ -107,10 +103,6 @@ describe('scoreEnergy — RESILIENCE_ENERGY_V2_ENABLED=true', () => {
   });
   after(() => {
     delete process.env.RESILIENCE_ENERGY_V2_ENABLED;
-  });
-
-  it('flag is on', () => {
-    assert.equal(process.env.RESILIENCE_ENERGY_V2_ENABLED, 'true');
   });
 
   it('v2 path reads importedFossilDependence — lower fossilElectricityShare raises score', async () => {

--- a/tests/seed-contract-transform-regressions.test.mjs
+++ b/tests/seed-contract-transform-regressions.test.mjs
@@ -105,10 +105,10 @@ test('seed-token-panels: an empty AI panel from a partial fetch is skipped, not 
 
 // ─── validateFn also runs on post-transform shape ────────────────────────
 //
-// atomicPublish() calls validateFn(publishData). A validate() written against
-// the pre-transform shape returns false on transformed input → skipped path →
-// no write. This bug survived the declareRecords fix because runSeed never
-// reached the RETRY branch — it exited earlier via `publishResult.skipped`.
+// atomicPublish() calls validateFn(publishData). The imported validate() cases
+// below must accept the transformed panel and reject empty or zero-price data;
+// that production contract prevents a pre-transform shape check from silently
+// skipping the write.
 
 test('seed-token-panels: validate accepts transformed defi panel with priced tokens', async () => {
   const { validate } = await import('../scripts/seed-token-panels.mjs');
@@ -127,33 +127,6 @@ test('seed-token-panels: validate rejects empty/missing tokens', async () => {
   assert.equal(validate({ tokens: [] }), false);
   assert.equal(validate({}), false);
   assert.equal(validate(null), false);
-});
-
-test('seed-token-panels: pre-fix validate would have returned false on transformed shape', async () => {
-  // Repro-guard: if a future refactor puts validate() back to checking
-  // data.defi.tokens / data.ai.tokens / data.other.tokens, it will fail on
-  // the transformed payload (publishTransform narrows to the defi panel).
-  const transformed = { tokens: [{ symbol: 'UNI', price: 1 }] };
-  const buggyOld = (data) =>
-    Array.isArray(data?.defi?.tokens) &&
-    data.defi.tokens.length >= 1 &&
-    (data.defi.tokens.some((t) => t.price > 0) ||
-      data.ai.tokens.some((t) => t.price > 0) ||
-      data.other.tokens.some((t) => t.price > 0));
-  assert.equal(Boolean(buggyOld(transformed)), false, 'Pre-fix behavior — MUST NOT return to this');
-});
-
-// ─── Commit B sanity: old bug reproduction ───────────────────────────────
-
-test('seed-token-panels: old buggy signature would have returned 0', async () => {
-  // This test documents what the PRE-fix code did, proving the RETRY bug. If
-  // declareRecords were *still* counting defi+ai+other from pre-transform
-  // fields on the transformed payload, it would return 0 and runSeed would
-  // RETRY. Keep this so anyone "simplifying" back to the old form fails.
-  const transformedDefi = { tokens: [{ symbol: 'UNI' }] };
-  const buggyOld = (data) =>
-    (data?.defi?.tokens?.length || 0) + (data?.ai?.tokens?.length || 0) + (data?.other?.tokens?.length || 0);
-  assert.equal(buggyOld(transformedDefi), 0, 'Pre-fix behavior — MUST NOT return to this');
 });
 
 // ─── Commit E: resolveRecordCount contract invariants ────────────────────


### PR DESCRIPTION
## Summary

This cleanup restores regression value to the affected test set. The latest-brief outage case now crosses Clerk authentication and the real route handler. The follow-button case checks the exhaustiveness guard and the observable `INVALID_INPUT` warning. The Washington matcher cases now read the production keyword registry.

No runtime code changes.

## Removed cases

- `a raw colon-delimited string (the P1 bug) fails JSON.parse` only proved the built-in JSON parser rejects invalid JSON.
- `safeNum gotcha: safeNum(null) returns 0` only proved JavaScript numeric coercion and never called the production scorer helper.
- `pre-fix validate would have returned false on transformed shape` tested a local copy of the removed implementation instead of the imported production validator.
- `old buggy signature would have returned 0` tested a local copy of the removed counter instead of the imported production function.
- `repo default remains legacy until production v2 seed health is verified` only asserted the value that the suite hook had just set.
- `flag is on` only asserted the value that the suite hook had just set.
- `does NOT contain "house" as standalone keyword` only inspected a test-owned keyword array.
- `does NOT contain "us " trailing-space hack` only inspected a test-owned keyword array.
- `a STRING replacement expands $-patterns in the injected markup` only demonstrated built-in `String.replace` behavior.
- `the function form leaves the same headline verbatim` only demonstrated built-in `String.replace` behavior.

## Verification

- `node scripts/run-data-tests.mjs tests/brief-edge-route-smoke.test.mjs tests/follow-button.test.mjs tests/brief-share-url.test.mts tests/resilience-displacement-field-mapping.test.mts tests/seed-contract-transform-regressions.test.mjs tests/resilience-energy-v2.test.mts tests/geo-keyword-matching.test.mts tests/pro-welcome-teaser-links.test.mts` passed 172 tests in 38 suites.
- `npm run typecheck` passed.
- `npm run lint` passed. It reported existing diagnostics outside this diff.
- `git diff --check origin/main...HEAD` passed.
- The pre-push hook passed its affected checks.

## Post-deploy monitoring and validation

No additional operational monitoring required: this change only removes vacuous tests and strengthens test assertions; it does not alter runtime code.

Fixes #7773

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
