### PR TITLE
fix(wildfires): preserve rolling FIRMS coverage across UTC midnight

### DIFF
--- a/scripts/wildfire/firms-area.mjs
+++ b/scripts/wildfire/firms-area.mjs
@@ -21,6 +21,7 @@ export const MONITORED_REGIONS = Object.freeze({
 });
 
 const REQUEST_PACE_MS = 6_000;
+const OBSERVATION_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 function mapConfidence(value) {
   switch ((value || '').toLowerCase()) {
@@ -60,7 +61,8 @@ function safeFailureReason(error) {
 }
 
 function buildAreaUrl(baseUrl, apiKey, source, bbox) {
-  return `${baseUrl}/api/area/csv/${apiKey}/${source}/${bbox}/1`;
+  // NASA day ranges are calendar days, so /1 loses yesterday at midnight UTC.
+  return `${baseUrl}/api/area/csv/${apiKey}/${source}/${bbox}/2`;
 }
 
 export async function fetchFirmsRegionSource(apiKey, regionName, bbox, source, {
@@ -116,11 +118,13 @@ export async function fetchAllFirmsRegions(apiKey, {
           logger,
         });
         fulfilled++;
+        const now = Date.now();
         for (const row of rows) {
+          const detectedAt = parseDetectedAt(row.acq_date || '', row.acq_time || '');
+          if (!Number.isFinite(detectedAt) || detectedAt < now - OBSERVATION_WINDOW_MS || detectedAt > now) continue;
           const id = `${row.latitude ?? ''}-${row.longitude ?? ''}-${row.acq_date ?? ''}-${row.acq_time ?? ''}`;
           if (seen.has(id)) continue;
           seen.add(id);
-          const detectedAt = parseDetectedAt(row.acq_date || '', row.acq_time || '');
           const brightness = parseFloat(row.bright_ti4 ?? '0') || 0;
           const frp = parseFloat(row.frp ?? '0') || 0;
           fireDetections.push({

--- a/tests/firms-area.test.mjs
+++ b/tests/firms-area.test.mjs
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 import { readFileSync } from 'node:fs';
 import {
   hasCompleteWorldwideWildfireCoverage,
@@ -34,6 +34,7 @@ function captureLogger() {
 }
 
 describe('NASA FIRMS Area API sequence', () => {
+  beforeEach((t) => t.mock.method(Date, 'now', () => Date.parse('2026-09-04T12:00:00Z')));
   it('recovers complete coverage with one paced retry on the primary host', async () => {
     const urls = [];
     const sleeps = [];
@@ -197,7 +198,7 @@ describe('NASA FIRMS Area API sequence', () => {
     assert.deepEqual(
       requestPaths.slice(0, 9),
       Object.values(MONITORED_REGIONS).map(
-        (bbox) => `/api/area/csv/test-map-key/${FIRMS_SOURCES[0]}/${bbox}/1`,
+        (bbox) => `/api/area/csv/test-map-key/${FIRMS_SOURCES[0]}/${bbox}/2`,
       ),
     );
     assert.match(requestPaths[9], new RegExp(`/${FIRMS_SOURCES[1]}/`));
@@ -226,4 +227,42 @@ describe('NASA FIRMS Area API sequence', () => {
     );
     assert.doesNotMatch(messages.error[0], /test-map-key/);
   });
+});
+
+describe('NASA FIRMS rolling observation window', () => {
+  const csv = readFileSync(new URL('./fixtures/wildfire/firms-ukraine-2026-09-06.csv', import.meta.url), 'utf8');
+  const header = `${csv.split('\n')[0]}\n`;
+
+  for (const [at, count] of [
+    ['2026-09-07T00:00:00Z', 4],
+    ['2026-09-07T02:41:00Z', 2],
+    ['2026-09-07T23:44:00Z', 1],
+    ['2026-09-07T23:44:00.001Z', 0],
+    ['2026-09-06T12:00:00Z', 3],
+  ]) {
+    it(`keeps only the rolling 24-hour observations at ${at}`, async (t) => {
+      const now = Date.parse(at);
+      t.mock.method(Date, 'now', () => now);
+      const urls = [];
+      const { logger } = captureLogger();
+      const result = await fetchAllFirmsRegions('test-map-key', {
+        fetchFn: async (url) => {
+          urls.push(url);
+          return response(200, url.endsWith('/2') ? csv : header);
+        },
+        sleepFn: async () => {},
+        logger,
+      });
+      assert.equal(result.fireDetections.length, count);
+      assert.equal(result._firmsFulfilledCalls, 27);
+      assert.equal(result._firmsFailedCalls, 0);
+      assert.equal(urls.length, 27);
+      assert.ok(result.fireDetections.every(({ detectedAt }) => detectedAt <= now && detectedAt >= now - 86_400_000));
+      if (at === '2026-09-07T02:41:00Z') {
+        assert.deepEqual(result.fireDetections.map(({ detectedAt }) => detectedAt), [
+          Date.parse('2026-09-06T11:30:00Z'), Date.parse('2026-09-06T23:44:00Z'),
+        ]);
+      }
+    });
+  }
 });

--- a/tests/firms-area.test.mjs
+++ b/tests/firms-area.test.mjs
@@ -248,7 +248,7 @@ describe('NASA FIRMS rolling observation window', () => {
       const result = await fetchAllFirmsRegions('test-map-key', {
         fetchFn: async (url) => {
           urls.push(url);
-          return response(200, url.endsWith('/2') ? csv : header);
+          return response(200, url.includes('/VIIRS_SNPP_NRT/22,44,40,53/2') ? csv : header);
         },
         sleepFn: async () => {},
         logger,
@@ -265,4 +265,17 @@ describe('NASA FIRMS rolling observation window', () => {
       }
     });
   }
+
+  it('does not publish undatable satellite observations', async (t) => {
+    t.mock.method(Date, 'now', () => Date.parse('2026-09-07T02:41:00Z'));
+    const { logger } = captureLogger();
+    const result = await fetchAllFirmsRegions('test-map-key', {
+      fetchFn: async () => response(200, csv.replaceAll('2026-09-06', 'invalid-date')),
+      sleepFn: async () => {},
+      logger,
+    });
+    assert.deepEqual(result.fireDetections, []);
+    assert.equal(result._firmsFulfilledCalls, 27);
+    assert.equal(result._firmsFailedCalls, 0);
+  });
 });

--- a/tests/fixtures/wildfire/firms-ukraine-2026-09-06.csv
+++ b/tests/fixtures/wildfire/firms-ukraine-2026-09-06.csv
@@ -1,0 +1,5 @@
+latitude,longitude,bright_ti4,scan,track,acq_date,acq_time,satellite,instrument,confidence,version,bright_ti5,frp,daynight
+46.60931,38.29577,332.53,0.49,0.4,2026-09-06,1,N,VIIRS,n,2.0NRT,292.21,5.11,N
+44.77468,33.86148,307.29,0.4,0.37,2026-09-06,3,N,VIIRS,n,2.0NRT,287.28,0.83,N
+48.12339,28.99302,332.23,0.57,0.43,2026-09-06,1130,N,VIIRS,n,2.0NRT,294.45,5.35,D
+50.51327,30.81692,295.16,0.41,0.45,2026-09-06,2344,N,VIIRS,n,2.0NRT,282.17,0.56,N

--- a/tests/fixtures/wildfire/firms-ukraine-2026-09-06.md
+++ b/tests/fixtures/wildfire/firms-ukraine-2026-09-06.md
@@ -1,0 +1,14 @@
+# FIRMS UTC rollover fixture
+
+Four unchanged rows sampled from NASA FIRMS Area API on 2026-09-07 at 02:41:39 UTC.
+Source `VIIRS_SNPP_NRT`, existing Ukraine bounds `22,44,40,53`, day range `2`.
+The response was HTTP 200 with 412 observations, all dated 2026-09-06.
+The same bounds and source with day range `1` at 02:41:32 UTC returned HTTP 200 and only the CSV header.
+The credential is omitted. No seeder was run and no production data was changed.
+
+Rows are positions 0, 100, 300 and 411 after stable sorting by acquisition time.
+The fixture preserves the original coordinates, times and measurements.
+At 02:41 UTC, its 00:01 and 00:03 observations are over 24 hours old; the 11:30 and 23:44 rows remain in the rolling window.
+
+[NASA Area API documentation](https://firms.modaps.eosdis.nasa.gov/api/area/) defines the undated range as today through today minus (day range minus one).
+Two calendar days plus acquisition-time filtering are required for rolling 24-hour coverage.

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { readFileSync } from 'node:fs';
 import { fetchAllFirmsRegions } from '../scripts/wildfire/firms-area.mjs';
-import { mergeWildfireSourcesWithBc } from '../scripts/wildfire/bc-fire-points.mjs';
+import { hasCompleteWorldwideWildfireCoverage, mergeWildfireSourcesWithBc } from '../scripts/wildfire/bc-fire-points.mjs';
 import { compactWildfireDashboardPayload, WILDFIRE_CANONICAL_DETECTION_LIMIT } from '../scripts/_wildfire-dashboard.mjs';
 
 import { __testing__ } from '../api/health.js';
@@ -1150,7 +1150,7 @@ describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
     const csv = readFileSync(new URL('./fixtures/wildfire/firms-ukraine-2026-09-06.csv', import.meta.url), 'utf8');
     const header = `${csv.split('\n')[0]}\n`;
     const firms = await fetchAllFirmsRegions('test-key', {
-      fetchFn: async (url: string) => new Response(url.endsWith('/2') ? csv : header),
+      fetchFn: async (url: string) => new Response(url.includes('/VIIRS_SNPP_NRT/22,44,40,53/2') ? csv : header),
       sleepFn: async () => {},
       logger: { log() {}, warn() {}, error() {} },
     });
@@ -1159,6 +1159,7 @@ describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
       fetchCwfis: async () => ({ fireDetections: [{ id: 'agency', source: 'cwfis', detectedAt: now }] }),
       fetchBcWildfire: async () => ({ fireDetections: [] }),
     });
+    assert.equal(hasCompleteWorldwideWildfireCoverage(merged), true);
     const payload = compactWildfireDashboardPayload(merged, WILDFIRE_CANONICAL_DETECTION_LIMIT);
     const { calls } = await runWithRedisStub({
       'news:insights:v1': liveNews(now),

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fetchAllFirmsRegions } from '../scripts/wildfire/firms-area.mjs';
+import { mergeWildfireSourcesWithBc } from '../scripts/wildfire/bc-fire-points.mjs';
+import { compactWildfireDashboardPayload, WILDFIRE_CANONICAL_DETECTION_LIMIT } from '../scripts/_wildfire-dashboard.mjs';
 
 import { __testing__ } from '../api/health.js';
 import { evaluateFreshness } from '../api/mcp/freshness.ts';
@@ -1140,6 +1144,35 @@ describe('temporal anomalies content-age extractor (#7141)', () => {
 });
 
 describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
+  it('dates global satellite coverage across midnight through the real producer and reader', async (t) => {
+    const now = Date.parse('2026-09-07T02:41:00Z');
+    t.mock.method(Date, 'now', () => now);
+    const csv = readFileSync(new URL('./fixtures/wildfire/firms-ukraine-2026-09-06.csv', import.meta.url), 'utf8');
+    const header = `${csv.split('\n')[0]}\n`;
+    const firms = await fetchAllFirmsRegions('test-key', {
+      fetchFn: async (url: string) => new Response(url.endsWith('/2') ? csv : header),
+      sleepFn: async () => {},
+      logger: { log() {}, warn() {}, error() {} },
+    });
+    const merged = await mergeWildfireSourcesWithBc({
+      fetchFirms: async () => firms,
+      fetchCwfis: async () => ({ fireDetections: [{ id: 'agency', source: 'cwfis', detectedAt: now }] }),
+      fetchBcWildfire: async () => ({ fireDetections: [] }),
+    });
+    const payload = compactWildfireDashboardPayload(merged, WILDFIRE_CANONICAL_DETECTION_LIMIT);
+    const { calls } = await runWithRedisStub({
+      'news:insights:v1': liveNews(now),
+      'wildfire:fires:v1': payload,
+      ...altSourcesLiveRedis(now),
+    });
+    const meta = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
+    assert.ok(meta);
+    assert.equal(meta.newestItemAt, Date.parse('2026-09-06T23:44:00Z'));
+    assert.equal(classifyTemporalMeta(meta, now).status, 'OK');
+    assert.equal(evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale, false);
+    assert.equal(merged._firmsCount, 2);
+  });
+
   it('stamps content age from the payloads, not the rebuild clock', async () => {
     const now = Date.now();
     const frozenAge = 72 * HOUR_MS;


### PR DESCRIPTION
## Summary

FIRMS observations disappear from temporal health after UTC midnight because NASA's `/1` area window contains only the current calendar day. At 02:41 UTC on September 7, the existing Ukraine request returned HTTP 200 with zero rows. The same source and region with `/2` returned 412 observations from September 6.

Request two calendar days and retain only observations within the preceding 24 hours. Preserve acquisition timestamps, geographic coverage, 27 request slots, one transient retry, pacing, timeouts, and existing publication caps. Reader freshness and bounded grace are unchanged. Two days can consume more NASA transactions because transaction cost depends on returned volume.

## Verification

- Authentic four-row fixture reproduces the null temporal content clock on unchanged code. The regression commit precedes the fix.
- Producer, merge, publication validator, compactor, temporal handler, health and MCP pass with the original observation timestamp.
- 141 affected Node tests pass, including missing, agency-only, failed, partial, stale, future, invalid and 24-hour boundary cases.
- FIRMS DOM timeout recovery passes with Vitest. API typecheck, Convex call audit and `git diff --check` pass.
- A local replay of the full captured NASA response retains 258 genuine observations and produces a valid temporal clock.
- Sequential ce-code-review completed with no remaining P0/P1/P2 findings. No independent or formal GitHub approval claimed.

Production access was read-only. Deployment and natural production acceptance remain pending. Acceptance requires a natural post-deployment rollover with dated FIRMS observations and temporal content metadata, without extending grace.

[NASA Area API window documentation](https://firms.modaps.eosdis.nasa.gov/api/area/)
