### PR TITLE
fix(storage): stop the null-localStorage crash class recurring

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -96,7 +96,7 @@ jobs:
       - run: npm run sync:bootstrap-tier-keys:check
       - run: npm run lint:rate-limit-policies
       - run: npm run lint:premium-fetch
-      - run: npm run lint:local-storage
+      - run: npm run lint:safe-local-storage
       - run: npm run security:vite-env-secrets
       - name: Version sync check
         run: npm run version:check

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -96,6 +96,7 @@ jobs:
       - run: npm run sync:bootstrap-tier-keys:check
       - run: npm run lint:rate-limit-policies
       - run: npm run lint:premium-fetch
+      - run: npm run lint:local-storage
       - run: npm run security:vite-env-secrets
       - name: Version sync check
         run: npm run version:check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -629,7 +629,7 @@ fi
 # — WORLDMONITOR-122 came in through src/App.ts and src/main.ts (#7833).
 if changed '^(src/|scripts/enforce-safe-local-storage\.mjs$)'; then
   echo "Running raw localStorage check..."
-  npm run lint:local-storage || exit 1
+  npm run lint:safe-local-storage || exit 1
 fi
 
 if changed '^(src/|api/|server/|scripts/check-sentry-coverage\.mjs$)'; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -619,7 +619,7 @@ fi
 # catch is "someone changed a panel" — prepush-changed-tests.sh only selects a
 # test file when that test file is itself in the changed set, so a test-only
 # guard would first surface in CI after the PR was already open (#6557).
-if changed '^(src/components/|scripts/enforce-panel-content-writes\.mjs$)'; then
+if changed '^(src/components/|scripts/(enforce-panel-content-writes|lib/source-scan)\.mjs$)'; then
   echo "Running Panel content-write check..."
   npm run lint:panel-content-writes || exit 1
 fi
@@ -627,7 +627,7 @@ fi
 # Gated on all of src/ (not just components/) because a null localStorage
 # crashes a service, a config leaf or a boot module just as readily as a panel
 # — WORLDMONITOR-122 came in through src/App.ts and src/main.ts (#7833).
-if changed '^(src/|scripts/enforce-safe-local-storage\.mjs$)'; then
+if changed '^(src/|scripts/(enforce-safe-local-storage|lib/source-scan)\.mjs$)'; then
   echo "Running raw localStorage check..."
   npm run lint:safe-local-storage || exit 1
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -624,6 +624,14 @@ if changed '^(src/components/|scripts/enforce-panel-content-writes\.mjs$)'; then
   npm run lint:panel-content-writes || exit 1
 fi
 
+# Gated on all of src/ (not just components/) because a null localStorage
+# crashes a service, a config leaf or a boot module just as readily as a panel
+# — WORLDMONITOR-122 came in through src/App.ts and src/main.ts (#7833).
+if changed '^(src/|scripts/enforce-safe-local-storage\.mjs$)'; then
+  echo "Running raw localStorage check..."
+  npm run lint:local-storage || exit 1
+fi
+
 if changed '^(src/|api/|server/|scripts/check-sentry-coverage\.mjs$)'; then
   echo "Running Sentry-coverage check..."
   node scripts/check-sentry-coverage.mjs || exit 1

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:api-contract": "node scripts/enforce-sebuf-api-contract.mjs",
     "lint:safe-html": "node scripts/enforce-safe-html.mjs",
     "lint:panel-content-writes": "node scripts/enforce-panel-content-writes.mjs",
-    "lint:local-storage": "node scripts/enforce-safe-local-storage.mjs",
+    "lint:safe-local-storage": "node scripts/enforce-safe-local-storage.mjs",
     "lint:rate-limit-policies": "tsx scripts/enforce-rate-limit-policies.mjs",
     "lint:premium-fetch": "tsx scripts/enforce-premium-fetch.mjs",
     "lint:mintlify-slugs": "node scripts/enforce-mintlify-reserved-slugs.mjs",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:api-contract": "node scripts/enforce-sebuf-api-contract.mjs",
     "lint:safe-html": "node scripts/enforce-safe-html.mjs",
     "lint:panel-content-writes": "node scripts/enforce-panel-content-writes.mjs",
+    "lint:local-storage": "node scripts/enforce-safe-local-storage.mjs",
     "lint:rate-limit-policies": "tsx scripts/enforce-rate-limit-policies.mjs",
     "lint:premium-fetch": "tsx scripts/enforce-premium-fetch.mjs",
     "lint:mintlify-slugs": "node scripts/enforce-mintlify-reserved-slugs.mjs",

--- a/scripts/enforce-panel-content-writes.mjs
+++ b/scripts/enforce-panel-content-writes.mjs
@@ -28,11 +28,12 @@
 // scope. `Panel` itself is exempted BY NAME below, not by the incidental fact
 // that `class Panel` currently has no `extends` clause.
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, lstatSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { isMainModule } from './lib/main-module.mjs';
+import { collectTsFiles, stripComments } from './lib/source-scan.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -186,18 +187,11 @@ export const GUARD_EXEMPT_FILES = new Set(['src/components/Panel.ts']);
  */
 export const MIN_PANEL_SUBCLASS_FILES = 100;
 
-/**
- * Blank out comments while preserving offsets and line count. A mention of an
- * idiom in a comment is not a call: scanning raw text both false-fails a
- * correctly-migrated file that documents the rule, and — worse, because it is
- * silent — keeps a legacy entry "observed" after its only real call is gone,
- * so the stale check never asks anyone to delete it.
- */
-export function stripComments(source) {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-    .replace(/\/\/[^\n]*/g, (m) => m.replace(/[^\n]/g, ' '));
-}
+// `stripComments` and `collectTsFiles` moved to ./lib/source-scan.mjs in #7833.
+// The copy that lived here ran its block-comment regex over RAW source, so a
+// `/*` inside a line comment or string opened a bogus region — it was blanking
+// 106 lines of src/components/ that this guard therefore never scanned.
+export { stripComments } from './lib/source-scan.mjs';
 
 // `(?:<[^>]*>)?` so a generic subclass (`class Foo<T> extends Panel`) is not
 // silently dropped from the population.
@@ -242,20 +236,10 @@ export function adviceFor(label) {
   return 'render through Panel.setContentNodes() / setTrustedContent() / setSafeContent()';
 }
 
-function collectTsFiles(dir) {
-  const out = [];
-  for (const entry of readdirSync(dir)) {
-    const abs = path.join(dir, entry);
-    if (statSync(abs).isDirectory()) out.push(...collectTsFiles(abs));
-    else if (abs.endsWith('.ts')) out.push(abs);
-  }
-  return out.sort();
-}
-
 /** Scan the tree and return everything the assertions and the CLI both need. */
 export function scanRepo(root = REPO_ROOT) {
   const componentsDir = path.join(root, 'src/components');
-  const allFiles = collectTsFiles(componentsDir);
+  const allFiles = collectTsFiles(componentsDir, { readdirSync, lstatSync, join: path.join });
   const codeByFile = new Map(
     allFiles.map((abs) => [abs, stripComments(readFileSync(abs, 'utf8'))]),
   );

--- a/scripts/enforce-panel-content-writes.mjs
+++ b/scripts/enforce-panel-content-writes.mjs
@@ -33,7 +33,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { isMainModule } from './lib/main-module.mjs';
-import { collectTsFiles, stripComments } from './lib/source-scan.mjs';
+import { collectTsFiles, lexSource } from './lib/source-scan.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -240,8 +240,17 @@ export function adviceFor(label) {
 export function scanRepo(root = REPO_ROOT) {
   const componentsDir = path.join(root, 'src/components');
   const allFiles = collectTsFiles(componentsDir, { readdirSync, lstatSync, join: path.join });
+  // Track files the lexer could not read confidently. A mis-lex does not throw
+  // — it silently blanks real code, and the guard then reports a clean scan of
+  // a file it never saw. Surfacing it is the difference between a gate that is
+  // wrong and a gate that is wrong AND quiet (#7833 review).
+  const unlexable = [];
   const codeByFile = new Map(
-    allFiles.map((abs) => [abs, stripComments(readFileSync(abs, 'utf8'))]),
+    allFiles.map((abs) => {
+      const { code, ok, terminalMode } = lexSource(readFileSync(abs, 'utf8'));
+      if (!ok) unlexable.push(`${path.relative(root, abs)} (ended in ${terminalMode})`);
+      return [abs, code];
+    }),
   );
 
   const baseOf = new Map();
@@ -270,6 +279,7 @@ export function scanRepo(root = REPO_ROOT) {
   const observedFiles = new Set(observed.map((pair) => pair.split(' :: ')[0]));
 
   return {
+    unlexable,
     subclassFiles,
     observed,
     observedFiles,
@@ -285,6 +295,13 @@ export function scanRepo(root = REPO_ROOT) {
 function main() {
   const result = scanRepo();
   const problems = [];
+
+  if (result.unlexable.length > 0) {
+    problems.push(
+      'These files could not be lexed confidently, so this guard scanned less of them than it reports. Fix the scanner in scripts/lib/source-scan.mjs rather than lowering this check:',
+      ...result.unlexable.map((entry) => `  - ${entry}`),
+    );
+  }
 
   if (result.subclassFiles.length < MIN_PANEL_SUBCLASS_FILES) {
     problems.push(

--- a/scripts/enforce-safe-local-storage.mjs
+++ b/scripts/enforce-safe-local-storage.mjs
@@ -35,16 +35,26 @@
 //
 // Note what a green run does and does not mean. It means "no NEW dereference
 // outside `safe-storage.ts`, and the recorded legacy population still matches
-// the tree". It does NOT mean storage access is safe everywhere: a local alias
-// (`const ls = globalThis.localStorage; ls.getItem(k)`) still slips through, as
-// does a `sessionStorage` deref, which has the same null shape. Widen the
-// patterns when a new idiom appears rather than reading silence as proof.
+// the tree". It does NOT mean storage access is safe everywhere. Known gaps,
+// all of which need an AST pass rather than a wider regex to close:
+//
+//   - a local alias (`const ls = globalThis.localStorage; ls.getItem(k)`) or a
+//     destructure (`const { getItem } = localStorage`);
+//   - a `sessionStorage` deref, which has the identical null shape;
+//   - a count-NEUTRAL swap inside an already-inventoried file: deleting one
+//     dereference and adding another keeps N the same and passes green.
+//
+// Widen the patterns when a new idiom appears rather than reading silence as
+// proof. The review that shipped this gate found three separate bypasses in its
+// own first draft, which is the honest calibration for how much a green run
+// buys you.
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, lstatSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { isMainModule } from './lib/main-module.mjs';
+import { collectTsFiles, stripComments } from './lib/source-scan.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -78,16 +88,29 @@ export const RAW_STORAGE_PATTERNS = [
     probe: 'localStorage[key] = value;',
   },
   {
-    label: 'window.localStorage',
-    re: /\bwindow(?:\?\.)?\.localStorage\b/,
+    // Every global that names the same Storage object. The receiver prefix is
+    // load-bearing for two reasons: `(?<![.?])` above deliberately refuses to
+    // match a dotted `X.localStorage`, so WITHOUT this alternation
+    // `globalThis.localStorage.getItem(k)` matched nothing at all — and the
+    // repo already ships the safe `globalThis.localStorage?.getItem(k)` at
+    // ChatAnalystPanel.ts:133, so the crashing variant was one deleted
+    // character away with CI green.
+    //
+    // The optional chain is `\??\.`, not `(?:\?\.)?\.` — the latter demanded
+    // `window?..localStorage` (two dots) and could never match anything.
+    label: '<global>.localStorage',
+    re: /\b(?:window|globalThis|self|top|parent)\??\.localStorage\b/,
     probe: 'const ls = window.localStorage;',
+    extraProbes: [
+      'globalThis.localStorage.getItem(key);',
+      'self.localStorage.setItem(key, value);',
+      'window?.localStorage.getItem(key);',
+    ],
   },
   {
     // `Storage.prototype.setItem.call(localStorage, …)` throws exactly the same
     // TypeError on a null receiver, and reads as deliberate enough that a
-    // reviewer waves it through. cloud-prefs-sync needs the prototype form so
-    // an own-property override on the instance cannot intercept a state-key
-    // write; it wraps each one in a null-safe accessor instead.
+    // reviewer waves it through.
     label: 'Storage.prototype.<member>.call(…)',
     re: /\bStorage\.prototype\.\w+\.call\(/,
     probe: 'Storage.prototype.setItem.call(localStorage, key, value);',
@@ -99,12 +122,15 @@ export const RAW_STORAGE_PATTERNS = [
  * currently lives at this path — move it and this entry has to move with it,
  * which is the point.
  *
- * Nothing else is exempt. The other three "safe storage" implementations
+ * Nothing else is exempt. The remaining "safe storage" implementations
  * (`loadFromStorage`/`saveToStorage` in `src/utils/index.ts`, the file-private
- * helpers in `browser-key-session.ts` and `cloud-prefs-sync.ts`, and
- * `safeLocalStorage()` in `passkey-offer-state.ts`) are counted in the
- * inventory below rather than waved through, so the duplication stays visible
- * and a fourth implementation cannot land quietly.
+ * helpers in `browser-key-session.ts`, and `safeLocalStorage()` in
+ * `passkey-offer-state.ts`) are counted in the inventory below rather than
+ * waved through, so the duplication stays visible and a further implementation
+ * cannot land quietly. #7833 review caught this file's own author adding one:
+ * cloud-prefs-sync grew a private rawGet/rawSet/rawRemove trio justified by a
+ * threat (an own-property override of `localStorage`) that exists nowhere in
+ * this repo. It now uses the shared helper.
  */
 export const GUARD_EXEMPT_FILES = new Set(['src/utils/safe-storage.ts']);
 
@@ -154,10 +180,11 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
   'src/App.ts :: localStorage.<member> x74',
   'src/app/event-handlers.ts :: localStorage.<member> x5',
   'src/app/map-dimension-control.ts :: localStorage.<member> x1',
-  'src/app/panel-layout.ts :: localStorage.<member> x7',
-  'src/app/pro-activation-controller.ts :: window.localStorage x8',
+  'src/app/panel-layout.ts :: localStorage.<member> x9',
+  'src/app/pro-activation-controller.ts :: <global>.localStorage x8',
   'src/bootstrap/sw-update.ts :: localStorage.<member> x1',
   'src/components/AviationCommandBar.ts :: localStorage.<member> x1',
+  'src/components/ChatAnalystPanel.ts :: <global>.localStorage x2',
   'src/components/ChatAnalystPanel.ts :: localStorage?.<member> x2',
   'src/components/ConsumerPricesPanel.ts :: localStorage.<member> x2',
   'src/components/GlobeMap.ts :: localStorage.<member> x2',
@@ -172,10 +199,10 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
   'src/config/basemap.ts :: localStorage.<member> x2',
   'src/config/beta.ts :: localStorage.<member> x1',
   'src/config/variant.ts :: localStorage.<member> x1',
-  'src/main.ts :: localStorage.<member> x2',
+  'src/main.ts :: localStorage.<member> x4',
   'src/mcp-grant-main.ts :: localStorage.<member> x1',
   'src/services/ai-flow-settings.ts :: localStorage.<member> x4',
-  'src/services/analytics.ts :: window.localStorage x3',
+  'src/services/analytics.ts :: <global>.localStorage x3',
   'src/services/anonymous-identity-storage.ts :: localStorage.<member> x5',
   'src/services/aviation/watchlist.ts :: localStorage.<member> x2',
   'src/services/breaking-news-alerts.ts :: localStorage.<member> x4',
@@ -186,7 +213,7 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
   'src/services/font-scale-settings.ts :: localStorage.<member> x2',
   'src/services/font-settings.ts :: localStorage.<member> x2',
   'src/services/globe-render-settings.ts :: localStorage.<member> x6',
-  'src/services/i18n.ts :: localStorage.<member> x2',
+  'src/services/i18n.ts :: localStorage.<member> x3',
   'src/services/live-stream-settings.ts :: localStorage.<member> x2',
   'src/services/map-mode-preference.ts :: localStorage.<member> x1',
   'src/services/market-watchlist.ts :: localStorage.<member> x6',
@@ -197,12 +224,10 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
   'src/services/sentiment-gate.ts :: localStorage.<member> x1',
   'src/services/tab-store.ts :: localStorage.<member> x2',
   'src/services/telegram-watchlist.ts :: localStorage.<member> x2',
+  'src/services/trending-keywords.ts :: <global>.localStorage x1',
   'src/services/trending-keywords.ts :: localStorage.<member> x2',
-  'src/services/trending-keywords.ts :: window.localStorage x1',
   'src/services/webcams/pinned-store.ts :: localStorage.<member> x2',
   'src/services/widget-store.ts :: localStorage.<member> x4',
-  'src/utils/cloud-prefs-sync.ts :: Storage.prototype.<member>.call(…) x2',
-  'src/utils/cloud-prefs-sync.ts :: localStorage?.<member> x1',
   'src/utils/followed-only-chip.ts :: localStorage.<member> x4',
   'src/utils/index.ts :: localStorage.<member> x2',
   'src/utils/panel-storage.ts :: localStorage.<member> x3',
@@ -218,19 +243,6 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
  */
 export const MIN_SCANNED_FILES = 700;
 
-/**
- * Blank out comments while preserving offsets and line count. A mention of an
- * idiom in a comment is not a dereference: scanning raw text both false-fails
- * a correctly-migrated file that documents the rule, and — worse, because it
- * is silent — keeps a legacy entry "observed" after its only real call is
- * gone, so the stale check never asks anyone to delete it.
- */
-export function stripComments(source) {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-    .replace(/\/\/[^\n]*/g, (m) => m.replace(/[^\n]/g, ' '));
-}
-
 /** `<idiom> xN` for every raw-storage idiom present in `code`, with counts. */
 export function rawStorageUsesIn(code) {
   return RAW_STORAGE_PATTERNS.flatMap(({ label, re }) => {
@@ -239,19 +251,9 @@ export function rawStorageUsesIn(code) {
   });
 }
 
-export function collectTsFiles(dir) {
-  const out = [];
-  for (const entry of readdirSync(dir)) {
-    const abs = path.join(dir, entry);
-    if (statSync(abs).isDirectory()) out.push(...collectTsFiles(abs));
-    else if (abs.endsWith('.ts')) out.push(abs);
-  }
-  return out.sort();
-}
-
 /** Scan the tree and return everything the assertions and the CLI both need. */
 export function scanRepo(root = REPO_ROOT) {
-  const allFiles = collectTsFiles(path.join(root, 'src'));
+  const allFiles = collectTsFiles(path.join(root, 'src'), { readdirSync, lstatSync, join: path.join });
   const scanned = allFiles.filter(
     (abs) => !GUARD_EXEMPT_FILES.has(path.relative(root, abs)),
   );

--- a/scripts/enforce-safe-local-storage.mjs
+++ b/scripts/enforce-safe-local-storage.mjs
@@ -83,6 +83,16 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // dot would forbid the wrapped shape, so `\s` it is — the cost is that a
 // `localStorage` on one line and an unrelated `.foo` on the next can pair up,
 // which over-counts (a LOUD inventory mismatch) rather than under-counting.
+//
+// Whitespace is tolerated at EVERY accessor position in EVERY pattern below —
+// both sides of the receiver dot, not just the identifier's. Review found the
+// receiver side still unhandled after the identifier side was fixed, and
+// patching one position per round is the whack-a-mole this note exists to stop.
+// Note what closing it does and does not buy: a plain AST walk would cover
+// exactly this same syntactic class, because the gaps that actually survive —
+// aliasing, destructuring — need symbol/type resolution, not a parser. That is
+// why this stays a regex with the limits named in the header rather than
+// growing a TypeScript dependency for no additional coverage.
 export const RAW_STORAGE_PATTERNS = [
   {
     label: 'localStorage.<member>',
@@ -123,20 +133,28 @@ export const RAW_STORAGE_PATTERNS = [
     // The optional chain is `\??\.`, not `(?:\?\.)?\.` — the latter demanded
     // `window?..localStorage` (two dots) and could never match anything.
     label: '<global>.localStorage',
-    re: /\b(?:window|globalThis|self|top|parent)\??\.localStorage\b/,
+    re: /\b(?:window|globalThis|self|top|parent)\s*\??\.\s*localStorage\b/,
     probe: 'const ls = window.localStorage;',
     extraProbes: [
       'globalThis.localStorage.getItem(key);',
       'self.localStorage.setItem(key, value);',
       'window?.localStorage.getItem(key);',
+      'window .localStorage.getItem(key);',
+      'window\n  .localStorage.getItem(key);',
     ],
+  },
+  {
+    // A computed receiver defeats every identifier-anchored pattern above.
+    label: "<global>['localStorage']",
+    re: /\b(?:window|globalThis|self|top|parent)\s*(?:\?\.)?\s*\[\s*['"`]localStorage['"`]\s*\]/,
+    probe: "window['localStorage'].getItem(key);",
   },
   {
     // `Storage.prototype.setItem.call(localStorage, …)` throws exactly the same
     // TypeError on a null receiver, and reads as deliberate enough that a
     // reviewer waves it through.
     label: 'Storage.prototype.<member>.call(…)',
-    re: /\bStorage\.prototype\.\w+\.call\(/,
+    re: /\bStorage\s*\.\s*prototype\s*\.\s*\w+\s*\.\s*call\s*\(/,
     probe: 'Storage.prototype.setItem.call(localStorage, key, value);',
   },
 ];

--- a/scripts/enforce-safe-local-storage.mjs
+++ b/scripts/enforce-safe-local-storage.mjs
@@ -33,131 +33,157 @@
 // inside the cloud-prefs setItem patch is an identity comparison that cannot
 // throw on a null, and `vi.stubGlobal('localStorage', null)` is a string.
 //
+// Matching is done on the TypeScript AST. It began as regex, and review found
+// a fresh bypass in three consecutive rounds — whitespace around the
+// identifier's accessor, then around the RECEIVER's accessor, then
+// `localStorage!.getItem(k)` (valid TS; `biome.json` leaves noNonNullAssertion
+// off). Each round the patterns were widened and the class declared closed;
+// each time the next round found another token. Enumerating TypeScript's
+// receiver syntax by hand is the whack-a-mole, and the parser already does it
+// exactly — so the parser does it. Switching also found three REAL
+// dereferences the regex never saw, all `(localStorage as unknown as {…})`
+// casts in `followed-only-chip.ts`.
+//
 // Note what a green run does and does not mean. It means "no NEW dereference
 // outside `safe-storage.ts`, and the recorded legacy population still matches
-// the tree". It does NOT mean storage access is safe everywhere. Known gaps,
-// all of which need an AST pass rather than a wider regex to close:
+// the tree". It does NOT mean storage access is safe everywhere. Known gaps:
 //
 //   - a local alias (`const ls = globalThis.localStorage; ls.getItem(k)`) or a
-//     destructure (`const { getItem } = localStorage`);
+//     destructure (`const { getItem } = localStorage`). These need the type
+//     CHECKER, not the parser — an AST alone cannot resolve what `ls` is — so
+//     they are the one class this gate structurally cannot close;
 //   - a `sessionStorage` deref, which has the identical null shape;
 //   - a count-NEUTRAL swap inside an already-inventoried file: deleting one
 //     dereference and adding another keeps N the same and passes green.
 //
-// Widen the patterns when a new idiom appears rather than reading silence as
-// proof. The review that shipped this gate found three separate bypasses in its
-// own first draft, which is the honest calibration for how much a green run
-// buys you.
+// Add a shape to DEREF_PROBES when a new one appears rather than reading
+// silence as proof.
 
 import { readFileSync, readdirSync, lstatSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import ts from 'typescript';
+
 import { isMainModule } from './lib/main-module.mjs';
-import { collectTsFiles, stripComments } from './lib/source-scan.mjs';
+import { collectTsFiles } from './lib/source-scan.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 
 /**
- * Ways to reach through `localStorage` to something that can throw on a null.
+ * Every syntactic shape that reaches THROUGH `localStorage` to something that
+ * can throw when the store is null or its property getter throws.
  *
- * `probe` is the fixture the self-test matches each pattern against, so a
- * pattern that silently stops matching fails loudly instead of going quiet.
+ * These are matched on the TypeScript AST, not on source text. Three rounds of
+ * review found three separate token classes a regex missed — whitespace around
+ * the identifier's accessor, whitespace around the RECEIVER's accessor, and
+ * the non-null assertion in `localStorage!.getItem(k)` (which `biome.json`
+ * permits, since `noNonNullAssertion` is off). Each round I patched the token
+ * and claimed the class was closed; each time the next round found another.
+ * Hand-enumerating TypeScript's receiver syntax is the whack-a-mole, and the
+ * parser already does it exactly.
  *
- * `localStorage?.foo()` is listed even though optional chaining survives the
- * NULL shape: it does nothing for the THROWING shape (a sandboxed iframe or
- * blocked cookies make the property access itself throw), so on its own it is
- * still a hand-rolled half-guard. Inside `safe-storage.ts` it is paired with a
- * try/catch, which is why that file — and only that file — is exempt.
+ * The AST also removes this gate's dependence on comment stripping — a comment
+ * simply is not a node — which retires the blindness class that made the old
+ * regex scanner miss 1826 lines of `panel-layout.ts`.
+ *
+ * `probes` are the fixtures the self-test matches, so a matcher that silently
+ * stops recognizing a shape fails loudly instead of going quiet. Optional
+ * chaining (`localStorage?.getItem`) is deliberately still counted: it survives
+ * the NULL shape but does nothing for the THROWING one, so on its own it is a
+ * half-guard. `safe-storage.ts` pairs it with a try/catch, which is why that
+ * file — and only that file — is exempt.
+ *
+ * NOT closed by this, and not closable without type resolution: a local alias
+ * (`const ls = localStorage; ls.getItem(k)`) or a destructure. Those need the
+ * checker, not the parser. They stay named in the header as known gaps.
  */
-// Whitespace is permitted between the identifier, the accessor and the member
-// throughout: `localStorage .getItem(k)` and a formatter-wrapped
-//
-//     localStorage
-//       .getItem(k)
-//
-// are ordinary code a bare `localStorage\.` pattern misses entirely, and
-// `stripComments` turns `localStorage /* c */.getItem(k)` into exactly the
-// spaced form. `[^\S\n]` rather than `\s` on the identifier side of a bare
-// dot would forbid the wrapped shape, so `\s` it is — the cost is that a
-// `localStorage` on one line and an unrelated `.foo` on the next can pair up,
-// which over-counts (a LOUD inventory mismatch) rather than under-counting.
-//
-// Whitespace is tolerated at EVERY accessor position in EVERY pattern below —
-// both sides of the receiver dot, not just the identifier's. Review found the
-// receiver side still unhandled after the identifier side was fixed, and
-// patching one position per round is the whack-a-mole this note exists to stop.
-// Note what closing it does and does not buy: a plain AST walk would cover
-// exactly this same syntactic class, because the gaps that actually survive —
-// aliasing, destructuring — need symbol/type resolution, not a parser. That is
-// why this stays a regex with the limits named in the header rather than
-// growing a TypeScript dependency for no additional coverage.
-export const RAW_STORAGE_PATTERNS = [
-  {
-    label: 'localStorage.<member>',
-    re: /(?<![.?])\blocalStorage\s*\.\s*\w/,
-    probe: 'localStorage.getItem(key);',
-    extraProbes: [
-      'localStorage .getItem(key);',
-      'localStorage\n  .getItem(key);',
-    ],
-  },
-  {
-    label: 'localStorage?.<member>',
-    re: /\blocalStorage\s*\?\.\s*\w/,
-    probe: 'localStorage?.getItem(key);',
-  },
-  {
-    label: 'localStorage[<expr>]',
-    re: /\blocalStorage\s*(?:\?\.)?\s*\[/,
-    probe: 'localStorage[key] = value;',
-  },
-  {
-    // `(localStorage).getItem(k)` reads as deliberate obfuscation more than as
-    // an accident, but it is valid code that crashes identically, and the
-    // parenthesised receiver defeats every identifier-anchored pattern above.
-    label: '(localStorage).<member>',
-    re: /\(\s*localStorage\s*\)\s*\??\.\s*\w/,
-    probe: '(localStorage).getItem(key);',
-  },
-  {
-    // Every global that names the same Storage object. The receiver prefix is
-    // load-bearing for two reasons: `(?<![.?])` above deliberately refuses to
-    // match a dotted `X.localStorage`, so WITHOUT this alternation
-    // `globalThis.localStorage.getItem(k)` matched nothing at all — and the
-    // repo already ships the safe `globalThis.localStorage?.getItem(k)` at
-    // ChatAnalystPanel.ts:133, so the crashing variant was one deleted
-    // character away with CI green.
-    //
-    // The optional chain is `\??\.`, not `(?:\?\.)?\.` — the latter demanded
-    // `window?..localStorage` (two dots) and could never match anything.
-    label: '<global>.localStorage',
-    re: /\b(?:window|globalThis|self|top|parent)\s*\??\.\s*localStorage\b/,
-    probe: 'const ls = window.localStorage;',
-    extraProbes: [
-      'globalThis.localStorage.getItem(key);',
-      'self.localStorage.setItem(key, value);',
-      'window?.localStorage.getItem(key);',
-      'window .localStorage.getItem(key);',
-      'window\n  .localStorage.getItem(key);',
-    ],
-  },
-  {
-    // A computed receiver defeats every identifier-anchored pattern above.
-    label: "<global>['localStorage']",
-    re: /\b(?:window|globalThis|self|top|parent)\s*(?:\?\.)?\s*\[\s*['"`]localStorage['"`]\s*\]/,
-    probe: "window['localStorage'].getItem(key);",
-  },
-  {
-    // `Storage.prototype.setItem.call(localStorage, …)` throws exactly the same
-    // TypeError on a null receiver, and reads as deliberate enough that a
-    // reviewer waves it through.
-    label: 'Storage.prototype.<member>.call(…)',
-    re: /\bStorage\s*\.\s*prototype\s*\.\s*\w+\s*\.\s*call\s*\(/,
-    probe: 'Storage.prototype.setItem.call(localStorage, key, value);',
-  },
-];
+export const DEREF_LABELS = {
+  direct: 'localStorage.<member>',
+  global: '<global>.localStorage',
+  prototype: 'Storage.prototype.<member>.call(…)',
+};
+
+/** Globals that name the same Storage object. */
+const STORAGE_GLOBALS = new Set(['window', 'globalThis', 'self', 'top', 'parent']);
+
+/**
+ * Fixtures per label. Every entry must be matched by the AST walk below; the
+ * self-test asserts that, which is what keeps the matcher honest.
+ */
+export const DEREF_PROBES = {
+  [DEREF_LABELS.direct]: [
+    'localStorage.getItem(key);',
+    'localStorage .getItem(key);',
+    'localStorage\n  .getItem(key);',
+    'localStorage /* c */.getItem(key);',
+    'localStorage?.getItem(key);',
+    'localStorage!.getItem(key);',
+    '(localStorage).getItem(key);',
+    '(localStorage!).getItem(key);',
+    '(localStorage as Storage).getItem(key);',
+    'localStorage[key] = value;',
+    'localStorage!["k"];',
+  ],
+  [DEREF_LABELS.global]: [
+    'const ls = window.localStorage;',
+    'globalThis.localStorage.getItem(key);',
+    'self.localStorage.setItem(key, value);',
+    'window?.localStorage.getItem(key);',
+    'window .localStorage.getItem(key);',
+    'window!.localStorage.getItem(key);',
+    "window['localStorage'].getItem(key);",
+  ],
+  [DEREF_LABELS.prototype]: [
+    'Storage.prototype.setItem.call(localStorage, key, value);',
+    'Storage . prototype . setItem . call(localStorage, key, value);',
+  ],
+};
+
+/** Strip the receiver wrappers TypeScript allows around an expression. */
+function unwrapReceiver(node) {
+  let current = node;
+  for (;;) {
+    if (
+      ts.isParenthesizedExpression(current)
+      || ts.isNonNullExpression(current)
+      || ts.isAsExpression(current)
+      || (ts.isSatisfiesExpression?.(current) ?? false)
+      || (ts.isTypeAssertionExpression?.(current) ?? false)
+    ) {
+      current = current.expression;
+      continue;
+    }
+    return current;
+  }
+}
+
+/** Does this node read `.localStorage` / `['localStorage']` off a global? */
+function isGlobalStorageAccess(node) {
+  const base = unwrapReceiver(node.expression);
+  if (!ts.isIdentifier(base) || !STORAGE_GLOBALS.has(base.text)) return false;
+  if (ts.isPropertyAccessExpression(node)) return node.name.text === 'localStorage';
+  return (
+    ts.isElementAccessExpression(node)
+    && !!node.argumentExpression
+    && ts.isStringLiteralLike(node.argumentExpression)
+    && node.argumentExpression.text === 'localStorage'
+  );
+}
+
+/** `Storage.prototype.<member>.call(` — the same TypeError on a null receiver. */
+function isStoragePrototypeCall(node) {
+  if (!ts.isCallExpression(node)) return false;
+  const callee = unwrapReceiver(node.expression);
+  if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== 'call') return false;
+  const member = unwrapReceiver(callee.expression);
+  if (!ts.isPropertyAccessExpression(member)) return false;
+  const proto = unwrapReceiver(member.expression);
+  if (!ts.isPropertyAccessExpression(proto) || proto.name.text !== 'prototype') return false;
+  const base = unwrapReceiver(proto.expression);
+  return ts.isIdentifier(base) && base.text === 'Storage';
+}
 
 /**
  * The canonical helper. Exempt BY NAME, not by the incidental fact that it
@@ -194,8 +220,9 @@ export const GUARD_EXEMPT_FILES = new Set(['src/utils/safe-storage.ts']);
  *   - a pair that shrank or vanished MUST be updated here, so the inventory
  *     can never quietly outlive the drift it records.
  *
- * Counts are measured on COMMENT-STRIPPED source, so documenting the rule in a
- * comment neither inflates an entry nor keeps a migrated one alive.
+ * Counts come from the AST, so a comment mentioning an idiom is simply not a
+ * node — documenting the rule neither inflates an entry nor keeps a migrated
+ * one alive.
  *
  * An entry here is NOT automatically a bug. Three populations are mixed in,
  * and the CLI cannot tell them apart — read the call site before "fixing" one:
@@ -227,7 +254,6 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
   'src/bootstrap/sw-update.ts :: localStorage.<member> x1',
   'src/components/AviationCommandBar.ts :: localStorage.<member> x1',
   'src/components/ChatAnalystPanel.ts :: <global>.localStorage x2',
-  'src/components/ChatAnalystPanel.ts :: localStorage?.<member> x2',
   'src/components/ConsumerPricesPanel.ts :: localStorage.<member> x2',
   'src/components/GlobeMap.ts :: localStorage.<member> x2',
   'src/components/InsightsPanel.ts :: localStorage.<member> x1',
@@ -241,7 +267,7 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
   'src/config/basemap.ts :: localStorage.<member> x2',
   'src/config/beta.ts :: localStorage.<member> x1',
   'src/config/variant.ts :: localStorage.<member> x1',
-  'src/main.ts :: localStorage.<member> x4',
+  'src/main.ts :: localStorage.<member> x2',
   'src/mcp-grant-main.ts :: localStorage.<member> x1',
   'src/services/ai-flow-settings.ts :: localStorage.<member> x4',
   'src/services/analytics.ts :: <global>.localStorage x3',
@@ -270,7 +296,7 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
   'src/services/trending-keywords.ts :: localStorage.<member> x2',
   'src/services/webcams/pinned-store.ts :: localStorage.<member> x2',
   'src/services/widget-store.ts :: localStorage.<member> x4',
-  'src/utils/followed-only-chip.ts :: localStorage.<member> x4',
+  'src/utils/followed-only-chip.ts :: localStorage.<member> x7',
   'src/utils/index.ts :: localStorage.<member> x2',
   'src/utils/panel-storage.ts :: localStorage.<member> x3',
   'src/utils/settings-persistence.ts :: localStorage.<member> x1',
@@ -285,12 +311,43 @@ export const LEGACY_RAW_LOCAL_STORAGE = [
  */
 export const MIN_SCANNED_FILES = 700;
 
-/** `<idiom> xN` for every raw-storage idiom present in `code`, with counts. */
-export function rawStorageUsesIn(code) {
-  return RAW_STORAGE_PATTERNS.flatMap(({ label, re }) => {
-    const n = (code.match(new RegExp(re.source, 'g')) ?? []).length;
-    return n === 0 ? [] : [`${label} x${n}`];
-  });
+/**
+ * `<idiom> xN` for every raw-storage dereference in `source`, with counts.
+ *
+ * Counting rule, and why it does not double-count: a node is counted when EITHER
+ * it reads `localStorage` off a global (`window.localStorage`), OR it is a
+ * member access whose unwrapped receiver is the bare `localStorage` identifier.
+ * The two are mutually exclusive per node, so `window.localStorage.getItem(k)`
+ * counts once — at the inner global read — because the outer access's receiver
+ * unwraps to a property access rather than to a bare identifier.
+ *
+ * A bare `localStorage` that is never accessed through is NOT counted:
+ * `this === localStorage` is an identity comparison that cannot throw, and
+ * flagging it would push callers to "fix" working code.
+ */
+export function rawStorageUsesIn(source) {
+  const file = ts.createSourceFile('scan.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const counts = new Map();
+  const bump = (label) => counts.set(label, (counts.get(label) ?? 0) + 1);
+
+  const visit = (node) => {
+    if (isStoragePrototypeCall(node)) {
+      bump(DEREF_LABELS.prototype);
+    } else if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      if (isGlobalStorageAccess(node)) {
+        bump(DEREF_LABELS.global);
+      } else {
+        const receiver = unwrapReceiver(node.expression);
+        if (ts.isIdentifier(receiver) && receiver.text === 'localStorage') bump(DEREF_LABELS.direct);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(file, visit);
+
+  return [...counts.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([label, n]) => `${label} x${n}`);
 }
 
 /** Scan the tree and return everything the assertions and the CLI both need. */
@@ -302,7 +359,7 @@ export function scanRepo(root = REPO_ROOT) {
 
   const observed = scanned
     .flatMap((abs) =>
-      rawStorageUsesIn(stripComments(readFileSync(abs, 'utf8'))).map(
+      rawStorageUsesIn(readFileSync(abs, 'utf8')).map(
         (label) => `${path.relative(root, abs)} :: ${label}`,
       ),
     )

--- a/scripts/enforce-safe-local-storage.mjs
+++ b/scripts/enforce-safe-local-storage.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// Raw localStorage guard (#7833)
+// ---------------------------------------------------------------------------
+//
+// Android WebView with DOM storage disabled exposes `window.localStorage` as
+// NULL rather than throwing, so an unguarded `localStorage.getItem(…)` is a
+// TypeError, not a catchable SecurityError. That shape has produced three
+// separate Sentry issues (WORLDMONITOR-122, -11X, -XG). `-11X` was resolved in
+// Sentry on 2026-09-04 with no code change, which is why it came back.
+//
+// Nothing mechanical stood between those crashes and a green CI: `biome.json`
+// has no matching rule, the repo has no eslint config, and none of the other
+// `enforce-*.mjs` checks look at storage. Every guard was a hand-rolled
+// convention — and conventions are exactly what produced the two call sites
+// that LOOK guarded and are not:
+//
+//   - `cloud-prefs-sync.applyCloudBlob` wrapped its writes in
+//     `try { … } finally { … }`. A `finally` catches nothing.
+//   - `persistent-cache.deleteFromLocalStorageByPrefix` opened with
+//     `typeof localStorage === 'undefined'`, and `typeof null` is `'object'`.
+//
+// Both are fixed; this guard is what stops the class from coming back a fourth
+// time. It runs as a `lint:*` script rather than a test because the edit it
+// must catch is "someone touched a service or a panel", which touches nothing
+// under tests/ — and `scripts/prepush-changed-tests.sh` only runs a test file
+// when that test file is itself in the changed set, so a test-only guard would
+// first surface in CI with the PR already open.
+//
+// WHAT IS BANNED: a DEREFERENCE of `localStorage` outside the sanctioned
+// helper. Dereferencing is what throws, so that is what the guard measures. A
+// bare mention of the identifier is deliberately legal — `this === localStorage`
+// inside the cloud-prefs setItem patch is an identity comparison that cannot
+// throw on a null, and `vi.stubGlobal('localStorage', null)` is a string.
+//
+// Note what a green run does and does not mean. It means "no NEW dereference
+// outside `safe-storage.ts`, and the recorded legacy population still matches
+// the tree". It does NOT mean storage access is safe everywhere: a local alias
+// (`const ls = globalThis.localStorage; ls.getItem(k)`) still slips through, as
+// does a `sessionStorage` deref, which has the same null shape. Widen the
+// patterns when a new idiom appears rather than reading silence as proof.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { isMainModule } from './lib/main-module.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/**
+ * Ways to reach through `localStorage` to something that can throw on a null.
+ *
+ * `probe` is the fixture the self-test matches each pattern against, so a
+ * pattern that silently stops matching fails loudly instead of going quiet.
+ *
+ * `localStorage?.foo()` is listed even though optional chaining survives the
+ * NULL shape: it does nothing for the THROWING shape (a sandboxed iframe or
+ * blocked cookies make the property access itself throw), so on its own it is
+ * still a hand-rolled half-guard. Inside `safe-storage.ts` it is paired with a
+ * try/catch, which is why that file — and only that file — is exempt.
+ */
+export const RAW_STORAGE_PATTERNS = [
+  {
+    label: 'localStorage.<member>',
+    re: /(?<![.?])\blocalStorage\.\w/,
+    probe: 'localStorage.getItem(key);',
+  },
+  {
+    label: 'localStorage?.<member>',
+    re: /\blocalStorage\?\.\w/,
+    probe: 'localStorage?.getItem(key);',
+  },
+  {
+    label: 'localStorage[<expr>]',
+    re: /\blocalStorage(?:\?\.)?\[/,
+    probe: 'localStorage[key] = value;',
+  },
+  {
+    label: 'window.localStorage',
+    re: /\bwindow(?:\?\.)?\.localStorage\b/,
+    probe: 'const ls = window.localStorage;',
+  },
+  {
+    // `Storage.prototype.setItem.call(localStorage, …)` throws exactly the same
+    // TypeError on a null receiver, and reads as deliberate enough that a
+    // reviewer waves it through. cloud-prefs-sync needs the prototype form so
+    // an own-property override on the instance cannot intercept a state-key
+    // write; it wraps each one in a null-safe accessor instead.
+    label: 'Storage.prototype.<member>.call(…)',
+    re: /\bStorage\.prototype\.\w+\.call\(/,
+    probe: 'Storage.prototype.setItem.call(localStorage, key, value);',
+  },
+];
+
+/**
+ * The canonical helper. Exempt BY NAME, not by the incidental fact that it
+ * currently lives at this path — move it and this entry has to move with it,
+ * which is the point.
+ *
+ * Nothing else is exempt. The other three "safe storage" implementations
+ * (`loadFromStorage`/`saveToStorage` in `src/utils/index.ts`, the file-private
+ * helpers in `browser-key-session.ts` and `cloud-prefs-sync.ts`, and
+ * `safeLocalStorage()` in `passkey-offer-state.ts`) are counted in the
+ * inventory below rather than waved through, so the duplication stays visible
+ * and a fourth implementation cannot land quietly.
+ */
+export const GUARD_EXEMPT_FILES = new Set(['src/utils/safe-storage.ts']);
+
+/**
+ * Every `<file> :: <idiom> xN` triple outside the helper, as of #7833.
+ *
+ * Recorded with an OCCURRENCE COUNT, not a per-file or per-(file, idiom)
+ * boolean, for the reason `enforce-panel-content-writes.mjs` learned the hard
+ * way: a boolean cannot see a SECOND deref of an idiom the file already
+ * carries, so a fresh `localStorage.getItem` in `App.ts` — which already has
+ * dozens — would pass green. That is the highest-traffic regression shape
+ * there is, because new code lands in the files that already read storage.
+ * With counts, a new deref bumps N and fails `unlisted`; a migration lowers N
+ * and fails `stale`.
+ *
+ * This list is a ratchet, not a permission slip:
+ *   - a NEW pair, or a HIGHER count, fails the guard — route the access
+ *     through `@/utils/safe-storage` instead;
+ *   - a pair that shrank or vanished MUST be updated here, so the inventory
+ *     can never quietly outlive the drift it records.
+ *
+ * Counts are measured on COMMENT-STRIPPED source, so documenting the rule in a
+ * comment neither inflates an entry nor keeps a migrated one alive.
+ *
+ * An entry here is NOT automatically a bug. Three populations are mixed in,
+ * and the CLI cannot tell them apart — read the call site before "fixing" one:
+ *
+ *   1. Genuinely unguarded, and reachable. These are the #7833 backlog. Boot
+ *      path first.
+ *   2. Guarded by a surrounding try/catch or a capability probe that really
+ *      does fire. `src/App.ts` is the large one: its constructor probes with a
+ *      write/remove inside a try and drops to `storageAvailable = false`, and
+ *      every migration below it sits behind that flag. Its entry exists to
+ *      catch a NEW deref landing OUTSIDE the probe, not because the cascade
+ *      is broken.
+ *   3. Deliberately raw, because the helper's contract is wrong for the site.
+ *      `persistent-cache` needs the QuotaExceededError to distinguish a full
+ *      disk (`markStorageQuotaExceeded`) from an unusable store, and
+ *      `settings-persistence.importSettings` must fail LOUDLY rather than
+ *      report "0 keys imported" as success. These are terminal states, not
+ *      unfinished migrations.
+ *
+ * The CLI derives and reports the entry and call-site totals from this
+ * registry; do not duplicate those shrinking counts in this comment.
+ */
+export const LEGACY_RAW_LOCAL_STORAGE = [
+  'src/App.ts :: localStorage.<member> x74',
+  'src/app/event-handlers.ts :: localStorage.<member> x5',
+  'src/app/map-dimension-control.ts :: localStorage.<member> x1',
+  'src/app/panel-layout.ts :: localStorage.<member> x7',
+  'src/app/pro-activation-controller.ts :: window.localStorage x8',
+  'src/bootstrap/sw-update.ts :: localStorage.<member> x1',
+  'src/components/AviationCommandBar.ts :: localStorage.<member> x1',
+  'src/components/ChatAnalystPanel.ts :: localStorage?.<member> x2',
+  'src/components/ConsumerPricesPanel.ts :: localStorage.<member> x2',
+  'src/components/GlobeMap.ts :: localStorage.<member> x2',
+  'src/components/InsightsPanel.ts :: localStorage.<member> x1',
+  'src/components/NewsPanel.ts :: localStorage.<member> x6',
+  'src/components/ProActivationChip.ts :: localStorage.<member> x4',
+  'src/components/ProBanner.ts :: localStorage.<member> x5',
+  'src/components/ProPreviewSection.ts :: localStorage.<member> x2',
+  'src/components/SearchModal.ts :: localStorage.<member> x2',
+  'src/components/StrategicPosturePanel.ts :: localStorage.<member> x2',
+  'src/components/WorldClockPanel.ts :: localStorage.<member> x1',
+  'src/config/basemap.ts :: localStorage.<member> x2',
+  'src/config/beta.ts :: localStorage.<member> x1',
+  'src/config/variant.ts :: localStorage.<member> x1',
+  'src/main.ts :: localStorage.<member> x2',
+  'src/mcp-grant-main.ts :: localStorage.<member> x1',
+  'src/services/ai-flow-settings.ts :: localStorage.<member> x4',
+  'src/services/analytics.ts :: window.localStorage x3',
+  'src/services/anonymous-identity-storage.ts :: localStorage.<member> x5',
+  'src/services/aviation/watchlist.ts :: localStorage.<member> x2',
+  'src/services/breaking-news-alerts.ts :: localStorage.<member> x4',
+  'src/services/browser-key-session.ts :: localStorage.<member> x2',
+  'src/services/cached-risk-scores.ts :: localStorage.<member> x5',
+  'src/services/cached-theater-posture.ts :: localStorage.<member> x4',
+  'src/services/followed-countries.ts :: localStorage.<member> x3',
+  'src/services/font-scale-settings.ts :: localStorage.<member> x2',
+  'src/services/font-settings.ts :: localStorage.<member> x2',
+  'src/services/globe-render-settings.ts :: localStorage.<member> x6',
+  'src/services/i18n.ts :: localStorage.<member> x2',
+  'src/services/live-stream-settings.ts :: localStorage.<member> x2',
+  'src/services/map-mode-preference.ts :: localStorage.<member> x1',
+  'src/services/market-watchlist.ts :: localStorage.<member> x6',
+  'src/services/mission-presets.ts :: localStorage.<member> x7',
+  'src/services/persistent-cache.ts :: localStorage.<member> x3',
+  'src/services/referral-capture.ts :: localStorage.<member> x7',
+  'src/services/runtime-config.ts :: localStorage.<member> x2',
+  'src/services/sentiment-gate.ts :: localStorage.<member> x1',
+  'src/services/tab-store.ts :: localStorage.<member> x2',
+  'src/services/telegram-watchlist.ts :: localStorage.<member> x2',
+  'src/services/trending-keywords.ts :: localStorage.<member> x2',
+  'src/services/trending-keywords.ts :: window.localStorage x1',
+  'src/services/webcams/pinned-store.ts :: localStorage.<member> x2',
+  'src/services/widget-store.ts :: localStorage.<member> x4',
+  'src/utils/cloud-prefs-sync.ts :: Storage.prototype.<member>.call(…) x2',
+  'src/utils/cloud-prefs-sync.ts :: localStorage?.<member> x1',
+  'src/utils/followed-only-chip.ts :: localStorage.<member> x4',
+  'src/utils/index.ts :: localStorage.<member> x2',
+  'src/utils/panel-storage.ts :: localStorage.<member> x3',
+  'src/utils/settings-persistence.ts :: localStorage.<member> x1',
+  'src/utils/theme-manager.ts :: localStorage.<member> x5',
+];
+
+/**
+ * Floor for the scanned population, derived from the file count at #7833. A
+ * moved directory or a changed extension filter would otherwise shrink the
+ * scan toward zero and let every assertion pass vacuously — the silent
+ * failure mode this guard exists to prevent.
+ */
+export const MIN_SCANNED_FILES = 700;
+
+/**
+ * Blank out comments while preserving offsets and line count. A mention of an
+ * idiom in a comment is not a dereference: scanning raw text both false-fails
+ * a correctly-migrated file that documents the rule, and — worse, because it
+ * is silent — keeps a legacy entry "observed" after its only real call is
+ * gone, so the stale check never asks anyone to delete it.
+ */
+export function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/\/\/[^\n]*/g, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+/** `<idiom> xN` for every raw-storage idiom present in `code`, with counts. */
+export function rawStorageUsesIn(code) {
+  return RAW_STORAGE_PATTERNS.flatMap(({ label, re }) => {
+    const n = (code.match(new RegExp(re.source, 'g')) ?? []).length;
+    return n === 0 ? [] : [`${label} x${n}`];
+  });
+}
+
+export function collectTsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const abs = path.join(dir, entry);
+    if (statSync(abs).isDirectory()) out.push(...collectTsFiles(abs));
+    else if (abs.endsWith('.ts')) out.push(abs);
+  }
+  return out.sort();
+}
+
+/** Scan the tree and return everything the assertions and the CLI both need. */
+export function scanRepo(root = REPO_ROOT) {
+  const allFiles = collectTsFiles(path.join(root, 'src'));
+  const scanned = allFiles.filter(
+    (abs) => !GUARD_EXEMPT_FILES.has(path.relative(root, abs)),
+  );
+
+  const observed = scanned
+    .flatMap((abs) =>
+      rawStorageUsesIn(stripComments(readFileSync(abs, 'utf8'))).map(
+        (label) => `${path.relative(root, abs)} :: ${label}`,
+      ),
+    )
+    .sort();
+
+  const allowed = new Set(LEGACY_RAW_LOCAL_STORAGE);
+  const observedSet = new Set(observed);
+
+  return {
+    scannedFiles: scanned,
+    observed,
+    unlisted: observed.filter((pair) => !allowed.has(pair)),
+    stale: LEGACY_RAW_LOCAL_STORAGE.filter((pair) => !observedSet.has(pair)),
+  };
+}
+
+function main() {
+  const result = scanRepo();
+  const problems = [];
+
+  if (result.scannedFiles.length < MIN_SCANNED_FILES) {
+    problems.push(
+      `Expected >= ${MIN_SCANNED_FILES} scanned files under src/ (860 at #7833), found ${result.scannedFiles.length} — the scan or the source layout has drifted.`,
+    );
+  }
+
+  if (result.unlisted.length > 0) {
+    problems.push(
+      'These dereference localStorage directly. Android WebView with DOM storage disabled exposes it as null, so each one is a TypeError on those devices (#7833, the WORLDMONITOR-122 class):',
+      ...result.unlisted.map(
+        (pair) =>
+          `  - ${pair}\n      read/write through safeStorageGet / safeStorageSet / safeStorageRemove / safeStorageKeys from @/utils/safe-storage`,
+      ),
+      'If the helper is genuinely wrong for the site — you need the QuotaExceededError, or the failure must be loud — say so in a comment at the call site and add the entry to LEGACY_RAW_LOCAL_STORAGE with its count.',
+    );
+  }
+
+  if (result.stale.length > 0) {
+    problems.push(
+      'These recorded dereferences no longer match the tree. Update LEGACY_RAW_LOCAL_STORAGE in scripts/enforce-safe-local-storage.mjs (lower the count, or delete the line) so the inventory keeps matching reality.',
+      ...result.stale.map((pair) => `  - ${pair}`),
+    );
+  }
+
+  if (problems.length > 0) {
+    console.error('Raw localStorage guard failed (#7833).');
+    for (const line of problems) console.error(line);
+    process.exitCode = 1;
+    return;
+  }
+
+  const sites = LEGACY_RAW_LOCAL_STORAGE.reduce(
+    (sum, pair) => sum + Number(pair.split(' x').pop()),
+    0,
+  );
+  console.log(
+    `Raw localStorage guard passed (${result.scannedFiles.length} files scanned; ${LEGACY_RAW_LOCAL_STORAGE.length} legacy entries / ${sites} dereferences tracked).`,
+  );
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  main();
+}

--- a/scripts/enforce-safe-local-storage.mjs
+++ b/scripts/enforce-safe-local-storage.mjs
@@ -125,6 +125,8 @@ export const DEREF_PROBES = {
     '(localStorage as Storage).getItem(key);',
     'localStorage[key] = value;',
     'localStorage!["k"];',
+    'async function f() { (await localStorage).getItem(key); }',
+    '(0, localStorage).getItem(key);',
   ],
   [DEREF_LABELS.global]: [
     'const ls = window.localStorage;',
@@ -141,7 +143,19 @@ export const DEREF_PROBES = {
   ],
 };
 
-/** Strip the receiver wrappers TypeScript allows around an expression. */
+/**
+ * Strip the value-preserving wrappers that can sit between an expression and
+ * the receiver position, so the identifier underneath is still recognized.
+ *
+ * The list is the one hand-maintained surface left in this matcher, and review
+ * has extended it twice (`!`/`as`, then `await`). DEREF_PROBES is its guard:
+ * every shape here has a fixture. Note the boundary though — this closes shapes
+ * an engineer might plausibly WRITE, not every shape one could construct. A
+ * receiver deliberately obfuscated past this point is not a threat a
+ * non-typechecking gate can close, and anyone editing this file could simply
+ * add an inventory entry instead; the gate exists to catch ACCIDENTAL
+ * reintroduction of the crash class.
+ */
 function unwrapReceiver(node) {
   let current = node;
   for (;;) {
@@ -149,10 +163,17 @@ function unwrapReceiver(node) {
       ts.isParenthesizedExpression(current)
       || ts.isNonNullExpression(current)
       || ts.isAsExpression(current)
+      || ts.isAwaitExpression(current)
       || (ts.isSatisfiesExpression?.(current) ?? false)
       || (ts.isTypeAssertionExpression?.(current) ?? false)
     ) {
       current = current.expression;
+      continue;
+    }
+    // `(0, localStorage).getItem(k)` — the comma operator yields its right
+    // operand, and is a real idiom (it unbinds `this` on the callee).
+    if (ts.isBinaryExpression(current) && current.operatorToken.kind === ts.SyntaxKind.CommaToken) {
+      current = current.right;
       continue;
     }
     return current;

--- a/scripts/enforce-safe-local-storage.mjs
+++ b/scripts/enforce-safe-local-storage.mjs
@@ -71,21 +71,45 @@ const REPO_ROOT = path.resolve(__dirname, '..');
  * still a hand-rolled half-guard. Inside `safe-storage.ts` it is paired with a
  * try/catch, which is why that file — and only that file — is exempt.
  */
+// Whitespace is permitted between the identifier, the accessor and the member
+// throughout: `localStorage .getItem(k)` and a formatter-wrapped
+//
+//     localStorage
+//       .getItem(k)
+//
+// are ordinary code a bare `localStorage\.` pattern misses entirely, and
+// `stripComments` turns `localStorage /* c */.getItem(k)` into exactly the
+// spaced form. `[^\S\n]` rather than `\s` on the identifier side of a bare
+// dot would forbid the wrapped shape, so `\s` it is — the cost is that a
+// `localStorage` on one line and an unrelated `.foo` on the next can pair up,
+// which over-counts (a LOUD inventory mismatch) rather than under-counting.
 export const RAW_STORAGE_PATTERNS = [
   {
     label: 'localStorage.<member>',
-    re: /(?<![.?])\blocalStorage\.\w/,
+    re: /(?<![.?])\blocalStorage\s*\.\s*\w/,
     probe: 'localStorage.getItem(key);',
+    extraProbes: [
+      'localStorage .getItem(key);',
+      'localStorage\n  .getItem(key);',
+    ],
   },
   {
     label: 'localStorage?.<member>',
-    re: /\blocalStorage\?\.\w/,
+    re: /\blocalStorage\s*\?\.\s*\w/,
     probe: 'localStorage?.getItem(key);',
   },
   {
     label: 'localStorage[<expr>]',
-    re: /\blocalStorage(?:\?\.)?\[/,
+    re: /\blocalStorage\s*(?:\?\.)?\s*\[/,
     probe: 'localStorage[key] = value;',
+  },
+  {
+    // `(localStorage).getItem(k)` reads as deliberate obfuscation more than as
+    // an accident, but it is valid code that crashes identically, and the
+    // parenthesised receiver defeats every identifier-anchored pattern above.
+    label: '(localStorage).<member>',
+    re: /\(\s*localStorage\s*\)\s*\??\.\s*\w/,
+    probe: '(localStorage).getItem(key);',
   },
   {
     // Every global that names the same Storage object. The receiver prefix is

--- a/scripts/lib/source-scan.mjs
+++ b/scripts/lib/source-scan.mjs
@@ -1,0 +1,127 @@
+// ---------------------------------------------------------------------------
+// Shared source-text scanning for the enforce-*.mjs gates
+// ---------------------------------------------------------------------------
+//
+// `enforce-panel-content-writes.mjs` and `enforce-safe-local-storage.mjs` both
+// count idioms in comment-stripped source. They carried byte-identical copies
+// of the two helpers below, and the copy carried a hole that made both gates
+// silently blind to real code (#7833 review).
+//
+// THE HOLE: the old implementation ran two regexes over RAW source, block
+// comments first:
+//
+//     .replace(/\/\*[\s\S]*?\*\//g, blank)   // then
+//     .replace(/\/\/[^\n]*/g, blank)
+//
+// A `/*` inside a LINE comment or a STRING is not a block-comment opener, but
+// that first regex cannot tell. `src/app/panel-layout.ts` contains the line
+// comment
+//
+//     // `className: 'panel-wide'`, declared in src/components/*Panel.ts). A deferred
+//
+// whose `/*` opened a bogus comment region that ran to the next `*/` and blanked
+// 1826 of the file's 4554 lines. Two live `localStorage` dereferences sat inside
+// that region, so the guard measured 7 where the file has 9 — and any NEW
+// dereference landing in those 1826 lines would have passed CI green. For a
+// merge-blocking gate that is the worst failure available: not a crash, a
+// confident all-clear over unread code.
+//
+// The fix is a single left-to-right pass with explicit state, because comment
+// and string starts are only meaningful when you already know which one you are
+// inside — which is exactly the context two independent regexes throw away.
+
+/**
+ * Blank out comments while preserving offsets and line count.
+ *
+ * Tracks four states in one pass — code, line comment, block comment, and
+ * string (`'`, `"`, and template literals, honoring backslash escapes) — so a
+ * `/*` or `//` inside a string or another comment can never open a region.
+ * Comment characters become spaces and newlines survive, so byte offsets and
+ * line numbers still line up with the original for error reporting.
+ *
+ * String CONTENTS are deliberately preserved rather than blanked. These gates
+ * count code idioms, and blanking strings would be the same silent-blindness
+ * trade in another coat; a scanner that keeps them can over-count an idiom
+ * quoted in a string, which fails LOUDLY as an inventory mismatch instead.
+ *
+ * KNOWN LIMIT: regex literals are not tracked, so a regex containing `//`
+ * (e.g. `/https:\/\//`) can still open a spurious line comment. That shape does
+ * not occur in the scanned trees today, and unlike the bug above it is visible
+ * as an inventory mismatch rather than a silent pass on the common case. Track
+ * regex state here if it ever appears, rather than reverting to regex stripping.
+ */
+export function stripComments(source) {
+  const out = source.split('');
+  let state = 'code';
+  let quote = '';
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    if (state === 'code') {
+      if (ch === '/' && next === '/') {
+        state = 'line';
+        out[i] = ' ';
+        out[i + 1] = ' ';
+        i++;
+      } else if (ch === '/' && next === '*') {
+        state = 'block';
+        out[i] = ' ';
+        out[i + 1] = ' ';
+        i++;
+      } else if (ch === "'" || ch === '"' || ch === '`') {
+        state = 'string';
+        quote = ch;
+      }
+      continue;
+    }
+
+    if (state === 'string') {
+      // Consume the escaped character wholesale: a trailing backslash before
+      // the closing quote (`'\\'`) would otherwise swallow it and run the
+      // string state on into real code.
+      if (ch === '\\') { i++; continue; }
+      if (ch === quote) { state = 'code'; quote = ''; }
+      continue;
+    }
+
+    if (state === 'line') {
+      // Newlines are never blanked, in any state, so line numbers hold.
+      if (ch === '\n') state = 'code';
+      else out[i] = ' ';
+      continue;
+    }
+
+    // state === 'block'
+    if (ch === '*' && next === '/') {
+      out[i] = ' ';
+      out[i + 1] = ' ';
+      i++;
+      state = 'code';
+    } else if (ch !== '\n') {
+      out[i] = ' ';
+    }
+  }
+
+  return out.join('');
+}
+
+/**
+ * Every `.ts` file under `dir`, recursively, sorted for stable output.
+ *
+ * Uses `lstatSync` rather than `statSync` so a symlinked directory is skipped
+ * instead of followed — a link pointing outside the repo (or at an ancestor)
+ * would otherwise let a gate scan foreign files or recurse until it hangs.
+ */
+export function collectTsFiles(dir, { readdirSync, lstatSync, join }) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const abs = join(dir, entry);
+    const stat = lstatSync(abs);
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isDirectory()) out.push(...collectTsFiles(abs, { readdirSync, lstatSync, join }));
+    else if (abs.endsWith('.ts')) out.push(abs);
+  }
+  return out.sort();
+}

--- a/scripts/lib/source-scan.mjs
+++ b/scripts/lib/source-scan.mjs
@@ -33,8 +33,9 @@
 /**
  * Blank out comments while preserving offsets and line count.
  *
- * Tracks four states in one pass — code, line comment, block comment, and
- * string (`'`, `"`, and template literals, honoring backslash escapes) — so a
+ * Tracks five states in one pass — code, line comment, block comment, quoted
+ * string, and template literal (honoring backslash escapes), with a stack of
+ * open `${…}` interpolations so nested templates resume the right one — so a
  * `/*` or `//` inside a string or another comment can never open a region.
  * Comment characters become spaces and newlines survive, so byte offsets and
  * line numbers still line up with the original for error reporting.
@@ -52,53 +53,69 @@
  */
 export function stripComments(source) {
   const out = source.split('');
-  let state = 'code';
+  let mode = 'code';
   let quote = '';
+  // Brace depth per OPEN template interpolation. A template can contain `${…}`
+  // whose expression contains another template, so a single in-string flag is
+  // not enough: it treats the inner opening backtick as the outer closing one,
+  // drops back to code mid-string, and a `/*` in the remaining text then opens
+  // a comment that blanks everything to EOF. Review caught the panel gate
+  // passing green over a newly added direct content write that way.
+  const interpolations = [];
 
   for (let i = 0; i < source.length; i++) {
     const ch = source[i];
     const next = source[i + 1];
 
-    if (state === 'code') {
-      if (ch === '/' && next === '/') {
-        state = 'line';
-        out[i] = ' ';
-        out[i + 1] = ' ';
-        i++;
-      } else if (ch === '/' && next === '*') {
-        state = 'block';
-        out[i] = ' ';
-        out[i + 1] = ' ';
-        i++;
-      } else if (ch === "'" || ch === '"' || ch === '`') {
-        state = 'string';
-        quote = ch;
+    if (mode === 'code') {
+      if (ch === '/' && next === '/') { mode = 'line'; out[i] = ' '; out[i + 1] = ' '; i++; continue; }
+      if (ch === '/' && next === '*') { mode = 'block'; out[i] = ' '; out[i + 1] = ' '; i++; continue; }
+      if (ch === "'" || ch === '"') { mode = 'string'; quote = ch; continue; }
+      if (ch === '`') { mode = 'template'; continue; }
+      if (interpolations.length > 0) {
+        if (ch === '{') {
+          interpolations[interpolations.length - 1] += 1;
+        } else if (ch === '}') {
+          if (interpolations[interpolations.length - 1] === 0) {
+            interpolations.pop();
+            mode = 'template';
+          } else {
+            interpolations[interpolations.length - 1] -= 1;
+          }
+        }
       }
       continue;
     }
 
-    if (state === 'string') {
+    if (mode === 'string') {
       // Consume the escaped character wholesale: a trailing backslash before
       // the closing quote (`'\\'`) would otherwise swallow it and run the
       // string state on into real code.
       if (ch === '\\') { i++; continue; }
-      if (ch === quote) { state = 'code'; quote = ''; }
+      if (ch === quote) { mode = 'code'; quote = ''; }
       continue;
     }
 
-    if (state === 'line') {
-      // Newlines are never blanked, in any state, so line numbers hold.
-      if (ch === '\n') state = 'code';
+    if (mode === 'template') {
+      if (ch === '\\') { i++; continue; }
+      if (ch === '$' && next === '{') { interpolations.push(0); mode = 'code'; i++; continue; }
+      if (ch === '`') mode = 'code';
+      continue;
+    }
+
+    if (mode === 'line') {
+      // Newlines are never blanked, in any mode, so line numbers hold.
+      if (ch === '\n') mode = 'code';
       else out[i] = ' ';
       continue;
     }
 
-    // state === 'block'
+    // mode === 'block'
     if (ch === '*' && next === '/') {
       out[i] = ' ';
       out[i + 1] = ' ';
       i++;
-      state = 'code';
+      mode = 'code';
     } else if (ch !== '\n') {
       out[i] = ' ';
     }

--- a/scripts/lib/source-scan.mjs
+++ b/scripts/lib/source-scan.mjs
@@ -1,3 +1,5 @@
+import ts from 'typescript';
+
 // ---------------------------------------------------------------------------
 // Shared source-text scanning for the enforce-*.mjs gates
 // ---------------------------------------------------------------------------
@@ -52,132 +54,73 @@
  * regex state here if it ever appears, rather than reverting to regex stripping.
  */
 /**
- * Keywords after which a `/` begins a REGEX, not a division. `return /re/` is
- * the common one; the rest complete the operator-position set.
- */
-const REGEX_PRECEDING_KEYWORDS = new Set([
-  'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
-  'case', 'do', 'else', 'yield', 'await', 'throw',
-]);
-
-/**
- * Is the `/` at `index` the start of a regex literal rather than a division?
+ * Blank out comments while preserving offsets and line count, and report
+ * whether the result can be trusted.
  *
- * The classic JS lexing ambiguity, resolved the classic way: look back at the
- * last significant character. After a value (identifier, number, `)`, `]`, or a
- * closing quote) a `/` divides; after an operator, a punctuator, or one of the
- * keywords above it opens a regex. This is a heuristic, not a parse — which is
- * why `lexSource` still reports an untrustworthy terminal state, so anything it
- * gets wrong surfaces loudly instead of silently blanking code.
+ * Comment ranges come from the TypeScript PARSER, not from a hand lexer. Five
+ * review rounds found five ways a hand lexer loses track — a `/*` inside a line
+ * comment, one inside a string, a nested template interpolation, an untracked
+ * regex literal (live in `src/main.ts:454`, de-syncing that file from line 455
+ * to EOF), and a regex statement after a control condition. Each fix closed one
+ * shape and the next round found another, because separating a regex from a
+ * division genuinely requires parser context. The parser already has it.
+ *
+ * The failure mode being designed out is specific and nasty: a mis-lex does not
+ * throw, it silently blanks real code, and the gate then reports a clean scan
+ * of a file it never read. `ok: false` (a file that does not parse) is the
+ * backstop for that, and callers fail on it rather than scanning less than they
+ * claim.
+ *
+ * String CONTENTS are deliberately preserved. These gates count code idioms,
+ * and blanking strings would be the same silent-blindness trade in another
+ * coat; keeping them can over-count an idiom quoted in a string, which fails
+ * LOUDLY as an inventory mismatch instead.
  */
-function startsRegex(source, index) {
-  let i = index - 1;
-  while (i >= 0 && /\s/.test(source[i])) i--;
-  if (i < 0) return true;
-  const prev = source[i];
-  if (/[)\]}]/.test(prev)) return prev === '}';
-  if (/[A-Za-z0-9_$]/.test(prev)) {
-    let end = i;
-    while (i >= 0 && /[A-Za-z0-9_$]/.test(source[i])) i--;
-    return REGEX_PRECEDING_KEYWORDS.has(source.slice(i + 1, end + 1));
-  }
-  if (prev === "'" || prev === '"' || prev === '`') return false;
-  return true;
-}
-
 export function lexSource(source) {
+  const file = ts.createSourceFile('scan.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
   const out = source.split('');
-  let mode = 'code';
-  let quote = '';
-  // Inside a regex, `/` within a `[...]` class does not terminate it.
-  let regexInClass = false;
-  // Brace depth per OPEN template interpolation. A template can contain `${…}`
-  // whose expression contains another template, so a single in-string flag is
-  // not enough: it treats the inner opening backtick as the outer closing one,
-  // drops back to code mid-string, and a `/*` in the remaining text then opens
-  // a comment that blanks everything to EOF. Review caught the panel gate
-  // passing green over a newly added direct content write that way.
-  const interpolations = [];
+  const blankRange = (pos, end) => {
+    for (let i = pos; i < end && i < out.length; i++) {
+      // Newlines survive in every range, so byte offsets and line numbers
+      // still line up with the original for error reporting.
+      if (out[i] !== '\n') out[i] = ' ';
+    }
+  };
 
-  for (let i = 0; i < source.length; i++) {
-    const ch = source[i];
-    const next = source[i + 1];
-
-    if (mode === 'code') {
-      if (ch === '/' && next === '/') { mode = 'line'; out[i] = ' '; out[i + 1] = ' '; i++; continue; }
-      if (ch === '/' && next === '*') { mode = 'block'; out[i] = ' '; out[i + 1] = ' '; i++; continue; }
-      if (ch === '/' && startsRegex(source, i)) { mode = 'regex'; regexInClass = false; continue; }
-      if (ch === "'" || ch === '"') { mode = 'string'; quote = ch; continue; }
-      if (ch === '`') { mode = 'template'; continue; }
-      if (interpolations.length > 0) {
-        if (ch === '{') {
-          interpolations[interpolations.length - 1] += 1;
-        } else if (ch === '}') {
-          if (interpolations[interpolations.length - 1] === 0) {
-            interpolations.pop();
-            mode = 'template';
-          } else {
-            interpolations[interpolations.length - 1] -= 1;
-          }
-        }
+  // Comments live in the trivia around each token, so walking every token (not
+  // just every node) reaches all of them, including the ones before EOF.
+  //
+  // BOTH sides are required. `getLeadingCommentRanges` treats a comment sharing
+  // a line with preceding code as TRAILING trivia of that previous token and
+  // does not return it, so a leading-only walk left every end-of-line `/* … */`
+  // in place — which is a silent under-strip, the same failure direction this
+  // scanner exists to avoid.
+  const seenStarts = new Set();
+  const seenEnds = new Set();
+  const visit = (node) => {
+    const fullStart = node.getFullStart();
+    if (!seenStarts.has(fullStart)) {
+      seenStarts.add(fullStart);
+      for (const range of ts.getLeadingCommentRanges(source, fullStart) ?? []) {
+        blankRange(range.pos, range.end);
       }
-      continue;
     }
-
-    if (mode === 'regex') {
-      // A regex body is not code and not a string: `/^'[^']*'$/` has an odd
-      // number of apostrophes, and reading them as quotes de-synced the lexer
-      // for the whole rest of the file. That is live in src/main.ts:454.
-      if (ch === '\\') { i++; continue; }
-      if (ch === '[') { regexInClass = true; continue; }
-      if (ch === ']') { regexInClass = false; continue; }
-      if (ch === '/' && !regexInClass) mode = 'code';
-      continue;
+    const end = node.getEnd();
+    if (!seenEnds.has(end)) {
+      seenEnds.add(end);
+      for (const range of ts.getTrailingCommentRanges(source, end) ?? []) {
+        blankRange(range.pos, range.end);
+      }
     }
+    for (const child of node.getChildren(file)) visit(child);
+  };
+  visit(file);
 
-    if (mode === 'string') {
-      // Consume the escaped character wholesale: a trailing backslash before
-      // the closing quote (`'\\'`) would otherwise swallow it and run the
-      // string state on into real code.
-      if (ch === '\\') { i++; continue; }
-      if (ch === quote) { mode = 'code'; quote = ''; }
-      continue;
-    }
-
-    if (mode === 'template') {
-      if (ch === '\\') { i++; continue; }
-      if (ch === '$' && next === '{') { interpolations.push(0); mode = 'code'; i++; continue; }
-      if (ch === '`') mode = 'code';
-      continue;
-    }
-
-    if (mode === 'line') {
-      // Newlines are never blanked, in any mode, so line numbers hold.
-      if (ch === '\n') mode = 'code';
-      else out[i] = ' ';
-      continue;
-    }
-
-    // mode === 'block'
-    if (ch === '*' && next === '/') {
-      out[i] = ' ';
-      out[i + 1] = ' ';
-      i++;
-      mode = 'code';
-    } else if (ch !== '\n') {
-      out[i] = ' ';
-    }
-  }
-
-  // A correctly-lexed file ends back in code. Ending anywhere else means the
-  // scanner lost track — an untracked regex literal whose brace or slash was
-  // read as syntax is the known way — and the damage is always the same shape:
-  // a spurious open region blanking real code to EOF, which a gate then reports
-  // as a clean scan. Regex-vs-division cannot be disambiguated without parser
-  // context, so rather than pretend to close that, callers get to see it: a
-  // non-`code` terminal state makes the gate fail LOUDLY instead of quietly
-  // scanning less than it claims (#7833 review, fifth round).
-  return { code: out.join(''), ok: mode === 'code' && interpolations.length === 0, terminalMode: mode };
+  // `parseDiagnostics` is TypeScript-internal but stable, and it is the honest
+  // signal here: a file this scanner cannot parse is one it cannot be trusted
+  // to have read.
+  const parseErrors = file.parseDiagnostics ?? [];
+  return { code: out.join(''), ok: parseErrors.length === 0, terminalMode: parseErrors.length === 0 ? 'code' : 'parse-error' };
 }
 
 /**

--- a/scripts/lib/source-scan.mjs
+++ b/scripts/lib/source-scan.mjs
@@ -51,10 +51,46 @@
  * as an inventory mismatch rather than a silent pass on the common case. Track
  * regex state here if it ever appears, rather than reverting to regex stripping.
  */
-export function stripComments(source) {
+/**
+ * Keywords after which a `/` begins a REGEX, not a division. `return /re/` is
+ * the common one; the rest complete the operator-position set.
+ */
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
+  'case', 'do', 'else', 'yield', 'await', 'throw',
+]);
+
+/**
+ * Is the `/` at `index` the start of a regex literal rather than a division?
+ *
+ * The classic JS lexing ambiguity, resolved the classic way: look back at the
+ * last significant character. After a value (identifier, number, `)`, `]`, or a
+ * closing quote) a `/` divides; after an operator, a punctuator, or one of the
+ * keywords above it opens a regex. This is a heuristic, not a parse — which is
+ * why `lexSource` still reports an untrustworthy terminal state, so anything it
+ * gets wrong surfaces loudly instead of silently blanking code.
+ */
+function startsRegex(source, index) {
+  let i = index - 1;
+  while (i >= 0 && /\s/.test(source[i])) i--;
+  if (i < 0) return true;
+  const prev = source[i];
+  if (/[)\]}]/.test(prev)) return prev === '}';
+  if (/[A-Za-z0-9_$]/.test(prev)) {
+    let end = i;
+    while (i >= 0 && /[A-Za-z0-9_$]/.test(source[i])) i--;
+    return REGEX_PRECEDING_KEYWORDS.has(source.slice(i + 1, end + 1));
+  }
+  if (prev === "'" || prev === '"' || prev === '`') return false;
+  return true;
+}
+
+export function lexSource(source) {
   const out = source.split('');
   let mode = 'code';
   let quote = '';
+  // Inside a regex, `/` within a `[...]` class does not terminate it.
+  let regexInClass = false;
   // Brace depth per OPEN template interpolation. A template can contain `${…}`
   // whose expression contains another template, so a single in-string flag is
   // not enough: it treats the inner opening backtick as the outer closing one,
@@ -70,6 +106,7 @@ export function stripComments(source) {
     if (mode === 'code') {
       if (ch === '/' && next === '/') { mode = 'line'; out[i] = ' '; out[i + 1] = ' '; i++; continue; }
       if (ch === '/' && next === '*') { mode = 'block'; out[i] = ' '; out[i + 1] = ' '; i++; continue; }
+      if (ch === '/' && startsRegex(source, i)) { mode = 'regex'; regexInClass = false; continue; }
       if (ch === "'" || ch === '"') { mode = 'string'; quote = ch; continue; }
       if (ch === '`') { mode = 'template'; continue; }
       if (interpolations.length > 0) {
@@ -84,6 +121,17 @@ export function stripComments(source) {
           }
         }
       }
+      continue;
+    }
+
+    if (mode === 'regex') {
+      // A regex body is not code and not a string: `/^'[^']*'$/` has an odd
+      // number of apostrophes, and reading them as quotes de-synced the lexer
+      // for the whole rest of the file. That is live in src/main.ts:454.
+      if (ch === '\\') { i++; continue; }
+      if (ch === '[') { regexInClass = true; continue; }
+      if (ch === ']') { regexInClass = false; continue; }
+      if (ch === '/' && !regexInClass) mode = 'code';
       continue;
     }
 
@@ -121,7 +169,24 @@ export function stripComments(source) {
     }
   }
 
-  return out.join('');
+  // A correctly-lexed file ends back in code. Ending anywhere else means the
+  // scanner lost track — an untracked regex literal whose brace or slash was
+  // read as syntax is the known way — and the damage is always the same shape:
+  // a spurious open region blanking real code to EOF, which a gate then reports
+  // as a clean scan. Regex-vs-division cannot be disambiguated without parser
+  // context, so rather than pretend to close that, callers get to see it: a
+  // non-`code` terminal state makes the gate fail LOUDLY instead of quietly
+  // scanning less than it claims (#7833 review, fifth round).
+  return { code: out.join(''), ok: mode === 'code' && interpolations.length === 0, terminalMode: mode };
+}
+
+/**
+ * Comment-stripped source only. Prefer `lexSource` in a gate: it also reports
+ * whether the lex is trustworthy, and a gate that ignores that can scan far
+ * less than it thinks while still passing.
+ */
+export function stripComments(source) {
+  return lexSource(source).code;
 }
 
 /**

--- a/scripts/shared/bundle-budgets.json
+++ b/scripts/shared/bundle-budgets.json
@@ -7,11 +7,11 @@
   "totalTolerancePct": 0.25,
   "totalToleranceBytes": 16384,
   "total": {
-    "raw": 1755789
+    "raw": 1755552
   },
   "chunks": {
     "analytics": {
-      "raw": 132816,
+      "raw": 133239,
       "files": 1
     },
     "cached-risk-scores": {
@@ -27,7 +27,7 @@
       "files": 1
     },
     "cross-domain-storage": {
-      "raw": 417,
+      "raw": 415,
       "files": 1
     },
     "data-freshness": {
@@ -59,11 +59,11 @@
       "files": 1
     },
     "main": {
-      "raw": 985381,
+      "raw": 985080,
       "files": 1
     },
     "panel-gating": {
-      "raw": 3143,
+      "raw": 3144,
       "files": 1
     },
     "panels": {
@@ -71,11 +71,7 @@
       "files": 1
     },
     "persistent-cache": {
-      "raw": 3768,
-      "files": 1
-    },
-    "safe-storage": {
-      "raw": 278,
+      "raw": 3697,
       "files": 1
     },
     "storage-facility-registry-store": {
@@ -99,7 +95,7 @@
       "files": 1
     },
     "widget-store": {
-      "raw": 25866,
+      "raw": 25857,
       "files": 1
     }
   }

--- a/src/components/AviationCommandBar.ts
+++ b/src/components/AviationCommandBar.ts
@@ -1,4 +1,5 @@
 import { fetchFlightStatus, fetchAirportOpsSummary, fetchFlightPrices, fetchAviationNews, fetchGoogleFlights } from '@/services/aviation';
+import { safeStorageSet } from '@/utils/safe-storage';
 import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 import { MONITORED_AIRPORTS } from '@/config/airports';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -401,7 +402,7 @@ export class AviationCommandBar {
     private addToHistory(cmd: string): void {
         const h = this.getHistory().filter(h => h !== cmd);
         h.unshift(cmd);
-        localStorage.setItem(HISTORY_KEY, JSON.stringify(h.slice(0, MAX_HISTORY)));
+        safeStorageSet(HISTORY_KEY, JSON.stringify(h.slice(0, MAX_HISTORY)));
         this.renderHistory();
     }
 

--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -1,4 +1,5 @@
 import { getRecentSignals, type CorrelationSignal } from '@/services/correlation';
+import { safeStorageGet, safeStorageRemove, safeStorageSet } from '@/utils/safe-storage';
 import type { UnifiedAlert } from '@/services/cross-module-integration';
 import { getAlertSettings, updateAlertSettings } from '@/services/breaking-news-alerts';
 import { t } from '@/services/i18n';
@@ -77,7 +78,7 @@ export class IntelligenceFindingsBadge {
 
   constructor() {
     this.enabled = IntelligenceFindingsBadge.getStoredEnabledState();
-    this.popupEnabled = localStorage.getItem(POPUP_STORAGE_KEY) === '1';
+    this.popupEnabled = safeStorageGet(POPUP_STORAGE_KEY) === '1';
 
     this.badge = document.createElement('button');
     this.badge.className = 'intel-findings-badge';
@@ -108,9 +109,9 @@ export class IntelligenceFindingsBadge {
         e.stopPropagation();
         this.popupEnabled = !this.popupEnabled;
         if (this.popupEnabled) {
-          localStorage.setItem(POPUP_STORAGE_KEY, '1');
+          safeStorageSet(POPUP_STORAGE_KEY, '1');
         } else {
-          localStorage.removeItem(POPUP_STORAGE_KEY);
+          safeStorageRemove(POPUP_STORAGE_KEY);
         }
         this.renderDropdown();
         return;
@@ -178,7 +179,7 @@ export class IntelligenceFindingsBadge {
   }
 
   public static getStoredEnabledState(): boolean {
-    return localStorage.getItem(STORAGE_KEY) !== 'hidden';
+    return safeStorageGet(STORAGE_KEY) !== 'hidden';
   }
 
   public isEnabled(): boolean {
@@ -194,7 +195,7 @@ export class IntelligenceFindingsBadge {
     this.enabled = enabled;
 
     if (enabled) {
-      localStorage.removeItem(STORAGE_KEY);
+      safeStorageRemove(STORAGE_KEY);
       document.addEventListener('click', this.boundCloseDropdown);
       this.mount();
       this.initAudio();
@@ -202,7 +203,7 @@ export class IntelligenceFindingsBadge {
       this.startRefresh();
     } else {
       this.updateEpoch++;
-      localStorage.setItem(STORAGE_KEY, 'hidden');
+      safeStorageSet(STORAGE_KEY, 'hidden');
       document.removeEventListener('click', this.boundCloseDropdown);
       document.removeEventListener('wm:intelligence-updated', this.boundUpdate);
       if (this.refreshInterval) {

--- a/src/components/WorldClockPanel.ts
+++ b/src/components/WorldClockPanel.ts
@@ -1,4 +1,5 @@
 import { Panel } from './Panel';
+import { safeStorageSet } from '@/utils/safe-storage';
 import { t, getLocale } from '@/services/i18n';
 import { unsafeRawHtml } from '@/utils/sanitize';
 
@@ -116,7 +117,7 @@ function loadSelectedCities(): string[] {
 }
 
 function saveSelectedCities(ids: string[]): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  safeStorageSet(STORAGE_KEY, JSON.stringify(ids));
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import './bootstrap/zod-csp';
 import { SITE_VARIANT } from '@/config/variant';
 import { installLcpAttributionDebug } from '@/bootstrap/lcp-attribution';
 import { markLcpDebug } from '@/utils/lcp-debug';
-import { safeStorageRemove } from '@/utils/safe-storage';
+import { safeStorageGet, safeStorageRemove, safeStorageSet } from '@/utils/safe-storage';
 import { enqueueSentryCall, installPreInitErrorQueue, scheduleSentryInit } from '@/bootstrap/sentry-defer';
 import { registerClsReporting } from '@/bootstrap/cls-report';
 import { registerInpReporting } from '@/bootstrap/inp-report';
@@ -630,13 +630,13 @@ if (urlParams.get('settings') === '1') {
 // Beta mode toggle: type `beta=true` / `beta=false` in console
 Object.defineProperty(window, 'beta', {
   get() {
-    const on = localStorage.getItem('worldmonitor-beta-mode') === 'true';
+    const on = safeStorageGet('worldmonitor-beta-mode') === 'true';
     console.log(`[Beta] ${on ? 'ON' : 'OFF'}`);
     return on;
   },
   set(v: boolean) {
-    if (v) localStorage.setItem('worldmonitor-beta-mode', 'true');
-    else localStorage.removeItem('worldmonitor-beta-mode');
+    if (v) safeStorageSet('worldmonitor-beta-mode', 'true');
+    else safeStorageRemove('worldmonitor-beta-mode');
     location.reload();
   },
 });

--- a/src/services/anonymous-identity-storage.ts
+++ b/src/services/anonymous-identity-storage.ts
@@ -1,3 +1,5 @@
+import { safeStorageSet } from '@/utils/safe-storage';
+
 const ANON_KEY = 'wm-anon-id';
 const ANON_CLAIM_TOKEN_KEY = 'wm-anon-claim-token';
 const ANON_CLAIM_TOKEN_VERSION = 'v2';
@@ -12,7 +14,7 @@ export function getStoredAnonId(): string | null {
 }
 
 export function saveAnonId(anonId: string): void {
-  localStorage.setItem(ANON_KEY, anonId);
+  safeStorageSet(ANON_KEY, anonId);
 }
 
 export function getStoredAnonClaimToken(): string | null {

--- a/src/services/persistent-cache.ts
+++ b/src/services/persistent-cache.ts
@@ -1,6 +1,7 @@
 import { isDesktopRuntime } from './runtime';
 import { invokeTauri } from './tauri-bridge';
 import { isStorageQuotaExceeded, isQuotaError, markStorageQuotaExceeded } from '@/utils/storage-quota';
+import { safeStorageKeys, safeStorageRemove } from '@/utils/safe-storage';
 
 type CacheEnvelope<T> = {
   key: string;
@@ -94,22 +95,19 @@ async function deleteFromIndexedDbByPrefix(prefix: string): Promise<void> {
   });
 }
 
+// The old `typeof localStorage === 'undefined'` gate here never fired for the
+// shape it was written for: Android WebView with DOM storage disabled exposes
+// `localStorage` as NULL, and `typeof null` is `'object'`, so the function fell
+// straight through to an unguarded `localStorage.length` (#7833). It was latent
+// only because the sole caller wraps it in a bare catch.
 function deleteFromLocalStorageByPrefix(prefix: string): void {
-  if (typeof localStorage === 'undefined') return;
-
   const storagePrefix = `${CACHE_PREFIX}${prefix}`;
-  const keysToDelete: string[] = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key?.startsWith(storagePrefix)) {
-      keysToDelete.push(key);
-    }
-  }
-
-  for (const key of keysToDelete) {
-    localStorage.removeItem(key);
+  for (const key of safeStorageKeys()) {
+    if (key.startsWith(storagePrefix)) safeStorageRemove(key);
   }
 }
+
+export const __testing__ = { deleteFromLocalStorageByPrefix };
 
 function validateBreakerPrefix(prefix: string): void {
   const trimmed = prefix.trim();

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -1,4 +1,5 @@
 import { isDesktopRuntime } from './runtime';
+import { safeStorageSet } from '@/utils/safe-storage';
 import { invokeTauri } from './tauri-bridge';
 
 export type RuntimeSecretKey =
@@ -449,7 +450,7 @@ export function getEffectiveSecrets(feature: RuntimeFeatureDefinition): RuntimeS
 
 export function setFeatureToggle(featureId: RuntimeFeatureId, enabled: boolean): void {
   runtimeConfig.featureToggles[featureId] = enabled;
-  localStorage.setItem(TOGGLES_STORAGE_KEY, JSON.stringify(runtimeConfig.featureToggles));
+  safeStorageSet(TOGGLES_STORAGE_KEY, JSON.stringify(runtimeConfig.featureToggles));
   notifyConfigChanged();
 }
 

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -1,4 +1,5 @@
 import { SITE_VARIANT } from '@/config/variant';
+import { safeStorageGet } from '@/utils/safe-storage';
 import { getClerkToken } from '@/services/clerk';
 import { withBillingVerificationRetry } from '@/services/billing-retry';
 import { hasExplicitDesktopSignals, isDesktopRuntime } from './desktop-runtime';
@@ -371,7 +372,7 @@ export function installRuntimeFetchPatch(): void {
   const nativeFetch = window.fetch.bind(window);
   const dispatch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const target = getApiTargetFromRequestInput(input);
-    const debug = localStorage.getItem('wm-debug-log') === '1';
+    const debug = safeStorageGet('wm-debug-log') === '1';
 
     if (!target?.startsWith('/api/')) {
       if (debug) {

--- a/src/services/tv-mode.ts
+++ b/src/services/tv-mode.ts
@@ -1,3 +1,5 @@
+import { safeStorageGet, safeStorageSet } from '@/utils/safe-storage';
+
 /**
  * TV Mode Controller — ambient fullscreen panel cycling for the happy variant.
  * Drives visual overrides via `document.documentElement.dataset.tvMode` which
@@ -30,7 +32,7 @@ export class TvModeController {
     this.onPanelChange = opts.onPanelChange;
 
     // Read persisted interval or use provided / default
-    const stored = localStorage.getItem(TV_INTERVAL_KEY);
+    const stored = safeStorageGet(TV_INTERVAL_KEY);
     const parsed = stored ? parseInt(stored, 10) : NaN;
     this.intervalMs = clampInterval(
       Number.isFinite(parsed) ? parsed : (opts.intervalMs ?? DEFAULT_INTERVAL)
@@ -102,7 +104,7 @@ export class TvModeController {
 
   setIntervalMs(ms: number): void {
     this.intervalMs = clampInterval(ms);
-    localStorage.setItem(TV_INTERVAL_KEY, String(this.intervalMs));
+    safeStorageSet(TV_INTERVAL_KEY, String(this.intervalMs));
 
     // Restart cycling if active
     if (this.intervalId !== null) {

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -1,4 +1,5 @@
 import { loadFromStorage, saveToStorage } from '@/utils';
+import { safeStorageGet } from '@/utils/safe-storage';
 import { clearPanelColSpanEntry, clearPanelSpanEntry } from '@/utils/panel-storage';
 import { getAuthState } from '@/services/auth-state';
 import { isEntitled, getEntitlementState } from '@/services/entitlements';
@@ -65,7 +66,7 @@ function materializeWidgets(raw: unknown, strict: boolean): CustomWidgetSpec[] {
     // the dashboard.
     const tier = w.tier === 'pro' ? 'pro' : 'basic';
     if (tier === 'pro') {
-      const sideKeyHtml = localStorage.getItem(proHtmlKey(w.id));
+      const sideKeyHtml = safeStorageGet(proHtmlKey(w.id));
       const storedHtml = typeof w.html === 'string' ? w.html : '';
       const proHtml = storedHtml || sideKeyHtml;
       if (!proHtml) {

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -2,7 +2,7 @@ import './styles/main.css';
 import './styles/settings-window.css';
 import { SettingsManager } from '@/services/settings-manager';
 import { exportSettings, importSettings, type ImportResult } from '@/utils/settings-persistence';
-import { safeStorageRemove, safeStorageSet } from '@/utils/safe-storage';
+import { safeStorageGet, safeStorageRemove, safeStorageSet } from '@/utils/safe-storage';
 import {
   SETTINGS_CATEGORIES,
   HUMAN_LABELS,
@@ -676,9 +676,9 @@ function initDiagnostics(): void {
   const trafficCount = document.getElementById('trafficCount');
 
   if (fetchDebugToggle) {
-    fetchDebugToggle.checked = localStorage.getItem('wm-debug-log') === '1';
+    fetchDebugToggle.checked = safeStorageGet('wm-debug-log') === '1';
     fetchDebugToggle.addEventListener('change', () => {
-      localStorage.setItem('wm-debug-log', fetchDebugToggle.checked ? '1' : '0');
+      safeStorageSet('wm-debug-log', fetchDebugToggle.checked ? '1' : '0');
     });
   }
 

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -631,6 +631,12 @@ function renderDebug(area: HTMLElement): void {
   });
 
   area.querySelector('#exportSettingsBtn')?.addEventListener('click', () => {
+    // NOTE: exportSettings throws when storage is unreadable, and this handler
+    // does not catch — same as before #7833. The user-visible fix landed on the
+    // dashboard surface (preferences-content.ts), which already shows
+    // `exportFailed`. Reporting it here needs `components.settings.exportFailed`
+    // in en.shell.json, and that file has ~128 bytes of first-paint budget left
+    // (tests/i18n-english-shell.test.mjs) — not worth spending on an error path.
     exportSettings();
   });
 

--- a/src/utils/cloud-prefs-flush.ts
+++ b/src/utils/cloud-prefs-flush.ts
@@ -3,7 +3,8 @@ export interface ObservableCloudPrefsFlushSuccessOptions {
   myGeneration: number;
   getAuthGeneration: () => number;
   getSyncVersion: () => number;
-  setSyncVersion: (syncVersion: number) => void;
+  /** Returns false when a usable store REJECTED the version write. */
+  setSyncVersion: (syncVersion: number) => boolean;
   clearSettledDirtyKeys: () => void;
   setLastSyncAt: (timestampMs: number) => void;
   isIdle: () => boolean;
@@ -23,7 +24,10 @@ export function applyObservableCloudPrefsFlushSuccess(
   if (opts.getAuthGeneration() !== opts.myGeneration) return false;
   if (opts.syncVersion <= opts.getSyncVersion()) return false;
 
-  opts.setSyncVersion(opts.syncVersion);
+  // A rejected version write means the durable marker is still stale. Going on
+  // to settle dirty keys and report synced would claim a reconciliation that
+  // did not persist, so bail before touching either (#7833 review).
+  if (!opts.setSyncVersion(opts.syncVersion)) return false;
   opts.clearSettledDirtyKeys();
   opts.setLastSyncAt((opts.now ?? Date.now)());
   if (opts.isIdle()) opts.setSynced();

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -56,6 +56,13 @@ import { applyObservableCloudPrefsFlushSuccess } from './cloud-prefs-flush';
 import { SerializedAsyncQueue } from './serialized-async-queue';
 import { TimeoutError, withTimeout } from './with-timeout';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import {
+  safeStorageGet,
+  safeStorageRemove,
+  safeStorageRemoveChecked,
+  safeStorageSet,
+  safeStorageSetChecked,
+} from '@/utils/safe-storage';
 
 export { isTemporaryCloudPrefsStatus, parseRetryAfterSeconds } from './cloud-prefs-retry';
 
@@ -210,17 +217,17 @@ let _dirtyKeysUserId: string | null = null;
  */
 function writePersistedDirtyKeys(payload: { userId: string; keys: string[] }): void {
   if (payload.keys.length === 0) {
-    rawRemove(KEY_DIRTY_KEYS);
+    safeStorageRemove(KEY_DIRTY_KEYS);
     return;
   }
-  rawSet(KEY_DIRTY_KEYS, JSON.stringify(payload));
+  safeStorageSet(KEY_DIRTY_KEYS, JSON.stringify(payload));
 }
 
 function persistDirtyKeyAddition(key: CloudSyncKey): void {
   if (!_dirtyKeysUserId) return;
   try {
     writePersistedDirtyKeys(unionPersistedDirtyKeys(
-      rawGet(KEY_DIRTY_KEYS),
+      safeStorageGet(KEY_DIRTY_KEYS),
       CLOUD_SYNC_KEYS,
       _dirtyKeysUserId,
       [key],
@@ -234,7 +241,7 @@ function persistSettledDirtyKeyRemovals(removals: string[]): void {
   if (!_dirtyKeysUserId) return;
   try {
     writePersistedDirtyKeys(withoutPersistedDirtyKeys(
-      rawGet(KEY_DIRTY_KEYS),
+      safeStorageGet(KEY_DIRTY_KEYS),
       CLOUD_SYNC_KEYS,
       _dirtyKeysUserId,
       removals,
@@ -247,11 +254,11 @@ function persistSettledDirtyKeyRemovals(removals: string[]): void {
 function persistDirtyKeys(): void {
   try {
     if (_dirtyKeys.size === 0) {
-      rawRemove(KEY_DIRTY_KEYS);
+      safeStorageRemove(KEY_DIRTY_KEYS);
       return;
     }
     if (!_dirtyKeysUserId) return;
-    rawSet(KEY_DIRTY_KEYS, JSON.stringify({
+    safeStorageSet(KEY_DIRTY_KEYS, JSON.stringify({
       userId: _dirtyKeysUserId,
       keys: [..._dirtyKeys],
     }));
@@ -264,7 +271,7 @@ function hydrateDirtyKeysFromStorage(userId: string): void {
   try {
     _dirtyKeys.clear();
     _dirtyKeysUserId = userId;
-    const raw = rawGet(KEY_DIRTY_KEYS);
+    const raw = safeStorageGet(KEY_DIRTY_KEYS);
     for (const key of parsePersistedDirtyKeys(raw, CLOUD_SYNC_KEYS, userId)) {
       _dirtyKeys.add(key as CloudSyncKey);
     }
@@ -360,60 +367,19 @@ export function isCloudSyncEnabled(): boolean {
   return isEnabled();
 }
 
-// ── Storage accessors ─────────────────────────────────────────────────────────
-
-/**
- * This module's `localStorage` accessors. Android WebView with DOM storage
- * disabled exposes `localStorage` as NULL rather than throwing, so an
- * unguarded call is a TypeError — and `onSignIn` runs its ownership-sidecar
- * reconciliation on the boot path, where that TypeError takes the whole
- * sign-in down (#7833, the same class as WORLDMONITOR-122).
- *
- * These are deliberately NOT `@/utils/safe-storage`. The writes go through
- * `Storage.prototype` so an own-property override on the `localStorage`
- * instance cannot intercept them, which is what lets a state-key write stay
- * distinguishable from the pref-key writes `install()` patches. Reads degrade
- * to "key absent" and writes to a no-op, matching the shared helper's contract.
- */
-function rawGet(key: string): string | null {
-  try {
-    return localStorage?.getItem(key) ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function rawSet(key: string, value: string): void {
-  try {
-    if (!localStorage) return;
-    Storage.prototype.setItem.call(localStorage, key, value);
-  } catch {
-    /* storage unavailable or full */
-  }
-}
-
-function rawRemove(key: string): void {
-  try {
-    if (!localStorage) return;
-    Storage.prototype.removeItem.call(localStorage, key);
-  } catch {
-    /* storage unavailable */
-  }
-}
-
 // ── State helpers ─────────────────────────────────────────────────────────────
 
 export function getSyncVersion(): number {
-  return parseInt(rawGet(KEY_SYNC_VERSION) ?? '0', 10) || 0;
+  return parseInt(safeStorageGet(KEY_SYNC_VERSION) ?? '0', 10) || 0;
 }
 
 function setSyncVersion(v: number): void {
   // A state key, not a pref key — nothing here should mark the blob dirty.
-  rawSet(KEY_SYNC_VERSION, String(v));
+  safeStorageSet(KEY_SYNC_VERSION, String(v));
 }
 
 function setState(s: SyncState): void {
-  rawSet(KEY_SYNC_STATE, s);
+  safeStorageSet(KEY_SYNC_STATE, s);
 }
 
 // ── Blob helpers ──────────────────────────────────────────────────────────────
@@ -421,7 +387,7 @@ function setState(s: SyncState): void {
 function buildCloudBlob(): Record<string, string> {
   const blob: Record<string, string> = {};
   for (const key of CLOUD_SYNC_KEYS) {
-    const val = rawGet(key);
+    const val = safeStorageGet(key);
     if (val !== null) blob[key] = val;
   }
   return blob;
@@ -456,7 +422,7 @@ function dispatchCloudPrefsSignInTerminal(
 }
 
 function clearForeignOwnershipSidecars(userId: string): void {
-  const lastSignedInAs = rawGet(KEY_LAST_SIGNED_IN_AS);
+  const lastSignedInAs = safeStorageGet(KEY_LAST_SIGNED_IN_AS);
   if (lastSignedInAs === null || lastSignedInAs === userId) return;
 
   // Preferences intentionally survive sign-out, but ownership sidecars are
@@ -464,12 +430,28 @@ function clearForeignOwnershipSidecars(userId: string): void {
   // keeping the prior account's local values attributes A's gate decisions to
   // B. B's explicit cloud values will still be applied later in this attempt.
   for (const key of ACCOUNT_PROVENANCE_SYNC_KEYS) {
-    rawRemove(key);
+    safeStorageRemove(key);
   }
 }
 
-function applyCloudBlob(data: Record<string, unknown>, syncVersion?: number): void {
+/**
+ * Write the cloud blob over local prefs. Returns false when a usable store
+ * REJECTED one of the writes.
+ *
+ * The return value is load-bearing, not decoration. Every caller follows this
+ * with `setSyncVersion` / `setLocalSchemaVersion`, and those markers are tiny
+ * while the pref values are not — so a `QuotaExceededError` can drop the value
+ * and still let the marker land. Local then claims to be at cloud's version
+ * while holding stale values, and the next upload posts them back over good
+ * cloud data. Before #7833 the raw `setItem` threw and aborted the whole
+ * reconciliation, which is the safety this restores.
+ *
+ * `changedKeys` now records only writes that actually landed, so a consumer of
+ * CLOUD_PREFS_APPLIED cannot re-read storage for a key that never changed.
+ */
+function applyCloudBlob(data: Record<string, unknown>, syncVersion?: number): boolean {
   const changedKeys: CloudSyncKey[] = [];
+  let allWritesLanded = true;
   _suppressPatch = true;
   try {
     for (const key of CLOUD_SYNC_KEYS) {
@@ -479,17 +461,26 @@ function applyCloudBlob(data: Record<string, unknown>, syncVersion?: number): vo
       const action = resolveCloudBlobKeyAction(key, data);
       if (action.kind === 'keep') continue;
       if (action.kind === 'set') {
-        if (rawGet(key) !== action.value) changedKeys.push(key);
-        rawSet(key, action.value);
+        const wasDifferent = safeStorageGet(key) !== action.value;
+        if (safeStorageSetChecked(key, action.value)) {
+          if (wasDifferent) changedKeys.push(key);
+        } else {
+          allWritesLanded = false;
+        }
       } else {
-        if (rawGet(key) !== null) changedKeys.push(key);
-        rawRemove(key);
+        const wasPresent = safeStorageGet(key) !== null;
+        if (safeStorageRemoveChecked(key)) {
+          if (wasPresent) changedKeys.push(key);
+        } else {
+          allWritesLanded = false;
+        }
       }
     }
   } finally {
     _suppressPatch = false;
   }
   dispatchCloudPrefsApplied(changedKeys, syncVersion);
+  return allWritesLanded;
 }
 
 interface AppliedMigrations {
@@ -524,14 +515,14 @@ function applyMigrationsWithSchemaVersion(
 }
 
 function getLocalSchemaVersion(): number {
-  const raw = rawGet(KEY_LOCAL_SCHEMA_VERSION);
+  const raw = safeStorageGet(KEY_LOCAL_SCHEMA_VERSION);
   if (raw === null) return 1; // No marker yet → assume oldest, run migrations
   const v = parseInt(raw, 10);
   return Number.isFinite(v) && v > 0 ? v : 1;
 }
 
 function setLocalSchemaVersion(v: number): void {
-  rawSet(KEY_LOCAL_SCHEMA_VERSION, String(v));
+  safeStorageSet(KEY_LOCAL_SCHEMA_VERSION, String(v));
 }
 
 /**
@@ -561,7 +552,13 @@ function migrateLocalBlobIfNeeded(): PreparedCloudBlob {
   }
   const migrated = applyMigrationsWithSchemaVersion(blob, localSchema);
   const migratedData = migrated.data as Record<string, string>;
-  if (migratedData !== blob) applyCloudBlob(migratedData);
+  if (migratedData !== blob && !applyCloudBlob(migratedData)) {
+    // The migrated blob did not land. Recording the new schema version anyway
+    // would cement the unmigrated local data at the new version — the exact
+    // poisoning KEY_LOCAL_SCHEMA_VERSION exists to prevent. Post what we have
+    // at the OLD version so the next attempt migrates again.
+    return { data: blob, schemaVersion: localSchema };
+  }
   setLocalSchemaVersion(migrated.schemaVersion);
   return { data: migratedData, schemaVersion: migrated.schemaVersion };
 }
@@ -594,8 +591,8 @@ function showUndoToast(prevBlobJson: string): void {
         for (const [k, v] of Object.entries(prev)) {
           if (!CLOUD_SYNC_KEYS.includes(k as CloudSyncKey)) continue;
           const key = k as CloudSyncKey;
-          if (rawGet(key) !== v) restoredKeys.push(key);
-          rawSet(key, v);
+          if (safeStorageGet(key) !== v) restoredKeys.push(key);
+          safeStorageSet(key, v);
         }
       } finally {
         _suppressPatch = false;
@@ -730,7 +727,13 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
   }
   const migratedCloud = applyMigrationsWithSchemaVersion(fresh.data, fresh.schemaVersion ?? 1);
   const merged = mergeCloudWithLocalDirty(migratedCloud.data, buildCloudBlob(), _dirtyKeys);
-  applyCloudBlob(merged, fresh.syncVersion);
+  if (!applyCloudBlob(merged, fresh.syncVersion)) {
+    // A usable store rejected part of the merge. Advancing the version here
+    // would let the next upload post the stale local values back over the
+    // cloud row we just fetched (#7833 review).
+    setState('error');
+    return false;
+  }
   setSyncVersion(fresh.syncVersion);
   setLocalSchemaVersion(migratedCloud.schemaVersion);
   const retry = await postCloudPrefs(token, variant, merged, fresh.syncVersion, migratedCloud.schemaVersion);
@@ -745,7 +748,7 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
   // write would durably corrupt their persisted dirty-key entry.
   setSyncVersion(retry.syncVersion);
   clearSettledDirtyKeys(merged);
-  rawSet(KEY_LAST_SYNC_AT, String(Date.now()));
+  safeStorageSet(KEY_LAST_SYNC_AT, String(Date.now()));
   setState('synced');
   return true;
 }
@@ -813,7 +816,13 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
         const toApply = hasDirty
           ? mergeCloudWithLocalDirty(migrated.data, buildCloudBlob(), _dirtyKeys)
           : migrated.data;
-        applyCloudBlob(toApply, cloud.syncVersion);
+        if (!applyCloudBlob(toApply, cloud.syncVersion)) {
+          // Same reasoning as resolveConflictWithMerge: a rejected write must
+          // not leave local claiming cloud's version over stale values.
+          setState('error');
+          completeSignInAttempt(attempt, 'error');
+          return;
+        }
         setSyncVersion(cloud.syncVersion);
         // An ambiguous schema-5 fingerprint deliberately stops at schema 4,
         // so the same row remains eligible for a future disambiguated retry.
@@ -822,7 +831,7 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
         // catches up — otherwise the migration re-runs every load) OR when we
         // merged in local dirty keys the cloud row doesn't have yet.
         if (migrationChanged || hasDirty) schedulePrefUpload(variant);
-        rawSet(KEY_LAST_SYNC_AT, String(Date.now()));
+        safeStorageSet(KEY_LAST_SYNC_AT, String(Date.now()));
 
         if (isFirstEverSync && prevBlobJson && Object.keys(cloud.data).length > 0) {
           showUndoToast(prevBlobJson);
@@ -857,13 +866,13 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
         } else {
           setSyncVersion(result.syncVersion);
           clearSettledDirtyKeys(prepared.data);
-          rawSet(KEY_LAST_SYNC_AT, String(Date.now()));
+          safeStorageSet(KEY_LAST_SYNC_AT, String(Date.now()));
           setState('synced');
         }
       }
 
       if (_authGeneration === myGeneration) {
-        rawSet(KEY_LAST_SIGNED_IN_AS, userId);
+        safeStorageSet(KEY_LAST_SIGNED_IN_AS, userId);
         completeSignInAttempt(attempt, 'synced');
       }
     } catch (err) {
@@ -996,8 +1005,8 @@ export function onSignOut(): void {
   _dirtyKeysUserId = null;
 
   // Preserve prefs; only clear sync metadata
-  rawRemove(KEY_SYNC_VERSION);
-  rawRemove(KEY_LAST_SYNC_AT);
+  safeStorageRemove(KEY_SYNC_VERSION);
+  safeStorageRemove(KEY_LAST_SYNC_AT);
   setState('signed-out');
 }
 
@@ -1050,7 +1059,7 @@ async function performUploadNow(variant: string): Promise<'completed' | 'retry-d
       // moved.
       setSyncVersion(result.syncVersion);
       clearSettledDirtyKeys(postedBlob);
-      rawSet(KEY_LAST_SYNC_AT, String(Date.now()));
+      safeStorageSet(KEY_LAST_SYNC_AT, String(Date.now()));
       setState('synced');
     }
   } catch (err) {
@@ -1137,11 +1146,11 @@ export async function syncNow(): Promise<void> {
 }
 
 export function getSyncState(): SyncState {
-  return (rawGet(KEY_SYNC_STATE) as SyncState) || 'signed-out';
+  return (safeStorageGet(KEY_SYNC_STATE) as SyncState) || 'signed-out';
 }
 
 export function getLastSyncAt(): number {
-  return parseInt(rawGet(KEY_LAST_SYNC_AT) ?? '0', 10) || 0;
+  return parseInt(safeStorageGet(KEY_LAST_SYNC_AT) ?? '0', 10) || 0;
 }
 
 // ── install ───────────────────────────────────────────────────────────────────
@@ -1181,7 +1190,7 @@ export function install(variant: string): void {
           _debounceTimer = null;
           setState('synced');
         }
-        rawSet(KEY_SYNC_VERSION, e.newValue);
+        safeStorageSet(KEY_SYNC_VERSION, e.newValue);
       }
     }
   });
@@ -1253,7 +1262,7 @@ export function install(variant: string): void {
           setSyncVersion,
           clearSettledDirtyKeys: () => clearSettledDirtyKeys(blob),
           setLastSyncAt: (timestampMs) => {
-            rawSet(KEY_LAST_SYNC_AT, String(timestampMs));
+            safeStorageSet(KEY_LAST_SYNC_AT, String(timestampMs));
           },
           // Only claim 'synced' when no newer edit re-armed the debounce AND no
           // uploadNow is active or queued (performUploadNow does not start

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -58,6 +58,7 @@ import { TimeoutError, withTimeout } from './with-timeout';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import {
   safeStorageGet,
+  safeStorageGetChecked,
   safeStorageRemove,
   safeStorageRemoveChecked,
   safeStorageSet,
@@ -300,8 +301,13 @@ function markDirtyKey(key: CloudSyncKey): void {
  * current local value.
  */
 function clearSettledDirtyKeys(postedBlob: Record<string, string>): void {
+  const current = buildCloudBlob();
+  // A key is settled iff the posted value still equals the CURRENT local value,
+  // so a failed re-read cannot answer that. Keeping the keys dirty costs one
+  // redundant upload; clearing them on a guess loses the edit.
+  if (current === null) return;
   const settled: string[] = [];
-  for (const key of settledDirtyKeys(postedBlob, buildCloudBlob(), _dirtyKeys)) {
+  for (const key of settledDirtyKeys(postedBlob, current, _dirtyKeys)) {
     if (_dirtyKeys.delete(key as CloudSyncKey)) settled.push(key);
   }
   if (settled.length > 0) persistSettledDirtyKeyRemovals(settled);
@@ -394,11 +400,22 @@ function setState(s: SyncState): void {
 
 // ── Blob helpers ──────────────────────────────────────────────────────────────
 
-function buildCloudBlob(): Record<string, string> {
+/**
+ * The local values to upload, or `null` when a read failed.
+ *
+ * The null return is load-bearing. This blob REPLACES the server's, and a key
+ * is omitted when its local value is absent — so a read that fails and degrades
+ * to `null` is indistinguishable from "the user cleared this", and the upload
+ * deletes a preference from the cloud that was only ever unreadable. The raw
+ * read here before #7833 threw and aborted the upload; `safeStorageGetChecked`
+ * restores that outcome without reintroducing the null-storage crash.
+ */
+function buildCloudBlob(): Record<string, string> | null {
   const blob: Record<string, string> = {};
   for (const key of CLOUD_SYNC_KEYS) {
-    const val = safeStorageGet(key);
-    if (val !== null) blob[key] = val;
+    const read = safeStorageGetChecked(key);
+    if (!read.ok) return null;
+    if (read.value !== null) blob[key] = read.value;
   }
   return blob;
 }
@@ -554,9 +571,10 @@ interface PreparedCloudBlob {
   schemaVersion: number;
 }
 
-function migrateLocalBlobIfNeeded(): PreparedCloudBlob {
+function migrateLocalBlobIfNeeded(): PreparedCloudBlob | null {
   const localSchema = getLocalSchemaVersion();
   const blob = buildCloudBlob();
+  if (blob === null) return null;
   if (localSchema >= CURRENT_PREFS_SCHEMA_VERSION) {
     return { data: blob, schemaVersion: CURRENT_PREFS_SCHEMA_VERSION };
   }
@@ -751,7 +769,14 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
     return false;
   }
   const migratedCloud = applyMigrationsWithSchemaVersion(fresh.data, fresh.schemaVersion ?? 1);
-  const merged = mergeCloudWithLocalDirty(migratedCloud.data, buildCloudBlob(), _dirtyKeys);
+  const localBlob = buildCloudBlob();
+  if (localBlob === null) {
+    // Merging against a partial local blob would drop the unread keys from the
+    // merge result, and this path re-posts that result.
+    setState('error');
+    return false;
+  }
+  const merged = mergeCloudWithLocalDirty(migratedCloud.data, localBlob, _dirtyKeys);
   if (!applyCloudBlob(merged, fresh.syncVersion)) {
     // A usable store rejected part of the merge. Advancing the version here
     // would let the next upload post the stale local values back over the
@@ -836,7 +861,15 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
 
       if (cloud && cloud.syncVersion > getSyncVersion()) {
         const isFirstEverSync = getSyncVersion() === 0;
-        const prevBlobJson = isFirstEverSync ? JSON.stringify(buildCloudBlob()) : null;
+        const localBlob = buildCloudBlob();
+        if (localBlob === null) {
+          // An unreadable local blob cannot be merged over, and the undo
+          // snapshot below would record an incomplete "previous" state.
+          setState('error');
+          completeSignInAttempt(attempt, 'error');
+          return;
+        }
+        const prevBlobJson = isFirstEverSync ? JSON.stringify(localBlob) : null;
 
         const cloudSchemaVersion = cloud.schemaVersion ?? 1;
         const migrated = applyMigrationsWithSchemaVersion(cloud.data, cloudSchemaVersion);
@@ -846,7 +879,7 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
         // those dirty keys over the cloud blob instead of clobbering them.
         const hasDirty = _dirtyKeys.size > 0;
         const toApply = hasDirty
-          ? mergeCloudWithLocalDirty(migrated.data, buildCloudBlob(), _dirtyKeys)
+          ? mergeCloudWithLocalDirty(migrated.data, localBlob, _dirtyKeys)
           : migrated.data;
         if (!applyCloudBlob(toApply, cloud.syncVersion)) {
           // Same reasoning as resolveConflictWithMerge: a rejected write must
@@ -882,6 +915,13 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
         // subsequent sign-ins and post the bad blob back at schema 2,
         // cementing the poisoning at the new schema).
         const prepared = migrateLocalBlobIfNeeded();
+        if (prepared === null) {
+          // A preference could not be read. Posting now would replace the
+          // server blob with one that omits it — a deletion, not an update.
+          setState('error');
+          completeSignInAttempt(attempt, 'error');
+          return;
+        }
         const result = await postCloudPrefs(
           token,
           variant,
@@ -1014,6 +1054,9 @@ export function onSignOut(): void {
     // the active operation / next sign-in remains the recovery path.
     if (!_syncOperations.busy) {
       const prepared = migrateLocalBlobIfNeeded();
+      // Best-effort flush, but "best effort" must not mean "post a blob that
+      // deletes an unreadable preference from the cloud". Skip instead.
+      if (prepared === null) return;
       const token = _cachedToken;
       void _syncOperations.run(async () => {
         await fetch('/api/user-prefs', {
@@ -1075,6 +1118,12 @@ async function performUploadNow(variant: string): Promise<'completed' | 'retry-d
     setState('syncing');
 
     const prepared = migrateLocalBlobIfNeeded();
+    if (prepared === null) {
+      // Same as the sign-in post path: an unreadable preference would be
+      // uploaded as an absent one, deleting it from the cloud row.
+      setState('error');
+      return 'stopped';
+    }
     const postedBlob = prepared.data;
     const result = await postCloudPrefs(
       token,
@@ -1261,6 +1310,7 @@ export function install(variant: string): void {
     // CURRENT_PREFS_SCHEMA_VERSION onto unmigrated local data, even on
     // best-effort unload flush.
     const prepared = migrateLocalBlobIfNeeded();
+    if (prepared === null) return;
     const blob = prepared.data;
     const myGeneration = _authGeneration;
     const payload = JSON.stringify({ variant: _currentVariant, data: blob, expectedSyncVersion: getSyncVersion(), schemaVersion: prepared.schemaVersion });

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -373,9 +373,19 @@ export function getSyncVersion(): number {
   return parseInt(safeStorageGet(KEY_SYNC_VERSION) ?? '0', 10) || 0;
 }
 
-function setSyncVersion(v: number): void {
+/**
+ * Record the durable sync version. Returns false when a usable store REJECTED
+ * the write.
+ *
+ * The marker is small, so a store that rejects it is nearly full — but the
+ * consequence is not cosmetic: callers follow this by settling dirty keys and
+ * reporting `synced`, and a stale durable version makes every later upload
+ * conflict and every reload re-reconcile. Same contract as applyCloudBlob's,
+ * for the same reason (#7833 review).
+ */
+function setSyncVersion(v: number): boolean {
   // A state key, not a pref key — nothing here should mark the blob dirty.
-  safeStorageSet(KEY_SYNC_VERSION, String(v));
+  return safeStorageSetChecked(KEY_SYNC_VERSION, String(v));
 }
 
 function setState(s: SyncState): void {
@@ -584,22 +594,37 @@ function showUndoToast(prevBlobJson: string): void {
   toast.addEventListener('click', (e) => {
     const action = (e.target as HTMLElement).closest('[data-action]')?.getAttribute('data-action');
     if (action === 'undo') {
+      // Same checked-write contract as applyCloudBlob, for the same reason: a
+      // rejected restore must not be announced as one. `restoredKeys` is built
+      // from a read taken BEFORE the write, so an unchecked write would tell
+      // every CLOUD_PREFS_APPLIED listener to re-read a key that still holds
+      // the cloud value — and dismissing the toast would take away the only
+      // affordance the user had to try again.
       const prev = JSON.parse(prevBlobJson) as Record<string, string>;
       const restoredKeys: CloudSyncKey[] = [];
+      let allRestored = true;
       _suppressPatch = true;
       try {
         for (const [k, v] of Object.entries(prev)) {
           if (!CLOUD_SYNC_KEYS.includes(k as CloudSyncKey)) continue;
           const key = k as CloudSyncKey;
-          if (safeStorageGet(key) !== v) restoredKeys.push(key);
-          safeStorageSet(key, v);
+          const wasDifferent = safeStorageGet(key) !== v;
+          if (safeStorageSetChecked(key, v)) {
+            if (wasDifferent) restoredKeys.push(key);
+          } else {
+            allRestored = false;
+          }
         }
       } finally {
         _suppressPatch = false;
       }
       dispatchCloudPrefsApplied(restoredKeys);
-      toast.remove();
-      clearTimeout(autoTimer);
+      // Leave the toast up when the undo did not fully land, so the action is
+      // still available; the 5s auto-dismiss timer still applies.
+      if (allRestored) {
+        toast.remove();
+        clearTimeout(autoTimer);
+      }
     } else if (action === 'dismiss') {
       toast.remove();
       clearTimeout(autoTimer);
@@ -734,7 +759,10 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
     setState('error');
     return false;
   }
-  setSyncVersion(fresh.syncVersion);
+  if (!setSyncVersion(fresh.syncVersion)) {
+    setState('error');
+    return false;
+  }
   setLocalSchemaVersion(migratedCloud.schemaVersion);
   const retry = await postCloudPrefs(token, variant, merged, fresh.syncVersion, migratedCloud.schemaVersion);
   if (_authGeneration !== callerGeneration) return false;
@@ -746,7 +774,11 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
   // signed-in user switched during the awaits above, do not clear/persist
   // settled dirty keys — _dirtyKeys now belongs to another user and the
   // write would durably corrupt their persisted dirty-key entry.
-  setSyncVersion(retry.syncVersion);
+  if (!setSyncVersion(retry.syncVersion)) {
+    // As above: do not settle dirty keys against a version that is not durable.
+    setState('error');
+    return false;
+  }
   clearSettledDirtyKeys(merged);
   safeStorageSet(KEY_LAST_SYNC_AT, String(Date.now()));
   setState('synced');
@@ -823,7 +855,11 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
           completeSignInAttempt(attempt, 'error');
           return;
         }
-        setSyncVersion(cloud.syncVersion);
+        if (!setSyncVersion(cloud.syncVersion)) {
+          setState('error');
+          completeSignInAttempt(attempt, 'error');
+          return;
+        }
         // An ambiguous schema-5 fingerprint deliberately stops at schema 4,
         // so the same row remains eligible for a future disambiguated retry.
         setLocalSchemaVersion(migrated.schemaVersion);
@@ -863,11 +899,17 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
             completeSignInAttempt(attempt, 'error');
             return;
           }
-        } else {
-          setSyncVersion(result.syncVersion);
+        } else if (setSyncVersion(result.syncVersion)) {
           clearSettledDirtyKeys(prepared.data);
           safeStorageSet(KEY_LAST_SYNC_AT, String(Date.now()));
           setState('synced');
+        } else {
+        // The durable marker did not land. Settling dirty keys and reporting
+        // synced on top of a stale version would claim a reconciliation that
+        // is not persisted (#7833 review).
+          setState('error');
+          completeSignInAttempt(attempt, 'error');
+          return;
         }
       }
 
@@ -1057,7 +1099,12 @@ async function performUploadNow(variant: string): Promise<'completed' | 'retry-d
       // user's dirty-key entry using this upload's stale postedBlob. Match the
       // 503 retry branch and the flush-success path — bail if the generation
       // moved.
-      setSyncVersion(result.syncVersion);
+      if (!setSyncVersion(result.syncVersion)) {
+        // Same contract as the sign-in branch: a stale durable version must not
+        // be reported as synced with its dirty keys settled.
+        setState('error');
+        return 'stopped';
+      }
       clearSettledDirtyKeys(postedBlob);
       safeStorageSet(KEY_LAST_SYNC_AT, String(Date.now()));
       setState('synced');

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -874,11 +874,13 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
     setState('error');
     return false;
   }
-  if (!setSyncVersion(fresh.syncVersion)) {
+  // Same ordering rule as the sign-in path: schema marker first, so a rejected
+  // marker cannot leave the sync version claiming a reconciliation happened.
+  if (!setLocalSchemaVersion(migratedCloud.schemaVersion)) {
     setState('error');
     return false;
   }
-  if (!setLocalSchemaVersion(migratedCloud.schemaVersion)) {
+  if (!setSyncVersion(fresh.syncVersion)) {
     setState('error');
     return false;
   }
@@ -989,14 +991,21 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
           completeSignInAttempt(attempt, 'error');
           return;
         }
-        if (!setSyncVersion(cloud.syncVersion)) {
+        // ORDER IS LOAD-BEARING: the schema marker persists BEFORE the sync
+        // version. Both writes are checked, but advancing the version first
+        // leaves a durable claim that this cloud generation was reconciled
+        // while the schema marker is still old — and the next sign-in sees
+        // equal versions, takes the local-upload branch, and reruns one-shot
+        // migrations over already-migrated data (#7833 review).
+        //
+        // An ambiguous schema-5 fingerprint deliberately stops at schema 4,
+        // so the same row remains eligible for a future disambiguated retry.
+        if (!setLocalSchemaVersion(migrated.schemaVersion)) {
           setState('error');
           completeSignInAttempt(attempt, 'error');
           return;
         }
-        // An ambiguous schema-5 fingerprint deliberately stops at schema 4,
-        // so the same row remains eligible for a future disambiguated retry.
-        if (!setLocalSchemaVersion(migrated.schemaVersion)) {
+        if (!setSyncVersion(cloud.syncVersion)) {
           setState('error');
           completeSignInAttempt(attempt, 'error');
           return;
@@ -1365,7 +1374,13 @@ export async function syncNow(): Promise<void> {
 // (preferences-content.ts) and nothing else — no branch, no upload, no
 // reconciliation. A failed read renders "Signed out / Never", which is a
 // degraded DISPLAY rather than a wrong decision, so a checked read here would
-// buy nothing. Every read that feeds a decision uses safeStorageGetChecked.
+// buy nothing.
+//
+// Narrower claim than an earlier round of this branch made: the reads that feed
+// a decision are checked, but `getSyncVersion()` deliberately still degrades
+// for the four `expectedSyncVersion` POST bodies, where a wrong value returns
+// 409 and routes into the merge path — loud and self-correcting, unlike the
+// storage-event cancellation, which is checked.
 
 export function getSyncState(): SyncState {
   return (safeStorageGet(KEY_SYNC_STATE) as SyncState) || 'signed-out';
@@ -1406,7 +1421,13 @@ export function install(variant: string): void {
   window.addEventListener('storage', (e) => {
     if (e.key === KEY_SYNC_VERSION && e.newValue !== null) {
       const newV = parseInt(e.newValue, 10);
-      if (newV > getSyncVersion()) {
+      // Checked, because this CANCELS a pending upload. Degrading to 0 makes
+      // any other tab's version look newer, so this tab's debounced local edit
+      // is dropped and reported as synced — silently, unlike the POST sites,
+      // where a wrong expectedSyncVersion returns 409 and routes into the
+      // merge path (#7833 review).
+      const localVersion = getSyncVersionChecked();
+      if (localVersion !== null && newV > localVersion) {
         if (_debounceTimer !== null) {
           clearTimeout(_debounceTimer);
           _debounceTimer = null;

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -210,17 +210,17 @@ let _dirtyKeysUserId: string | null = null;
  */
 function writePersistedDirtyKeys(payload: { userId: string; keys: string[] }): void {
   if (payload.keys.length === 0) {
-    Storage.prototype.removeItem.call(localStorage, KEY_DIRTY_KEYS);
+    rawRemove(KEY_DIRTY_KEYS);
     return;
   }
-  Storage.prototype.setItem.call(localStorage, KEY_DIRTY_KEYS, JSON.stringify(payload));
+  rawSet(KEY_DIRTY_KEYS, JSON.stringify(payload));
 }
 
 function persistDirtyKeyAddition(key: CloudSyncKey): void {
   if (!_dirtyKeysUserId) return;
   try {
     writePersistedDirtyKeys(unionPersistedDirtyKeys(
-      localStorage.getItem(KEY_DIRTY_KEYS),
+      rawGet(KEY_DIRTY_KEYS),
       CLOUD_SYNC_KEYS,
       _dirtyKeysUserId,
       [key],
@@ -234,7 +234,7 @@ function persistSettledDirtyKeyRemovals(removals: string[]): void {
   if (!_dirtyKeysUserId) return;
   try {
     writePersistedDirtyKeys(withoutPersistedDirtyKeys(
-      localStorage.getItem(KEY_DIRTY_KEYS),
+      rawGet(KEY_DIRTY_KEYS),
       CLOUD_SYNC_KEYS,
       _dirtyKeysUserId,
       removals,
@@ -247,11 +247,11 @@ function persistSettledDirtyKeyRemovals(removals: string[]): void {
 function persistDirtyKeys(): void {
   try {
     if (_dirtyKeys.size === 0) {
-      Storage.prototype.removeItem.call(localStorage, KEY_DIRTY_KEYS);
+      rawRemove(KEY_DIRTY_KEYS);
       return;
     }
     if (!_dirtyKeysUserId) return;
-    Storage.prototype.setItem.call(localStorage, KEY_DIRTY_KEYS, JSON.stringify({
+    rawSet(KEY_DIRTY_KEYS, JSON.stringify({
       userId: _dirtyKeysUserId,
       keys: [..._dirtyKeys],
     }));
@@ -264,7 +264,7 @@ function hydrateDirtyKeysFromStorage(userId: string): void {
   try {
     _dirtyKeys.clear();
     _dirtyKeysUserId = userId;
-    const raw = localStorage.getItem(KEY_DIRTY_KEYS);
+    const raw = rawGet(KEY_DIRTY_KEYS);
     for (const key of parsePersistedDirtyKeys(raw, CLOUD_SYNC_KEYS, userId)) {
       _dirtyKeys.add(key as CloudSyncKey);
     }
@@ -360,19 +360,60 @@ export function isCloudSyncEnabled(): boolean {
   return isEnabled();
 }
 
+// ── Storage accessors ─────────────────────────────────────────────────────────
+
+/**
+ * This module's `localStorage` accessors. Android WebView with DOM storage
+ * disabled exposes `localStorage` as NULL rather than throwing, so an
+ * unguarded call is a TypeError — and `onSignIn` runs its ownership-sidecar
+ * reconciliation on the boot path, where that TypeError takes the whole
+ * sign-in down (#7833, the same class as WORLDMONITOR-122).
+ *
+ * These are deliberately NOT `@/utils/safe-storage`. The writes go through
+ * `Storage.prototype` so an own-property override on the `localStorage`
+ * instance cannot intercept them, which is what lets a state-key write stay
+ * distinguishable from the pref-key writes `install()` patches. Reads degrade
+ * to "key absent" and writes to a no-op, matching the shared helper's contract.
+ */
+function rawGet(key: string): string | null {
+  try {
+    return localStorage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function rawSet(key: string, value: string): void {
+  try {
+    if (!localStorage) return;
+    Storage.prototype.setItem.call(localStorage, key, value);
+  } catch {
+    /* storage unavailable or full */
+  }
+}
+
+function rawRemove(key: string): void {
+  try {
+    if (!localStorage) return;
+    Storage.prototype.removeItem.call(localStorage, key);
+  } catch {
+    /* storage unavailable */
+  }
+}
+
 // ── State helpers ─────────────────────────────────────────────────────────────
 
 export function getSyncVersion(): number {
-  return parseInt(localStorage.getItem(KEY_SYNC_VERSION) ?? '0', 10) || 0;
+  return parseInt(rawGet(KEY_SYNC_VERSION) ?? '0', 10) || 0;
 }
 
 function setSyncVersion(v: number): void {
-  // Use direct Storage.prototype.setItem to bypass our patch (state key, not a pref key)
-  Storage.prototype.setItem.call(localStorage, KEY_SYNC_VERSION, String(v));
+  // A state key, not a pref key — nothing here should mark the blob dirty.
+  rawSet(KEY_SYNC_VERSION, String(v));
 }
 
 function setState(s: SyncState): void {
-  Storage.prototype.setItem.call(localStorage, KEY_SYNC_STATE, s);
+  rawSet(KEY_SYNC_STATE, s);
 }
 
 // ── Blob helpers ──────────────────────────────────────────────────────────────
@@ -380,7 +421,7 @@ function setState(s: SyncState): void {
 function buildCloudBlob(): Record<string, string> {
   const blob: Record<string, string> = {};
   for (const key of CLOUD_SYNC_KEYS) {
-    const val = localStorage.getItem(key);
+    const val = rawGet(key);
     if (val !== null) blob[key] = val;
   }
   return blob;
@@ -415,7 +456,7 @@ function dispatchCloudPrefsSignInTerminal(
 }
 
 function clearForeignOwnershipSidecars(userId: string): void {
-  const lastSignedInAs = localStorage.getItem(KEY_LAST_SIGNED_IN_AS);
+  const lastSignedInAs = rawGet(KEY_LAST_SIGNED_IN_AS);
   if (lastSignedInAs === null || lastSignedInAs === userId) return;
 
   // Preferences intentionally survive sign-out, but ownership sidecars are
@@ -423,7 +464,7 @@ function clearForeignOwnershipSidecars(userId: string): void {
   // keeping the prior account's local values attributes A's gate decisions to
   // B. B's explicit cloud values will still be applied later in this attempt.
   for (const key of ACCOUNT_PROVENANCE_SYNC_KEYS) {
-    Storage.prototype.removeItem.call(localStorage, key);
+    rawRemove(key);
   }
 }
 
@@ -438,11 +479,11 @@ function applyCloudBlob(data: Record<string, unknown>, syncVersion?: number): vo
       const action = resolveCloudBlobKeyAction(key, data);
       if (action.kind === 'keep') continue;
       if (action.kind === 'set') {
-        if (localStorage.getItem(key) !== action.value) changedKeys.push(key);
-        localStorage.setItem(key, action.value);
+        if (rawGet(key) !== action.value) changedKeys.push(key);
+        rawSet(key, action.value);
       } else {
-        if (localStorage.getItem(key) !== null) changedKeys.push(key);
-        localStorage.removeItem(key);
+        if (rawGet(key) !== null) changedKeys.push(key);
+        rawRemove(key);
       }
     }
   } finally {
@@ -483,14 +524,14 @@ function applyMigrationsWithSchemaVersion(
 }
 
 function getLocalSchemaVersion(): number {
-  const raw = localStorage.getItem(KEY_LOCAL_SCHEMA_VERSION);
+  const raw = rawGet(KEY_LOCAL_SCHEMA_VERSION);
   if (raw === null) return 1; // No marker yet → assume oldest, run migrations
   const v = parseInt(raw, 10);
   return Number.isFinite(v) && v > 0 ? v : 1;
 }
 
 function setLocalSchemaVersion(v: number): void {
-  Storage.prototype.setItem.call(localStorage, KEY_LOCAL_SCHEMA_VERSION, String(v));
+  rawSet(KEY_LOCAL_SCHEMA_VERSION, String(v));
 }
 
 /**
@@ -553,8 +594,8 @@ function showUndoToast(prevBlobJson: string): void {
         for (const [k, v] of Object.entries(prev)) {
           if (!CLOUD_SYNC_KEYS.includes(k as CloudSyncKey)) continue;
           const key = k as CloudSyncKey;
-          if (localStorage.getItem(key) !== v) restoredKeys.push(key);
-          localStorage.setItem(key, v);
+          if (rawGet(key) !== v) restoredKeys.push(key);
+          rawSet(key, v);
         }
       } finally {
         _suppressPatch = false;
@@ -704,7 +745,7 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
   // write would durably corrupt their persisted dirty-key entry.
   setSyncVersion(retry.syncVersion);
   clearSettledDirtyKeys(merged);
-  Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+  rawSet(KEY_LAST_SYNC_AT, String(Date.now()));
   setState('synced');
   return true;
 }
@@ -781,7 +822,7 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
         // catches up — otherwise the migration re-runs every load) OR when we
         // merged in local dirty keys the cloud row doesn't have yet.
         if (migrationChanged || hasDirty) schedulePrefUpload(variant);
-        Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+        rawSet(KEY_LAST_SYNC_AT, String(Date.now()));
 
         if (isFirstEverSync && prevBlobJson && Object.keys(cloud.data).length > 0) {
           showUndoToast(prevBlobJson);
@@ -816,13 +857,13 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
         } else {
           setSyncVersion(result.syncVersion);
           clearSettledDirtyKeys(prepared.data);
-          Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+          rawSet(KEY_LAST_SYNC_AT, String(Date.now()));
           setState('synced');
         }
       }
 
       if (_authGeneration === myGeneration) {
-        Storage.prototype.setItem.call(localStorage, KEY_LAST_SIGNED_IN_AS, userId);
+        rawSet(KEY_LAST_SIGNED_IN_AS, userId);
         completeSignInAttempt(attempt, 'synced');
       }
     } catch (err) {
@@ -955,8 +996,8 @@ export function onSignOut(): void {
   _dirtyKeysUserId = null;
 
   // Preserve prefs; only clear sync metadata
-  localStorage.removeItem(KEY_SYNC_VERSION);
-  localStorage.removeItem(KEY_LAST_SYNC_AT);
+  rawRemove(KEY_SYNC_VERSION);
+  rawRemove(KEY_LAST_SYNC_AT);
   setState('signed-out');
 }
 
@@ -1009,7 +1050,7 @@ async function performUploadNow(variant: string): Promise<'completed' | 'retry-d
       // moved.
       setSyncVersion(result.syncVersion);
       clearSettledDirtyKeys(postedBlob);
-      Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+      rawSet(KEY_LAST_SYNC_AT, String(Date.now()));
       setState('synced');
     }
   } catch (err) {
@@ -1096,11 +1137,11 @@ export async function syncNow(): Promise<void> {
 }
 
 export function getSyncState(): SyncState {
-  return (localStorage.getItem(KEY_SYNC_STATE) as SyncState) || 'signed-out';
+  return (rawGet(KEY_SYNC_STATE) as SyncState) || 'signed-out';
 }
 
 export function getLastSyncAt(): number {
-  return parseInt(localStorage.getItem(KEY_LAST_SYNC_AT) ?? '0', 10) || 0;
+  return parseInt(rawGet(KEY_LAST_SYNC_AT) ?? '0', 10) || 0;
 }
 
 // ── install ───────────────────────────────────────────────────────────────────
@@ -1140,7 +1181,7 @@ export function install(variant: string): void {
           _debounceTimer = null;
           setState('synced');
         }
-        Storage.prototype.setItem.call(localStorage, KEY_SYNC_VERSION, e.newValue);
+        rawSet(KEY_SYNC_VERSION, e.newValue);
       }
     }
   });
@@ -1212,7 +1253,7 @@ export function install(variant: string): void {
           setSyncVersion,
           clearSettledDirtyKeys: () => clearSettledDirtyKeys(blob),
           setLastSyncAt: (timestampMs) => {
-            Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(timestampMs));
+            rawSet(KEY_LAST_SYNC_AT, String(timestampMs));
           },
           // Only claim 'synced' when no newer edit re-armed the debounce AND no
           // uploadNow is active or queued (performUploadNow does not start

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -536,17 +536,31 @@ function applyCloudBlob(data: Record<string, unknown>, syncVersion?: number): bo
       // client during rolling deployments. See resolveCloudBlobKeyAction.
       const action = resolveCloudBlobKeyAction(key, data);
       if (action.kind === 'keep') continue;
+      // The pre-read decides whether to ANNOUNCE the key, and a failed read
+      // degrading to null answers wrongly in both directions: a `set` looks
+      // different when it was not, and a `remove` looks absent when it was
+      // present — so the deletion lands but is never announced, and consumers
+      // keep serving the removed preference until a reload (#7833 review).
+      //
+      // On an undeterminable pre-read this ANNOUNCES the key rather than
+      // aborting, which is a deliberate departure from the suggested fix. The
+      // write itself is separately checked, so storage is already correct; a
+      // spurious announcement just makes consumers re-read a key that did not
+      // change, which is a no-op. Aborting would fail a whole reconciliation
+      // over a recoverable read, and announcing self-heals.
       if (action.kind === 'set') {
-        const wasDifferent = safeStorageGet(key) !== action.value;
+        const before = safeStorageGetChecked(key);
+        const shouldAnnounce = !before.ok || before.value !== action.value;
         if (safeStorageSetChecked(key, action.value)) {
-          if (wasDifferent) changedKeys.push(key);
+          if (shouldAnnounce) changedKeys.push(key);
         } else {
           allWritesLanded = false;
         }
       } else {
-        const wasPresent = safeStorageGet(key) !== null;
+        const before = safeStorageGetChecked(key);
+        const shouldAnnounce = !before.ok || before.value !== null;
         if (safeStorageRemoveChecked(key)) {
-          if (wasPresent) changedKeys.push(key);
+          if (shouldAnnounce) changedKeys.push(key);
         } else {
           allWritesLanded = false;
         }
@@ -700,9 +714,11 @@ function showUndoToast(prevBlobJson: string): void {
         for (const [k, v] of Object.entries(prev)) {
           if (!CLOUD_SYNC_KEYS.includes(k as CloudSyncKey)) continue;
           const key = k as CloudSyncKey;
-          const wasDifferent = safeStorageGet(key) !== v;
+          // Same announce-on-doubt rule as applyCloudBlob above.
+          const before = safeStorageGetChecked(key);
+          const shouldAnnounce = !before.ok || before.value !== v;
           if (safeStorageSetChecked(key, v)) {
-            if (wasDifferent) restoredKeys.push(key);
+            if (shouldAnnounce) restoredKeys.push(key);
           } else {
             allRestored = false;
           }
@@ -1343,6 +1359,13 @@ export async function syncNow(): Promise<void> {
   }
   await uploadNow(_currentVariant);
 }
+
+// The last two DEGRADING reads in this module, and deliberately so. Both feed
+// the settings panel's status dot, label, and "Last synced" line
+// (preferences-content.ts) and nothing else — no branch, no upload, no
+// reconciliation. A failed read renders "Signed out / Never", which is a
+// degraded DISPLAY rather than a wrong decision, so a checked read here would
+// buy nothing. Every read that feeds a decision uses safeStorageGetChecked.
 
 export function getSyncState(): SyncState {
   return (safeStorageGet(KEY_SYNC_STATE) as SyncState) || 'signed-out';

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -199,6 +199,9 @@ let _cachedToken: string | null = null; // synchronous token cache for flush()
 // SETTLED ones. See resolveConflictWithMerge + mergeCloudWithLocalDirty.
 const _dirtyKeys = new Set<CloudSyncKey>();
 let _dirtyKeysUserId: string | null = null;
+// Whether the persisted dirty-key sidecar was successfully READ this session.
+// An empty in-memory set means 'nothing pending' only when this is true.
+let _dirtyKeysHydrated = false;
 
 /**
  * #4746: persistDirtyKeys used to serialize only THIS tab's in-memory set,
@@ -265,6 +268,9 @@ function persistSettledDirtyKeyRemovals(removals: string[]): void {
 
 function persistDirtyKeys(): void {
   try {
+    // Removing on an empty set is only safe when the set is trustworthy — i.e.
+    // we actually read the sidecar. Otherwise this deletes markers we never saw.
+    if (_dirtyKeys.size === 0 && !_dirtyKeysHydrated) return;
     if (_dirtyKeys.size === 0) {
       safeStorageRemove(KEY_DIRTY_KEYS);
       return;
@@ -283,7 +289,13 @@ function hydrateDirtyKeysFromStorage(userId: string): void {
   try {
     _dirtyKeys.clear();
     _dirtyKeysUserId = userId;
-    const raw = safeStorageGet(KEY_DIRTY_KEYS);
+    // Not review-reported; found auditing the rest of this class. A failed read
+    // degrades to "no persisted markers", and the empty in-memory set is then
+    // treated as authoritative — so the sign-out `persistDirtyKeys()` REMOVES
+    // the sidecar and another tab's unsynced edits lose their markers.
+    const read = safeStorageGetChecked(KEY_DIRTY_KEYS);
+    _dirtyKeysHydrated = read.ok;
+    const raw = read.value;
     for (const key of parsePersistedDirtyKeys(raw, CLOUD_SYNC_KEYS, userId)) {
       _dirtyKeys.add(key as CloudSyncKey);
     }
@@ -387,7 +399,21 @@ export function isCloudSyncEnabled(): boolean {
 // ── State helpers ─────────────────────────────────────────────────────────────
 
 export function getSyncVersion(): number {
-  return parseInt(safeStorageGet(KEY_SYNC_VERSION) ?? '0', 10) || 0;
+  return getSyncVersionChecked() ?? 0;
+}
+
+/**
+ * The durable sync version, or `null` when it could not be READ.
+ *
+ * Also not review-reported. Degrading to 0 means "never synced", which decides
+ * two things wrongly at once: `cloud.syncVersion > getSyncVersion()` becomes
+ * true so the cloud blob is applied OVER local edits, and `isFirstEverSync`
+ * becomes true so the undo toast snapshots a "previous" state that is not one.
+ */
+function getSyncVersionChecked(): number | null {
+  const read = safeStorageGetChecked(KEY_SYNC_VERSION);
+  if (!read.ok) return null;
+  return parseInt(read.value ?? '0', 10) || 0;
 }
 
 /**
@@ -459,17 +485,29 @@ function dispatchCloudPrefsSignInTerminal(
   ));
 }
 
-function clearForeignOwnershipSidecars(userId: string): void {
-  const lastSignedInAs = safeStorageGet(KEY_LAST_SIGNED_IN_AS);
-  if (lastSignedInAs === null || lastSignedInAs === userId) return;
+/**
+ * Returns false when prior-account ownership could not be DETERMINED.
+ *
+ * Absent legitimately means "no prior account, nothing to clear". A failed read
+ * degrading to null is indistinguishable from that, and skipping the cleanup on
+ * an account transition leaves account A's ownership sidecars in place for B —
+ * so tier reconciliation attributes A's gate decisions to B (#7833 review).
+ * Provenance is exactly the kind of question to fail closed on.
+ */
+function clearForeignOwnershipSidecars(userId: string): boolean {
+  const read = safeStorageGetChecked(KEY_LAST_SIGNED_IN_AS);
+  if (!read.ok) return false;
+  const lastSignedInAs = read.value;
+  if (lastSignedInAs === null || lastSignedInAs === userId) return true;
 
   // Preferences intentionally survive sign-out, but ownership sidecars are
   // account provenance. If the next account has a legacy row that omits them,
   // keeping the prior account's local values attributes A's gate decisions to
   // B. B's explicit cloud values will still be applied later in this attempt.
   for (const key of ACCOUNT_PROVENANCE_SYNC_KEYS) {
-    safeStorageRemove(key);
+    if (!safeStorageRemoveChecked(key)) return false;
   }
+  return true;
 }
 
 /**
@@ -552,10 +590,20 @@ function applyMigrationsWithSchemaVersion(
   return { ...migrated, dataChanged: migrated.data !== data };
 }
 
-function getLocalSchemaVersion(): number {
-  const raw = safeStorageGet(KEY_LOCAL_SCHEMA_VERSION);
-  if (raw === null) return 1; // No marker yet → assume oldest, run migrations
-  const v = parseInt(raw, 10);
+/**
+ * The schema the local blob has reached, or `null` when the marker could not be
+ * READ.
+ *
+ * An absent marker legitimately means "assume oldest, run migrations". A failed
+ * read looks identical after degrading to null — and reruns one-shot migrations
+ * over already-migrated data, where schema 2 re-enables a whole source category
+ * the user may have deliberately disabled since (#7833 review).
+ */
+function getLocalSchemaVersion(): number | null {
+  const read = safeStorageGetChecked(KEY_LOCAL_SCHEMA_VERSION);
+  if (!read.ok) return null;
+  if (read.value === null) return 1; // No marker yet → assume oldest, run migrations
+  const v = parseInt(read.value, 10);
   return Number.isFinite(v) && v > 0 ? v : 1;
 }
 
@@ -593,6 +641,7 @@ interface PreparedCloudBlob {
 
 function migrateLocalBlobIfNeeded(): PreparedCloudBlob | null {
   const localSchema = getLocalSchemaVersion();
+  if (localSchema === null) return null;
   const blob = buildCloudBlob();
   if (blob === null) return null;
   if (localSchema >= CURRENT_PREFS_SCHEMA_VERSION) {
@@ -601,18 +650,17 @@ function migrateLocalBlobIfNeeded(): PreparedCloudBlob | null {
   const migrated = applyMigrationsWithSchemaVersion(blob, localSchema);
   const migratedData = migrated.data as Record<string, string>;
   if (migratedData !== blob && !applyCloudBlob(migratedData)) {
-    // The migrated blob did not land. Recording the new schema version anyway
-    // would cement the unmigrated local data at the new version — the exact
-    // poisoning KEY_LOCAL_SCHEMA_VERSION exists to prevent. Post what we have
-    // at the OLD version so the next attempt migrates again.
-    return { data: blob, schemaVersion: localSchema };
+    // The migrated blob did not land, so the local state is neither the old
+    // snapshot nor the new one. Returning `blob` here — as an earlier round of
+    // this fix did — hands callers a VALID PreparedCloudBlob, which they then
+    // POST, advance the sync version for, and report as synced.
+    return null;
   }
   if (!setLocalSchemaVersion(migrated.schemaVersion)) {
-    // The marker did not persist, so the migration is not durably recorded.
-    // Posting at the NEW version would tell the cloud the data is migrated
-    // while the local marker still says otherwise, and the next load would run
-    // one-shot migrations again over already-migrated data.
-    return { data: blob, schemaVersion: localSchema };
+    // Storage took the migrated preference writes but rejected the marker, so
+    // `blob` is now a stale pre-migration snapshot. Posting it would overwrite
+    // the cloud with values the migration already replaced.
+    return null;
   }
   return { data: migratedData, schemaVersion: migrated.schemaVersion };
 }
@@ -888,8 +936,16 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
       const cloud = await fetchCloudPrefs(token, variant);
       if (_authGeneration !== myGeneration) return;
 
-      if (cloud && cloud.syncVersion > getSyncVersion()) {
-        const isFirstEverSync = getSyncVersion() === 0;
+      const localVersion = getSyncVersionChecked();
+      if (localVersion === null) {
+        // Cannot tell whether cloud is ahead. Applying it on a guess overwrites
+        // local edits; treating it as first-ever sync fabricates an undo state.
+        setState('error');
+        completeSignInAttempt(attempt, 'error');
+        return;
+      }
+      if (cloud && cloud.syncVersion > localVersion) {
+        const isFirstEverSync = localVersion === 0;
         const localBlob = buildCloudBlob();
         if (localBlob === null) {
           // An unreadable local blob cannot be merged over, and the undo
@@ -1056,7 +1112,19 @@ export function onSignIn(
   // Ownership sidecars describe which changes a particular account's gate
   // produced. Preserve them for a same-account legacy cloud row, but never
   // carry them across an observed account transition.
-  clearForeignOwnershipSidecars(userId);
+  if (!clearForeignOwnershipSidecars(userId)) {
+    // Provenance is undeterminable, so proceeding could attribute the previous
+    // account's gate decisions to this one. Report a terminal error rather than
+    // reconcile on a guess.
+    setState('error');
+    dispatchCloudPrefsSignInTerminal(
+      userId,
+      myGeneration,
+      options.handoffGeneration,
+      'error',
+    );
+    return Promise.resolve();
+  }
 
   // Establish dirty-key ownership synchronously. Preference writes may happen
   // while this sign-in waits behind an older queued writer; hydrating inside

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -227,8 +227,15 @@ function writePersistedDirtyKeys(payload: { userId: string; keys: string[] }): v
 function persistDirtyKeyAddition(key: CloudSyncKey): void {
   if (!_dirtyKeysUserId) return;
   try {
+    // Read-modify-write over a sidecar SHARED with other tabs. A read that
+    // degrades to null makes the union treat the persisted set as empty, so the
+    // write replaces another tab's durable markers with just this key and its
+    // unsynced edits become overwritable. Abandon the update instead — the
+    // in-memory set still guards this page view (#7833 review).
+    const existing = safeStorageGetChecked(KEY_DIRTY_KEYS);
+    if (!existing.ok) return;
     writePersistedDirtyKeys(unionPersistedDirtyKeys(
-      safeStorageGet(KEY_DIRTY_KEYS),
+      existing.value,
       CLOUD_SYNC_KEYS,
       _dirtyKeysUserId,
       [key],
@@ -241,8 +248,12 @@ function persistDirtyKeyAddition(key: CloudSyncKey): void {
 function persistSettledDirtyKeyRemovals(removals: string[]): void {
   if (!_dirtyKeysUserId) return;
   try {
+    // Same shared-sidecar hazard as the addition path: a failed read here would
+    // settle the set down to empty, dropping another tab's pending markers.
+    const existing = safeStorageGetChecked(KEY_DIRTY_KEYS);
+    if (!existing.ok) return;
     writePersistedDirtyKeys(withoutPersistedDirtyKeys(
-      safeStorageGet(KEY_DIRTY_KEYS),
+      existing.value,
       CLOUD_SYNC_KEYS,
       _dirtyKeysUserId,
       removals,
@@ -548,8 +559,17 @@ function getLocalSchemaVersion(): number {
   return Number.isFinite(v) && v > 0 ? v : 1;
 }
 
-function setLocalSchemaVersion(v: number): void {
-  safeStorageSet(KEY_LOCAL_SCHEMA_VERSION, String(v));
+/**
+ * Record the schema the LOCAL blob has reached. Returns false when a usable
+ * store rejected the write.
+ *
+ * Same contract as setSyncVersion, and the consequence of skipping it is worse:
+ * a stale marker makes one-shot migrations run again, and schema 2 re-enables
+ * a whole source category — which a user may have deliberately disabled after
+ * the first migration ran (#7833 review).
+ */
+function setLocalSchemaVersion(v: number): boolean {
+  return safeStorageSetChecked(KEY_LOCAL_SCHEMA_VERSION, String(v));
 }
 
 /**
@@ -587,7 +607,13 @@ function migrateLocalBlobIfNeeded(): PreparedCloudBlob | null {
     // at the OLD version so the next attempt migrates again.
     return { data: blob, schemaVersion: localSchema };
   }
-  setLocalSchemaVersion(migrated.schemaVersion);
+  if (!setLocalSchemaVersion(migrated.schemaVersion)) {
+    // The marker did not persist, so the migration is not durably recorded.
+    // Posting at the NEW version would tell the cloud the data is migrated
+    // while the local marker still says otherwise, and the next load would run
+    // one-shot migrations again over already-migrated data.
+    return { data: blob, schemaVersion: localSchema };
+  }
   return { data: migratedData, schemaVersion: migrated.schemaVersion };
 }
 
@@ -788,7 +814,10 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
     setState('error');
     return false;
   }
-  setLocalSchemaVersion(migratedCloud.schemaVersion);
+  if (!setLocalSchemaVersion(migratedCloud.schemaVersion)) {
+    setState('error');
+    return false;
+  }
   const retry = await postCloudPrefs(token, variant, merged, fresh.syncVersion, migratedCloud.schemaVersion);
   if (_authGeneration !== callerGeneration) return false;
   if ('conflict' in retry) {
@@ -895,7 +924,11 @@ function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
         }
         // An ambiguous schema-5 fingerprint deliberately stops at schema 4,
         // so the same row remains eligible for a future disambiguated retry.
-        setLocalSchemaVersion(migrated.schemaVersion);
+        if (!setLocalSchemaVersion(migrated.schemaVersion)) {
+          setState('error');
+          completeSignInAttempt(attempt, 'error');
+          return;
+        }
         // Force an upload when the cloud row's schemaVersion is behind (so it
         // catches up — otherwise the migration re-runs every load) OR when we
         // merged in local dirty keys the cloud row doesn't have yet.
@@ -1055,10 +1088,12 @@ export function onSignOut(): void {
     if (!_syncOperations.busy) {
       const prepared = migrateLocalBlobIfNeeded();
       // Best-effort flush, but "best effort" must not mean "post a blob that
-      // deletes an unreadable preference from the cloud". Skip instead.
-      if (prepared === null) return;
+      // deletes an unreadable preference from the cloud". Skip the FLUSH only —
+      // returning here would abandon the sign-out cleanup below, leaving the
+      // auth generation un-bumped, the retry timers live, and `_cachedToken`
+      // holding the signed-out user's token for a later unload handler to use.
       const token = _cachedToken;
-      void _syncOperations.run(async () => {
+      if (prepared !== null) void _syncOperations.run(async () => {
         await fetch('/api/user-prefs', {
           method: 'POST',
           keepalive: true,

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -42,6 +42,62 @@ export function safeStorageRemove(key: string): void {
 }
 
 /**
+ * Whether storage is reachable at all right now.
+ *
+ * For the callers that must tell "storage is empty" apart from "storage is
+ * unusable". Most callers should not need this — degrading to "key absent" is
+ * the whole point of the accessors above — but a caller whose UI reports
+ * SUCCESS does: settings export handed the user an empty file and a green
+ * "Exported" toast on a browser where nothing could be read (#7833 review).
+ */
+export function isStorageAvailable(): boolean {
+  try {
+    return !!localStorage;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Like `safeStorageSet`, but reports whether the value actually landed.
+ *
+ * Swallowing every failure is right for a best-effort flag and WRONG for a
+ * caller that goes on to record durable state describing what it just wrote.
+ * Cloud-prefs applies a downloaded blob and then advances the local sync
+ * version; when a `QuotaExceededError` silently dropped one of those writes the
+ * version advanced anyway, so the next upload posted the STALE local value back
+ * over good cloud data. That is silent data loss, and it is why this variant
+ * exists (#7833 review).
+ *
+ * Returns `false` ONLY when a usable store rejected the write. A browser with
+ * no usable storage at all returns `true`: nothing was written, but nothing
+ * durable disagrees either — the version marker the caller writes next is
+ * equally inert, so the profile simply re-reconciles from scratch next load.
+ * The dangerous case is precisely the mixed one, where the small marker fits
+ * and the large value does not.
+ */
+export function safeStorageSetChecked(key: string, value: string): boolean {
+  try {
+    if (!localStorage) return true;
+    localStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `safeStorageRemove` with the same landed/not-landed report as above. */
+export function safeStorageRemoveChecked(key: string): boolean {
+  try {
+    if (!localStorage) return true;
+    localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Every key currently in storage, or `[]` when storage is unusable.
  *
  * Snapshotting up front is deliberate: `localStorage.key(i)` is index-based

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -121,6 +121,36 @@ export function safeStorageRemoveChecked(key: string): boolean {
 }
 
 /**
+ * Every key/value pair in storage, or `ok: false` when reading them failed.
+ *
+ * For the caller that must not report success over a partial read. A handle can
+ * exist while enumeration or an individual `getItem` throws, so
+ * `isStorageAvailable()` is not enough on its own: settings export checked
+ * availability, then built its payload from the degrading accessors, and
+ * produced an empty file the UI still announced as a successful backup — the
+ * exact outcome that check was added to prevent (#7833 review).
+ *
+ * The whole enumeration runs inside one `try`, so a throw part-way through
+ * reports failure rather than silently truncating.
+ */
+export function safeStorageSnapshot(): { ok: boolean; entries: Array<[string, string]> } {
+  const store = storageHandle();
+  if (store === null) return { ok: false, entries: [] };
+  try {
+    const entries: Array<[string, string]> = [];
+    for (let i = 0; i < store.length; i++) {
+      const key = store.key(i);
+      if (key === null) continue;
+      const value = store.getItem(key);
+      if (value !== null) entries.push([key, value]);
+    }
+    return { ok: true, entries };
+  } catch {
+    return { ok: false, entries: [] };
+  }
+}
+
+/**
  * Every key currently in storage, or `[]` when storage is unusable.
  *
  * Snapshotting up front is deliberate: `localStorage.key(i)` is index-based

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -121,6 +121,26 @@ export function safeStorageRemoveChecked(key: string): boolean {
 }
 
 /**
+ * Like `safeStorageGet`, but distinguishes "key absent" from "read failed".
+ *
+ * Degrading a failed read to `null` is right for a flag with a default and
+ * WRONG for a caller that treats absence as intent. Cloud-prefs builds its
+ * upload blob by reading each synced key and omitting the nulls; a throwing
+ * read therefore looked like "the user cleared this", and the next upload
+ * replaced the server blob and DELETED the unread preference from the cloud.
+ * The raw read this replaced threw and aborted the upload (#7833 review).
+ */
+export function safeStorageGetChecked(key: string): { ok: boolean; value: string | null } {
+  const store = storageHandle();
+  if (store === null) return { ok: false, value: null };
+  try {
+    return { ok: true, value: store.getItem(key) };
+  } catch {
+    return { ok: false, value: null };
+  }
+}
+
+/**
  * Every key/value pair in storage, or `ok: false` when reading them failed.
  *
  * For the caller that must not report success over a partial read. A handle can

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -40,3 +40,25 @@ export function safeStorageRemove(key: string): void {
     /* storage unavailable */
   }
 }
+
+/**
+ * Every key currently in storage, or `[]` when storage is unusable.
+ *
+ * Snapshotting up front is deliberate: `localStorage.key(i)` is index-based
+ * over a live collection, so a caller that removes while iterating shifts the
+ * indices under itself and silently skips keys. Both callers here scan for a
+ * prefix and then delete or read the matches, which is exactly that shape.
+ */
+export function safeStorageKeys(): string[] {
+  try {
+    if (!localStorage) return [];
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key !== null) keys.push(key);
+    }
+    return keys;
+  } catch {
+    return [];
+  }
+}

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -42,6 +42,27 @@ export function safeStorageRemove(key: string): void {
 }
 
 /**
+ * The storage object, or `null` when it cannot be reached at all.
+ *
+ * Retrieving the handle has to be its own guarded step, separate from the
+ * write. Both broken shapes have to end up as `null` here — the NULL property
+ * and the property whose GETTER throws — because the checked writers below owe
+ * their caller a different answer for "there is no store" (`true`, nothing
+ * durable disagrees) than for "the store rejected this write" (`false`). With
+ * the handle read inside the write's own `try`, a throwing getter fell into the
+ * write's catch and reported a rejection, so on a sandboxed iframe or with
+ * cookies blocked every cloud-pref write looked rejected and sign-in
+ * terminated in an error state on every load (#7833 review, second round).
+ */
+function storageHandle(): Storage | null {
+  try {
+    return localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Whether storage is reachable at all right now.
  *
  * For the callers that must tell "storage is empty" apart from "storage is
@@ -77,9 +98,10 @@ export function isStorageAvailable(): boolean {
  * and the large value does not.
  */
 export function safeStorageSetChecked(key: string, value: string): boolean {
+  const store = storageHandle();
+  if (store === null) return true;
   try {
-    if (!localStorage) return true;
-    localStorage.setItem(key, value);
+    store.setItem(key, value);
     return true;
   } catch {
     return false;
@@ -88,9 +110,10 @@ export function safeStorageSetChecked(key: string, value: string): boolean {
 
 /** `safeStorageRemove` with the same landed/not-landed report as above. */
 export function safeStorageRemoveChecked(key: string): boolean {
+  const store = storageHandle();
+  if (store === null) return true;
   try {
-    if (!localStorage) return true;
-    localStorage.removeItem(key);
+    store.removeItem(key);
     return true;
   } catch {
     return false;

--- a/src/utils/settings-persistence.ts
+++ b/src/utils/settings-persistence.ts
@@ -13,7 +13,7 @@ export interface ImportResult {
 
 import { CLOUD_SYNC_KEYS } from './sync-keys';
 import { invalidatePanelStorageCacheForKeys } from './panel-storage';
-import { safeStorageGet, safeStorageKeys } from './safe-storage';
+import { isStorageAvailable, safeStorageGet, safeStorageKeys } from './safe-storage';
 
 const MAX_IMPORT_SIZE_BYTES = 5 * 1024 * 1024;
 
@@ -45,10 +45,15 @@ export const __testing__ = { isSettingsKey };
 export function exportSettings(): void {
   const data: Record<string, string> = {};
 
-  // A null `localStorage` (Android WebView with DOM storage disabled) used to
-  // throw straight out of this function, so the Export button did nothing at
-  // all on those devices — #7833. There is nothing to export there, so the
-  // honest outcome is an empty payload the user still receives as a file.
+  // Storage that cannot be read has no settings to export, and handing the
+  // user a downloadable file anyway is worse than failing: the caller in
+  // preferences-content.ts wraps this in try/catch and shows `exportSuccess`
+  // when it returns, so a silent empty payload becomes a green "Exported"
+  // toast over a backup containing nothing (#7833 review). Stay loud.
+  if (!isStorageAvailable()) {
+    throw new Error('Settings export requires browser storage, which is unavailable here.');
+  }
+
   for (const key of safeStorageKeys()) {
     if (!isSettingsKey(key)) continue;
     const value = safeStorageGet(key);

--- a/src/utils/settings-persistence.ts
+++ b/src/utils/settings-persistence.ts
@@ -13,6 +13,7 @@ export interface ImportResult {
 
 import { CLOUD_SYNC_KEYS } from './sync-keys';
 import { invalidatePanelStorageCacheForKeys } from './panel-storage';
+import { safeStorageGet, safeStorageKeys } from './safe-storage';
 
 const MAX_IMPORT_SIZE_BYTES = 5 * 1024 * 1024;
 
@@ -44,17 +45,20 @@ export const __testing__ = { isSettingsKey };
 export function exportSettings(): void {
   const data: Record<string, string> = {};
 
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (!key || !isSettingsKey(key)) continue;
-    const value = localStorage.getItem(key);
+  // A null `localStorage` (Android WebView with DOM storage disabled) used to
+  // throw straight out of this function, so the Export button did nothing at
+  // all on those devices — #7833. There is nothing to export there, so the
+  // honest outcome is an empty payload the user still receives as a file.
+  for (const key of safeStorageKeys()) {
+    if (!isSettingsKey(key)) continue;
+    const value = safeStorageGet(key);
     if (value !== null) data[key] = value;
   }
 
   const exportData: ExportedSettings = {
     version: 1,
     timestamp: new Date().toISOString(),
-    variant: localStorage.getItem('worldmonitor-variant') || 'full',
+    variant: safeStorageGet('worldmonitor-variant') || 'full',
     data,
   };
 

--- a/src/utils/settings-persistence.ts
+++ b/src/utils/settings-persistence.ts
@@ -13,7 +13,7 @@ export interface ImportResult {
 
 import { CLOUD_SYNC_KEYS } from './sync-keys';
 import { invalidatePanelStorageCacheForKeys } from './panel-storage';
-import { isStorageAvailable, safeStorageGet, safeStorageKeys } from './safe-storage';
+import { safeStorageSnapshot } from './safe-storage';
 
 const MAX_IMPORT_SIZE_BYTES = 5 * 1024 * 1024;
 
@@ -50,20 +50,28 @@ export function exportSettings(): void {
   // preferences-content.ts wraps this in try/catch and shows `exportSuccess`
   // when it returns, so a silent empty payload becomes a green "Exported"
   // toast over a backup containing nothing (#7833 review). Stay loud.
-  if (!isStorageAvailable()) {
-    throw new Error('Settings export requires browser storage, which is unavailable here.');
+  //
+  // Testing AVAILABILITY is not enough on its own, which an earlier round of
+  // this fix got wrong: a handle can exist while enumeration or an individual
+  // read throws, and the degrading accessors then return `[]`/`null` and
+  // rebuild exactly that empty-but-successful backup. The snapshot reports
+  // whether the reads themselves succeeded, so a partial one fails instead of
+  // shipping a backup the user would only discover was empty when restoring.
+  const snapshot = safeStorageSnapshot();
+  if (!snapshot.ok) {
+    throw new Error('Settings export could not read browser storage.');
   }
 
-  for (const key of safeStorageKeys()) {
-    if (!isSettingsKey(key)) continue;
-    const value = safeStorageGet(key);
-    if (value !== null) data[key] = value;
+  let variant = 'full';
+  for (const [key, value] of snapshot.entries) {
+    if (key === 'worldmonitor-variant' && value) variant = value;
+    if (isSettingsKey(key)) data[key] = value;
   }
 
   const exportData: ExportedSettings = {
     version: 1,
     timestamp: new Date().toISOString(),
-    variant: safeStorageGet('worldmonitor-variant') || 'full',
+    variant,
     data,
   };
 

--- a/tests/cloud-prefs-flush-success.test.mts
+++ b/tests/cloud-prefs-flush-success.test.mts
@@ -12,7 +12,7 @@ describe('applyObservableCloudPrefsFlushSuccess', () => {
       myGeneration: 3,
       getAuthGeneration: () => 3,
       getSyncVersion: () => 7,
-      setSyncVersion: (syncVersion) => { calls.push(`version:${syncVersion}`); },
+      setSyncVersion: (syncVersion) => { calls.push(`version:${syncVersion}`); return true; },
       clearSettledDirtyKeys: () => { calls.push('clear-dirty'); },
       setLastSyncAt: (timestampMs) => { calls.push(`last-sync:${timestampMs}`); },
       isIdle: () => true,
@@ -37,7 +37,7 @@ describe('applyObservableCloudPrefsFlushSuccess', () => {
       myGeneration: 3,
       getAuthGeneration: () => 4,
       getSyncVersion: () => 7,
-      setSyncVersion: () => { touched = true; },
+      setSyncVersion: () => { touched = true; return true; },
       clearSettledDirtyKeys: () => { touched = true; },
       setLastSyncAt: () => { touched = true; },
       isIdle: () => true,
@@ -56,7 +56,7 @@ describe('applyObservableCloudPrefsFlushSuccess', () => {
       myGeneration: 3,
       getAuthGeneration: () => 3,
       getSyncVersion: () => 9,
-      setSyncVersion: () => { touched = true; },
+      setSyncVersion: () => { touched = true; return true; },
       clearSettledDirtyKeys: () => { touched = true; },
       setLastSyncAt: () => { touched = true; },
       isIdle: () => true,
@@ -75,7 +75,7 @@ describe('applyObservableCloudPrefsFlushSuccess', () => {
       myGeneration: 3,
       getAuthGeneration: () => 3,
       getSyncVersion: () => 7,
-      setSyncVersion: (syncVersion) => { calls.push(`version:${syncVersion}`); },
+      setSyncVersion: (syncVersion) => { calls.push(`version:${syncVersion}`); return true; },
       clearSettledDirtyKeys: () => { calls.push('clear-dirty'); },
       setLastSyncAt: (timestampMs) => { calls.push(`last-sync:${timestampMs}`); },
       isIdle: () => false,
@@ -99,7 +99,7 @@ describe('applyObservableCloudPrefsFlushSuccess', () => {
       myGeneration: 3,
       getAuthGeneration: () => 3,
       getSyncVersion: () => 7,
-      setSyncVersion: () => { touched = true; },
+      setSyncVersion: () => { touched = true; return true; },
       clearSettledDirtyKeys: () => { touched = true; },
       setLastSyncAt: () => { touched = true; },
       isIdle: () => true,
@@ -108,5 +108,29 @@ describe('applyObservableCloudPrefsFlushSuccess', () => {
 
     assert.equal(applied, false);
     assert.equal(touched, false);
+  });
+});
+
+describe('applyObservableCloudPrefsFlushSuccess storage rejection (#7833)', () => {
+  it('does not settle dirty keys or report synced when the version write is rejected', () => {
+    // A nearly-full store can reject even this small marker. Settling the
+    // posted dirty keys against a version that never persisted is what makes
+    // every later upload conflict and every reload re-reconcile.
+    const calls: string[] = [];
+
+    const applied = applyObservableCloudPrefsFlushSuccess({
+      syncVersion: 8,
+      myGeneration: 3,
+      getAuthGeneration: () => 3,
+      getSyncVersion: () => 7,
+      setSyncVersion: () => false,
+      clearSettledDirtyKeys: () => { calls.push('clear-dirty'); },
+      setLastSyncAt: () => { calls.push('last-sync'); },
+      isIdle: () => true,
+      setSynced: () => { calls.push('synced'); },
+    });
+
+    assert.equal(applied, false);
+    assert.deepEqual(calls, []);
   });
 });

--- a/tests/cloud-prefs-panel-sync-guard.test.mjs
+++ b/tests/cloud-prefs-panel-sync-guard.test.mjs
@@ -278,10 +278,11 @@ describe('cloud prefs panel sync guardrails', () => {
     );
     assert.match(
       cloudSyncSrc,
-      // The removal idiom is `rawRemove` since #7833 routed this module's
-      // storage through null-safe accessors; what this pins is the ORDER —
-      // the empty-set delete has to happen before the ownerless bail.
-      /if \(_dirtyKeys\.size === 0\) \{[\s\S]*rawRemove\(KEY_DIRTY_KEYS\);[\s\S]*return;[\s\S]*\}[\s\S]*if \(!_dirtyKeysUserId\) return;/,
+      // Accessor-agnostic on purpose: #7833 moved this module onto
+      // safeStorageRemove, and pinning a spelling just re-breaks on the next
+      // migration. What this pins is the ORDER — the empty-set delete has to
+      // happen before the ownerless bail.
+      /if \(_dirtyKeys\.size === 0\) \{[\s\S]*(?:safeStorageRemove|rawRemove|Storage\.prototype\.removeItem\.call)\([^)]*KEY_DIRTY_KEYS[^)]*\);[\s\S]*return;[\s\S]*\}[\s\S]*if \(!_dirtyKeysUserId\) return;/,
       'ownerless dirty writes before sign-in must not delete the previous persisted dirty-key marker',
     );
     assert.match(

--- a/tests/cloud-prefs-panel-sync-guard.test.mjs
+++ b/tests/cloud-prefs-panel-sync-guard.test.mjs
@@ -278,7 +278,10 @@ describe('cloud prefs panel sync guardrails', () => {
     );
     assert.match(
       cloudSyncSrc,
-      /if \(_dirtyKeys\.size === 0\) \{[\s\S]*Storage\.prototype\.removeItem\.call\(localStorage, KEY_DIRTY_KEYS\);[\s\S]*return;[\s\S]*\}[\s\S]*if \(!_dirtyKeysUserId\) return;/,
+      // The removal idiom is `rawRemove` since #7833 routed this module's
+      // storage through null-safe accessors; what this pins is the ORDER —
+      // the empty-set delete has to happen before the ownerless bail.
+      /if \(_dirtyKeys\.size === 0\) \{[\s\S]*rawRemove\(KEY_DIRTY_KEYS\);[\s\S]*return;[\s\S]*\}[\s\S]*if \(!_dirtyKeysUserId\) return;/,
       'ownerless dirty writes before sign-in must not delete the previous persisted dirty-key marker',
     );
     assert.match(

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -62,6 +62,8 @@ interface HarnessControls {
   fireSignInRetry: () => void;
   holdNextGet: () => HeldRequest;
   holdNextPost: () => HeldRequest;
+  /** Make the backing store REJECT writes to `key`, as a full disk does. */
+  rejectWritesTo: (key: string) => void;
   seedRow: (token: string, data: Record<string, string>, syncVersion: number, schemaVersion?: number) => void;
   setToken: (token: string) => void;
   stateHistory: string[];
@@ -97,6 +99,14 @@ async function getBundledSource(enabled = true): Promise<string> {
           loader: 'ts',
         }));
         buildApi.onResolve({ filter: /^@\// }, (args) => {
+          // safe-storage is bundled REAL, not stubbed. It is the accessor every
+          // storage call in cloud-prefs-sync now goes through (#7833), so a
+          // stub would quietly replace the exact code this harness exists to
+          // drive against its fake Storage — including safeStorageSetChecked,
+          // whose quota-rejection report the sync-version guard depends on.
+          if (args.path === '@/utils/safe-storage') {
+            return { path: resolve(root, 'src/utils/safe-storage.ts'), namespace: 'file' };
+          }
           if (!(args.path in stubs)) throw new Error(`unexpected alias import: ${args.path}`);
           return { path: args.path, namespace: 'stub' };
         });
@@ -139,8 +149,13 @@ async function runHarness(
   const originalSetTimeout = globalThis.setTimeout;
   const stateHistory: string[] = [];
   const events: Array<{ detail: unknown; type: string }> = [];
+  const rejectedWriteKeys = new Set<string>();
   class TestStorage extends MiniStorage {
     override setItem(key: string, value: string): void {
+      // A full disk rejects the write for a large value while still accepting
+      // the small sync-version marker written straight afterwards — the exact
+      // asymmetry that let stale prefs overwrite cloud data (#7833 review).
+      if (rejectedWriteKeys.has(key)) throw new Error('QuotaExceededError');
       super.setItem(key, value);
       if (key === 'wm-cloud-sync-state') stateHistory.push(value);
     }
@@ -333,6 +348,7 @@ async function runHarness(
       for (const listener of documentListeners.get('visibilitychange') ?? []) listener();
     },
     events,
+    rejectWritesTo: (key: string) => { rejectedWriteKeys.add(key); },
     failNextGetTemporarily: () => {
       failNextGetTemporarily = true;
     },
@@ -826,5 +842,41 @@ describe('two-tab dirty-key persistence (#4746)', () => {
         'a settled upload must remove only the keys that tab durably synced',
       );
     });
+  });
+});
+
+describe('cloud prefs storage-rejection safety (#7833)', () => {
+  it('does not advance the sync version when a pref write is rejected', async () => {
+    // The data-loss shape review found: safeStorageSet swallowed a
+    // QuotaExceededError, so applyCloudBlob "succeeded", setSyncVersion
+    // advanced local to the cloud row's version, and the NEXT upload posted the
+    // stale local value back over good cloud data with no conflict to stop it.
+    // The pref value is what gets rejected; the small version marker would
+    // still fit, which is exactly why the version must not be written.
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', { 'wm-market-watchlist-v1': 'cloud-value' }, 9);
+      controls.rejectWritesTo('wm-market-watchlist-v1');
+      await cloudPrefs.onSignIn('user-1', 'full');
+    });
+
+    assert.notEqual(
+      result.localSyncVersion,
+      9,
+      'local must not claim the cloud version after a write that never landed',
+    );
+    assert.equal(result.state, 'error', 'a rejected reconciliation must surface as error');
+  });
+
+  it('still reconciles normally when the same write is accepted', async () => {
+    // The control. Without it the assertions above would also pass if sign-in
+    // were broken outright, which is the failure mode a negative-only
+    // regression test cannot see.
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', { 'wm-market-watchlist-v1': 'cloud-value' }, 9);
+      await cloudPrefs.onSignIn('user-1', 'full');
+    });
+
+    assert.equal(result.localSyncVersion, 9);
+    assert.equal(result.state, 'synced');
   });
 });

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -987,3 +987,25 @@ describe('cloud prefs fail closed on undeterminable state (#7833 review)', () =>
   });
 });
 
+
+describe('cloud prefs marker ordering (#7833 review)', () => {
+  it('does not advance the sync version when the schema marker is rejected', async () => {
+    // Both writes are checked, but ORDER decides what a partial failure leaves
+    // behind. Advancing the version first leaves a durable claim that this
+    // cloud generation was reconciled while the schema marker is still old, and
+    // the next sign-in then sees equal versions, takes the local-upload branch,
+    // and reruns one-shot migrations over already-migrated data.
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', { 'wm-market-watchlist-v1': 'cloud-value' }, 9, 8);
+      controls.rejectWritesTo('wm-cloud-prefs-local-schema-version');
+      await cloudPrefs.onSignIn('user-1', 'full');
+    });
+
+    assert.notEqual(
+      result.localSyncVersion,
+      9,
+      'the sync version must not advance past a rejected schema marker',
+    );
+    assert.equal(result.state, 'error');
+  });
+});

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -915,3 +915,31 @@ describe('cloud prefs read-failure safety (#7833 review)', () => {
     });
   });
 });
+
+describe('cloud prefs sign-out cleanup (#7833 review)', () => {
+  it('completes sign-out cleanup even when the pending flush cannot be built', async () => {
+    // The flush is best-effort; the CLEANUP is not. Returning early from
+    // onSignOut on an unreadable preference left the auth generation un-bumped,
+    // the retry timers live, and _cachedToken holding the signed-out user's
+    // token — which a later unload handler could still post with.
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', { 'wm-market-watchlist-v1': 'cloud-value' }, 1);
+      await cloudPrefs.onSignIn('user-1', 'full');
+      cloudPrefs.install('full');
+      localStorage.setItem('wm-market-watchlist-v1', 'local-edit');
+      controls.rejectReadsOf('wm-market-watchlist-v1');
+      cloudPrefs.onSignOut();
+    });
+
+    assert.equal(
+      result.state,
+      'signed-out',
+      'sign-out must reach its state cleanup even when the flush is skipped',
+    );
+    assert.equal(
+      result.localSyncVersion,
+      0,
+      'sign-out must clear the durable sync-version metadata',
+    );
+  });
+});

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -406,6 +406,10 @@ async function runHarness(
   try {
     const cloudPrefs = await loadCloudPrefsModule(enabled);
     await invoke(cloudPrefs, controls);
+    // Rejections simulate a condition during the RUN, not during measurement —
+    // the result assembly below reads the same keys directly and would throw.
+    rejectedReadKeys.clear();
+    rejectedWriteKeys.clear();
     const activeToken = String(Reflect.get(globalThis, '__cloudPrefsToken'));
     const activeRow = rows.get(activeToken) ?? { data: {}, schemaVersion: 2, syncVersion: 0 };
     return {
@@ -941,5 +945,44 @@ describe('cloud prefs sign-out cleanup (#7833 review)', () => {
       0,
       'sign-out must clear the durable sync-version metadata',
     );
+  });
+});
+
+describe('cloud prefs fail closed on undeterminable state (#7833 review)', () => {
+  it('does not apply the cloud blob when the local sync version cannot be read', async () => {
+    // Degrading this read to 0 means "never synced", which makes the cloud
+    // unconditionally look ahead — so the cloud blob is applied over local
+    // edits that were never uploaded.
+    // The local value has to be captured INSIDE the harness: it restores the
+    // globals on exit, so `localStorage` is gone by the time assertions run.
+    let watchlistAfter: string | null = null;
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', { 'wm-market-watchlist-v1': 'cloud-value' }, 9);
+      localStorage.setItem('wm-market-watchlist-v1', 'local-edit');
+      controls.rejectReadsOf('wm-cloud-sync-version');
+      await cloudPrefs.onSignIn('user-1', 'full');
+      watchlistAfter = localStorage.getItem('wm-market-watchlist-v1');
+    });
+
+    assert.equal(
+      watchlistAfter,
+      'local-edit',
+      'an unreadable sync version must not let cloud overwrite local edits',
+    );
+    assert.equal(result.state, 'error');
+  });
+
+  it('does not sign in when prior-account ownership cannot be determined', async () => {
+    // Skipping the sidecar cleanup on an account transition leaves account A's
+    // ownership values in place for B, so tier reconciliation attributes A's
+    // gate decisions to B.
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', {}, 1);
+      controls.rejectReadsOf('wm-last-signed-in-as');
+      await cloudPrefs.onSignIn('user-b', 'full');
+    });
+
+    assert.equal(result.state, 'error', 'undeterminable provenance must fail closed');
+    assert.equal(result.postCount, 0, 'nothing may be uploaded on a provenance failure');
   });
 });

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -986,3 +986,4 @@ describe('cloud prefs fail closed on undeterminable state (#7833 review)', () =>
     assert.equal(result.postCount, 0, 'nothing may be uploaded on a provenance failure');
   });
 });
+

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -64,6 +64,8 @@ interface HarnessControls {
   holdNextPost: () => HeldRequest;
   /** Make the backing store REJECT writes to `key`, as a full disk does. */
   rejectWritesTo: (key: string) => void;
+  /** Make the backing store THROW when `key` is read. */
+  rejectReadsOf: (key: string) => void;
   seedRow: (token: string, data: Record<string, string>, syncVersion: number, schemaVersion?: number) => void;
   setToken: (token: string) => void;
   stateHistory: string[];
@@ -150,7 +152,13 @@ async function runHarness(
   const stateHistory: string[] = [];
   const events: Array<{ detail: unknown; type: string }> = [];
   const rejectedWriteKeys = new Set<string>();
+  const rejectedReadKeys = new Set<string>();
   class TestStorage extends MiniStorage {
+    override getItem(key: string): string | null {
+      if (rejectedReadKeys.has(key)) throw new Error('SecurityError');
+      return super.getItem(key);
+    }
+
     override setItem(key: string, value: string): void {
       // A full disk rejects the write for a large value while still accepting
       // the small sync-version marker written straight afterwards — the exact
@@ -349,6 +357,7 @@ async function runHarness(
     },
     events,
     rejectWritesTo: (key: string) => { rejectedWriteKeys.add(key); },
+    rejectReadsOf: (key: string) => { rejectedReadKeys.add(key); },
     failNextGetTemporarily: () => {
       failNextGetTemporarily = true;
     },
@@ -878,5 +887,31 @@ describe('cloud prefs storage-rejection safety (#7833)', () => {
 
     assert.equal(result.localSyncVersion, 9);
     assert.equal(result.state, 'synced');
+  });
+});
+
+describe('cloud prefs read-failure safety (#7833 review)', () => {
+  it('does not upload a blob that omits a preference it could not read', () => {
+    // The deletion path: this blob REPLACES the server's, and an omitted key
+    // means "cleared". Degrading a throwing read to null therefore turned a
+    // transient read failure into a permanent cloud deletion of that
+    // preference. The raw read before #7833 threw and aborted the upload.
+    return runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', { 'wm-market-watchlist-v1': 'cloud-value' }, 1);
+      await cloudPrefs.onSignIn('user-1', 'full');
+      cloudPrefs.install('full');
+      localStorage.setItem('wm-market-watchlist-v1', 'local-edit');
+      controls.rejectReadsOf('wm-market-watchlist-v1');
+      await cloudPrefs.syncNow();
+    }).then((result) => {
+      // The assertion has to be that the key SURVIVES on the server. Accepting
+      // "absent from the posted blob" would accept the deletion itself, which
+      // is how the first version of this test passed against the bug.
+      const row = result.acceptedDataByToken['test-token'] ?? {};
+      assert.ok(
+        'wm-market-watchlist-v1' in row,
+        'an unreadable preference must not be deleted from the cloud row by an upload',
+      );
+    });
   });
 });

--- a/tests/dom/null-storage-call-sites-7833.test.mts
+++ b/tests/dom/null-storage-call-sites-7833.test.mts
@@ -1,0 +1,92 @@
+/**
+ * #7833 — call sites that still crash on a NULL `localStorage`.
+ *
+ * Android WebView with DOM storage disabled exposes `window.localStorage` as
+ * `null`, so an unguarded `localStorage.getItem(…)` is a TypeError rather than
+ * a thrown SecurityError. #7832 fixed the sites with production evidence
+ * (`WORLDMONITOR-122`); these are the ones a survey found afterwards, including
+ * two that LOOK guarded and are not:
+ *
+ *   - `cloud-prefs-sync.applyCloudBlob` wraps its storage writes in
+ *     `try { … } finally { … }`. A `finally` restores the patch-suppression
+ *     flag but catches nothing, so the TypeError still propagates.
+ *   - `persistent-cache.deleteFromLocalStorageByPrefix` opens with
+ *     `if (typeof localStorage === 'undefined') return;`. `typeof null` is
+ *     `'object'`, so that gate never fires for the null shape.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Android WebView with DOM storage disabled: the property itself is null. */
+function stubNullStorage(): void {
+  vi.stubGlobal('localStorage', null);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('cloud-prefs-sync under a null localStorage', () => {
+  beforeEach(() => {
+    // `ENABLED` is captured from import.meta.env at module load, so the stub
+    // has to be in place before the dynamic import below.
+    vi.stubEnv('VITE_CLOUD_PREFS_ENABLED', 'true');
+  });
+
+  it('reads sync metadata without throwing', async () => {
+    const sync = await import('@/utils/cloud-prefs-sync');
+    stubNullStorage();
+
+    expect(sync.getSyncVersion()).toBe(0);
+    expect(sync.getSyncState()).toBe('signed-out');
+    expect(sync.getLastSyncAt()).toBe(0);
+  });
+
+  it('reconciles a sign-in without throwing (boot-path ownership sidecars)', async () => {
+    const sync = await import('@/utils/cloud-prefs-sync');
+    expect(sync.isCloudSyncEnabled()).toBe(true);
+    stubNullStorage();
+
+    // onSignIn does its ownership-sidecar reconciliation synchronously before
+    // returning the async attempt; the throw we care about is the sync one.
+    expect(() => { void sync.onSignIn('user-1', 'full').catch(() => {}); }).not.toThrow();
+  });
+
+  it('clears sync metadata on sign-out without throwing', async () => {
+    const sync = await import('@/utils/cloud-prefs-sync');
+    stubNullStorage();
+
+    expect(() => sync.onSignOut()).not.toThrow();
+  });
+});
+
+describe('settings export under a null localStorage', () => {
+  it('exports an empty settings payload instead of throwing', async () => {
+    const { exportSettings } = await import('@/utils/settings-persistence');
+    // Spy rather than stubGlobal: replacing `URL` wholesale leaves happy-dom
+    // without a URL constructor, and the anchor click below then blows up
+    // inside its navigator instead of inside the code under test.
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:stub');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    // The download anchor is clicked for real; happy-dom would try to navigate.
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    stubNullStorage();
+
+    expect(() => exportSettings()).not.toThrow();
+
+    const blob = createObjectURL.mock.calls[0]?.[0] as Blob;
+    expect(JSON.parse(await blob.text()).data).toEqual({});
+  });
+});
+
+describe('persistent-cache prefix invalidation under a null localStorage', () => {
+  it('returns without throwing instead of falling through the undefined-only gate', async () => {
+    const { __testing__ } = await import('@/services/persistent-cache');
+    stubNullStorage();
+
+    expect(() => __testing__.deleteFromLocalStorageByPrefix('news')).not.toThrow();
+  });
+});

--- a/tests/dom/null-storage-call-sites-7833.test.mts
+++ b/tests/dom/null-storage-call-sites-7833.test.mts
@@ -64,21 +64,37 @@ describe('cloud-prefs-sync under a null localStorage', () => {
 });
 
 describe('settings export under a null localStorage', () => {
-  it('exports an empty settings payload instead of throwing', async () => {
+  // NOT "returns an empty export". The caller does
+  // `try { exportSettings(); showToast(exportSuccess) } catch { showToast(exportFailed) }`,
+  // so returning quietly turns an unreadable store into a green "Exported"
+  // toast over a file containing nothing. Failing is the correct outcome; what
+  // #7833 owes this path is a legible failure, not a silent one.
+  it('fails loudly rather than handing back an empty backup', async () => {
     const { exportSettings } = await import('@/utils/settings-persistence');
-    // Spy rather than stubGlobal: replacing `URL` wholesale leaves happy-dom
-    // without a URL constructor, and the anchor click below then blows up
-    // inside its navigator instead of inside the code under test.
     const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:stub');
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
-    // The download anchor is clicked for real; happy-dom would try to navigate.
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
     stubNullStorage();
 
-    expect(() => exportSettings()).not.toThrow();
+    expect(() => exportSettings()).toThrow(/storage/i);
+    // The decisive assertion: no file was ever produced, so nothing downstream
+    // can mistake this for a successful backup.
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
 
+  it('still exports normally when storage works', async () => {
+    const { exportSettings } = await import('@/utils/settings-persistence');
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:stub');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    localStorage.setItem('worldmonitor-variant', 'full');
+    localStorage.setItem('positive-threshold', '7');
+
+    expect(() => exportSettings()).not.toThrow();
     const blob = createObjectURL.mock.calls[0]?.[0] as Blob;
-    expect(JSON.parse(await blob.text()).data).toEqual({});
+    const exported = JSON.parse(await blob.text());
+    expect(exported.variant).toBe('full');
+    expect(exported.data['positive-threshold']).toBe('7');
   });
 });
 
@@ -88,5 +104,22 @@ describe('persistent-cache prefix invalidation under a null localStorage', () =>
     stubNullStorage();
 
     expect(() => __testing__.deleteFromLocalStorageByPrefix('news')).not.toThrow();
+  });
+});
+
+describe('custom widgets under a null localStorage', () => {
+  it('degrades the whole load chain to an empty list rather than throwing', async () => {
+    // NOTE what this does and does not prove. `loadFromStorage` already
+    // catches, so `materializeWidgets` never reaches its PRO side-key read on
+    // a broken store — routing that read through safeStorageGet was defence in
+    // depth and a guard requirement, NOT a live crash fix. What this pins is
+    // the chain-level resilience the module documents ("degrades those failures
+    // to [] for dashboard resilience"), which nothing else asserted.
+    stubNullStorage();
+
+    const { loadWidgets } = await import('@/services/widget-store');
+
+    expect(() => loadWidgets()).not.toThrow();
+    expect(loadWidgets()).toEqual([]);
   });
 });

--- a/tests/dom/safe-storage.test.mts
+++ b/tests/dom/safe-storage.test.mts
@@ -162,3 +162,37 @@ describe('isStorageAvailable', () => {
     expect(isStorageAvailable()).toBe(false);
   });
 });
+
+describe('checked-write call-site contract (#7833 review)', () => {
+  beforeEach(stubWorkingStorage);
+
+  it('lets a caller record only the writes that landed', () => {
+    // The shape both applyCloudBlob and showUndoToast's undo handler use: the
+    // "did this change?" read happens BEFORE the write, so without the checked
+    // result a rejected write still gets announced as applied.
+    const backing = new Map<string, string>([['a', 'old'], ['b', 'old']]);
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => backing.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        if (k === 'b') throw new Error('QuotaExceededError');
+        backing.set(k, v);
+      },
+      removeItem: (k: string) => { backing.delete(k); },
+    });
+
+    const applied: string[] = [];
+    let allLanded = true;
+    for (const key of ['a', 'b']) {
+      const wasDifferent = safeStorageGet(key) !== 'new';
+      if (safeStorageSetChecked(key, 'new')) {
+        if (wasDifferent) applied.push(key);
+      } else {
+        allLanded = false;
+      }
+    }
+
+    expect(applied).toEqual(['a']);
+    expect(allLanded).toBe(false);
+    expect(backing.get('b')).toBe('old');
+  });
+});

--- a/tests/dom/safe-storage.test.mts
+++ b/tests/dom/safe-storage.test.mts
@@ -196,3 +196,20 @@ describe('checked-write call-site contract (#7833 review)', () => {
     expect(backing.get('b')).toBe('old');
   });
 });
+
+describe('checked writes under a THROWING storage property (#7833 review)', () => {
+  it('reports success, because an unreachable store is not a rejection', () => {
+    // The distinction the cloud-prefs callers now branch on. Reading the
+    // `localStorage` property itself throws in a sandboxed iframe or with
+    // cookies blocked; folding that into the write's own catch reported it as
+    // a REJECTED write, so every cloud-pref write looked rejected and sign-in
+    // terminated in an error state on those surfaces (the embed runs in an
+    // iframe). Only a store that was actually obtained and refused the write
+    // returns false.
+    stubThrowingStorage();
+
+    expect(safeStorageSetChecked('wm-test-key', 'v')).toBe(true);
+    expect(safeStorageRemoveChecked('wm-test-key')).toBe(true);
+    expect(isStorageAvailable()).toBe(false);
+  });
+});

--- a/tests/dom/safe-storage.test.mts
+++ b/tests/dom/safe-storage.test.mts
@@ -1,6 +1,14 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { safeStorageGet, safeStorageRemove, safeStorageSet } from '@/utils/safe-storage';
+import {
+  isStorageAvailable,
+  safeStorageGet,
+  safeStorageKeys,
+  safeStorageRemove,
+  safeStorageRemoveChecked,
+  safeStorageSet,
+  safeStorageSetChecked,
+} from '@/utils/safe-storage';
 
 /** Android WebView with DOM storage disabled: the property itself is null. */
 function stubNullStorage(): void {
@@ -25,6 +33,23 @@ function stubFullStorage(): void {
       throw new Error('QuotaExceededError');
     },
     removeItem: () => {},
+  });
+}
+
+/**
+ * A working, Map-backed Storage. The suite's afterEach DELETES
+ * globalThis.localStorage, so any test that needs a live store has to install
+ * one rather than assume happy-dom still provides it.
+ */
+function stubWorkingStorage(): void {
+  const backing = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    get length() { return backing.size; },
+    key: (i: number) => [...backing.keys()][i] ?? null,
+    getItem: (k: string) => backing.get(k) ?? null,
+    setItem: (k: string, v: string) => { backing.set(k, String(v)); },
+    removeItem: (k: string) => { backing.delete(k); },
+    clear: () => backing.clear(),
   });
 }
 
@@ -63,5 +88,77 @@ describe('safe storage', () => {
     stubFullStorage();
 
     expect(() => safeStorageSet('wm-test-key', '1')).not.toThrow();
+  });
+});
+
+describe('safeStorageKeys', () => {
+  beforeEach(stubWorkingStorage);
+
+  it('snapshots keys so a delete-while-iterating caller cannot skip one', () => {
+    // The index-shifting bug this helper's contract exists to prevent: a live
+    // `for (i = 0; i < localStorage.length; i++) localStorage.key(i)` loop that
+    // removes as it goes walks past half its matches. Both real call sites
+    // (persistent-cache prefix invalidation, settings export) have that shape.
+    for (const key of ['wm-x-1', 'wm-x-2', 'wm-x-3', 'wm-x-4', 'keep-me']) {
+      localStorage.setItem(key, '1');
+    }
+
+    for (const key of safeStorageKeys()) {
+      if (key.startsWith('wm-x-')) safeStorageRemove(key);
+    }
+
+    expect(safeStorageKeys().filter((k) => k.startsWith('wm-x-'))).toEqual([]);
+    expect(safeStorageGet('keep-me')).toBe('1');
+  });
+
+  it('returns [] rather than throwing on both broken-storage shapes', () => {
+    stubNullStorage();
+    expect(safeStorageKeys()).toEqual([]);
+    vi.unstubAllGlobals();
+    stubThrowingStorage();
+    expect(safeStorageKeys()).toEqual([]);
+  });
+});
+
+describe('checked writes', () => {
+  beforeEach(stubWorkingStorage);
+
+  it('reports a quota rejection instead of swallowing it', () => {
+    stubFullStorage();
+    // The distinction the cloud-prefs sync-version guard depends on: a usable
+    // store that REJECTED the write must be false, so the caller does not go
+    // on to record durable state claiming the value landed.
+    expect(safeStorageSetChecked('wm-test-key', 'v')).toBe(false);
+    // The swallowing variant stays silent on the same input.
+    expect(() => safeStorageSet('wm-test-key', 'v')).not.toThrow();
+  });
+
+  it('reports success when there is no store to write to', () => {
+    // Nothing was written, but nothing durable disagrees either — the marker
+    // the caller writes next is equally inert. Returning false here would make
+    // every sign-in on a null-storage device report an error.
+    stubNullStorage();
+    expect(safeStorageSetChecked('wm-test-key', 'v')).toBe(true);
+    expect(safeStorageRemoveChecked('wm-test-key')).toBe(true);
+  });
+
+  it('reports success on a working store', () => {
+    expect(safeStorageSetChecked('wm-test-key', 'v')).toBe(true);
+    expect(safeStorageGet('wm-test-key')).toBe('v');
+    expect(safeStorageRemoveChecked('wm-test-key')).toBe(true);
+    expect(safeStorageGet('wm-test-key')).toBeNull();
+  });
+});
+
+describe('isStorageAvailable', () => {
+  beforeEach(stubWorkingStorage);
+
+  it('separates an empty store from an unusable one', () => {
+    expect(isStorageAvailable()).toBe(true);
+    stubNullStorage();
+    expect(isStorageAvailable()).toBe(false);
+    vi.unstubAllGlobals();
+    stubThrowingStorage();
+    expect(isStorageAvailable()).toBe(false);
   });
 });

--- a/tests/main-module-gates.test.mjs
+++ b/tests/main-module-gates.test.mjs
@@ -42,6 +42,20 @@ const GATES = [
     expected: /Panel content-write guard failed/,
   },
   {
+    file: 'scripts/enforce-safe-local-storage.mjs',
+    setup(root) {
+      mkdirSync(join(root, 'src/services'), { recursive: true });
+      writeFileSync(
+        join(root, 'src/services/failing-store.ts'),
+        "export const stored = localStorage.getItem('wm-key');\n",
+      );
+    },
+    // Deliberately the unlisted-deref line rather than the headline. The
+    // fixture tree is one file, so the population floor also trips — matching
+    // the headline alone would pass even if the deref patterns had gone stale.
+    expected: /These dereference localStorage directly/,
+  },
+  {
     file: 'scripts/check-local-secret-dumps.mjs',
     setup(root) {
       writeFileSync(join(root, '.env.vercel-backup'), 'do-not-use\n');

--- a/tests/main-module-gates.test.mjs
+++ b/tests/main-module-gates.test.mjs
@@ -82,6 +82,12 @@ function createSymlinkedGateFixture(gate) {
   mkdirSync(join(root, 'scripts/lib'), { recursive: true });
   copyFileSync(join(REPO_ROOT, gate.file), scriptPath);
   for (const lib of SHARED_LIB_MODULES) copyFileSync(join(REPO_ROOT, lib), join(root, lib));
+  // A gate may import a real dependency — enforce-safe-local-storage.mjs uses
+  // the TypeScript parser — and ESM resolves those from node_modules, not from
+  // NODE_PATH. Without this the fixture run dies on ERR_MODULE_NOT_FOUND, which
+  // exits non-zero and so passes the status check while producing none of the
+  // gate's output: the exact silent-no-op shape this test exists to catch.
+  symlinkSync(join(REPO_ROOT, 'node_modules'), join(root, 'node_modules'), 'dir');
   gate.setup(root);
 
   const linkedRoot = join(root, 'linked-checkout');

--- a/tests/main-module-gates.test.mjs
+++ b/tests/main-module-gates.test.mjs
@@ -15,7 +15,11 @@ import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const MAIN_MODULE_HELPER = join(REPO_ROOT, 'scripts/lib/main-module.mjs');
+// Every scripts/lib/ module a gate imports has to be copied into the fixture,
+// not just main-module.mjs — a gate that also imports source-scan.mjs would
+// otherwise fail the symlink run with a module-resolution error that looks
+// exactly like the silent no-op this test exists to detect.
+const SHARED_LIB_MODULES = ['scripts/lib/main-module.mjs', 'scripts/lib/source-scan.mjs'];
 const INLINE_MAIN_GUARD = /(?:import\.meta\.url\s*===\s*pathToFileURL\s*\(\s*process\.argv\s*\[\s*1\s*\]\s*\)\.href|pathToFileURL\s*\(\s*process\.argv\s*\[\s*1\s*\]\s*\)\.href\s*===\s*import\.meta\.url)/;
 
 const GATES = [
@@ -77,7 +81,7 @@ function createSymlinkedGateFixture(gate) {
   mkdirSync(dirname(scriptPath), { recursive: true });
   mkdirSync(join(root, 'scripts/lib'), { recursive: true });
   copyFileSync(join(REPO_ROOT, gate.file), scriptPath);
-  copyFileSync(MAIN_MODULE_HELPER, join(root, 'scripts/lib/main-module.mjs'));
+  for (const lib of SHARED_LIB_MODULES) copyFileSync(join(REPO_ROOT, lib), join(root, lib));
   gate.setup(root);
 
   const linkedRoot = join(root, 'linked-checkout');

--- a/tests/safe-local-storage-guard.test.mts
+++ b/tests/safe-local-storage-guard.test.mts
@@ -6,11 +6,11 @@ import {
   GUARD_EXEMPT_FILES,
   LEGACY_RAW_LOCAL_STORAGE,
   MIN_SCANNED_FILES,
-  RAW_STORAGE_PATTERNS,
+  DEREF_LABELS,
+  DEREF_PROBES,
   rawStorageUsesIn,
   scanRepo,
 } from '../scripts/enforce-safe-local-storage.mjs';
-import { stripComments } from '../scripts/lib/source-scan.mjs';
 
 // ---------------------------------------------------------------------------
 // Why this test exists (#7833)
@@ -44,65 +44,18 @@ describe('raw localStorage guard (#7833)', () => {
     );
   });
 
-  it('catches every receiver prefix that names the same Storage object', () => {
-    // Negative coverage, and the reason it exists: "every pattern matches its
-    // own probe" is circular — it cannot see an idiom class no probe covers.
-    // All three of these returned [] in the first draft of this gate, while the
-    // SAFE `globalThis.localStorage?.getItem(k)` was the one form it caught, so
-    // the crashing variant was one deleted character away with CI green.
-    for (const src of [
-      'globalThis.localStorage.getItem(k);',
-      'self.localStorage.setItem(k, v);',
-      'window?.localStorage.getItem(k);',
-      'window.localStorage.removeItem(k);',
-      'top.localStorage.getItem(k);',
-      'parent.localStorage.getItem(k);',
-    ]) {
-      assert.notDeepEqual(rawStorageUsesIn(src), [], `${src} is not caught by any pattern`);
-    }
-  });
-
-  it('catches lexical variants of the dereference itself', () => {
-    // A bare `localStorage\.` pattern anchors on the dot immediately following
-    // the identifier, so ordinary spacing defeated it. The wrapped form is what
-    // makes this more than adversarial — a formatter produces it for a long
-    // chain — and `stripComments` turns the inline-comment form into exactly
-    // the spaced one.
-    for (const src of [
-      'localStorage .getItem(k);',
-      'localStorage\n  .getItem(k);',
-      '(localStorage).getItem(k);',
-      '( localStorage ) ?. getItem(k);',
-      'localStorage [k] = v;',
-      // Receiver side, found still open after the identifier side was fixed.
-      'window .localStorage.getItem(k);',
-      'window /* c */.localStorage.getItem(k);',
-      'globalThis\n  .localStorage.getItem(k);',
-      "window['localStorage'].getItem(k);",
-      'Storage . prototype . setItem . call(localStorage, k, v);',
-    ]) {
-      assert.notDeepEqual(
-        rawStorageUsesIn(stripComments(src)),
-        [],
-        `${JSON.stringify(src)} is not caught by any pattern`,
-      );
-    }
-  });
-
-  it('every pattern matches its own probe', () => {
-    // Asserting something like `re.source.length > 0` would be a tautology:
-    // even `new RegExp('').source` is the 4-character string "(?:)". Matching
-    // a fixture is the only assertion that goes red on a typo'd pattern.
-    for (const { label, re, probe, extraProbes = [] } of RAW_STORAGE_PATTERNS) {
-      assert.ok(re.test(probe), `${label} no longer matches its own probe — the pattern has drifted`);
-      for (const extra of extraProbes) {
-        assert.ok(re.test(extra), `${label} no longer matches its recorded variant: ${extra}`);
+  it('matches every recorded fixture, for every idiom', () => {
+    // Not circular: DEREF_PROBES is the accumulated evidence from three review
+    // rounds — whitespace on the identifier side, whitespace on the receiver
+    // side, and the `!` / `as` receiver wrappers. Each entry returned [] from
+    // some earlier version of this gate.
+    for (const [label, probes] of Object.entries(DEREF_PROBES)) {
+      for (const src of probes) {
+        assert.ok(
+          rawStorageUsesIn(src).some((entry) => entry.startsWith(`${label} `)),
+          `${label} no longer matches ${JSON.stringify(src)}`,
+        );
       }
-      assert.deepEqual(
-        rawStorageUsesIn(probe).filter((entry) => entry.startsWith(`${label} `)),
-        [`${label} x1`],
-        `${label} did not count its own probe exactly once`,
-      );
     }
   });
 
@@ -112,50 +65,43 @@ describe('raw localStorage guard (#7833)', () => {
     // second call site, so the count is what makes the ratchet real.
     assert.deepEqual(
       rawStorageUsesIn('localStorage.getItem(a); localStorage.setItem(b, c);'),
-      ['localStorage.<member> x2'],
+      [`${DEREF_LABELS.direct} x2`],
+    );
+  });
+
+  it('counts a global-qualified dereference exactly once', () => {
+    // `window.localStorage.getItem(k)` is two nested accesses. The regex era
+    // counted it under two labels at once, inflating those files' entries.
+    assert.deepEqual(
+      rawStorageUsesIn('window.localStorage.getItem(k);'),
+      [`${DEREF_LABELS.global} x1`],
     );
   });
 
   it('treats a bare identifier as legal and a dereference as not', () => {
-    // `this === localStorage` inside the cloud-prefs setItem patch is an
-    // identity comparison; it cannot throw on a null. Flagging it would push
-    // callers to "fix" working code, and an inventory nobody trusts gets
-    // rubber-stamped.
+    // `this === localStorage` is an identity comparison; it cannot throw on a
+    // null. Flagging it would push callers to "fix" working code, and an
+    // inventory nobody trusts gets rubber-stamped.
     assert.deepEqual(rawStorageUsesIn('if (this === localStorage) return;'), []);
-    // Whitespace tolerance must not start matching unrelated identifiers.
-    assert.deepEqual(rawStorageUsesIn('const x = windowFoo.localStorageBar;'), []);
     assert.deepEqual(rawStorageUsesIn("vi.stubGlobal('localStorage', null);"), []);
+    assert.deepEqual(rawStorageUsesIn('const x = windowFoo.localStorageBar;'), []);
+    assert.deepEqual(rawStorageUsesIn('keyFn.call(localStorage, i);'), []);
+  });
+
+  it('ignores an idiom that only appears in a comment', () => {
+    // Free with an AST — a comment is not a node. The regex era needed a
+    // comment stripper for this, and that stripper is what went blind on 1826
+    // lines of panel-layout.ts.
     assert.deepEqual(
-      rawStorageUsesIn('const v = localStorage.getItem(k);'),
-      ['localStorage.<member> x1'],
+      rawStorageUsesIn([
+        '// call localStorage.getItem(k) here',
+        '/* or localStorage.setItem(k, v) */',
+        "const glob = '../locales/*.json';",
+        '// see src/components/*Panel.ts',
+        'safeStorageGet(k);',
+      ].join('\n')),
+      [],
     );
-  });
-
-  it('preserves real code that merely LOOKS like a comment boundary', () => {
-    // The bug that made this gate blind on 1826 lines of panel-layout.ts: the
-    // old two-regex stripper ran its block-comment pass over RAW source, so a
-    // `/*` inside a line comment or a string opened a bogus region that ran to
-    // the next `*/` and swallowed everything between. Asserting only that
-    // comments are REMOVED cannot catch that; this asserts code SURVIVES.
-    const tricky = [
-      "// see the panels declared in src/components/*Panel.ts for the list",
-      "const glob = '../locales/*.json';",
-      "const url = 'https://example.com/x'; localStorage.getItem('a');",
-      "localStorage.setItem('b', '1');",
-      "/* a real block comment mentioning localStorage.getItem */",
-      "localStorage.removeItem('c');",
-    ].join('\n');
-    assert.deepEqual(rawStorageUsesIn(stripComments(tricky)), ['localStorage.<member> x3']);
-  });
-
-  it('does not count a dereference that only appears in a comment', () => {
-    // Scanning raw text would both false-fail a migrated file that documents
-    // the rule, and — worse, because it is silent — keep a legacy entry
-    // "observed" after its last real call is gone, so `stale` never fires.
-    const documented = stripComments(
-      ['// call localStorage.getItem(k) here', '/* or localStorage.setItem(k, v) */', 'safeStorageGet(k);'].join('\n'),
-    );
-    assert.deepEqual(rawStorageUsesIn(documented), []);
   });
 
   it('exempts the canonical helper and nothing else', () => {

--- a/tests/safe-local-storage-guard.test.mts
+++ b/tests/safe-local-storage-guard.test.mts
@@ -9,8 +9,8 @@ import {
   RAW_STORAGE_PATTERNS,
   rawStorageUsesIn,
   scanRepo,
-  stripComments,
 } from '../scripts/enforce-safe-local-storage.mjs';
+import { stripComments } from '../scripts/lib/source-scan.mjs';
 
 // ---------------------------------------------------------------------------
 // Why this test exists (#7833)
@@ -44,12 +44,33 @@ describe('raw localStorage guard (#7833)', () => {
     );
   });
 
+  it('catches every receiver prefix that names the same Storage object', () => {
+    // Negative coverage, and the reason it exists: "every pattern matches its
+    // own probe" is circular — it cannot see an idiom class no probe covers.
+    // All three of these returned [] in the first draft of this gate, while the
+    // SAFE `globalThis.localStorage?.getItem(k)` was the one form it caught, so
+    // the crashing variant was one deleted character away with CI green.
+    for (const src of [
+      'globalThis.localStorage.getItem(k);',
+      'self.localStorage.setItem(k, v);',
+      'window?.localStorage.getItem(k);',
+      'window.localStorage.removeItem(k);',
+      'top.localStorage.getItem(k);',
+      'parent.localStorage.getItem(k);',
+    ]) {
+      assert.notDeepEqual(rawStorageUsesIn(src), [], `${src} is not caught by any pattern`);
+    }
+  });
+
   it('every pattern matches its own probe', () => {
     // Asserting something like `re.source.length > 0` would be a tautology:
     // even `new RegExp('').source` is the 4-character string "(?:)". Matching
     // a fixture is the only assertion that goes red on a typo'd pattern.
-    for (const { label, re, probe } of RAW_STORAGE_PATTERNS) {
+    for (const { label, re, probe, extraProbes = [] } of RAW_STORAGE_PATTERNS) {
       assert.ok(re.test(probe), `${label} no longer matches its own probe — the pattern has drifted`);
+      for (const extra of extraProbes) {
+        assert.ok(re.test(extra), `${label} no longer matches its recorded variant: ${extra}`);
+      }
       assert.deepEqual(
         rawStorageUsesIn(probe).filter((entry) => entry.startsWith(`${label} `)),
         [`${label} x1`],
@@ -79,6 +100,23 @@ describe('raw localStorage guard (#7833)', () => {
       rawStorageUsesIn('const v = localStorage.getItem(k);'),
       ['localStorage.<member> x1'],
     );
+  });
+
+  it('preserves real code that merely LOOKS like a comment boundary', () => {
+    // The bug that made this gate blind on 1826 lines of panel-layout.ts: the
+    // old two-regex stripper ran its block-comment pass over RAW source, so a
+    // `/*` inside a line comment or a string opened a bogus region that ran to
+    // the next `*/` and swallowed everything between. Asserting only that
+    // comments are REMOVED cannot catch that; this asserts code SURVIVES.
+    const tricky = [
+      "// see the panels declared in src/components/*Panel.ts for the list",
+      "const glob = '../locales/*.json';",
+      "const url = 'https://example.com/x'; localStorage.getItem('a');",
+      "localStorage.setItem('b', '1');",
+      "/* a real block comment mentioning localStorage.getItem */",
+      "localStorage.removeItem('c');",
+    ].join('\n');
+    assert.deepEqual(rawStorageUsesIn(stripComments(tricky)), ['localStorage.<member> x3']);
   });
 
   it('does not count a dereference that only appears in a comment', () => {
@@ -142,6 +180,11 @@ describe('raw localStorage guard (#7833)', () => {
       'src/services/runtime.ts',
       'src/services/tv-mode.ts',
       'src/settings-main.ts',
+      // Re-listing this one would mean the private rawGet/rawSet/rawRemove
+      // trio came back. It was added by #7833 itself and removed in review:
+      // its justification (bypassing an own-property override of
+      // `localStorage`) described a threat that exists nowhere in this repo.
+      'src/utils/cloud-prefs-sync.ts',
     ]) {
       assert.equal(
         LEGACY_RAW_LOCAL_STORAGE.some((entry) => entry.startsWith(`${file} ::`)),

--- a/tests/safe-local-storage-guard.test.mts
+++ b/tests/safe-local-storage-guard.test.mts
@@ -74,6 +74,12 @@ describe('raw localStorage guard (#7833)', () => {
       '(localStorage).getItem(k);',
       '( localStorage ) ?. getItem(k);',
       'localStorage [k] = v;',
+      // Receiver side, found still open after the identifier side was fixed.
+      'window .localStorage.getItem(k);',
+      'window /* c */.localStorage.getItem(k);',
+      'globalThis\n  .localStorage.getItem(k);',
+      "window['localStorage'].getItem(k);",
+      'Storage . prototype . setItem . call(localStorage, k, v);',
     ]) {
       assert.notDeepEqual(
         rawStorageUsesIn(stripComments(src)),
@@ -116,6 +122,8 @@ describe('raw localStorage guard (#7833)', () => {
     // callers to "fix" working code, and an inventory nobody trusts gets
     // rubber-stamped.
     assert.deepEqual(rawStorageUsesIn('if (this === localStorage) return;'), []);
+    // Whitespace tolerance must not start matching unrelated identifiers.
+    assert.deepEqual(rawStorageUsesIn('const x = windowFoo.localStorageBar;'), []);
     assert.deepEqual(rawStorageUsesIn("vi.stubGlobal('localStorage', null);"), []);
     assert.deepEqual(
       rawStorageUsesIn('const v = localStorage.getItem(k);'),

--- a/tests/safe-local-storage-guard.test.mts
+++ b/tests/safe-local-storage-guard.test.mts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+import {
+  GUARD_EXEMPT_FILES,
+  LEGACY_RAW_LOCAL_STORAGE,
+  MIN_SCANNED_FILES,
+  RAW_STORAGE_PATTERNS,
+  rawStorageUsesIn,
+  scanRepo,
+  stripComments,
+} from '../scripts/enforce-safe-local-storage.mjs';
+
+// ---------------------------------------------------------------------------
+// Why this test exists (#7833)
+// ---------------------------------------------------------------------------
+//
+// The scan lives in scripts/enforce-safe-local-storage.mjs so it can run from
+// .husky/pre-push on any `src/` change — the edit it must catch is "someone
+// touched a service or a panel", which touches nothing under tests/, and
+// scripts/prepush-changed-tests.sh only selects a test file when that test
+// file is itself in the changed set.
+//
+// This file is the other half: it proves the scanner has TEETH. A guard whose
+// patterns quietly stopped matching would report a clean tree forever, which
+// is indistinguishable from success and worse than no guard at all.
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+describe('raw localStorage guard (#7833)', () => {
+  const scan = scanRepo(REPO_ROOT);
+
+  it('sees the whole src population', () => {
+    // Without this the scan could silently match nothing (a moved directory, a
+    // changed extension filter) and every assertion below would pass vacuously.
+    assert.ok(
+      scan.scannedFiles.length >= MIN_SCANNED_FILES,
+      `expected >= ${MIN_SCANNED_FILES} scanned files under src/ (860 at #7833), found ${scan.scannedFiles.length} — the scan or the source layout has drifted`,
+    );
+    assert.ok(
+      scan.observed.length > 0,
+      'the raw-storage patterns matched nothing — the patterns have gone stale',
+    );
+  });
+
+  it('every pattern matches its own probe', () => {
+    // Asserting something like `re.source.length > 0` would be a tautology:
+    // even `new RegExp('').source` is the 4-character string "(?:)". Matching
+    // a fixture is the only assertion that goes red on a typo'd pattern.
+    for (const { label, re, probe } of RAW_STORAGE_PATTERNS) {
+      assert.ok(re.test(probe), `${label} no longer matches its own probe — the pattern has drifted`);
+      assert.deepEqual(
+        rawStorageUsesIn(probe).filter((entry) => entry.startsWith(`${label} `)),
+        [`${label} x1`],
+        `${label} did not count its own probe exactly once`,
+      );
+    }
+  });
+
+  it('counts a repeated dereference rather than collapsing it to a boolean', () => {
+    // The regression shape this guard exists for: new code lands in the files
+    // that ALREADY read storage. A per-file boolean would pass green on a
+    // second call site, so the count is what makes the ratchet real.
+    assert.deepEqual(
+      rawStorageUsesIn('localStorage.getItem(a); localStorage.setItem(b, c);'),
+      ['localStorage.<member> x2'],
+    );
+  });
+
+  it('treats a bare identifier as legal and a dereference as not', () => {
+    // `this === localStorage` inside the cloud-prefs setItem patch is an
+    // identity comparison; it cannot throw on a null. Flagging it would push
+    // callers to "fix" working code, and an inventory nobody trusts gets
+    // rubber-stamped.
+    assert.deepEqual(rawStorageUsesIn('if (this === localStorage) return;'), []);
+    assert.deepEqual(rawStorageUsesIn("vi.stubGlobal('localStorage', null);"), []);
+    assert.deepEqual(
+      rawStorageUsesIn('const v = localStorage.getItem(k);'),
+      ['localStorage.<member> x1'],
+    );
+  });
+
+  it('does not count a dereference that only appears in a comment', () => {
+    // Scanning raw text would both false-fail a migrated file that documents
+    // the rule, and — worse, because it is silent — keep a legacy entry
+    // "observed" after its last real call is gone, so `stale` never fires.
+    const documented = stripComments(
+      ['// call localStorage.getItem(k) here', '/* or localStorage.setItem(k, v) */', 'safeStorageGet(k);'].join('\n'),
+    );
+    assert.deepEqual(rawStorageUsesIn(documented), []);
+  });
+
+  it('exempts the canonical helper and nothing else', () => {
+    assert.deepEqual([...GUARD_EXEMPT_FILES], ['src/utils/safe-storage.ts']);
+    // The helper is the one file that MUST dereference storage, so its
+    // exemption has to be real — if the scan started including it, the
+    // inventory would grow an entry nobody can ever remove.
+    assert.equal(
+      scan.scannedFiles.some((abs) => abs.endsWith('src/utils/safe-storage.ts')),
+      false,
+    );
+  });
+
+  it('keeps the recorded inventory matching the tree', () => {
+    assert.deepEqual(
+      scan.unlisted,
+      [],
+      'new raw localStorage dereferences — route them through @/utils/safe-storage, or record them with a reason',
+    );
+    assert.deepEqual(
+      scan.stale,
+      [],
+      'recorded dereferences that no longer exist — lower the count or delete the line in LEGACY_RAW_LOCAL_STORAGE',
+    );
+  });
+
+  it('records every entry with a count so the ratchet can only tighten', () => {
+    for (const entry of LEGACY_RAW_LOCAL_STORAGE) {
+      assert.match(
+        entry,
+        / :: .+ x[1-9]\d*$/,
+        `${entry} is missing a positive occurrence count`,
+      );
+    }
+    assert.deepEqual(
+      [...LEGACY_RAW_LOCAL_STORAGE].sort(),
+      LEGACY_RAW_LOCAL_STORAGE,
+      'inventory must stay sorted so diffs stay readable',
+    );
+    assert.equal(
+      new Set(LEGACY_RAW_LOCAL_STORAGE).size,
+      LEGACY_RAW_LOCAL_STORAGE.length,
+      'a duplicated entry would let one of the pair go stale unnoticed',
+    );
+  });
+
+  it('keeps the sites #7833 migrated off raw storage', () => {
+    // These had genuinely unguarded, reachable dereferences before #7833.
+    // Re-listing one here would silence the guard on a regression.
+    for (const file of [
+      'src/services/runtime.ts',
+      'src/services/tv-mode.ts',
+      'src/settings-main.ts',
+    ]) {
+      assert.equal(
+        LEGACY_RAW_LOCAL_STORAGE.some((entry) => entry.startsWith(`${file} ::`)),
+        false,
+        `${file} was migrated off raw localStorage by #7833 and must not return to the inventory`,
+      );
+    }
+  });
+});

--- a/tests/safe-local-storage-guard.test.mts
+++ b/tests/safe-local-storage-guard.test.mts
@@ -62,6 +62,27 @@ describe('raw localStorage guard (#7833)', () => {
     }
   });
 
+  it('catches lexical variants of the dereference itself', () => {
+    // A bare `localStorage\.` pattern anchors on the dot immediately following
+    // the identifier, so ordinary spacing defeated it. The wrapped form is what
+    // makes this more than adversarial — a formatter produces it for a long
+    // chain — and `stripComments` turns the inline-comment form into exactly
+    // the spaced one.
+    for (const src of [
+      'localStorage .getItem(k);',
+      'localStorage\n  .getItem(k);',
+      '(localStorage).getItem(k);',
+      '( localStorage ) ?. getItem(k);',
+      'localStorage [k] = v;',
+    ]) {
+      assert.notDeepEqual(
+        rawStorageUsesIn(stripComments(src)),
+        [],
+        `${JSON.stringify(src)} is not caught by any pattern`,
+      );
+    }
+  });
+
   it('every pattern matches its own probe', () => {
     // Asserting something like `re.source.length > 0` would be a tautology:
     // even `new RegExp('').source` is the 4-character string "(?:)". Matching

--- a/tests/source-scan.test.mts
+++ b/tests/source-scan.test.mts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { stripComments } from '../scripts/lib/source-scan.mjs';
+
+// ---------------------------------------------------------------------------
+// Why this test exists (#7833)
+// ---------------------------------------------------------------------------
+//
+// `stripComments` is shared infrastructure for two merge-blocking gates
+// (`enforce-panel-content-writes`, and `enforce-safe-local-storage` until it
+// moved to the AST). Its failure mode is not a crash — it is blanking real code
+// so the gate scans less than it reports, then passes green over the very edit
+// it exists to catch. That has now happened twice, from two different lexing
+// bugs, so the assertions below are about what SURVIVES stripping, not only
+// about what gets removed. A test that checks comments are gone cannot see
+// this class at all.
+
+/** The last line is the code the gate must still be able to see. */
+function survives(source: string): boolean {
+  return stripComments(source).split('\n').pop()!.trim() !== '';
+}
+
+describe('stripComments', () => {
+  it('removes comments while preserving line count and offsets', () => {
+    const src = ['// a line comment', '/* a block', '   comment */', 'const x = 1;'].join('\n');
+    const out = stripComments(src);
+    assert.equal(out.length, src.length, 'offsets must be preserved');
+    assert.equal(out.split('\n').length, src.split('\n').length, 'line count must be preserved');
+    assert.match(out, /const x = 1;/);
+    assert.doesNotMatch(out, /line comment|block/);
+  });
+
+  it('does not let a comment opener inside a LINE comment open a region', () => {
+    // The first blindness: the old two-regex stripper ran its block-comment
+    // pass over raw source, so this `/*` opened a region running to the next
+    // `*/` — 1826 of panel-layout.ts's 4554 lines, in practice.
+    assert.ok(survives([
+      "// declared in src/components/*Panel.ts). A deferred note",
+      'this.content.append(row);',
+    ].join('\n')));
+  });
+
+  it('does not let a comment opener inside a STRING open a region', () => {
+    assert.ok(survives(["const glob = '../locales/*.json';", 'localStorage.getItem(k);'].join('\n')));
+    assert.ok(survives(["const url = 'https://example.com/x';", 'localStorage.getItem(k);'].join('\n')));
+  });
+
+  it('resumes the right template when an interpolation nests another', () => {
+    // The second blindness: a single in-string flag treats the INNER opening
+    // backtick as the outer closing quote, drops back to code mid-string, and
+    // the `/*` in the remaining text then blanks everything to EOF — so the
+    // panel gate passed green over a newly added direct content write.
+    assert.ok(survives(['const s = `outer ${`/*`}`;', 'this.content.append(row);'].join('\n')));
+    assert.ok(survives(['const a = `x ${ obj[`y ${z}`] } w`;', 'localStorage.getItem(k);'].join('\n')));
+  });
+
+  it('still strips a template that is genuinely unterminated-looking but closed', () => {
+    const out = stripComments(['const t = `hello ${name}`; /* gone */', 'const y = 2;'].join('\n'));
+    assert.match(out, /const t = `hello \$\{name\}`;/);
+    assert.doesNotMatch(out, /gone/);
+    assert.match(out, /const y = 2;/);
+  });
+
+  it('does not run the string state past an escaped closing quote', () => {
+    // A trailing backslash before the quote would otherwise swallow it and
+    // leak the string state into the code that follows.
+    assert.ok(survives(["const b = '\\\\';", 'this.content.append(row);'].join('\n')));
+  });
+});

--- a/tests/source-scan.test.mts
+++ b/tests/source-scan.test.mts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { stripComments } from '../scripts/lib/source-scan.mjs';
+import { readFileSync, readdirSync, lstatSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { collectTsFiles, lexSource, stripComments } from '../scripts/lib/source-scan.mjs';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 // ---------------------------------------------------------------------------
 // Why this test exists (#7833)
@@ -66,5 +72,46 @@ describe('stripComments', () => {
     // A trailing backslash before the quote would otherwise swallow it and
     // leak the string state into the code that follows.
     assert.ok(survives(["const b = '\\\\';", 'this.content.append(row);'].join('\n')));
+  });
+
+  it('reads a regex literal as a regex, not as quoted string content', () => {
+    // Live in src/main.ts:454 — `!/^'[^']*'$/.test(token)`. An odd number of
+    // apostrophes inside a regex de-synced the lexer for the entire rest of
+    // the file, which is how 13 src/ files were being mis-scanned.
+    const src = [
+      "const ok = tokens.some(t => !/^'[^']*'$/.test(t));",
+      'this.content.append(row);',
+    ].join('\n');
+    assert.ok(survives(src));
+    assert.equal(lexSource(src).ok, true);
+  });
+
+  it('does not mistake division for a regex', () => {
+    // The other half of the ambiguity: after a value, `/` divides. Reading it
+    // as a regex would swallow code up to the next slash.
+    const src = ['const ratio = width / height;', 'this.content.append(row);'].join('\n');
+    assert.ok(survives(src));
+    assert.equal(lexSource(src).ok, true);
+  });
+
+  it('reports an untrustworthy lex instead of silently blanking', () => {
+    // The backstop for whatever the regex heuristic still gets wrong: a
+    // terminal state other than `code` means the scan cannot be trusted, and
+    // the gates fail on it rather than reporting a clean run over unread code.
+    assert.equal(lexSource("const s = 'unterminated;").ok, false);
+    assert.equal(lexSource('const t = `unterminated;').ok, false);
+    assert.equal(lexSource('const u = `a ${ b ;').ok, false);
+    assert.equal(lexSource('const v = 1; // fine\n/* also fine */').ok, true);
+  });
+
+  it('lexes every scanned source file cleanly', () => {
+    // The assertion that would have caught this class at the source: if any
+    // real file fails to lex, both gates are scanning less than they claim.
+    const files = collectTsFiles(join(REPO_ROOT, 'src'), { readdirSync, lstatSync, join });
+    const bad = files
+      .map((abs) => [abs, lexSource(readFileSync(abs, 'utf8'))] as const)
+      .filter(([, r]) => !r.ok)
+      .map(([abs, r]) => `${abs} (ended in ${r.terminalMode})`);
+    assert.deepEqual(bad, []);
   });
 });

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1131,7 +1131,10 @@ describe('PRO widget — store and sanitizer', () => {
     assert.ok(loadIdx !== -1, 'shared widget materializer not found');
     const loadBody = store.slice(loadIdx, loadIdx + 2_000);
     assert.ok(
-      /localStorage\.getItem\(proHtmlKey\(w\.id\)\)/.test(loadBody),
+      // Accessor-agnostic: #7833 moved this read onto safeStorageGet, and what
+      // the assertion is actually about is that the side key is consulted at
+      // all — pinning the spelling just re-breaks on the next migration.
+      /(?:localStorage\.getItem|safeStorageGet)\(proHtmlKey\(w\.id\)\)/.test(loadBody),
       'loadWidgets must read legacy PRO HTML from the side key',
     );
   });


### PR DESCRIPTION
## Summary

On Android WebView with DOM storage disabled, `window.localStorage` is `null` rather than throwing, so any unguarded `localStorage.foo()` is a `TypeError`. Affected users lost the sign-in reconciliation on boot, and the Export Settings button did nothing at all. #7832 fixed the two sites with production evidence; this closes the rest of the class and adds the CI gate that stops it recurring a fourth time (`WORLDMONITOR-122`, `-11X`, `-XG`).

Three call sites read as guarded and were not. Each was reproduced red before the fix:

| Site | Why the guard never fired |
|---|---|
| `cloud-prefs-sync.applyCloudBlob` | `try { … } finally { … }` — a `finally` restores the patch-suppression flag but catches nothing, and `onSignIn` reconciles ownership sidecars synchronously on the boot path |
| `persistent-cache.deleteFromLocalStorageByPrefix` | opened with `typeof localStorage === 'undefined'`, and `typeof null` is `'object'` |
| `settings-persistence.exportSettings` | no guard at all |

## The gate is the deliverable

Nothing mechanical stood between these crashes and a green CI: `biome.json` has no matching rule, there is no eslint config, and no other `enforce-*.mjs` looked at storage. `scripts/enforce-safe-local-storage.mjs` bans dereferencing `localStorage` outside `src/utils/safe-storage.ts`, with an occurrence-counted inventory so a **new** dereference in a file that already has some fails as `unlisted` rather than hiding inside the count. It runs in `.husky/pre-push` and in the `biome` CI job that `deploy-gate.sh` already requires.

**It matches on the TypeScript AST, not on source text.** It started as regex, and review found a fresh bypass in three consecutive rounds — whitespace around the identifier's accessor, then around the receiver's, then `localStorage!.getItem(k)` (valid TS; `biome.json` leaves `noNonNullAssertion` off). Each round the patterns were widened and the class declared closed; each time the next round found another token. Separating a regex from a division genuinely needs parser context, so the parser does it. Switching also surfaced three **real** dereferences the regex never saw — all `(localStorage as unknown as {…})` casts in `followed-only-chip.ts`.

## The review found more than the original diff did

Eleven rounds. The most useful findings were against this PR's own new code, so they are worth reading before the diff:

- **The gate was blind on 1826 lines.** The shared comment stripper ran its block-comment regex over raw source, so a `/*` inside a *line comment* (`src/components/*Panel.ts`) opened a bogus region running to the next `*/`. `panel-layout.ts` measured 7 dereferences where it has 9. Inherited by copy from `enforce-panel-content-writes.mjs`, which was blind on 106 lines the same way.
- **The scanner lost track five different ways** — that `/*`, one inside a string, a nested template interpolation, an untracked regex literal (**live** in `src/main.ts:454`, de-syncing that file from line 455 to EOF across 13 files), and a regex statement after a control condition. `scripts/lib/source-scan.mjs` now takes comment ranges from the TypeScript parser, and reports `ok: false` when a file will not parse so a gate fails loudly instead of scanning less than it claims.
- **Silent cloud data loss, in several shapes.** Replacing raw reads with a degrading accessor turned *"I could not read this"* into *"this is absent"*, and every site treating absence as intent became a corruption path: `buildCloudBlob` **deleted** an unreadable preference from the cloud; the dirty-key sidecar clobbered other tabs' markers; `onSignOut` skipped its whole cleanup and left a live cached token for the signed-out user; a rejected marker write let a stale version claim a reconciliation. Every read that feeds a decision is checked now, with `getSyncState`/`getLastSyncAt` documented as the intentional display-only exceptions.

## Behavior changes worth reviewing

- `exportSettings` **throws** again when storage cannot be read. Its caller does `try { export } catch { showToast(exportFailed) }`, so returning an empty payload turned an unreadable store into a green "Exported" toast over an empty backup. Testing *availability* was not enough either — a handle can exist while reads throw, so `safeStorageSnapshot()` reports whether the reads succeeded.
- Cloud-prefs reconciliation now **fails closed** on anything undeterminable: a rejected pref write, an unreadable sync or schema marker, unresolvable account provenance. The schema marker persists **before** the sync version, so a partial failure cannot leave a durable claim that a generation was reconciled.
- `safeStorageSetChecked` returns `true` when there is **no** store at all — nothing was written, but nothing durable disagrees, so a null-storage device re-reconciles rather than erroring on every load. `false` is reserved for a store that was obtained and refused the write.

## Known gaps, left deliberately

- A **count-neutral swap** inside an inventoried file passes — deleting one dereference and adding another keeps `N` constant.
- **Aliasing and destructuring** (`const ls = localStorage`) need the type *checker*, not the parser, so they are the one class this gate structurally cannot close. Same for **`sessionStorage`**, which has the identical null shape.
- The scan is `src/**/*.ts`, so `index.html` prepaint scripts and `pro-test/src` are outside it.
- `src/App.ts` stays inventoried rather than migrated: its constructor capability probe genuinely fires, and every migration below sits behind that flag.
- `followed-only-chip.ts:297` has the same `typeof localStorage === 'undefined'` false guard fixed in `persistent-cache` — pre-existing, now visible in the inventory, deliberately not pulled into this PR.

## Validation

- `test:data` 31,195 passing / 0 failing with built output; `test:dom` 944 passing.
- `typecheck`, `lint`, `lint:boundaries`, and both enforcement gates green.
- Bundle budget re-checked against a clean build (env files moved aside, `SENTRY_AUTH_TOKEN` unset — with it set every chunk inflates ~460 B and the snapshot silently mismatches CI). Net **-237 B**.
- The gate was verified to fail on a new dereference, on a count bump in an already-inventoried file, and through a symlinked checkout.
- Every behavioural regression test here was verified **red with its fix reverted**. Two that could not be made to fail were removed rather than shipped: one asserted "key absent from the posted blob", which is the deletion it was meant to catch, and one could not reach its branch because an earlier fix already guards the path.

Fixes #7833

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5-D97757?logo=claude&logoColor=white)
