### PR TITLE
fix(storage): survive a null localStorage on Android WebView

### DIFF
--- a/scripts/shared/bundle-budgets.json
+++ b/scripts/shared/bundle-budgets.json
@@ -7,11 +7,11 @@
   "totalTolerancePct": 0.25,
   "totalToleranceBytes": 16384,
   "total": {
-    "raw": 1747489
+    "raw": 1755789
   },
   "chunks": {
     "analytics": {
-      "raw": 132730,
+      "raw": 132816,
       "files": 1
     },
     "cached-risk-scores": {
@@ -27,7 +27,7 @@
       "files": 1
     },
     "cross-domain-storage": {
-      "raw": 392,
+      "raw": 417,
       "files": 1
     },
     "data-freshness": {
@@ -39,7 +39,7 @@
       "files": 1
     },
     "embed-url": {
-      "raw": 62783,
+      "raw": 63771,
       "files": 1
     },
     "font-settings": {
@@ -59,7 +59,7 @@
       "files": 1
     },
     "main": {
-      "raw": 979239,
+      "raw": 985381,
       "files": 1
     },
     "panel-gating": {
@@ -72,6 +72,10 @@
     },
     "persistent-cache": {
       "raw": 3768,
+      "files": 1
+    },
+    "safe-storage": {
+      "raw": 278,
       "files": 1
     },
     "storage-facility-registry-store": {
@@ -91,11 +95,11 @@
       "files": 1
     },
     "user-location": {
-      "raw": 12111,
+      "raw": 12676,
       "files": 1
     },
     "widget-store": {
-      "raw": 25650,
+      "raw": 25866,
       "files": 1
     }
   }

--- a/src/App.ts
+++ b/src/App.ts
@@ -72,6 +72,7 @@ import type { ParsedMapUrlState } from '@/utils';
 import { BreakingNewsBanner } from '@/components/BreakingNewsBanner';
 import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
 import { markLcpDebug } from '@/utils/lcp-debug';
+import { safeStorageGet } from '@/utils/safe-storage';
 import type { ServiceStatusPanel } from '@/components/ServiceStatusPanel';
 import type { MonitorPanel } from '@/components/MonitorPanel';
 import type { StablecoinPanel } from '@/components/StablecoinPanel';
@@ -3566,7 +3567,7 @@ export class App {
       this.state.findingsBadge = new IntelligenceGapBadge();
       this.state.findingsBadge.setOnSignalClick((signal) => {
         if (this.state.countryBriefPage?.isVisible()) return;
-        if (localStorage.getItem('wm-settings-open') === '1') return;
+        if (safeStorageGet('wm-settings-open') === '1') return;
         void this.state.ensureSignalModal()
           .then((signalModal) => {
             if (!this.state.isDestroyed) signalModal.showSignal(signal);
@@ -3577,7 +3578,7 @@ export class App {
       });
       this.state.findingsBadge.setOnAlertClick((alert) => {
         if (this.state.countryBriefPage?.isVisible()) return;
-        if (localStorage.getItem('wm-settings-open') === '1') return;
+        if (safeStorageGet('wm-settings-open') === '1') return;
         void this.state.ensureSignalModal()
           .then((signalModal) => {
             if (!this.state.isDestroyed) signalModal.showAlert(alert);

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -28,6 +28,7 @@ import {
 } from '@/components/unified-settings-interactions';
 import type { MapProvider } from '@/config/basemap';
 import { escapeHtml } from '@/utils/sanitize';
+import { safeStorageRemove, safeStorageSet } from '@/utils/safe-storage';
 import type { PanelConfig } from '@/types';
 import { renderPreferences } from '@/services/preferences-content';
 import { renderNotificationsSettings, type NotificationsSettingsResult } from '@/services/notifications-settings';
@@ -582,7 +583,7 @@ export class UnifiedSettings {
       if (replaceOverlayId) overlayHistory.replace(replaceOverlayId, 'settings', close);
       else overlayHistory.open('settings', close);
     }
-    localStorage.setItem('wm-settings-open', '1');
+    safeStorageSet('wm-settings-open', '1');
     document.addEventListener('keydown', this.escapeHandler);
     (this.overlay.querySelector('.unified-settings-tabs') as HTMLElement)?.addEventListener('keydown', (e: KeyboardEvent) => this.handleKeyDown(e));
     track('settings-open', { tab: tab ?? 'default' });
@@ -713,7 +714,7 @@ export class UnifiedSettings {
     this.unsubscribeSubscription = null;
     this.stopMcpQuotaPolling();
     this.resetPanelDraft();
-    localStorage.removeItem('wm-settings-open');
+    safeStorageRemove('wm-settings-open');
     document.removeEventListener('keydown', this.escapeHandler);
     // Last: the host reloads data in response, and the overlay covering the
     // dashboard has to be gone before that lands for the user to see it.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import './bootstrap/zod-csp';
 import { SITE_VARIANT } from '@/config/variant';
 import { installLcpAttributionDebug } from '@/bootstrap/lcp-attribution';
 import { markLcpDebug } from '@/utils/lcp-debug';
+import { safeStorageRemove } from '@/utils/safe-storage';
 import { enqueueSentryCall, installPreInitErrorQueue, scheduleSentryInit } from '@/bootstrap/sentry-defer';
 import { registerClsReporting } from '@/bootstrap/cls-report';
 import { registerInpReporting } from '@/bootstrap/inp-report';
@@ -577,12 +578,7 @@ requestAnimationFrame(() => {
 });
 
 // Clear stale settings-open flag (survives ungraceful shutdown)
-try {
-  localStorage.removeItem('wm-settings-open');
-} catch {
-  // Storage may be unavailable (blocked cookies, sandboxed iframe). The flag is
-  // only a convenience hint, so boot must continue with the in-memory default.
-}
+safeStorageRemove('wm-settings-open');
 
 // Standalone windows: ?settings=1 = panel display settings, ?live-channels=1 = channel management
 // Both need i18n initialized so t() does not return undefined.

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -2,6 +2,7 @@ import './styles/main.css';
 import './styles/settings-window.css';
 import { SettingsManager } from '@/services/settings-manager';
 import { exportSettings, importSettings, type ImportResult } from '@/utils/settings-persistence';
+import { safeStorageRemove, safeStorageSet } from '@/utils/safe-storage';
 import {
   SETTINGS_CATEGORIES,
   HUMAN_LABELS,
@@ -953,7 +954,7 @@ async function initSettingsWindow(): Promise<void> {
   });
 }
 
-localStorage.setItem('wm-settings-open', '1');
-window.addEventListener('beforeunload', () => localStorage.removeItem('wm-settings-open'));
+safeStorageSet('wm-settings-open', '1');
+window.addEventListener('beforeunload', () => safeStorageRemove('wm-settings-open'));
 
 void initSettingsWindow();

--- a/src/utils/cross-domain-storage.ts
+++ b/src/utils/cross-domain-storage.ts
@@ -1,3 +1,5 @@
+import { safeStorageGet, safeStorageSet } from '@/utils/safe-storage';
+
 const COOKIE_DOMAIN = '.worldmonitor.app';
 const MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
 
@@ -9,12 +11,13 @@ export function getDismissed(key: string): boolean {
   if (usesCookies()) {
     return document.cookie.split('; ').some((c) => c === `${key}=1`);
   }
-  return localStorage.getItem(key) === '1' || localStorage.getItem(key) === 'true';
+  const stored = safeStorageGet(key);
+  return stored === '1' || stored === 'true';
 }
 
 export function setDismissed(key: string): void {
   if (usesCookies()) {
     document.cookie = `${key}=1; domain=${COOKIE_DOMAIN}; path=/; max-age=${MAX_AGE_SECONDS}; SameSite=Lax; Secure`;
   }
-  localStorage.setItem(key, '1');
+  safeStorageSet(key, '1');
 }

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -1,0 +1,37 @@
+/**
+ * `localStorage` accessors that survive a browser without usable storage.
+ *
+ * Two distinct failure shapes, and a guard for one does not cover the other.
+ * Sandboxed iframes and blocked cookies make `localStorage` THROW on access.
+ * Android WebView with DOM storage disabled exposes it as NULL, so the call
+ * itself is a TypeError (WORLDMONITOR-122). `typeof localStorage !== 'undefined'`
+ * is true for null and protects neither, which is why every accessor here pairs
+ * optional chaining with a try/catch.
+ *
+ * Reads degrade to "key absent" and writes to a no-op, so callers treat storage
+ * as a best-effort cache rather than branching on availability.
+ */
+
+export function safeStorageGet(key: string): string | null {
+  try {
+    return localStorage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function safeStorageSet(key: string, value: string): void {
+  try {
+    localStorage?.setItem(key, value);
+  } catch {
+    /* storage unavailable or full */
+  }
+}
+
+export function safeStorageRemove(key: string): void {
+  try {
+    localStorage?.removeItem(key);
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -1,15 +1,20 @@
 /**
  * `localStorage` accessors that survive a browser without usable storage.
  *
- * Two distinct failure shapes, and a guard for one does not cover the other.
- * Sandboxed iframes and blocked cookies make `localStorage` THROW on access.
- * Android WebView with DOM storage disabled exposes it as NULL, so the call
- * itself is a TypeError (WORLDMONITOR-122). `typeof localStorage !== 'undefined'`
- * is true for null and protects neither, which is why every accessor here pairs
- * optional chaining with a try/catch.
+ * Two distinct failure shapes. Android WebView with DOM storage disabled
+ * exposes `localStorage` as NULL, so the call itself is a TypeError
+ * (WORLDMONITOR-122). Sandboxed iframes and blocked cookies make the property
+ * THROW on access, and a full disk makes the write throw. `typeof localStorage
+ * !== 'undefined'` guards against neither, because `typeof null` is `'object'`.
+ *
+ * The try/catch is what makes every shape safe. The optional chain is there
+ * because on an affected device null is a permanent steady state rather than an
+ * error, and branching beats throwing and catching on every single access.
  *
  * Reads degrade to "key absent" and writes to a no-op, so callers treat storage
- * as a best-effort cache rather than branching on availability.
+ * as best-effort rather than branching on availability. These are for small
+ * flags. A caller storing anything big enough to hit the quota wants
+ * `saveToStorage` from `@/utils`, which reports via `markStorageQuotaExceeded`.
  */
 
 export function safeStorageGet(key: string): string | null {

--- a/tests/dom/dismiss-null-storage.test.mts
+++ b/tests/dom/dismiss-null-storage.test.mts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MobileWarningModal } from '@/components/MobileWarningModal';
+import { getDismissed, setDismissed } from '@/utils/cross-domain-storage';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.innerHTML = '';
+});
+
+describe('dismissal under a null localStorage', () => {
+  it('closes the mobile warning when the user ticks "don’t show again"', () => {
+    const modal = new MobileWarningModal();
+    modal.show();
+
+    const overlay = document.querySelector('.mobile-warning-overlay');
+    const remember = document.querySelector<HTMLInputElement>('#mobileWarningRemember');
+    const gotIt = document.querySelector<HTMLButtonElement>('.mobile-warning-btn');
+    expect(overlay?.classList.contains('active')).toBe(true);
+
+    remember!.checked = true;
+    vi.stubGlobal('localStorage', null);
+    gotIt!.click();
+
+    expect(overlay?.classList.contains('active')).toBe(false);
+  });
+
+  it('records and reads a dismissal without throwing', () => {
+    vi.stubGlobal('localStorage', null);
+
+    expect(() => setDismissed('wm-test-dismissed')).not.toThrow();
+    expect(() => getDismissed('wm-test-dismissed')).not.toThrow();
+    expect(getDismissed('wm-test-dismissed')).toBe(false);
+  });
+});

--- a/tests/dom/safe-storage.test.mts
+++ b/tests/dom/safe-storage.test.mts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { safeStorageGet, safeStorageRemove, safeStorageSet } from '@/utils/safe-storage';
+
+/** Android WebView with DOM storage disabled: the property itself is null. */
+function stubNullStorage(): void {
+  vi.stubGlobal('localStorage', null);
+}
+
+/** Sandboxed iframe or blocked cookies: reading the property throws. */
+function stubThrowingStorage(): void {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    get() {
+      throw new Error('SecurityError: access is denied for this document');
+    },
+  });
+}
+
+/** Storage is present but full, so only the write throws. */
+function stubFullStorage(): void {
+  vi.stubGlobal('localStorage', {
+    getItem: () => null,
+    setItem: () => {
+      throw new Error('QuotaExceededError');
+    },
+    removeItem: () => {},
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete (globalThis as { localStorage?: unknown }).localStorage;
+});
+
+describe('safe storage', () => {
+  it('round-trips a value when storage works', () => {
+    safeStorageSet('wm-test-key', '1');
+    expect(safeStorageGet('wm-test-key')).toBe('1');
+
+    safeStorageRemove('wm-test-key');
+    expect(safeStorageGet('wm-test-key')).toBeNull();
+  });
+
+  it('reports a missing key as null rather than undefined', () => {
+    expect(safeStorageGet('wm-key-that-was-never-set')).toBeNull();
+  });
+
+  for (const [shape, stub] of [
+    ['null storage', stubNullStorage],
+    ['throwing storage', stubThrowingStorage],
+  ] as const) {
+    it(`degrades to no-op reads and writes under ${shape}`, () => {
+      stub();
+
+      expect(() => safeStorageSet('wm-test-key', '1')).not.toThrow();
+      expect(() => safeStorageRemove('wm-test-key')).not.toThrow();
+      expect(safeStorageGet('wm-test-key')).toBeNull();
+    });
+  }
+
+  it('swallows a quota failure on write', () => {
+    stubFullStorage();
+
+    expect(() => safeStorageSet('wm-test-key', '1')).not.toThrow();
+  });
+});

--- a/tests/dom/unified-settings-null-storage.test.mts
+++ b/tests/dom/unified-settings-null-storage.test.mts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { UnifiedSettings } from '@/components/UnifiedSettings';
+
+/**
+ * Android WebView with DOM storage disabled exposes `window.localStorage` as
+ * `null` instead of throwing, so a bare `localStorage.removeItem(...)` is a
+ * TypeError there rather than a catchable storage failure (WORLDMONITOR-122).
+ */
+function withNullLocalStorage(): void {
+  vi.stubGlobal('localStorage', null);
+}
+
+function createSettings(): UnifiedSettings {
+  return new UnifiedSettings({
+    getPanelSettings: () => ({}),
+    savePanelSettings: () => {},
+    getDisabledSources: () => new Set<string>(),
+    toggleSource: () => {},
+    setSourcesEnabled: () => {},
+    getAllSourceNames: () => [],
+    getLocalizedPanelName: (_key: string, fallback: string) => fallback,
+    resetLayout: () => {},
+    isDesktopApp: false,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('UnifiedSettings under a null localStorage', () => {
+  it('closes without throwing', () => {
+    const settings = createSettings();
+    withNullLocalStorage();
+
+    expect(() => settings.close()).not.toThrow();
+  });
+
+  it('opens without throwing', () => {
+    const settings = createSettings();
+    withNullLocalStorage();
+
+    expect(() => settings.open()).not.toThrow();
+  });
+});

--- a/tests/unified-settings-active-tab.test.mjs
+++ b/tests/unified-settings-active-tab.test.mjs
@@ -78,6 +78,7 @@ function extractOpen() {
     'track',
     'isMobileDevice',
     'overlayHistory',
+    'safeStorageSet',
     `${js}\nreturn __UnifiedSettingsOpenHarness;`,
   );
 }
@@ -101,6 +102,7 @@ const Harness = extractOpen()(
   () => {},
   () => false,
   { open() {}, replace() {} },
+  () => {},
 );
 
 /**


### PR DESCRIPTION
## What was broken

On Android WebView with DOM storage disabled, `window.localStorage` is `null`. It does not throw, so the property access succeeds and the *method call* is what fails. Every unguarded `localStorage.foo()` on those clients is a `TypeError: Cannot read properties of null`.

Sentry `WORLDMONITOR-122` caught the teardown half. The production event's breadcrumbs show all three shapes failing inside one session, which is what pinned the cause to the property rather than to any one call site:

```
warning  Failed to load wm-analysis-frameworks from storage: ...null (reading 'getItem')
warning  [settings] Failed to load settings window: ...null (reading 'setItem')
ui.click button.modal-close.unified-settings-close
```

Two user-facing failures came out of that, and the second is worse than the one Sentry reported.

**Settings could not be opened or closed.** `UnifiedSettings` read storage unguarded on both paths. The `open()` throw was swallowed by the `.catch()` in `src/app/event-handlers.ts`, so the user got a generic error toast and no settings. The `close()` throw had no handler and became `WORLDMONITOR-122`.

**The mobile warning modal became undismissable.** `cross-domain-storage.setDismissed` writes to `localStorage` unconditionally, including on the cookie branch, so it throws on production `worldmonitor.app` hosts too. `MobileWarningModal.dismiss()` calls it *before* `this.hide()`, so ticking "don't show again" stranded the dialog open with a dead close button. `CommunityWidget` has the identical ordering. This never reached Sentry because the throw dies inside a DOM event listener.

## The fix

New `src/utils/safe-storage.ts`, and every call site on the affected keys migrated onto it. `src/main.ts` already guarded its copy of this exact call with a hand-rolled try/catch, so this replaces the sixth variant of that idiom with one helper and moves the rationale into its docblock.

The guard is optional chaining plus try/catch. A `typeof localStorage !== 'undefined'` check does not work here, because `typeof null` is `'object'`, so it passes and leaves the call unprotected. `src/services/persistent-cache.ts:97` already has exactly that mistake (latent, its one caller wraps it) and is filed in the follow-up below.

## Verification

Both bugs land as a failing test before their fix, so the history replays the problem then the proof.

```
× closes without throwing
  "TypeError: Cannot read properties of null (reading 'removeItem')"   ← WORLDMONITOR-122
× opens without throwing
  "TypeError: Cannot read properties of null (reading 'setItem')"      ← WORLDMONITOR-11X
× closes the mobile warning when the user ticks "don't show again"
  expected the overlay to be inactive, it was still active
```

After the fix, `npm run test:dom` is **116 files / 929 tests green**, `tsc --noEmit` is clean, and biome is clean.

The new tests were checked adversarially rather than trusted: stripping the guards out of `safe-storage.ts` turns 6 of the 7 helper assertions red, and the one that survives is correctly the happy-path round-trip. An independent review agent separately checked out the test-only commit into a throwaway worktree and confirmed both component assertions fail there with the exact production error strings, so the stub really does reach the module-scope reference under vitest and happy-dom.

Review also confirmed no site on these keys was missed. A repo-wide sweep covering `pro-test/`, `e2e/`, `scripts/`, and `src-tauri/` finds zero remaining direct `localStorage` references to them.

## Deliberately not in this PR

A survey of the remaining surface found roughly 66 unguarded synchronous `localStorage` sites across `src/`, plus two guards that do not do what they look like: `cloud-prefs-sync.ts` uses `try/finally` in `applyCloudBlob` and `showUndoToast`, which does not catch, and the `persistent-cache.ts:97` `typeof` gate above. There is also no lint rule anywhere in the repo restricting raw `localStorage` use, which is why this keeps recurring (`WORLDMONITOR-11X` and `-XG` are the same class, and `11X` was resolved in Sentry without a code change). Follow-up issue filed; sweeping 66 sites does not belong in a crash fix.

Fixes WORLDMONITOR-122
Fixes WORLDMONITOR-11X
