### PR TITLE
fix(china): rotate retries within the China sticky port range

### DIFF
--- a/docs/china-corporate-disclosures.mdx
+++ b/docs/china-corporate-disclosures.mdx
@@ -88,7 +88,11 @@ SZSE: SZSE_PROXY_URL → PROXY_URL
 This is configuration precedence, not sequential URL failover. After a proxy
 URL is selected, a failed attempt does not advance to the next environment
 variable. Distinct SZSE proxy attempts rotate eligible Decodo sticky gateway
-ports within the selected proxy configuration.
+ports within the selected proxy configuration. Supported sticky ranges are
+`10001–49999` for `gate.decodo.com` and `30001–39999` for `cn.decodo.com`, per
+the [provider's endpoint table](https://help.decodo.com/docs/cn/residential-proxy-endpoints-and-ports).
+Retries keep the selected host, credentials, and TLS mode. The China rotating
+port `30000` and unrecognized endpoint ranges stay unchanged.
 
 SSE uses up to four direct and four proxy requests with bounded concurrency.
 SZSE uses one direct attempt and up to two proxy attempts on distinct eligible

--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -8,8 +8,11 @@ const zlib = require('node:zlib');
 const DECODO_GATE_HOST = 'gate.decodo.com';
 // Decodo's curl endpoint differs from its CONNECT endpoint.
 const DECODO_CURL_HOST = 'us.decodo.com';
-const DECODO_STICKY_PORT_MIN = 10_001;
-const DECODO_STICKY_PORT_MAX = 49_999;
+// Country endpoints have their own sticky ranges; never wrap into another pool.
+const DECODO_STICKY_PORT_RANGES = new Map([
+  [DECODO_GATE_HOST, [10_001, 49_999]],
+  ['cn.decodo.com', [30_001, 39_999]],
+]);
 
 function parseProxyConfig(raw) {
   if (!raw) return null;
@@ -55,7 +58,7 @@ function parseProxyConfig(raw) {
 }
 
 /**
- * Parse a proxy configuration and, for Decodo sticky gateway ports, advance
+ * Parse a proxy configuration and, for supported Decodo sticky ports, advance
  * each retry to a distinct sticky session. Other providers and Decodo rotating
  * ports retain their configured route exactly.
  */
@@ -67,20 +70,21 @@ function parseProxyConfigForAttempt(raw, attempt = 0) {
   // whatever casing the operator typed, while the URL form is lowercased by the
   // URL parser. config.host stays verbatim so the connection is unchanged.
   const host = String(config.host || '').toLowerCase().replace(/\.$/u, '');
+  const range = DECODO_STICKY_PORT_RANGES.get(host);
   if (
-    host !== DECODO_GATE_HOST
+    !range
     || !Number.isInteger(port)
-    || port < DECODO_STICKY_PORT_MIN
-    || port > DECODO_STICKY_PORT_MAX
+    || port < range[0]
+    || port > range[1]
   ) {
     return config;
   }
 
-  const stickyPortCount = DECODO_STICKY_PORT_MAX - DECODO_STICKY_PORT_MIN + 1;
+  const [minPort, maxPort] = range;
+  const stickyPortCount = maxPort - minPort + 1;
   return {
     ...config,
-    port: DECODO_STICKY_PORT_MIN
-      + ((port - DECODO_STICKY_PORT_MIN + attempt) % stickyPortCount),
+    port: minPort + ((port - minPort + attempt) % stickyPortCount),
   };
 }
 

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -1180,7 +1180,7 @@ describe('official China corporate disclosures (#5577)', () => {
 
     assert.equal(snapshot.status, 'healthy');
     assert.equal(proxyCalls.length, 4);
-    assert.deepEqual(proxyCalls.map((call) => call.port), [30001, 30001, 30001, 30001]);
+    assert.deepEqual(proxyCalls.map((call) => call.port), [30001, 30002, 30003, 30004]);
     assert.equal(
       proxyCalls.every((call) => call.url.startsWith('https://query.sse.com.cn/')),
       true,
@@ -1209,8 +1209,8 @@ describe('official China corporate disclosures (#5577)', () => {
         emptyResultCount: 0,
         transportPath: 'proxy',
         fallbackReason: 'ETIMEDOUT',
-        proxyExitPorts: [30001, 30001, 30001, 30001],
-        proxyExitRotated: false,
+        proxyExitPorts: [30001, 30002, 30003, 30004],
+        proxyExitRotated: true,
         reliabilityStatus: 'stable',
         requiredRecoverySuccesses: 1,
         consecutiveTransportSuccesses: 1,

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -4,6 +4,8 @@ import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 
 import { validateDecisionSignalProvenance } from '../shared/decision-signal-provenance';
+import { composeChinaDecisionSignals } from '../shared/china-decision-signals';
+import { summarizeChinaDecisionGroups } from '../scripts/seed-china-decision-signals.mjs';
 import {
   CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS,
   CHINA_CORPORATE_DISCLOSURE_KEY,
@@ -1341,6 +1343,67 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(szse?.requestCount, 3);
     assert.equal(szse?.transportPath, 'proxy');
     assert.doesNotMatch(JSON.stringify(snapshot), /proxy-user|proxy-secret/);
+  });
+
+  it('recovers quiet coverage through China sticky retries only after two successful runs', async () => {
+    const ssePayload = fixture('sse.json');
+    ssePayload.result = ssePayload.result.map((row) => ({ ...row, TITLE: '关于召开业绩说明会的更正公告' }));
+    const szsePayload = fixture('szse.json');
+    szsePayload.data = szsePayload.data.map((row) => ({ ...row, title: '关于召开业绩说明会的更正公告' }));
+    let previousSnapshot = null;
+    const initialAt = Date.parse(retrievedAt);
+    for (let run = 0; run < 4; run += 1) {
+      const now = initialAt + run * 30 * 60_000;
+      const checkedAt = new Date(now).toISOString();
+      const ports: number[] = [];
+      const decisions: Array<Record<string, unknown>> = [];
+      const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+        now,
+        previousSnapshot,
+        proxyUrl: 'cn.decodo.com:30001:proxy-user:proxy-secret',
+        onDecision: (entry) => decisions.push(entry),
+        fetchFn: async (input) => {
+          if (String(input).includes('query.sse.com.cn')) {
+            return new Response(JSON.stringify(ssePayload), { status: 200 });
+          }
+          throw Object.assign(new TypeError('fetch failed'), {
+            cause: Object.assign(new Error('connect timed out'), { code: 'ETIMEDOUT' }),
+          });
+        },
+        proxyRequestFn: async (_input, config, options) => {
+          ports.push(config.port);
+          assert.equal(config.host, 'cn.decodo.com');
+          assert.equal(config.auth, 'proxy-user:proxy-secret');
+          assert.equal(options.timeoutMs, 12_000);
+          assert.equal(options.method, 'POST');
+          assert.deepEqual(JSON.parse(options.body).stock, ['300750']);
+          if (run === 1 || (run > 1 && config.port === 30001)) {
+            throw new DOMException('upstream timed out', 'TimeoutError');
+          }
+          return { buffer: Buffer.from(JSON.stringify(szsePayload)), status: 200, contentType: 'application/json' };
+        },
+      });
+      const szse = snapshot.sources.find((source) => source.id === 'szse');
+      const decision = decisions.find((entry) => entry.sourceId === 'szse');
+      assert.deepEqual(ports, run === 0 ? [30001] : [30001, 30002]);
+      assert.equal(szse.requestCount, run === 0 ? 2 : 3);
+      assert.equal(decision?.proxyExitRotated, run !== 0);
+      assert.equal(szse.lastSuccessAt, run === 1 ? retrievedAt : checkedAt);
+      assert.equal(szse.transportReliability.status, ['stable', 'degraded', 'recovering', 'stable'][run]);
+      if (run > 0) {
+        assert.equal(szse.transportReliability.lastFailureAt, new Date(initialAt + 30 * 60_000).toISOString());
+        assert.equal(szse.transportReliability.lastFailureReason, 'TIMEOUT');
+      }
+      assert.equal(snapshot.events.length, 0);
+      assert.ok(snapshot.unclassifiedRevisions.length > 0);
+      const signals = composeChinaDecisionSignals({ generatedAt: checkedAt, corporate: snapshot });
+      const corporate = signals.groups.find((entry) => entry.id === 'corporate-disclosures');
+      assert.equal(corporate?.metadata.unavailableCause, run === 0 || run === 3 ? 'healthy_quiet_window' : 'upstream_unavailable');
+      assert.equal(corporate?.items.length, 0);
+      assert.equal(summarizeChinaDecisionGroups([corporate]).operationallyCovered, run === 0 || run === 3 ? 1 : 0);
+      assert.doesNotMatch(JSON.stringify(snapshot), /proxy-user|proxy-secret/);
+      previousSnapshot = snapshot;
+    }
   });
 
   it('rotates to a fresh sticky exit when the origin blocks the first one', async () => {

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -138,6 +138,31 @@ describe('proxy utilities', () => {
     );
   });
 
+  it('rotates China sticky ports within their country range without changing the route', () => {
+    for (const host of ['cn.decodo.com', 'CN.DECODO.COM', 'Cn.Decodo.Com', 'cn.decodo.com.']) {
+      const raw = `${host}:30001:proxy-user:proxy-secret`;
+      const initial = parseProxyConfig(raw);
+      assert.deepEqual(parseProxyConfigForAttempt(raw, 0), initial);
+      assert.deepEqual(parseProxyConfigForAttempt(raw, 1), { ...initial, port: 30002 });
+      assert.equal(parseProxyConfigForAttempt(`${host}:39999:proxy-user:proxy-secret`, 1).port, 30001);
+      for (const port of [7000, 10000, 29999, 30000, 40000, 49999]) {
+        assert.equal(parseProxyConfigForAttempt(`${host}:${port}:proxy-user:proxy-secret`, 1).port, port);
+      }
+    }
+    for (const protocol of ['http', 'https']) {
+      const raw = `${protocol}://proxy-user:proxy-secret@cn.decodo.com:30001`;
+      assert.deepEqual(parseProxyConfigForAttempt(raw, 1), { ...parseProxyConfig(raw), port: 30002 });
+    }
+    for (const host of ['cn.decodo.com.proxy.test', 'cn.proxy.test', 'jp.decodo.com']) {
+      const raw = `${host}:30001:proxy-user:proxy-secret`;
+      assert.deepEqual(parseProxyConfigForAttempt(raw, 1), parseProxyConfig(raw));
+    }
+    assert.equal(
+      resolveProxyStringForAttempt(1, 'cn.decodo.com:30001:proxy-user:proxy-secret'),
+      'proxy-user:proxy-secret@cn.decodo.com:30002',
+    );
+  });
+
   it('rotates the curl proxy string onto a distinct Decodo sticky exit per attempt', () => {
     const decodo = 'gate.decodo.com:10001:proxy-user:proxy-secret';
 


### PR DESCRIPTION
## Why

SZSE retries could reuse the same failed China sticky proxy session. `parseProxyConfigForAttempt` recognized the global Decodo gateway only, so a configured China country endpoint never advanced its port.

## Scope

Add the documented `cn.decodo.com` sticky range to the existing resolver. The second eligible attempt advances within that country's range. Preserve the selected host, credentials, TLS mode, initial route, request bounds, and rotating ports. SSE's existing per-issuer proxy attempts use the same resolver and now advance on this endpoint too.

The tests reproduce duplicate ports before the fix and exercise disclosure failure, recovery, and decision coverage. Unclassified revisions remain excluded from classified coverage. Quiet windows become operationally covered only after the existing two-success recovery rule is satisfied.

## Verification

- Two regression tests failed before the repair with port `30001` instead of `30002`.
- 133 exchange, coverage, access, registration, and documentation tests passed.
- 243 other shared-proxy tests passed.
- Browser/API typechecks, boundary lint, scoped Biome lint, source attribution, and `git diff --check` passed.
- Three bounded read-only metadata probes tested direct access and two documented China sticky ports. Both proxy ports returned HTTP 200 with 44 valid announcements. These workstation probes do not establish production latency or the original timeout stage.
- Sequential ce-code-review found no remaining P0/P1/P2 findings.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the incident owner must inspect natural `china_corporate_disclosure_source` logs for `sourceId=szse`. A failed first proxy attempt must use a different eligible port on retry. Check request count, source success clocks, and two distinct successful runs before accepting recovery. Verify decision coverage preserves unavailable versus healthy quiet states. Both ports can still fail; a timeout remains an error. Distinct sticky sessions do not guarantee distinct physical IPs.

Natural recurrence acceptance remains pending until this failure/retry sequence occurs. Persistent failures or an unexpected route change require source-level investigation before acceptance. This PR does not deploy or change health thresholds.
