### PR TITLE
fix(mnd): retain bounded request failure diagnostics

### DIFF
--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2625,7 +2625,7 @@ export async function fetchCrossStraitActivitySnapshot({
       break;
     }
     try {
-      let html;
+      let rows;
       for (let attempt = 0; attempt < 2; attempt += 1) {
         if (requestCount > 0) await sleepFn(REQUEST_CADENCE_MS);
         requestCount += 1;
@@ -2636,7 +2636,14 @@ export async function fetchCrossStraitActivitySnapshot({
           stage: 'response_headers', httpStatus: null,
         };
         try {
-          html = await fetchBoundedText(fetchFn, url, mndContract, diagnostic);
+          const html = await fetchBoundedText(fetchFn, url, mndContract, diagnostic);
+          rows = parseTaiwanMndList(html);
+          if (rows.length === 0) {
+            mndErrors.push('MND_LIST_ROWS_MISSING');
+            mndRequestDiagnostics.push({
+              ...diagnostic, errorCode: 'MND_LIST_ROWS_MISSING', elapsedMs: Math.round(monotonicNow() - startedAt),
+            });
+          }
           break;
         } catch (error) {
           mndRequestDiagnostics.push({
@@ -2649,7 +2656,7 @@ export async function fetchCrossStraitActivitySnapshot({
           }
         }
       }
-      const rows = parseTaiwanMndList(html).map((row) => {
+      rows = rows.map((row) => {
         const previous = previousMndByUrl.get(row.sourceUrl);
         return {
           ...row,
@@ -2657,7 +2664,6 @@ export async function fetchCrossStraitActivitySnapshot({
           ...(previous ? { expectedReportingDay: previous.reportingDay } : {}),
         };
       });
-      if (rows.length === 0) mndErrors.push('MND_LIST_ROWS_MISSING');
       discoveredCount += rows.length;
       for (const row of rows) {
         if (page === 1) {

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -1681,17 +1681,22 @@ function boundedHtmlRequestInit(sourceContract) {
   };
 }
 
-async function fetchBoundedTextWithStatus(fetchFn, url, sourceContract) {
+async function fetchBoundedTextWithStatus(fetchFn, url, sourceContract, diagnostic = null) {
   if (!isAllowedSourceUrl(url, sourceContract)) {
     throw new Error('UNSAFE_SOURCE_URL');
   }
   const response = await fetchFn(url, boundedHtmlRequestInit(sourceContract));
+  if (diagnostic) {
+    diagnostic.httpStatus = response.status;
+    diagnostic.stage = response.ok ? 'response_body' : 'response_headers';
+  }
   const text = await readBoundedTextResponse(response, sourceContract.maxResponseBytes);
+  if (diagnostic) diagnostic.stage = 'parse';
   return { text, status: response.status };
 }
 
-async function fetchBoundedText(fetchFn, url, sourceContract) {
-  const { text } = await fetchBoundedTextWithStatus(fetchFn, url, sourceContract);
+async function fetchBoundedText(fetchFn, url, sourceContract, diagnostic = null) {
+  const { text } = await fetchBoundedTextWithStatus(fetchFn, url, sourceContract, diagnostic);
   return text;
 }
 
@@ -2105,6 +2110,7 @@ export function buildCrossStraitActivitySnapshot({
       requestCount: mndOutcome?.requestCount ?? 0,
       errorCodes: mndOutcome?.errorCodes ?? [],
       refreshErrorCodes: mndOutcome?.refreshErrorCodes ?? [],
+      requestDiagnostics: mndOutcome?.requestDiagnostics ?? [],
       // WHEN this verdict was produced. lastSuccessAt is retained across failing
       // runs by design, so on its own an errored record cannot say whether the
       // seeder just ran or stopped running days ago — see the japan-mod note.
@@ -2577,6 +2583,7 @@ export async function fetchCrossStraitActivitySnapshot({
   const unseenBackfillCandidates = new Map();
   const mndErrors = [];
   const mndRefreshErrors = [];
+  const mndRequestDiagnostics = [];
   const mndContract = CROSS_STRAIT_SOURCE_CONTRACTS.taiwanMnd;
   const resolvedJapanProxyFetchFn = proxyUrl
     ? (input, init) => fetchJapanModViaConfiguredProxy(input, init, {
@@ -2623,10 +2630,18 @@ export async function fetchCrossStraitActivitySnapshot({
         if (requestCount > 0) await sleepFn(REQUEST_CADENCE_MS);
         requestCount += 1;
         listRequestCount += 1;
+        const startedAt = monotonicNow();
+        const diagnostic = {
+          path: new URL(url).pathname, purpose: 'list', attempt: attempt + 1,
+          stage: 'response_headers', httpStatus: null,
+        };
         try {
-          html = await fetchBoundedText(fetchFn, url, mndContract);
+          html = await fetchBoundedText(fetchFn, url, mndContract, diagnostic);
           break;
         } catch (error) {
+          mndRequestDiagnostics.push({
+            ...diagnostic, errorCode: errorCode(error), elapsedMs: Math.round(monotonicNow() - startedAt),
+          });
           if (errorCode(error) !== 'TIMEOUT' || attempt === 1
             || listRequestCount >= MND_MAX_LIST_PAGES_PER_BACKFILL_RUN
             || !hasMndOutboundBudget({ runStartedAt, nowFn, cadenceMs: REQUEST_CADENCE_MS })) {
@@ -2716,11 +2731,18 @@ export async function fetchCrossStraitActivitySnapshot({
         if (!isRefresh) primaryBudgetExhausted = true;
         break;
       }
+      const diagnostic = {
+        path: new URL(candidate.sourceUrl).pathname,
+        purpose: isRefresh ? 'refresh' : 'detail', attempt: retryErrorCode ? 2 : 1,
+        stage: 'response_headers', httpStatus: null,
+      };
+      let startedAt;
       try {
         await sleepFn(REQUEST_CADENCE_MS);
         detailRequestCount += 1;
         requestCount += 1;
-        const html = await fetchBoundedText(fetchFn, candidate.sourceUrl, mndContract);
+        startedAt = monotonicNow();
+        const html = await fetchBoundedText(fetchFn, candidate.sourceUrl, mndContract, diagnostic);
         parsedMnd.push(parseTaiwanMndDetail(html, {
           sourceUrl: candidate.sourceUrl,
           retrievedAt: generatedAt,
@@ -2731,6 +2753,9 @@ export async function fetchCrossStraitActivitySnapshot({
         break;
       } catch (error) {
         const code = errorCode(error);
+        if (startedAt !== undefined) mndRequestDiagnostics.push({
+          ...diagnostic, errorCode: code, elapsedMs: Math.round(monotonicNow() - startedAt),
+        });
         if (
           (code === 'MND_PUBLICATION_METADATA_MISSING' || code === 'TIMEOUT')
           && !retryErrorCode
@@ -2757,6 +2782,7 @@ export async function fetchCrossStraitActivitySnapshot({
     observations: parsedMnd,
     errorCodes: [...new Set(mndErrors)],
     refreshErrorCodes: [...new Set(mndRefreshErrors)],
+    requestDiagnostics: mndRequestDiagnostics,
   };
   return buildCrossStraitActivitySnapshot({
     generatedAt,

--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -87,6 +87,7 @@ function withoutOperatorOnlyDiagnostics(source) {
     proxyControlProbe: _proxyControlProbe,
     shadowIndexProbe: _shadowIndexProbe,
     candidates: _candidates,
+    requestDiagnostics: _requestDiagnostics,
     ...publicSource
   } = source;
   return publicSource;
@@ -325,6 +326,12 @@ export async function fetchCrossStraitActivitySeedSnapshot({
     ? null
     : await readSnapshot(CROSS_STRAIT_ACTIVITY_JAPAN_SOURCE_HEALTH_KEY);
   const snapshot = await fetchSnapshotFn({ previousSnapshot, previousSourceHealth });
+  const failures = snapshot.sources?.find(source => source.id === 'taiwan-mnd')?.requestDiagnostics;
+  if (failures?.length) {
+    console.warn('[cross-strait] MND request failures', JSON.stringify({
+      attemptedAt: snapshot.generatedAt, failures,
+    }));
+  }
   // A first-run MND failure cannot publish the durable archive, but its source
   // health still needs to tell operators why no archive exists yet.
   if (!validateCrossStraitActivitySnapshot(snapshot)) await writeHealth(snapshot);

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -50,7 +50,10 @@ test('cross-Strait bootstrap is a bounded current projection, not the durable re
     generatedAt: '2026-07-25T12:00:00.000Z',
     status: 'degraded',
     sources: [
-      { id: 'taiwan-mnd', transportStatus: 'error' },
+      { id: 'taiwan-mnd', transportStatus: 'error', requestDiagnostics: [{
+        path: '/en/News/PLAAct/87682', purpose: 'detail', attempt: 2,
+        stage: 'response_body', httpStatus: 200, errorCode: 'TIMEOUT', elapsedMs: 20_000,
+      }] },
       {
         id: 'japan-mod',
         transportStatus: 'error',
@@ -104,10 +107,12 @@ test('cross-Strait bootstrap is a bounded current projection, not the durable re
       proxyControlProbe: _proxyControlProbe,
       shadowIndexProbe: _shadowIndexProbe,
       candidates: _candidates,
+      requestDiagnostics: _requestDiagnostics,
       ...publicSource
     } = source;
     return publicSource;
   }));
+  assert.equal(projection.sources.some(source => 'requestDiagnostics' in source), false);
   assert.equal(
     projection.sources.some((source) => 'proxyFailureDetail' in source),
     false,

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { describe, it } from 'node:test';
+import { __testing__ as healthTesting } from '../api/health.js';
 
 import {
   DECISION_SIGNAL_PROVENANCE_FAMILY_REGISTRATIONS,
@@ -38,6 +39,7 @@ import {
   CROSS_STRAIT_ACTIVITY_TTL_SECONDS,
   crossStraitActivityContentMeta,
   fetchCrossStraitActivitySeedSnapshot,
+  projectCrossStraitActivityBootstrap,
   writeSourceHealth,
 } from '../scripts/seed-cross-strait-activity.mjs';
 import { isCrossStraitActivitySnapshot } from '../src/components/cross-strait-activity-summary';
@@ -2988,6 +2990,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     let listAttempts = 0;
     let detailAttempts = 0;
     const snapshot = await fetchCrossStraitActivitySnapshot({
+      mndListUrl: 'https://www.mnd.gov.tw/en/news/plaactlist?token=SECRET#SECRET',
       now: Date.parse(retrievedAt),
       proxyUrl: '',
       sleepFn: async () => {},
@@ -3008,7 +3011,12 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(mnd?.transportStatus, 'fresh');
     assert.deepEqual(mnd?.errorCodes, []);
     assert.equal(mnd?.requestCount, listAttempts + detailAttempts);
+    assert.deepEqual(mnd?.requestDiagnostics?.map(({ elapsedMs, ...failure }) => failure), [{
+      path: '/en/news/plaactlist', purpose: 'list', attempt: 1,
+      stage: 'response_headers', httpStatus: null, errorCode: 'TIMEOUT',
+    }]);
     assert.ok(detailAttempts <= MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(JSON.stringify(mnd.requestDiagnostics).includes('SECRET'), false);
   });
 
   for (const [failure, expectedAttempts, expectedCode] of [
@@ -3032,6 +3040,8 @@ describe('quantified cross-Strait activity (#5575)', () => {
       assert.equal(mnd?.requestCount, attempts);
       assert.equal(mnd?.transportStatus, 'error');
       assert.ok(mnd?.errorCodes.includes(expectedCode));
+      assert.equal(mnd?.requestDiagnostics?.length, expectedAttempts);
+      assert.ok(mnd.requestDiagnostics.every(row => row.errorCode === expectedCode));
     });
   }
 
@@ -3058,7 +3068,84 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(total, MND_MAX_LIST_PAGES_PER_BACKFILL_RUN);
     assert.ok([...listAttempts.values()].every(count => count <= 2));
     assert.equal(mnd?.requestCount, total + detailAttempts);
+    assert.ok(mnd.requestDiagnostics.length <= MND_MAX_LIST_PAGES_PER_BACKFILL_RUN);
+    assert.equal(mnd.requestDiagnostics.at(-1).path, '/en/news/plaactlist/6');
   });
+
+  for (const purpose of ['detail', 'refresh'] as const) {
+    it(`identifies MND ${purpose} body timeouts without leaking response or error text`, async (t) => {
+      const previousSnapshot = buildCrossStraitActivitySnapshot({
+        generatedAt: retrievedAt,
+        mndOutcome: { ok: true, observations: [mndObservationForDay(1)] },
+        japanOutcome: { ok: true, availableDocumentUrls: [] },
+      });
+      let clock = 0;
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        now: Date.parse(retrievedAt) + 60_000, nowFn: () => clock,
+        previousSnapshot, proxyUrl: '', sleepFn: async () => {},
+        fetchFn: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+          if (url.includes('plaactlist')) return new Response(mndListWithCount(20));
+          if (purpose === 'detail' ? url.endsWith('/90000') : url.includes('/86001')) {
+            return new Response(new ReadableStream({
+              pull(controller) {
+                clock += 20_000;
+                controller.error(new DOMException('timeout SECRET upstream body', 'TimeoutError'));
+              },
+            }), { status: 206 });
+          }
+          return new Response(fixture('mnd-detail.html'));
+        },
+      });
+      const mnd = snapshot.sources.find(source => source.id === 'taiwan-mnd');
+      const failures = mnd.requestDiagnostics.filter(row => row.stage === 'response_body');
+      assert.ok(failures.length > 0);
+      assert.ok(failures.every(row => row.purpose === purpose && row.httpStatus === 206
+        && row.errorCode === 'TIMEOUT' && Number.isInteger(row.elapsedMs) && row.elapsedMs >= 0));
+      assert.ok(failures.every(row => row.attempt <= 2));
+      assert.ok(mnd.requestDiagnostics.length <= mnd.requestCount);
+      assert.equal(JSON.stringify(mnd.requestDiagnostics).includes('SECRET'), false);
+      assert.ok(snapshot.observations.some(row => row.sourceUrl.endsWith('/86001')));
+      assert.equal(mnd.lastSuccessAt, purpose === 'detail' ? retrievedAt : snapshot.generatedAt);
+      assert.equal(mnd.transportStatus, purpose === 'detail' ? 'error' : 'fresh');
+      assert.ok((purpose === 'detail' ? mnd.errorCodes : mnd.refreshErrorCodes).includes('TIMEOUT'));
+      const stored = new Map();
+      const writer = async (key, value) => { stored.set(key, value); };
+      const reader = async key => stored.get(key) ?? null;
+      await writeSourceHealth(previousSnapshot, writer, reader);
+      await writeSourceHealth(snapshot, writer, reader);
+      const { classifyKey, SEED_META, STANDALONE_KEYS } = healthTesting;
+      const name = 'crossStraitActivityTaiwanMnd';
+      const dataKey = STANDALONE_KEYS[name];
+      const metaKey = SEED_META[name].key;
+      assert.deepEqual(stored.get(dataKey).requestDiagnostics, mnd.requestDiagnostics);
+      assert.equal(stored.get(metaKey).fetchedAt, Date.parse(mnd.lastSuccessAt));
+      const entry = classifyKey(name, dataKey, { allowOnDemand: true }, {
+        keyStrens: new Map([[dataKey, Buffer.byteLength(JSON.stringify(stored.get(dataKey)))]]),
+        keyErrors: new Map(), keyMetaErrors: new Map(),
+        keyMetaValues: new Map([[metaKey, JSON.stringify(stored.get(metaKey))]]),
+        now: Date.parse(snapshot.generatedAt),
+      });
+      assert.equal(entry.status, purpose === 'detail' ? 'SEED_ERROR' : 'OK');
+      assert.equal(projectCrossStraitActivityBootstrap(snapshot).sources
+        .some(source => 'requestDiagnostics' in source), false);
+      const logs: unknown[][] = [];
+      t.mock.method(console, 'warn', (...args: unknown[]) => { logs.push(args); });
+      await fetchCrossStraitActivitySeedSnapshot({
+        readSnapshot: async () => previousSnapshot,
+        fetchSnapshot: async () => snapshot,
+      });
+      assert.deepEqual(logs, [['[cross-strait] MND request failures', JSON.stringify({
+        attemptedAt: snapshot.generatedAt, failures: mnd.requestDiagnostics,
+      })]]);
+      await fetchCrossStraitActivitySeedSnapshot({
+        readSnapshot: async () => snapshot,
+        fetchSnapshot: async () => previousSnapshot,
+      });
+      assert.equal(logs.length, 1, 'a clean run does not log request failures');
+    });
+  }
 
   for (const failures of [['timeout', 'metadata'], ['metadata', 'timeout'], ['timeout', 'timeout']]) {
     it(`limits mixed MND detail failures ${failures.join('/')} to two attempts`, async () => {
@@ -3083,6 +3170,13 @@ describe('quantified cross-Strait activity (#5575)', () => {
       assert.equal(mnd?.transportStatus, 'error');
       assert.ok(mnd?.errorCodes.includes(failures[1] === 'timeout' ? 'TIMEOUT' : 'MND_PUBLICATION_METADATA_MISSING'));
       assert.ok(mnd?.requestCount <= 21);
+      assert.deepEqual(mnd?.requestDiagnostics?.filter(row => row.path.endsWith('/90000'))
+        .map(({ elapsedMs, ...failure }) => failure), failures.map((failure, index) => ({
+        path: '/en/News/PLAAct/90000', purpose: 'detail', attempt: index + 1,
+        stage: failure === 'timeout' ? 'response_headers' : 'parse',
+        httpStatus: failure === 'timeout' ? null : 200,
+        errorCode: failure === 'timeout' ? 'TIMEOUT' : 'MND_PUBLICATION_METADATA_MISSING',
+      })));
     });
   }
 

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -2628,6 +2628,12 @@ describe('quantified cross-Strait activity (#5575)', () => {
 
     assert.equal(mnd?.transportStatus, 'error');
     assert.ok(mnd?.errorCodes.includes('MND_LIST_ROWS_MISSING'));
+    assert.deepEqual(mnd.requestDiagnostics.filter(row => row.purpose === 'list')
+      .map(({ elapsedMs, ...failure }) => failure), [{
+      path: '/en/news/plaactlist', purpose: 'list', attempt: 1,
+      stage: 'parse', httpStatus: 200, errorCode: 'MND_LIST_ROWS_MISSING',
+    }]);
+    assert.equal(mnd.lastSuccessAt, retrievedAt);
     assert.ok(mnd?.refreshErrorCodes.includes('MND_PUBLICATION_METADATA_MISSING'));
     assert.match(mndRequests[0] ?? '', /plaactlist/i);
     assert.equal(mndRequests.length, 1 + MND_REFRESH_DETAIL_REQUESTS_PER_RUN * 2);
@@ -2636,6 +2642,29 @@ describe('quantified cross-Strait activity (#5575)', () => {
       snapshot.observations.filter((row: { sourceId: string }) => row.sourceId === 'taiwan-mnd').length,
       MND_REQUIRED_REPORTING_DAYS,
     );
+  });
+
+  it('records empty MND backfill pages without retrying or stopping pagination', async () => {
+    const requested: string[] = [];
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      now: Date.parse(retrievedAt), proxyUrl: '', sleepFn: async () => {},
+      fetchFn: async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+        requested.push(url);
+        return new Response('<html><body>no activity rows</body></html>');
+      },
+    });
+    const mnd = snapshot.sources.find(source => source.id === 'taiwan-mnd');
+    assert.equal(requested.length, MND_MAX_LIST_PAGES_PER_BACKFILL_RUN);
+    assert.equal(new Set(requested).size, requested.length);
+    assert.equal(mnd.requestCount, requested.length);
+    assert.deepEqual(mnd.requestDiagnostics.map(row => row.path), requested.map(url => new URL(url).pathname));
+    assert.ok(mnd.requestDiagnostics.every(row => row.purpose === 'list' && row.attempt === 1
+      && row.stage === 'parse' && row.httpStatus === 200 && row.errorCode === 'MND_LIST_ROWS_MISSING'
+      && Number.isInteger(row.elapsedMs) && row.elapsedMs >= 0));
+    assert.equal(mnd.transportStatus, 'error');
+    assert.equal(mnd.lastSuccessAt, null);
   });
 
   it('separates the three index-presence claims by whether the index covers the series', () => {


### PR DESCRIPTION
MND request failures currently retain only aggregate error codes and request counts. Operators cannot identify the failed request or distinguish a failure before response headers from a body-read or detail-parser failure. This change records a bounded set of sanitized failed attempts and emits one worker log entry when that set is nonempty.

The public bootstrap excludes request diagnostics. Existing retries, request and time limits, health verdicts, last-good data, and success timestamps keep their current behavior. This change fixes a diagnostic gap. It does not claim to repair an upstream transport outage.

The request diagnostics and public-field exclusion have regression coverage. A fresh code review found one additional P2 gap: HTTP-success list pages with no usable rows lacked a parse diagnostic. The existing empty-list fixture failed before the review fix. It now passes, and a cold-start fixture checks all 11 backfill pages without extra retries or early pagination termination.

The affected adapter, publication, health, and scheduler suites pass (222 tests). Both typechecks, boundaries, full lint, focused Biome, and whitespace checks pass. Full lint reports existing diagnostics outside this change. Review ran inline under repository instructions; no actionable P0/P1/P2 remains. No independent review or formal approval is claimed.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the H1 workstream owner should inspect natural runs for the `MND request failures` log entry. Confirm that a failed request records its path, purpose, attempt, response stage, status, error code, and elapsed time. A recovered retry can appear in diagnostics while source health remains fresh. Clean runs emit no failure log.

Verify that failed source attempts preserve last success and last-good records, and that public bootstrap data excludes diagnostics. Accept the diagnostic change only after a natural failed request exercises it. Upstream root-cause identification remains a separate requirement. Unexpected public disclosure, changed source clocks, or changed request limits requires a scoped correction or an authorized revert.
