### PR TITLE
fix(canada): verify BC active lists independently of event age

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -959,6 +959,7 @@ const SEED_META = {
     maxStaleMin: 45, // seed-alberta-emergency-alert cron */15; 45 = 3× interval
     cutover: { mode: 'expiring-ack', fromKey: null, issue: 6659, status: 'EMPTY' },
   },
+  // Event modification dates do not expire BC orders; fetchedAt ages active-list verification.
   canadaAlertsBcSource: {
     key: 'seed-meta:alerts:bc-emergency-info',
     maxStaleMin: 45,

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -67,6 +67,12 @@ The cable-health handler recomputes its response after 30 minutes but retains th
 
 Cache hits migrate legacy short TTLs to the snapshot's original 90-minute deadline and retry missing or incorrect metadata. The repair checks the current payload atomically before changing its expiry or metadata, so an older reader cannot alter a newer publication. Concurrent requests within one runtime share the full refresh, including cache publication when NGA data is already cached.
 
+### BC active evacuation lists
+
+`canadaAlertsBcSource` uses successful active-list ingestion with a 45-minute freshness budget. BC orders remain active until their status changes or they are removed. Their event modification age is not an expiry rule. See [BC evacuation guidance](https://www2.gov.bc.ca/gov/content/safety/wildfire-status/partners/evacuation).
+
+The seeder validates every page before it replaces the snapshot. A verified empty list is valid. Malformed or failed responses retain the previous snapshot and success time. Event `updatedAt`, `publishedAt`, and `onset` retain the publisher's dates. The old three-day content-age fields disappear after the first successful v2 publication. Existing missing-data, source-failure, and stale-ingestion checks still apply.
+
 ### Bundle tick heartbeats
 
 `_bundle-runner.mjs` writes `bundle:heartbeat:<label>` on every container start, including skip-all ticks. Member seed-meta cannot see a daily cron that never fires when its sections are weekly or monthly. `/api/health` probes `staticRefBundleTick` (`bundle:heartbeat:static-ref`) and, as of #6806, `staticRefHeavyBundleTick` (`bundle:heartbeat:static-ref-heavy`) — one heartbeat for the consolidated heavy bundle carrying Arms-Suppliers, Military-Bases and Mineral-Production. A 48h silence is `STALE_SEED`. Missing keys before the first tick are `EMPTY` under an expiring acknowledgement, not a page-out.

--- a/scripts/lib/bc-emergency-info.mjs
+++ b/scripts/lib/bc-emergency-info.mjs
@@ -14,13 +14,11 @@ export const BC_ALERTS_CATALOGUE_URL = 'https://catalogue.data.gov.bc.ca/dataset
 export const BC_ALERTS_SOURCE = 'bc-evacuation-orders-alerts';
 export const BC_ALERTS_PROVINCE = 'BC';
 export const BRITISH_COLUMBIA_CENTROID = Object.freeze([-124.5, 54.5]);
-export const BC_ALERTS_MAX_CONTENT_AGE_MIN = 3 * 24 * 60;
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const PAGE_SIZE = 200;
 const MAX_PAGES = 6;
 const MAX_ALERTS = 1_000;
-const INACTIVE_ORDER_ALERT_STATUSES = new Set(['', 'all clear']);
 const KNOWN_ACTIVE_ORDER_ALERT_STATUSES = new Set([
   'alert',
   'order',
@@ -103,9 +101,10 @@ function centroidOf(coords) {
 }
 
 function normalizeFeature(feature) {
-  if (!feature || typeof feature !== 'object') return null;
-  const properties = feature.properties;
-  if (!properties || typeof properties !== 'object') return null;
+  const properties = feature?.properties;
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+    throw new Error('bc-emergency-info: feature is missing usable properties');
+  }
 
   const sysId = String(properties.EMRG_OAA_SYSID ?? '').trim();
   if (!sysId) {
@@ -114,7 +113,7 @@ function normalizeFeature(feature) {
 
   const status = String(properties.ORDER_ALERT_STATUS ?? '').trim();
   const normalizedStatus = status.toLowerCase();
-  if (INACTIVE_ORDER_ALERT_STATUSES.has(normalizedStatus)) return null;
+  if (normalizedStatus === 'all clear') return null;
   if (!KNOWN_ACTIVE_ORDER_ALERT_STATUSES.has(normalizedStatus)) {
     throw new Error(`bc-emergency-info: unknown ORDER_ALERT_STATUS: ${status || '(empty)'}`);
   }
@@ -131,6 +130,10 @@ function normalizeFeature(feature) {
   const centroid = centroidOf(coords);
   const updatedAt = finiteTimestamp(properties.DATE_MODIFIED);
   const publishedAt = finiteTimestamp(properties.EVENT_START_DATE);
+  const eventTimestamp = updatedAt ?? publishedAt;
+  if (eventTimestamp == null || eventTimestamp > Date.now() + 60 * 60 * 1000) {
+    throw new Error('bc-emergency-info: active feature is missing a usable event timestamp');
+  }
 
   return {
     id: `bc-evacuation-${sysId}`,
@@ -245,12 +248,4 @@ export function validateBcAlertsEnvelope(data) {
 
 export function declareBcAlertRecords(data) {
   return Array.isArray(data?.alerts) ? data.alerts.length : 0;
-}
-
-export function bcAlertsContentMeta(data, nowMs = Date.now()) {
-  const timestamps = (data?.alerts ?? [])
-    .map((alert) => alert.updatedAt ?? alert.publishedAt)
-    .filter((value) => Number.isFinite(value) && value > 0 && value <= nowMs + 60 * 60 * 1000);
-  if (timestamps.length === 0) return null;
-  return { newestItemAt: Math.max(...timestamps), oldestItemAt: Math.min(...timestamps) };
 }

--- a/scripts/seed-bc-emergency-info.mjs
+++ b/scripts/seed-bc-emergency-info.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 // B.C. Evacuation Orders and Alerts member of seed-bundle-canada (#6659).
 
-import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
+import { CHROME_UA, loadEnvFile, readSeedSnapshot, resolveSeedMetaTtl, runSeed, writeExtraKey } from './_seed-utils.mjs';
 import {
-  BC_ALERTS_MAX_CONTENT_AGE_MIN,
-  bcAlertsContentMeta,
   declareBcAlertRecords,
   fetchBcEmergencyInfoAlerts,
   validateBcAlertsEnvelope,
@@ -21,16 +19,23 @@ const CACHE_TTL = 5_400;
 
 runSeed('alerts', 'bc-emergency-info', SOURCE.key, () => (
   fetchBcEmergencyInfoAlerts({ userAgent: CHROME_UA })
+    .catch(async (error) => {
+      const previous = await readSeedSnapshot(SOURCE.metaKey, { strict: true });
+      await writeExtraKey(SOURCE.metaKey, {
+        ...previous,
+        sourceState: 'error',
+        errorCode: 'BC_ACTIVE_LIST_FAILED',
+      }, resolveSeedMetaTtl(undefined, CACHE_TTL));
+      throw error;
+    })
 ), {
   validateFn: validateBcAlertsEnvelope,
   ttlSeconds: CACHE_TTL,
-  sourceVersion: 'bc-evacuation-orders-alerts-v1',
+  sourceVersion: 'bc-evacuation-orders-alerts-v2',
   declareRecords: declareBcAlertRecords,
   zeroIsValid: true,
   schemaVersion: 1,
   maxStaleMin: 45,
-  contentMeta: bcAlertsContentMeta,
-  maxContentAgeMin: BC_ALERTS_MAX_CONTENT_AGE_MIN,
   afterPublish: async (data) => {
     await rebuildCanadaAlertsUnion({
       currentSource: { province: 'BC', snapshot: data },

--- a/tests/bc-emergency-info-health.test.mjs
+++ b/tests/bc-emergency-info-health.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { __testing__ } from '../api/health.js';
+import { CANADA_ALERT_SOURCES, CANADA_ALERTS_KEY } from '../scripts/lib/canada-alerts-union.mjs';
+
+const fixture = JSON.parse(readFileSync(new URL('./fixtures/bc-emergency-info.geojson', import.meta.url)));
+const source = CANADA_ALERT_SOURCES.find(({ province }) => province === 'BC');
+const now = Date.UTC(2026, 8, 7);
+const prior = { id: 'bc-evacuation-removed', province: 'BC', severity: 'Extreme', updatedAt: now - 10 * 86400000 };
+
+// Execute the actual seeder and Redis writer with network I/O confined to this child.
+const harness = `
+import { readFileSync } from 'node:fs';
+const { feed, initial, now, unavailable } = JSON.parse(readFileSync(0, 'utf8'));
+const cache = new Map(initial);
+Date.now = () => now;
+process.env.UPSTASH_REDIS_REST_URL = 'https://bc-redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+const timer = globalThis.setTimeout;
+globalThis.setTimeout = (fn, ms, ...args) => timer(fn, ms >= 500 && ms <= 30000 ? 0 : ms, ...args);
+const command = ([op, key, value]) => {
+  if (op === 'SET') { cache.set(key, value); return 'OK'; }
+  if (op === 'GET') return cache.get(key) ?? null;
+  if (op === 'DEL') return Number(cache.delete(key));
+  if (op === 'EXPIRE') return Number(cache.has(key));
+  if (op === 'EVAL') return 1;
+  throw new Error('Unexpected Redis command ' + op);
+};
+globalThis.fetch = async (input, options = {}) => {
+  const url = new URL(input);
+  if (url.hostname === 'services6.arcgis.com') {
+    if (unavailable) return new Response('unavailable', { status: 503 });
+    return Response.json(feed);
+  }
+  if (url.hostname !== 'bc-redis.test') throw new Error('Unexpected network ' + url.hostname);
+  if (url.pathname.startsWith('/get/')) return Response.json({ result: cache.get(decodeURIComponent(url.pathname.slice(5))) ?? null });
+  const body = JSON.parse(options.body);
+  return Response.json(Array.isArray(body[0]) ? body.map(cmd => ({ result: command(cmd) })) : { result: command(body) });
+};
+process.on('exit', () => console.log('BC_RESULT=' + JSON.stringify([...cache])));
+await import(process.argv[1]);
+`;
+
+function publish(feed, { unavailable = false, initialCache } = {}) {
+  const initial = initialCache ? [...initialCache] : CANADA_ALERT_SOURCES.flatMap(entry => [
+    [entry.key, JSON.stringify({ alerts: entry.province === 'BC' ? [prior] : [] })],
+    [entry.metaKey, JSON.stringify({ fetchedAt: now - 60000, recordCount: entry.province === 'BC' ? 1 : 0, sourceState: 'ok',
+      ...(entry.province === 'BC' ? { newestItemAt: prior.updatedAt, maxContentAgeMin: 4320 } : {}) })],
+  ]);
+  const result = spawnSync(process.execPath, ['--input-type=module', '-e', harness, new URL('../scripts/seed-bc-emergency-info.mjs', import.meta.url).href], {
+    input: JSON.stringify({ feed, initial, now, unavailable }), encoding: 'utf8', timeout: 10000,
+    env: { PATH: process.env.PATH, NODE_ENV: 'test' },
+  });
+  assert.ifError(result.error);
+  const output = result.stdout.split('\n').find(line => line.startsWith('BC_RESULT='));
+  assert.ok(output, result.stderr + result.stdout);
+  return { exitCode: result.status, cache: new Map(JSON.parse(output.slice('BC_RESULT='.length))) };
+}
+
+function classify(cache, at = now) {
+  return __testing__.classifyKey('canadaAlertsBcSource', source.key, {}, {
+    now: at,
+    keyStrens: new Map([[source.key, cache.get(source.key)?.length ?? 0]]),
+    keyErrors: new Map(), keyMetaErrors: new Map(),
+    keyMetaValues: new Map([[source.metaKey, cache.get(source.metaKey)]]),
+  });
+}
+
+test('a newly verified unchanged BC active list is healthy and preserves event dates', () => {
+  const { exitCode, cache } = publish(fixture);
+  assert.equal(exitCode, 0);
+  const snapshot = JSON.parse(cache.get(source.key));
+  assert.equal(snapshot.data.alerts.length, 2);
+  const alert = snapshot.data.alerts.find(a => a.id === 'bc-evacuation-7');
+  assert.equal(alert.updatedAt, 1786956961000);
+  assert.equal(alert.publishedAt, 1782993600000);
+  assert.equal(alert.onset, new Date(1782993600000).toISOString());
+  assert.equal(snapshot._seed.maxContentAgeMin, undefined);
+  assert.equal(classify(cache).status, 'OK');
+  assert.equal(JSON.parse(cache.get(source.metaKey)).fetchedAt, now);
+  assert.equal(classify(cache, now + 46 * 60000).status, 'STALE_SEED');
+  cache.delete(source.key);
+  assert.equal(classify(cache).status, 'EMPTY');
+});
+
+test('BC publication replaces removed orders, applies status changes, and accepts a verified empty list', () => {
+  const changed = structuredClone(fixture);
+  changed.features = [changed.features[0]];
+  changed.features[0].properties.ORDER_ALERT_STATUS = 'Order';
+  const { cache, exitCode } = publish(changed);
+  assert.equal(exitCode, 0);
+  const alerts = JSON.parse(cache.get(CANADA_ALERTS_KEY)).data.alerts;
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].id, 'bc-evacuation-7');
+  assert.equal(alerts[0].severity, 'Extreme');
+  changed.features[0].properties.ORDER_ALERT_STATUS = 'All Clear';
+  for (const feed of [changed, { type: 'FeatureCollection', features: [] }]) {
+    const result = publish(feed);
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(JSON.parse(result.cache.get(CANADA_ALERTS_KEY)).data.alerts, []);
+    assert.equal(classify(result.cache).status, 'OK');
+  }
+});
+
+test('malformed and unavailable BC feeds preserve the previous snapshot and success clock', () => {
+  const missingStatus = structuredClone(fixture.features[0]);
+  missingStatus.properties.ORDER_ALERT_STATUS = '';
+  const missingDate = structuredClone(fixture.features[0]);
+  missingDate.properties.DATE_MODIFIED = null;
+  missingDate.properties.EVENT_START_DATE = null;
+  for (const [feed, options] of [
+    [{ error: { message: 'invalid query' } }, {}],
+    [{ type: 'FeatureCollection', features: [null] }, {}],
+    [{ type: 'FeatureCollection', features: [missingStatus] }, {}],
+    [{ type: 'FeatureCollection', features: [missingDate] }, {}],
+    [fixture, { unavailable: true }],
+  ]) {
+    const { exitCode, cache } = publish(feed, options);
+    assert.notEqual(exitCode, 0);
+    assert.deepEqual(JSON.parse(cache.get(source.key)).alerts, [prior]);
+    assert.equal(JSON.parse(cache.get(source.metaKey)).fetchedAt, now - 60000);
+    assert.equal(classify(cache).status, 'SEED_ERROR');
+  }
+});
+
+test('a successful BC fetch clears a previous source failure without changing event dates', () => {
+  const failed = publish(fixture, { unavailable: true });
+  const recovered = publish(fixture, { initialCache: failed.cache });
+  assert.equal(recovered.exitCode, 0);
+  assert.equal(classify(recovered.cache).status, 'OK');
+  const meta = JSON.parse(recovered.cache.get(source.metaKey));
+  assert.equal(meta.sourceState, 'ok');
+  assert.equal(meta.errorCode, undefined);
+  assert.equal(meta.maxContentAgeMin, undefined);
+});

--- a/tests/bc-emergency-info.test.mjs
+++ b/tests/bc-emergency-info.test.mjs
@@ -11,7 +11,6 @@ import {
   BC_ALERTS_QUERY_URL,
   BC_ALERTS_SOURCE,
   BRITISH_COLUMBIA_CENTROID,
-  bcAlertsContentMeta,
   declareBcAlertRecords,
   fetchBcEmergencyInfoAlerts,
   isAllowedBcAlertsHost,
@@ -22,7 +21,7 @@ import {
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 // First two records were captured from BC_ALERTS_QUERY_URL on 2026-08-17.
-// The All Clear and missing-status records are negative lifecycle test cases.
+// The All Clear record is a negative lifecycle test case.
 const fixture = JSON.parse(readFileSync(join(root, 'tests/fixtures/bc-emergency-info.geojson'), 'utf8'));
 
 test('maps only official active B.C. evacuation levels and fails closed otherwise', () => {
@@ -91,6 +90,14 @@ test('fails closed on an unknown ORDER_ALERT_STATUS instead of skipping the feat
     () => parseBcEmergencyInfoGeoJson(copy),
     /unknown ORDER_ALERT_STATUS: Warning/,
   );
+});
+
+test('a missing lifecycle status cannot verify an active list', () => {
+  for (const status of [null, '', '   ']) {
+    const feature = structuredClone(fixture.features[0]);
+    feature.properties.ORDER_ALERT_STATUS = status;
+    assert.throws(() => parseBcEmergencyInfoGeoJson({ type: 'FeatureCollection', features: [feature] }), /unknown ORDER_ALERT_STATUS/);
+  }
 });
 
 test('pins the official ArcGIS host and rejects redirects to lookalikes', () => {
@@ -188,17 +195,29 @@ test('fails closed instead of truncating when normalized valid alerts exceed the
   );
 });
 
-test('exposes the zero-valid envelope and content-age contract', () => {
+test('exposes the zero-valid envelope and preserves event dates', () => {
   const alerts = parseBcEmergencyInfoGeoJson(fixture);
   const envelope = { alerts };
   assert.equal(validateBcAlertsEnvelope(envelope), true);
   assert.equal(validateBcAlertsEnvelope({ alerts: 'nope' }), false);
   assert.equal(declareBcAlertRecords(envelope), 2);
   assert.equal(declareBcAlertRecords({ alerts: [] }), 0);
-  assert.deepEqual(bcAlertsContentMeta(envelope), {
-    newestItemAt: 1786956961000,
-    oldestItemAt: 1786894936000,
-  });
+  assert.deepEqual(alerts.map(alert => alert.updatedAt).sort(), [1786894936000, 1786956961000]);
+});
+
+test('rejects unusable active-event dates without imposing an event age limit', () => {
+  for (const timestamp of [null, 0, 'invalid', Date.now() + 2 * 60 * 60 * 1000]) {
+    const feature = structuredClone(fixture.features[0]);
+    feature.properties.DATE_MODIFIED = timestamp;
+    feature.properties.EVENT_START_DATE = null;
+    assert.throws(() => parseBcEmergencyInfoGeoJson({ type: 'FeatureCollection', features: [feature] }), /usable event timestamp/);
+  }
+  const feature = structuredClone(fixture.features[0]);
+  feature.properties.DATE_MODIFIED = null;
+  feature.properties.EVENT_START_DATE = Date.UTC(2020, 0, 1);
+  const [alert] = parseBcEmergencyInfoGeoJson({ type: 'FeatureCollection', features: [feature] });
+  assert.equal(alert.updatedAt, null);
+  assert.equal(alert.publishedAt, Date.UTC(2020, 0, 1));
 });
 
 test('map time filter uses DATE_MODIFIED so long-running evacuations stay visible', () => {

--- a/tests/fixtures/bc-emergency-info.geojson
+++ b/tests/fixtures/bc-emergency-info.geojson
@@ -50,18 +50,6 @@
         "DATE_MODIFIED": 1786894936000,
         "EVENT_START_DATE": 1786104000000
       }
-    },
-    {
-      "type": "Feature",
-      "geometry": null,
-      "properties": {
-        "EMRG_OAA_SYSID": 71,
-        "EVENT_NAME": "Unclassified incident",
-        "ORDER_ALERT_NAME": "Unknown area",
-        "ORDER_ALERT_STATUS": "",
-        "DATE_MODIFIED": 1786894936000,
-        "EVENT_START_DATE": 1786104000000
-      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

BC active evacuation lists can remain unchanged for more than three days. The seeder fetched 40 active records successfully, but health reported `STALE_CONTENT` because the newest event modification was September 3. BC guidance requires an explicit status change or rescission; event modification age is not an expiry rule.

Use the existing successful-ingestion clock for BC active-list verification. Preserve the publisher's event dates. Reject malformed records, missing lifecycle status, and unusable active-event timestamps before publication. On fetch failure, write `BC_ACTIVE_LIST_FAILED` while preserving the previous success time and snapshot. A successful v2 publication clears the failure and removes BC's old content-age fields. Global freshness budgets and grace rules are unchanged.

Publisher references: [BC evacuation guidance](https://www2.gov.bc.ca/gov/content/safety/wildfire-status/partners/evacuation) and [official ArcGIS layer](https://services6.arcgis.com/ubm4tcTYICKBpist/arcgis/rest/services/Evacuation_Orders_and_Alerts/FeatureServer/0).

## Verification

- Reproduced the live 40-record warning at 2026-09-07 02:40 UTC. The repaired parser accepted the same 40 records with unchanged dates at 02:47 UTC.
- The actual seeder, shared Redis writer, Canada union, and health reader run against controlled network responses. Tests cover old valid active orders, status changes, removal, empty lists, malformed/unavailable feeds, stale ingestion, missing data, and failure recovery.
- Observed regression failures before repair. All 122 focused tests now pass.
- API typecheck, Convex call audit, scoped Biome lint, public documentation check, and `git diff --check` pass.
- Sequential `ce-code-review` completed in the primary agent under repository tool mapping. No remaining P0/P1/P2 findings. No independent reviewer approval is claimed.

## Production acceptance

Production activity was read-only. This PR is not deployed or naturally accepted. After deployment, require a scheduled BC-specific v2 publication, unchanged true event dates, fresh `fetchedAt`, `sourceState: ok`, and an `OK` BC health result. Old v1 content metadata remains effective until a successful v2 publication. A parent bundle success alone is insufficient.
