### PR TITLE
fix(seed): retain FRED and BIS caches on refresh failure

### DIFF
--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -27,10 +27,10 @@ import {
   loadEnvFile,
   CHROME_UA,
   runSeed,
-  writeExtraKey,
   extendExistingTtl,
-  writeSeedMeta,
   resolveSeedMetaTtl,
+  withRetry,
+  writeExtraKeyWithMetaAtomically,
 } from './_seed-utils.mjs';
 import { tokensToContentMeta, DAY_MIN } from './_content-age-helpers.mjs';
 
@@ -401,7 +401,7 @@ async function fetchProperty(dataset, kind) {
 
 // Each dataset is handled independently: a single fetch failure in any ONE
 // of DSR/SPP/CPP must not block the healthy ones from publishing fresh data.
-// We do SPP/CPP writes as side-effects of fetchAll (via writeExtraKey or
+// We do SPP/CPP writes as side-effects of fetchAll (via atomic pair writes or
 // extendExistingTtl, per-dataset). The DSR slice flows through the normal
 // runSeed canonical-write path; when DSR is empty, publishTransform yields
 // an empty payload that fails validate() → atomicPublish.skipped=true →
@@ -421,21 +421,7 @@ export async function fetchAll() {
   await publishDatasetIndependently(KEYS.spp, spp, META_KEYS.spp);
   await publishDatasetIndependently(KEYS.cpp, cpp, META_KEYS.cpp);
 
-  // NOTE: DSR per-dataset seed-meta is written by `dsrAfterPublish` (passed to
-  // runSeed below), NOT here. That guarantees seed-meta:economic:bis-dsr is
-  // refreshed only AFTER atomicPublish succeeds on the canonical DSR key — a
-  // Redis hiccup at publish time must not leave health reporting "fresh"
-  // while the canonical key is stale.
-
   return { dsr, spp, cpp };
-}
-
-// runSeed afterPublish hook — fires only on a successful atomicPublish of the
-// canonical DSR key. `data` is the raw fetchAll() return value; we re-derive
-// the DSR slice and refresh its per-dataset seed-meta.
-export async function dsrAfterPublish(data) {
-  if (planDatasetAction(data?.dsr) !== 'write') return;
-  await writeSeedMeta(KEYS.dsr, data.dsr.entries.length, META_KEYS.dsr).catch(() => {});
 }
 
 // Pure decision function: classifies what action should be taken for a
@@ -459,16 +445,16 @@ export async function publishDatasetIndependently(key, payload, metaKey) {
   const action = planDatasetAction(payload);
   if (action === 'write') {
     try {
-      await writeExtraKey(key, payload, TTL);
-      if (metaKey) {
-        const wroteMeta = await writeSeedMeta(key, payload.entries.length, metaKey).catch(() => false);
-        if (!wroteMeta) {
-          console.warn(`  ${key}: metadata write failed; extending existing payload and metadata TTL`);
-          await preserveDatasetLastGood(key, metaKey).catch(() => {});
-        }
-      }
+      await withRetry(() => writeExtraKeyWithMetaAtomically({
+        key,
+        data: payload,
+        ttlSeconds: TTL,
+        recordCount: payload.entries.length,
+        metaKey,
+        metaTtlSeconds: META_TTL,
+      }), 2, 1_000);
     } catch (err) {
-      console.warn(`  ${key}: write failed (${err.message}); extending existing payload and metadata TTL`);
+      console.warn(`  ${key}: atomic publication failed (${err.message}); extending existing payload and metadata TTL`);
       await preserveDatasetLastGood(key, metaKey).catch(() => {});
     }
   } else {
@@ -504,6 +490,24 @@ export function bisDsrContentMeta(data) {
   return tokensToContentMeta(entries.map((e) => e?.period));
 }
 
+export async function publishBisDsrAtomically(data, {
+  canonicalKey = KEYS.dsr,
+  payloadValue,
+  ttlSeconds = TTL,
+} = {}) {
+  if (planDatasetAction(data?.dsr) !== 'write') {
+    throw new Error('BIS DSR atomic publication requires a non-empty DSR slice');
+  }
+  await writeExtraKeyWithMetaAtomically({
+    key: canonicalKey,
+    data: payloadValue ?? data.dsr,
+    ttlSeconds,
+    recordCount: data.dsr.entries.length,
+    metaKey: META_KEYS.dsr,
+    metaTtlSeconds: META_TTL,
+  });
+}
+
 export async function runBisExtendedSeed({
   fetchAllImpl = fetchAll,
   runSeedImpl,
@@ -513,7 +517,7 @@ export async function runBisExtendedSeed({
     ttlSeconds: TTL,
     sourceVersion: 'bis-sdmx-csv-extended',
     publishTransform,
-    afterPublish: dsrAfterPublish,
+    publishAtomically: publishBisDsrAtomically,
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 1440,

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -31,7 +31,6 @@ import {
   extendExistingTtl,
   resolveSeedMetaTtl,
   withRetry,
-  writeExtraKeyWithMetaAtomically,
 } from './_seed-utils.mjs';
 import { tokensToContentMeta, DAY_MIN } from './_content-age-helpers.mjs';
 
@@ -442,18 +441,47 @@ async function preserveDatasetLastGood(key, metaKey) {
   ]);
 }
 
+async function publishBisValuesAtomically(entries) {
+  const { url, token } = getRedisCredentials();
+  const commands = [
+    ['MSET', ...entries.flatMap(({ key, value }) => [key, JSON.stringify(value)])],
+    ...entries.map(({ key, ttlSeconds }) => ['EXPIRE', key, ttlSeconds]),
+  ];
+  const response = await fetch(`${url}/multi-exec`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': CHROME_UA,
+    },
+    body: JSON.stringify(commands),
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error(`BIS atomic publication failed: HTTP ${response.status}`);
+  const results = await response.json();
+  if (
+    !Array.isArray(results)
+    || results.length !== commands.length
+    || results[0]?.result !== 'OK'
+    || results.slice(1).some((result) => result?.result !== 1)
+  ) {
+    throw new Error('BIS atomic publication returned an invalid command result');
+  }
+}
+
 export async function publishDatasetIndependently(key, payload, metaKey) {
   const action = planDatasetAction(payload);
   if (action === 'write') {
     try {
-      await withRetry(() => writeExtraKeyWithMetaAtomically({
-        key,
-        data: payload,
-        ttlSeconds: TTL,
-        recordCount: payload.entries.length,
-        metaKey,
-        metaTtlSeconds: META_TTL,
-      }), 2, 1_000);
+      const fetchedAt = Date.now();
+      await withRetry(() => publishBisValuesAtomically([
+        { key, value: payload, ttlSeconds: TTL },
+        {
+          key: metaKey,
+          value: { fetchedAt, recordCount: payload.entries.length },
+          ttlSeconds: META_TTL,
+        },
+      ]), 2, 1_000);
     } catch (err) {
       console.warn(`  ${key}: atomic publication failed (${err.message}); extending existing payload and metadata TTL`);
       await preserveDatasetLastGood(key, metaKey).catch(() => {});
@@ -499,7 +527,6 @@ export async function publishBisDsrAtomically(data, {
   if (planDatasetAction(data?.dsr) !== 'write') {
     throw new Error('BIS DSR atomic publication requires a non-empty DSR slice');
   }
-  const { url, token } = getRedisCredentials();
   const recordCount = data.dsr.entries.length;
   const seed = payloadValue?._seed;
   const fetchedAt = Number.isFinite(seed?.fetchedAt) ? seed.fetchedAt : Date.now();
@@ -513,35 +540,11 @@ export async function publishBisDsrAtomically(data, {
   for (const field of ['newestItemAt', 'oldestItemAt', 'maxContentAgeMin']) {
     if (Object.hasOwn(seed ?? {}, field)) aggregateMeta[field] = seed[field];
   }
-  const commands = [
-    ['MSET',
-      canonicalKey, JSON.stringify(payloadValue ?? data.dsr),
-      META_KEYS.dsr, JSON.stringify({ fetchedAt, recordCount }),
-      AGGREGATE_META_KEY, JSON.stringify(aggregateMeta)],
-    ['EXPIRE', canonicalKey, ttlSeconds],
-    ['EXPIRE', META_KEYS.dsr, META_TTL],
-    ['EXPIRE', AGGREGATE_META_KEY, META_TTL],
-  ];
-  const response = await fetch(`${url}/multi-exec`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      'User-Agent': CHROME_UA,
-    },
-    body: JSON.stringify(commands),
-    signal: AbortSignal.timeout(5_000),
-  });
-  if (!response.ok) throw new Error(`BIS DSR atomic publication failed: HTTP ${response.status}`);
-  const results = await response.json();
-  if (
-    !Array.isArray(results)
-    || results.length !== commands.length
-    || results[0]?.result !== 'OK'
-    || results.slice(1).some((result) => result?.result !== 1)
-  ) {
-    throw new Error('BIS DSR atomic publication returned an invalid command result');
-  }
+  await publishBisValuesAtomically([
+    { key: canonicalKey, value: payloadValue ?? data.dsr, ttlSeconds },
+    { key: META_KEYS.dsr, value: { fetchedAt, recordCount }, ttlSeconds: META_TTL },
+    { key: AGGREGATE_META_KEY, value: aggregateMeta, ttlSeconds: META_TTL },
+  ]);
 }
 
 export async function runBisExtendedSeed({

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -26,6 +26,7 @@
 import {
   loadEnvFile,
   CHROME_UA,
+  getRedisCredentials,
   runSeed,
   extendExistingTtl,
   resolveSeedMetaTtl,
@@ -498,14 +499,49 @@ export async function publishBisDsrAtomically(data, {
   if (planDatasetAction(data?.dsr) !== 'write') {
     throw new Error('BIS DSR atomic publication requires a non-empty DSR slice');
   }
-  await writeExtraKeyWithMetaAtomically({
-    key: canonicalKey,
-    data: payloadValue ?? data.dsr,
-    ttlSeconds,
-    recordCount: data.dsr.entries.length,
-    metaKey: META_KEYS.dsr,
-    metaTtlSeconds: META_TTL,
+  const { url, token } = getRedisCredentials();
+  const recordCount = data.dsr.entries.length;
+  const seed = payloadValue?._seed;
+  const fetchedAt = Number.isFinite(seed?.fetchedAt) ? seed.fetchedAt : Date.now();
+  const aggregateMeta = {
+    fetchedAt,
+    recordCount: Number.isInteger(seed?.recordCount) ? seed.recordCount : recordCount,
+    sourceVersion: typeof seed?.sourceVersion === 'string'
+      ? seed.sourceVersion
+      : 'bis-sdmx-csv-extended',
+  };
+  for (const field of ['newestItemAt', 'oldestItemAt', 'maxContentAgeMin']) {
+    if (Object.hasOwn(seed ?? {}, field)) aggregateMeta[field] = seed[field];
+  }
+  const commands = [
+    ['MSET',
+      canonicalKey, JSON.stringify(payloadValue ?? data.dsr),
+      META_KEYS.dsr, JSON.stringify({ fetchedAt, recordCount }),
+      AGGREGATE_META_KEY, JSON.stringify(aggregateMeta)],
+    ['EXPIRE', canonicalKey, ttlSeconds],
+    ['EXPIRE', META_KEYS.dsr, META_TTL],
+    ['EXPIRE', AGGREGATE_META_KEY, META_TTL],
+  ];
+  const response = await fetch(`${url}/multi-exec`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': CHROME_UA,
+    },
+    body: JSON.stringify(commands),
+    signal: AbortSignal.timeout(5_000),
   });
+  if (!response.ok) throw new Error(`BIS DSR atomic publication failed: HTTP ${response.status}`);
+  const results = await response.json();
+  if (
+    !Array.isArray(results)
+    || results.length !== commands.length
+    || results[0]?.result !== 'OK'
+    || results.slice(1).some((result) => result?.result !== 1)
+  ) {
+    throw new Error('BIS DSR atomic publication returned an invalid command result');
+  }
 }
 
 export async function runBisExtendedSeed({

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -461,9 +461,6 @@ export async function publishDatasetIndependently(key, payload, metaKey) {
     try {
       await writeExtraKey(key, payload, TTL);
       if (metaKey) {
-        // Metadata is written only after the payload succeeds. If the write
-        // is rejected or throws, keep the old metadata body and fetchedAt;
-        // this preserves the health warning without fabricating success.
         const wroteMeta = await writeSeedMeta(key, payload.entries.length, metaKey).catch(() => false);
         if (!wroteMeta) {
           console.warn(`  ${key}: metadata write failed; extending existing payload and metadata TTL`);

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -23,7 +23,15 @@
  *   - health maxStaleMin = 24h = 2× interval (see api/health.js)
  */
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKey, extendExistingTtl, writeSeedMeta } from './_seed-utils.mjs';
+import {
+  loadEnvFile,
+  CHROME_UA,
+  runSeed,
+  writeExtraKey,
+  extendExistingTtl,
+  writeSeedMeta,
+  resolveSeedMetaTtl,
+} from './_seed-utils.mjs';
 import { tokensToContentMeta, DAY_MIN } from './_content-age-helpers.mjs';
 
 // Content-age budget — the canonical key holds the quarterly BIS WS_DSR
@@ -105,6 +113,18 @@ export const META_KEYS = {
 
 // Quarterly data, seeded on 12h cron. 3-day TTL absorbs 2 missed cycles.
 const TTL = 3 * 24 * 3600;
+const META_TTL = resolveSeedMetaTtl(undefined, TTL);
+const AGGREGATE_META_KEY = 'seed-meta:economic:bis-extended';
+
+const BIS_PRESERVE_KEY_TTLS = [
+  { key: AGGREGATE_META_KEY, ttlSeconds: META_TTL },
+  { key: KEYS.dsr, ttlSeconds: TTL },
+  { key: META_KEYS.dsr, ttlSeconds: META_TTL },
+  { key: KEYS.spp, ttlSeconds: TTL },
+  { key: META_KEYS.spp, ttlSeconds: META_TTL },
+  { key: KEYS.cpp, ttlSeconds: TTL },
+  { key: META_KEYS.cpp, ttlSeconds: META_TTL },
+];
 
 // ── HTTP / CSV helpers ─────────────────────────────────────────────────────
 
@@ -428,23 +448,34 @@ export function planDatasetAction(payload) {
   return 'extend';
 }
 
+async function preserveDatasetLastGood(key, metaKey) {
+  await Promise.all([
+    extendExistingTtl([key], TTL),
+    metaKey ? extendExistingTtl([metaKey], META_TTL) : true,
+  ]);
+}
+
 export async function publishDatasetIndependently(key, payload, metaKey) {
   const action = planDatasetAction(payload);
   if (action === 'write') {
     try {
       await writeExtraKey(key, payload, TTL);
-      // Per-dataset seed-meta is written ONLY on a successful fresh write.
-      // On the extend-TTL branch we deliberately do NOT refresh seed-meta —
-      // that is what lets api/health.js flag a stale per-dataset outage.
       if (metaKey) {
-        await writeSeedMeta(key, payload.entries.length, metaKey).catch(() => {});
+        // Metadata is written only after the payload succeeds. If the write
+        // is rejected or throws, keep the old metadata body and fetchedAt;
+        // this preserves the health warning without fabricating success.
+        const wroteMeta = await writeSeedMeta(key, payload.entries.length, metaKey).catch(() => false);
+        if (!wroteMeta) {
+          console.warn(`  ${key}: metadata write failed; extending existing payload and metadata TTL`);
+          await preserveDatasetLastGood(key, metaKey).catch(() => {});
+        }
       }
     } catch (err) {
-      console.warn(`  ${key}: write failed (${err.message}); extending existing TTL`);
-      await extendExistingTtl([key], TTL).catch(() => {});
+      console.warn(`  ${key}: write failed (${err.message}); extending existing payload and metadata TTL`);
+      await preserveDatasetLastGood(key, metaKey).catch(() => {});
     }
   } else {
-    await extendExistingTtl([key], TTL).catch(() => {});
+    await preserveDatasetLastGood(key, metaKey).catch(() => {});
   }
 }
 
@@ -476,8 +507,11 @@ export function bisDsrContentMeta(data) {
   return tokensToContentMeta(entries.map((e) => e?.period));
 }
 
-if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
-  runSeed('economic', 'bis-extended', KEYS.dsr, fetchAll, {
+export async function runBisExtendedSeed({
+  fetchAllImpl = fetchAll,
+  runSeedImpl = runSeed,
+} = {}) {
+  return runSeedImpl('economic', 'bis-extended', KEYS.dsr, fetchAllImpl, {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'bis-sdmx-csv-extended',
@@ -488,7 +522,12 @@ if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
     maxStaleMin: 1440,
     contentMeta: bisDsrContentMeta,
     maxContentAgeMin: BIS_DSR_MAX_CONTENT_AGE_MIN,
-  }).catch((err) => {
+    preserveKeyTtls: BIS_PRESERVE_KEY_TTLS,
+  });
+}
+
+if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
+  runBisExtendedSeed().catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);
     process.exit(1);

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -506,9 +506,9 @@ export function bisDsrContentMeta(data) {
 
 export async function runBisExtendedSeed({
   fetchAllImpl = fetchAll,
-  runSeedImpl = runSeed,
+  runSeedImpl,
 } = {}) {
-  return runSeedImpl('economic', 'bis-extended', KEYS.dsr, fetchAllImpl, {
+  const options = {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'bis-sdmx-csv-extended',
@@ -520,7 +520,12 @@ export async function runBisExtendedSeed({
     contentMeta: bisDsrContentMeta,
     maxContentAgeMin: BIS_DSR_MAX_CONTENT_AGE_MIN,
     preserveKeyTtls: BIS_PRESERVE_KEY_TTLS,
-  });
+  };
+
+  if (runSeedImpl) {
+    return runSeedImpl('economic', 'bis-extended', KEYS.dsr, fetchAllImpl, options);
+  }
+  return runSeed('economic', 'bis-extended', KEYS.dsr, fetchAllImpl, options);
 }
 
 if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {

--- a/scripts/seed-fred-rates.mjs
+++ b/scripts/seed-fred-rates.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
 import {
+  CHROME_UA,
+  getRedisCredentials,
   loadEnvFile,
   resolveSeedMetaTtl,
   runSeed,
-  withRetry,
-  writeExtraKeyWithMeta,
 } from './_seed-utils.mjs';
 import { getOptionalUpstashCreds, upstashCommand } from './_upstash-rest.mjs';
 import {
@@ -29,8 +29,6 @@ export const BATCH_TTL = FRED_TTL;
 // FRED batch has published successfully.
 export const FRED_RATES_ACTIVATION_KEY = 'seed-activated:economic:fred-rates:v1';
 const MIN_SERIES_COUNT = Math.ceil(FRED_SEED_SERIES.length * 0.75);
-const SIDE_WRITE_RETRIES = 2;
-const SIDE_WRITE_RETRY_DELAY_MS = 1_000;
 
 function seedMetaKeyFor(dataKey) {
   return `seed-meta:${dataKey.replace(/:v\d+$/, '')}`;
@@ -103,46 +101,58 @@ export function validateFredBatch(batch) {
   return Number.isInteger(batch?.seriesCount) && batch.seriesCount >= MIN_SERIES_COUNT;
 }
 
-async function writeSideKeyWithMeta(
-  writeFn,
-  withRetryImpl,
-  errorMessage,
-) {
-  await withRetryImpl(async () => {
-    const wroteMeta = await writeFn();
-    if (wroteMeta !== true) throw new Error(errorMessage);
-  }, SIDE_WRITE_RETRIES, SIDE_WRITE_RETRY_DELAY_MS);
-}
-
-export async function publishFredSideKeys(batch, {
-  writeExtraKeyWithMetaImpl = writeExtraKeyWithMeta,
-  withRetryImpl = withRetry,
+export async function publishFredCohortAtomically(batch, {
+  canonicalKey = CANONICAL_KEY,
+  payload,
+  ttlSeconds = BATCH_TTL,
+  fetchImpl = globalThis.fetch,
+  credentials = getRedisCredentials(),
+  fetchedAt = Date.now(),
 } = {}) {
+  if (typeof payload !== 'string') throw new Error('FRED atomic publish requires a serialized canonical payload');
+
+  const commands = [];
   for (const seriesId of batch.seriesIds) {
+    const key = `${FRED_KEY_PREFIX}:${seriesId}:0`;
     const series = batch.seriesById[seriesId];
-    await writeSideKeyWithMeta(
-      () => writeExtraKeyWithMetaImpl(
-        `${FRED_KEY_PREFIX}:${seriesId}:0`,
-        { series },
-        FRED_TTL,
-        series.observations.length,
-      ),
-      withRetryImpl,
-      `FRED ${seriesId} seed-meta write failed`,
+    commands.push(
+      ['SET', key, JSON.stringify({ series }), 'EX', FRED_TTL],
+      ['SET', seedMetaKeyFor(key), JSON.stringify({
+        fetchedAt,
+        recordCount: series.observations.length,
+      }), 'EX', resolveSeedMetaTtl(undefined, FRED_TTL)],
     );
   }
 
   if (batch.stress) {
-    await writeSideKeyWithMeta(
-      () => writeExtraKeyWithMetaImpl(
-        STRESS_INDEX_KEY,
-        batch.stress,
-        STRESS_INDEX_TTL,
-        batch.stress.components?.length ?? 0,
-      ),
-      withRetryImpl,
-      'FRED stress-index seed-meta write failed',
+    commands.push(
+      ['SET', STRESS_INDEX_KEY, JSON.stringify(batch.stress), 'EX', STRESS_INDEX_TTL],
+      ['SET', seedMetaKeyFor(STRESS_INDEX_KEY), JSON.stringify({
+        fetchedAt,
+        recordCount: batch.stress.components?.length ?? 0,
+      }), 'EX', resolveSeedMetaTtl(undefined, STRESS_INDEX_TTL)],
     );
+  }
+
+  commands.push(['SET', canonicalKey, payload, 'EX', ttlSeconds]);
+  const response = await fetchImpl(`${credentials.url}/multi-exec`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${credentials.token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': CHROME_UA,
+    },
+    body: JSON.stringify(commands),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) throw new Error(`FRED atomic publication failed: HTTP ${response.status}`);
+  const results = await response.json();
+  if (
+    !Array.isArray(results)
+    || results.length !== commands.length
+    || results.some((result) => result?.error || result?.result === 'ERR')
+  ) {
+    throw new Error('FRED atomic publication returned an invalid command result');
   }
 }
 
@@ -171,10 +181,9 @@ export async function runFredRatesSeed(deps = {}) {
     publishTransform: projectFredBatch,
     preserveKeyTtls: fredPreserveKeyTtls(),
     emptyDataIsFailure: true,
-    beforePublish: (batch) => publishFredSideKeys(batch, {
-      writeExtraKeyWithMetaImpl: deps.writeExtraKeyWithMetaImpl,
-      withRetryImpl: deps.withRetryImpl,
-    }),
+    publishAtomically: (batch, context) => (
+      deps.publishFredCohortImpl ?? publishFredCohortAtomically
+    )(batch, context),
     sourceVersion: 'fred-v1',
     recordCount: (data) => data?.seriesCount ?? 0,
     declareRecords: (data) => data?.seriesCount ?? 0,

--- a/scripts/seed-fred-rates.mjs
+++ b/scripts/seed-fred-rates.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, runSeed, withRetry, writeExtraKeyWithMeta } from './_seed-utils.mjs';
+import {
+  loadEnvFile,
+  resolveSeedMetaTtl,
+  runSeed,
+  withRetry,
+  writeExtraKeyWithMeta,
+} from './_seed-utils.mjs';
 import { getOptionalUpstashCreds, upstashCommand } from './_upstash-rest.mjs';
 import {
   FRED_KEY_PREFIX,
@@ -25,6 +31,31 @@ export const FRED_RATES_ACTIVATION_KEY = 'seed-activated:economic:fred-rates:v1'
 const MIN_SERIES_COUNT = Math.ceil(FRED_SEED_SERIES.length * 0.75);
 const SIDE_WRITE_RETRIES = 2;
 const SIDE_WRITE_RETRY_DELAY_MS = 1_000;
+
+function seedMetaKeyFor(dataKey) {
+  return `seed-meta:${dataKey.replace(/:v\d+$/, '')}`;
+}
+
+function fredPreserveKeyTtls() {
+  return [
+    {
+      key: 'seed-meta:economic:fred-rates',
+      ttlSeconds: resolveSeedMetaTtl(undefined, BATCH_TTL),
+    },
+    ...FRED_SEED_SERIES.flatMap((seriesId) => {
+      const key = `${FRED_KEY_PREFIX}:${seriesId}:0`;
+      return [
+        { key, ttlSeconds: FRED_TTL },
+        { key: seedMetaKeyFor(key), ttlSeconds: resolveSeedMetaTtl(undefined, FRED_TTL) },
+      ];
+    }),
+    { key: STRESS_INDEX_KEY, ttlSeconds: STRESS_INDEX_TTL },
+    {
+      key: seedMetaKeyFor(STRESS_INDEX_KEY),
+      ttlSeconds: resolveSeedMetaTtl(undefined, STRESS_INDEX_TTL),
+    },
+  ];
+}
 
 export async function fetchFredBatch({
   fetchFredSeriesImpl = fetchFredSeries,
@@ -138,6 +169,8 @@ export async function runFredRatesSeed(deps = {}) {
     ttlSeconds: BATCH_TTL,
     validateFn: validateFredBatch,
     publishTransform: projectFredBatch,
+    preserveKeyTtls: fredPreserveKeyTtls(),
+    emptyDataIsFailure: true,
     beforePublish: (batch) => publishFredSideKeys(batch, {
       writeExtraKeyWithMetaImpl: deps.writeExtraKeyWithMetaImpl,
       withRetryImpl: deps.withRetryImpl,

--- a/scripts/seed-fred-rates.mjs
+++ b/scripts/seed-fred-rates.mjs
@@ -104,6 +104,7 @@ export function validateFredBatch(batch) {
 export async function publishFredCohortAtomically(batch, {
   canonicalKey = CANONICAL_KEY,
   payload,
+  payloadValue,
   ttlSeconds = BATCH_TTL,
   fetchImpl = globalThis.fetch,
   credentials = getRedisCredentials(),
@@ -111,30 +112,39 @@ export async function publishFredCohortAtomically(batch, {
 } = {}) {
   if (typeof payload !== 'string') throw new Error('FRED atomic publish requires a serialized canonical payload');
 
-  const commands = [];
+  const seed = payloadValue?._seed;
+  const cohortFetchedAt = Number.isFinite(seed?.fetchedAt) ? seed.fetchedAt : fetchedAt;
+  const values = [];
+  const expirations = [];
+  const addValue = (key, value, keyTtlSeconds) => {
+    values.push(key, typeof value === 'string' ? value : JSON.stringify(value));
+    expirations.push(['EXPIRE', key, keyTtlSeconds]);
+  };
   for (const seriesId of batch.seriesIds) {
     const key = `${FRED_KEY_PREFIX}:${seriesId}:0`;
     const series = batch.seriesById[seriesId];
-    commands.push(
-      ['SET', key, JSON.stringify({ series }), 'EX', FRED_TTL],
-      ['SET', seedMetaKeyFor(key), JSON.stringify({
-        fetchedAt,
-        recordCount: series.observations.length,
-      }), 'EX', resolveSeedMetaTtl(undefined, FRED_TTL)],
-    );
+    addValue(key, { series }, FRED_TTL);
+    addValue(seedMetaKeyFor(key), {
+      fetchedAt: cohortFetchedAt,
+      recordCount: series.observations.length,
+    }, resolveSeedMetaTtl(undefined, FRED_TTL));
   }
 
   if (batch.stress) {
-    commands.push(
-      ['SET', STRESS_INDEX_KEY, JSON.stringify(batch.stress), 'EX', STRESS_INDEX_TTL],
-      ['SET', seedMetaKeyFor(STRESS_INDEX_KEY), JSON.stringify({
-        fetchedAt,
-        recordCount: batch.stress.components?.length ?? 0,
-      }), 'EX', resolveSeedMetaTtl(undefined, STRESS_INDEX_TTL)],
-    );
+    addValue(STRESS_INDEX_KEY, batch.stress, STRESS_INDEX_TTL);
+    addValue(seedMetaKeyFor(STRESS_INDEX_KEY), {
+      fetchedAt: cohortFetchedAt,
+      recordCount: batch.stress.components?.length ?? 0,
+    }, resolveSeedMetaTtl(undefined, STRESS_INDEX_TTL));
   }
 
-  commands.push(['SET', canonicalKey, payload, 'EX', ttlSeconds]);
+  addValue('seed-meta:economic:fred-rates', {
+    fetchedAt: cohortFetchedAt,
+    recordCount: Number.isInteger(seed?.recordCount) ? seed.recordCount : batch.seriesCount,
+    sourceVersion: typeof seed?.sourceVersion === 'string' ? seed.sourceVersion : 'fred-v1',
+  }, resolveSeedMetaTtl(undefined, ttlSeconds));
+  addValue(canonicalKey, payload, ttlSeconds);
+  const commands = [['MSET', ...values], ...expirations];
   const response = await fetchImpl(`${credentials.url}/multi-exec`, {
     method: 'POST',
     headers: {
@@ -150,7 +160,8 @@ export async function publishFredCohortAtomically(batch, {
   if (
     !Array.isArray(results)
     || results.length !== commands.length
-    || results.some((result) => result?.error || result?.result === 'ERR')
+    || results[0]?.result !== 'OK'
+    || results.slice(1).some((result) => result?.result !== 1)
   ) {
     throw new Error('FRED atomic publication returned an invalid command result');
   }

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -5,6 +5,12 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  GRACEFUL_FETCH_FAILURE_EXIT_CODE,
+  resolveSeedMetaTtl,
+  runSeed,
+} from '../scripts/_seed-utils.mjs';
+
+import {
   parseBisCSV,
   selectBestSeriesByCountry,
   buildDsr,
@@ -51,6 +57,54 @@ const SPP_CSV = [
   'Q,XM,628,R,2023-Q4,99.0',
   'Q,XM,628,R,2024-Q4,100.5',
 ].join('\n');
+
+const BIS_TTL_SECONDS = 3 * 24 * 3600;
+const BIS_META_TTL_SECONDS = resolveSeedMetaTtl(undefined, BIS_TTL_SECONDS);
+
+async function withRedisCapture(fetchImpl, fn) {
+  const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+  const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  process.env.UPSTASH_REDIS_REST_URL = 'https://mock.upstash.invalid';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
+  globalThis.fetch = async (url, options = {}) => {
+    const body = options.body ? JSON.parse(options.body) : null;
+    calls.push({ url: String(url), body });
+    return fetchImpl({ url: String(url), body, options });
+  };
+  try {
+    return await fn(calls);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+    if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+  }
+}
+
+function redisOk(result = 'OK') {
+  return { ok: true, status: 200, json: async () => ({ result }) };
+}
+
+function pipelineCommands(calls) {
+  return calls
+    .filter(({ body }) => Array.isArray(body) && Array.isArray(body[0]))
+    .flatMap(({ body }) => body);
+}
+
+function assertExpireCohort(calls, expected) {
+  const expire = pipelineCommands(calls)
+    .filter(([command]) => command === 'EXPIRE')
+    .map(([, key, ttl]) => [key, ttl]);
+  for (const [key, ttl] of expected) {
+    assert.ok(
+      expire.some(([actualKey, actualTtl]) => actualKey === key && actualTtl === ttl),
+      `expected EXPIRE ${key} ${ttl}, got ${JSON.stringify(expire)}`,
+    );
+  }
+}
 
 describe('seed-bis-extended parser', () => {
   it('exports the canonical Redis keys', () => {
@@ -202,6 +256,143 @@ describe('seed-bis-extended parser', () => {
       globalThis.fetch = origFetch;
       if (origUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL; else process.env.UPSTASH_REDIS_REST_URL = origUrl;
       if (origTok === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN; else process.env.UPSTASH_REDIS_REST_TOKEN = origTok;
+    }
+  });
+
+  it('retains property payload and companion metadata with independent TTLs on empty or failed publication', async () => {
+    const pipelineOk = ({ body }) => Array.isArray(body) && Array.isArray(body[0])
+      ? { ok: true, status: 200, json: async () => body.map(() => ({ result: 1 })) }
+      : redisOk();
+    const httpFailure = {
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      json: async () => ({ result: 'ERR' }),
+    };
+
+    await withRedisCapture(pipelineOk, async (calls) => {
+      await publishDatasetIndependently(KEYS.spp, null, META_KEYS.spp);
+      assert.equal(calls.filter(({ body }) => body?.[0] === 'SET').length, 0);
+      assertExpireCohort(calls, [
+        [KEYS.spp, BIS_TTL_SECONDS],
+        [META_KEYS.spp, BIS_META_TTL_SECONDS],
+      ]);
+    });
+
+    await withRedisCapture(({ body }) => {
+      if (body?.[0] === 'SET' && body?.[1] === KEYS.cpp) return httpFailure;
+      return pipelineOk({ body });
+    }, async (calls) => {
+      await publishDatasetIndependently(KEYS.cpp, {
+        entries: [{ countryCode: 'US', indexValue: 95.2 }],
+        fetchedAt: 'old',
+      }, META_KEYS.cpp);
+      assertExpireCohort(calls, [
+        [KEYS.cpp, BIS_TTL_SECONDS],
+        [META_KEYS.cpp, BIS_META_TTL_SECONDS],
+      ]);
+    });
+
+    await withRedisCapture(({ body }) => {
+      if (body?.[0] === 'SET' && body?.[1] === META_KEYS.spp) return httpFailure;
+      return pipelineOk({ body });
+    }, async (calls) => {
+      await publishDatasetIndependently(KEYS.spp, {
+        entries: [{ countryCode: 'US', indexValue: 108.5 }],
+        fetchedAt: 'new-payload',
+      }, META_KEYS.spp);
+      assertExpireCohort(calls, [
+        [KEYS.spp, BIS_TTL_SECONDS],
+        [META_KEYS.spp, BIS_META_TTL_SECONDS],
+      ]);
+    });
+  });
+
+  it('retention keeps missing property pairs absent when Redis reports EXPIRE 0', async () => {
+    const pipelineMissing = ({ body }) => Array.isArray(body) && Array.isArray(body[0])
+      ? { ok: true, status: 200, json: async () => body.map(() => ({ result: 0 })) }
+      : redisOk();
+
+    await withRedisCapture(pipelineMissing, async (calls) => {
+      await publishDatasetIndependently(KEYS.spp, null, META_KEYS.spp);
+      assert.equal(calls.filter(({ body }) => body?.[0] === 'SET').length, 0);
+      const expire = pipelineCommands(calls)
+        .filter(([command]) => command === 'EXPIRE')
+        .map(([, key, ttl]) => [key, ttl]);
+      assert.deepEqual(expire.sort(), [
+        [KEYS.spp, BIS_TTL_SECONDS],
+        [META_KEYS.spp, BIS_META_TTL_SECONDS],
+      ].sort());
+    });
+  });
+
+  it('runner retention manifest reaches both BIS property payload/meta pairs on total source failure', async () => {
+    const bis = await import('../scripts/seed-bis-extended.mjs');
+    assert.equal(typeof bis.runBisExtendedSeed, 'function');
+    let invocation;
+    await bis.runBisExtendedSeed({
+      runSeedImpl: async (...args) => {
+        invocation = args;
+      },
+    });
+    const manifest = invocation?.[4]?.preserveKeyTtls;
+    assert.ok(Array.isArray(manifest), 'runner must pass its preservation manifest to runSeed');
+    const ttlByKey = new Map(manifest.map(({ key, ttlSeconds }) => [key, ttlSeconds]));
+    for (const key of [KEYS.spp, KEYS.cpp]) {
+      assert.equal(ttlByKey.get(key), BIS_TTL_SECONDS, `missing payload retention for ${key}`);
+    }
+    for (const key of [META_KEYS.spp, META_KEYS.cpp]) {
+      assert.equal(ttlByKey.get(key), BIS_META_TTL_SECONDS, `missing metadata retention for ${key}`);
+    }
+    const originalExit = process.exit;
+    const originalListeners = new Set(process.rawListeners('SIGTERM'));
+    const pipelineOk = ({ body }) => Array.isArray(body) && Array.isArray(body[0])
+      ? { ok: true, status: 200, json: async () => body.map(() => ({ result: 1 })) }
+      : redisOk();
+    try {
+      process.exit = (code) => {
+        const error = new Error(`__bis_test_exit__:${code}`);
+        error.exitCode = code;
+        throw error;
+      };
+      await withRedisCapture(pipelineOk, async (calls) => {
+        let exitCode;
+        try {
+          await runSeed('economic', 'bis-extended', KEYS.dsr, async () => {
+            throw Object.assign(new Error('all BIS sources failed'), { nonRetryable: true });
+          }, {
+            ttlSeconds: BIS_TTL_SECONDS,
+            preserveKeyTtls: manifest,
+          });
+        } catch (error) {
+          exitCode = error.exitCode;
+        }
+        assert.equal(exitCode, GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+        assertExpireCohort(calls, [
+          [KEYS.spp, BIS_TTL_SECONDS],
+          [META_KEYS.spp, BIS_META_TTL_SECONDS],
+          [KEYS.cpp, BIS_TTL_SECONDS],
+          [META_KEYS.cpp, BIS_META_TTL_SECONDS],
+        ]);
+        const retainedKeys = new Set([
+          KEYS.dsr,
+          KEYS.spp,
+          KEYS.cpp,
+          META_KEYS.dsr,
+          META_KEYS.spp,
+          META_KEYS.cpp,
+          'seed-meta:economic:bis-extended',
+        ]);
+        assert.equal(
+          calls.filter(({ body }) => body?.[0] === 'SET' && retainedKeys.has(body[1])).length,
+          0,
+        );
+      });
+    } finally {
+      process.exit = originalExit;
+      for (const listener of process.rawListeners('SIGTERM')) {
+        if (!originalListeners.has(listener)) process.removeListener('SIGTERM', listener);
+      }
     }
   });
 

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -22,6 +22,7 @@ import {
   publishDatasetIndependently,
   dsrAfterPublish,
   fetchAll,
+  runBisExtendedSeed,
   KEYS,
   META_KEYS,
 } from '../scripts/seed-bis-extended.mjs';
@@ -351,9 +352,18 @@ describe('seed-bis-extended parser', () => {
       ]);
     });
 
+    const retainedValues = new Map([
+      [KEYS.spp, JSON.stringify({ entries: [{ countryCode: 'US', indexValue: 101.2 }], fetchedAt: 'old-payload' })],
+      [META_KEYS.spp, JSON.stringify({ fetchedAt: 1, recordCount: 1 })],
+    ]);
     await withRedisCapture(({ body }) => {
+      if (Array.isArray(body) && Array.isArray(body[0])) {
+        if (body.some(([command]) => command === 'SET')) return httpFailure;
+        return pipelineOk({ body });
+      }
       if (body?.[0] === 'SET' && body?.[1] === META_KEYS.spp) return httpFailure;
-      return pipelineOk({ body });
+      if (body?.[0] === 'SET') retainedValues.set(body[1], body[2]);
+      return redisOk();
     }, async (calls) => {
       await publishDatasetIndependently(KEYS.spp, {
         entries: [{ countryCode: 'US', indexValue: 108.5 }],
@@ -362,6 +372,68 @@ describe('seed-bis-extended parser', () => {
       assertExpireCohort(calls, [
         [KEYS.spp, BIS_TTL_SECONDS],
         [META_KEYS.spp, BIS_META_TTL_SECONDS],
+      ]);
+      assert.deepEqual(JSON.parse(retainedValues.get(KEYS.spp)), {
+        entries: [{ countryCode: 'US', indexValue: 101.2 }],
+        fetchedAt: 'old-payload',
+      });
+      assert.deepEqual(JSON.parse(retainedValues.get(META_KEYS.spp)), {
+        fetchedAt: 1,
+        recordCount: 1,
+      });
+    });
+  });
+
+  it('preserves the BIS last-good manifest when canonical DSR publication fails', async () => {
+    let invocation;
+    await runBisExtendedSeed({
+      runSeedImpl: async (...args) => {
+        invocation = args;
+      },
+    });
+    const options = invocation[4];
+    const failedTransaction = {
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      json: async () => ({ result: 'ERR' }),
+      text: async () => 'unavailable',
+    };
+    const pipelineOk = ({ body }) => ({
+      ok: true,
+      status: 200,
+      json: async () => body.map(() => ({ result: 1 })),
+    });
+
+    await withRedisCapture(({ body }) => {
+      if (Array.isArray(body) && Array.isArray(body[0])) {
+        if (body.some(([command]) => command === 'SET')) return failedTransaction;
+        return pipelineOk({ body });
+      }
+      if (body?.[0] === 'SET' && body?.[1] === KEYS.dsr) return failedTransaction;
+      return redisOk();
+    }, async (calls) => {
+      await assert.rejects(
+        runSeed(
+          'economic',
+          'bis-extended',
+          KEYS.dsr,
+          async () => ({
+            dsr: { entries: [{ countryCode: 'US', dsrPct: 10.4, period: '2024-Q4' }] },
+            spp: null,
+            cpp: null,
+          }),
+          options,
+        ),
+        /503|publication|transaction/i,
+      );
+      assertExpireCohort(calls, [
+        [KEYS.dsr, BIS_TTL_SECONDS],
+        [META_KEYS.dsr, BIS_META_TTL_SECONDS],
+        [KEYS.spp, BIS_TTL_SECONDS],
+        [META_KEYS.spp, BIS_META_TTL_SECONDS],
+        [KEYS.cpp, BIS_TTL_SECONDS],
+        [META_KEYS.cpp, BIS_META_TTL_SECONDS],
       ]);
     });
   });

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -299,7 +299,7 @@ describe('seed-bis-extended parser', () => {
         ok: true,
         status: 200,
         json: async () => Array.isArray(body[0])
-          ? body.map(() => ({ result: 'OK' }))
+          ? body.map(([command]) => ({ result: command === 'MSET' ? 'OK' : 1 }))
           : ({ result: 'OK' }),
       };
     };
@@ -311,11 +311,9 @@ describe('seed-bis-extended parser', () => {
         { entries: [{ countryCode: 'US', indexValue: 108.5 }], fetchedAt: 't' },
         META_KEYS.spp,
       );
-      const sets = calls.flatMap((body) => Array.isArray(body[0]) ? body : [body])
-        .filter(c => c[0] === 'SET')
-        .map(c => c[1]);
-      assert.ok(sets.includes(KEYS.spp), `expected SET on canonical key ${KEYS.spp}, got ${JSON.stringify(sets)}`);
-      assert.ok(sets.includes(META_KEYS.spp), `expected SET on seed-meta key ${META_KEYS.spp}, got ${JSON.stringify(sets)}`);
+      const published = msetEntries(calls.find((body) => body?.[0]?.[0] === 'MSET')?.[0]);
+      assert.ok(published.has(KEYS.spp), `expected ${KEYS.spp} in MSET`);
+      assert.ok(published.has(META_KEYS.spp), `expected ${META_KEYS.spp} in MSET`);
 
       // 2. Empty payload → canonical key TTL extended, seed-meta NOT written.
       //    (This is the core P1 invariant: a DSR outage must not refresh
@@ -498,7 +496,11 @@ describe('seed-bis-extended parser', () => {
 
   it('publishes fresh property payload and metadata after a retained failure recovers', async () => {
     const pipelineOk = ({ body }) => Array.isArray(body) && Array.isArray(body[0])
-      ? { ok: true, status: 200, json: async () => body.map(() => ({ result: 1 })) }
+      ? {
+          ok: true,
+          status: 200,
+          json: async () => body.map(([command]) => ({ result: command === 'MSET' ? 'OK' : 1 })),
+        }
       : redisOk();
 
     await withRedisCapture(pipelineOk, async (calls) => {
@@ -508,10 +510,8 @@ describe('seed-bis-extended parser', () => {
         fetchedAt: 'recovered',
       }, META_KEYS.spp);
 
-      const sets = pipelineCommands(calls)
-        .filter(([command]) => command === 'SET')
-        .map(([, key]) => key);
-      assert.deepEqual(sets, [KEYS.spp, META_KEYS.spp]);
+      const transaction = calls.find(({ body }) => body?.[0]?.[0] === 'MSET')?.body;
+      assert.deepEqual([...msetEntries(transaction[0]).keys()], [KEYS.spp, META_KEYS.spp]);
     });
   });
 

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -611,6 +611,11 @@ describe('seed-bis-extended parser', () => {
         oldestItemAt: 2,
         maxContentAgeMin: 3,
       });
+      assert.deepEqual(transaction.slice(1), [
+        ['EXPIRE', KEYS.dsr, BIS_TTL_SECONDS],
+        ['EXPIRE', META_KEYS.dsr, BIS_META_TTL_SECONDS],
+        ['EXPIRE', 'seed-meta:economic:bis-extended', BIS_META_TTL_SECONDS],
+      ]);
     });
 
     await assert.rejects(

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -21,9 +21,11 @@ import {
   planDatasetAction,
   publishDatasetIndependently,
   dsrAfterPublish,
+  fetchAll,
   KEYS,
   META_KEYS,
 } from '../scripts/seed-bis-extended.mjs';
+import { __testing__ as healthTesting } from '../api/health.js';
 
 // Minimal BIS-style SDMX CSV fixture covering:
 //   - Two DSR series per country (one private/adjusted → preferred, one
@@ -60,14 +62,23 @@ const SPP_CSV = [
 
 const BIS_TTL_SECONDS = 3 * 24 * 3600;
 const BIS_META_TTL_SECONDS = resolveSeedMetaTtl(undefined, BIS_TTL_SECONDS);
+const {
+  classifyKey,
+  BOOTSTRAP_KEYS,
+  STANDALONE_KEYS,
+  SEED_META,
+  ACTIVATION_MARKERS,
+} = healthTesting;
 
 async function withRedisCapture(fetchImpl, fn) {
   const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
   const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+  const originalRetryDelay = process.env.WM_SEED_RETRY_DELAY_MS;
   const originalFetch = globalThis.fetch;
   const calls = [];
   process.env.UPSTASH_REDIS_REST_URL = 'https://mock.upstash.invalid';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
+  process.env.WM_SEED_RETRY_DELAY_MS = '0';
   globalThis.fetch = async (url, options = {}) => {
     const body = options.body ? JSON.parse(options.body) : null;
     calls.push({ url: String(url), body });
@@ -81,6 +92,8 @@ async function withRedisCapture(fetchImpl, fn) {
     else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
     if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
     else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    if (originalRetryDelay === undefined) delete process.env.WM_SEED_RETRY_DELAY_MS;
+    else process.env.WM_SEED_RETRY_DELAY_MS = originalRetryDelay;
   }
 }
 
@@ -106,7 +119,52 @@ function assertExpireCohort(calls, expected) {
   }
 }
 
+function classifyRetainedBis(name, { now, fetchedAt }) {
+  const key = BOOTSTRAP_KEYS[name] ?? STANDALONE_KEYS[name];
+  return classifyKey(
+    name,
+    key,
+    { allowOnDemand: false },
+    {
+      keyStrens: new Map([[key, 128]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([[
+        SEED_META[name].key,
+        JSON.stringify({ fetchedAt, recordCount: 1 }),
+      ]]),
+      keyMetaErrors: new Map(),
+      activationStates: new Map(
+        Object.keys(ACTIVATION_MARKERS).map((markerName) => [markerName, false]),
+      ),
+      rolloutPendingUntilMs: new Map(),
+      now,
+    },
+  );
+}
+
 describe('seed-bis-extended parser', () => {
+  it('makes exactly nine BIS source requests and rejects when every source variant fails', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWarn = console.warn;
+    const requests = [];
+    globalThis.fetch = async (url) => {
+      requests.push(String(url));
+      return new Response('unavailable', { status: 503 });
+    };
+    console.warn = () => {};
+    try {
+      await assert.rejects(fetchAll(), /All BIS extended fetches returned empty/);
+      assert.equal(requests.length, 9);
+      assert.ok(requests.every((url) => url.startsWith('https://stats.bis.org/api/v1/data/')));
+      for (const dataflow of ['WS_DSR', 'WS_SPP', 'WS_CPP']) {
+        assert.equal(requests.filter((url) => url.includes(`/${dataflow}/`)).length, 3, dataflow);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+      console.warn = originalWarn;
+    }
+  });
+
   it('exports the canonical Redis keys', () => {
     assert.equal(KEYS.dsr, 'economic:bis:dsr:v1');
     assert.equal(KEYS.spp, 'economic:bis:property-residential:v1');
@@ -326,6 +384,25 @@ describe('seed-bis-extended parser', () => {
     });
   });
 
+  it('publishes fresh property payload and metadata after a retained failure recovers', async () => {
+    const pipelineOk = ({ body }) => Array.isArray(body) && Array.isArray(body[0])
+      ? { ok: true, status: 200, json: async () => body.map(() => ({ result: 1 })) }
+      : redisOk();
+
+    await withRedisCapture(pipelineOk, async (calls) => {
+      await publishDatasetIndependently(KEYS.spp, null, META_KEYS.spp);
+      await publishDatasetIndependently(KEYS.spp, {
+        entries: [{ countryCode: 'US', indexValue: 109.1 }],
+        fetchedAt: 'recovered',
+      }, META_KEYS.spp);
+
+      const sets = calls
+        .filter(({ body }) => body?.[0] === 'SET')
+        .map(({ body }) => body[1]);
+      assert.deepEqual(sets, [KEYS.spp, META_KEYS.spp]);
+    });
+  });
+
   it('runner retention manifest reaches both BIS property payload/meta pairs on total source failure', async () => {
     const bis = await import('../scripts/seed-bis-extended.mjs');
     assert.equal(typeof bis.runBisExtendedSeed, 'function');
@@ -450,6 +527,18 @@ describe('seed-bis-extended parser', () => {
     ];
     const out = selectBestSeriesByCountry(rows, { countryColumns: ['REF_AREA'], prefs: { PP_VALUATION: 'R' } });
     assert.equal(out.size, 0);
+  });
+
+  it('classifies retained BIS DSR and property payloads as STALE_SEED after 2160 minutes', () => {
+    const now = Date.parse('2031-04-12T09:30:00Z');
+    for (const name of ['bisDsr', 'bisPropertyResidential', 'bisPropertyCommercial']) {
+      const entry = classifyRetainedBis(name, {
+        now,
+        fetchedAt: now - (2160 + 1) * 60_000,
+      });
+      assert.equal(entry.status, 'STALE_SEED', name);
+      assert.equal(entry.maxStaleMin, 2160, name);
+    }
   });
 });
 

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -379,7 +379,26 @@ describe('seed-bis-extended parser', () => {
     ]);
     await withRedisCapture(({ body }) => {
       if (Array.isArray(body) && Array.isArray(body[0])) {
-        if (body.some(([command]) => command === 'SET')) return httpFailure;
+        if (body.some(([command]) => command === 'MSET')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => body.map(([command]) => command === 'MSET'
+              ? { error: 'ERR simulated atomic value failure' }
+              : { result: 1 }),
+          };
+        }
+        if (body.some(([command]) => command === 'SET')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => body.map(([command, key, value]) => {
+              if (key === META_KEYS.spp) return { error: 'ERR simulated metadata failure' };
+              if (command === 'SET') retainedValues.set(key, value);
+              return { result: 'OK' };
+            }),
+          };
+        }
         return pipelineOk({ body });
       }
       if (body?.[0] === 'SET' && body?.[1] === META_KEYS.spp) return httpFailure;

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -108,6 +108,14 @@ function pipelineCommands(calls) {
     .flatMap(({ body }) => body);
 }
 
+function msetEntries(command) {
+  assert.equal(command?.[0], 'MSET');
+  return new Map(Array.from({ length: (command.length - 1) / 2 }, (_, index) => [
+    command[index * 2 + 1],
+    command[index * 2 + 2],
+  ]));
+}
+
 function assertExpireCohort(calls, expected) {
   const expire = pipelineCommands(calls)
     .filter(([command]) => command === 'EXPIRE')
@@ -558,15 +566,22 @@ describe('seed-bis-extended parser', () => {
     }
   });
 
-  it('publishes the DSR payload and dedicated metadata in one transaction', async () => {
+  it('publishes the DSR payload and both freshness records in one transaction', async () => {
     const payloadValue = {
-      _seed: { fetchedAt: 1 },
+      _seed: {
+        fetchedAt: 1,
+        recordCount: 1,
+        sourceVersion: 'bis-sdmx-csv-extended',
+        newestItemAt: 2,
+        oldestItemAt: 2,
+        maxContentAgeMin: 3,
+      },
       data: { entries: [{ countryCode: 'US', dsrPct: 10.4 }] },
     };
     const transactionOk = ({ body }) => ({
       ok: true,
       status: 200,
-      json: async () => body.map(() => ({ result: 'OK' })),
+      json: async () => body.map(([command]) => ({ result: command === 'MSET' ? 'OK' : 1 })),
     });
 
     await withRedisCapture(transactionOk, async (calls) => {
@@ -579,10 +594,23 @@ describe('seed-bis-extended parser', () => {
         payloadValue,
         ttlSeconds: BIS_TTL_SECONDS,
       });
-      const sets = pipelineCommands(calls).filter(([command]) => command === 'SET');
-      assert.deepEqual(sets.map(([, key]) => key), [KEYS.dsr, META_KEYS.dsr]);
-      assert.deepEqual(JSON.parse(sets[0][2]), payloadValue);
-      assert.equal(JSON.parse(sets[1][2]).recordCount, 1);
+      const transaction = calls.find(({ body }) => body?.[0]?.[0] === 'MSET')?.body;
+      const published = msetEntries(transaction?.[0]);
+      assert.deepEqual([...published.keys()], [
+        KEYS.dsr,
+        META_KEYS.dsr,
+        'seed-meta:economic:bis-extended',
+      ]);
+      assert.deepEqual(JSON.parse(published.get(KEYS.dsr)), payloadValue);
+      assert.equal(JSON.parse(published.get(META_KEYS.dsr)).recordCount, 1);
+      assert.deepEqual(JSON.parse(published.get('seed-meta:economic:bis-extended')), {
+        fetchedAt: 1,
+        recordCount: 1,
+        sourceVersion: 'bis-sdmx-csv-extended',
+        newestItemAt: 2,
+        oldestItemAt: 2,
+        maxContentAgeMin: 3,
+      });
     });
 
     await assert.rejects(

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -20,7 +20,7 @@ import {
   publishTransform,
   planDatasetAction,
   publishDatasetIndependently,
-  dsrAfterPublish,
+  publishBisDsrAtomically,
   fetchAll,
   runBisExtendedSeed,
   KEYS,
@@ -286,8 +286,14 @@ describe('seed-bis-extended parser', () => {
     const calls = [];
     globalThis.fetch = async (_url, opts) => {
       const body = JSON.parse(opts.body);
-      calls.push(body); // e.g. ['SET', 'key', 'value', 'EX', 123] or ['EXPIRE', ...]
-      return { ok: true, status: 200, json: async () => ({ result: 'OK' }) };
+      calls.push(body);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => Array.isArray(body[0])
+          ? body.map(() => ({ result: 'OK' }))
+          : ({ result: 'OK' }),
+      };
     };
     try {
       // 1. Fresh payload → canonical key written + per-dataset seed-meta written.
@@ -297,7 +303,9 @@ describe('seed-bis-extended parser', () => {
         { entries: [{ countryCode: 'US', indexValue: 108.5 }], fetchedAt: 't' },
         META_KEYS.spp,
       );
-      const sets = calls.filter(c => c[0] === 'SET').map(c => c[1]);
+      const sets = calls.flatMap((body) => Array.isArray(body[0]) ? body : [body])
+        .filter(c => c[0] === 'SET')
+        .map(c => c[1]);
       assert.ok(sets.includes(KEYS.spp), `expected SET on canonical key ${KEYS.spp}, got ${JSON.stringify(sets)}`);
       assert.ok(sets.includes(META_KEYS.spp), `expected SET on seed-meta key ${META_KEYS.spp}, got ${JSON.stringify(sets)}`);
 
@@ -306,10 +314,11 @@ describe('seed-bis-extended parser', () => {
       //     seed-meta:economic:bis-dsr, otherwise health lies "fresh".)
       calls.length = 0;
       await publishDatasetIndependently(KEYS.dsr, null, META_KEYS.dsr);
-      const metaSets = calls.filter(c => c[0] === 'SET' && c[1] === META_KEYS.dsr);
+      const commands = calls.flatMap((body) => Array.isArray(body[0]) ? body : [body]);
+      const metaSets = commands.filter(c => c[0] === 'SET' && c[1] === META_KEYS.dsr);
       assert.equal(metaSets.length, 0, `seed-meta must NOT be written on extend-TTL path, got ${JSON.stringify(metaSets)}`);
       // Any SET at all on the extend path is wrong — only EXPIRE-style calls expected.
-      const canonicalSets = calls.filter(c => c[0] === 'SET' && c[1] === KEYS.dsr);
+      const canonicalSets = commands.filter(c => c[0] === 'SET' && c[1] === KEYS.dsr);
       assert.equal(canonicalSets.length, 0, `canonical key must NOT be re-written on extend-TTL path`);
     } finally {
       globalThis.fetch = origFetch;
@@ -339,7 +348,11 @@ describe('seed-bis-extended parser', () => {
     });
 
     await withRedisCapture(({ body }) => {
-      if (body?.[0] === 'SET' && body?.[1] === KEYS.cpp) return httpFailure;
+      if (
+        Array.isArray(body)
+        && Array.isArray(body[0])
+        && body.some(([command, key]) => command === 'SET' && key === KEYS.cpp)
+      ) return httpFailure;
       return pipelineOk({ body });
     }, async (calls) => {
       await publishDatasetIndependently(KEYS.cpp, {
@@ -468,9 +481,9 @@ describe('seed-bis-extended parser', () => {
         fetchedAt: 'recovered',
       }, META_KEYS.spp);
 
-      const sets = calls
-        .filter(({ body }) => body?.[0] === 'SET')
-        .map(({ body }) => body[1]);
+      const sets = pipelineCommands(calls)
+        .filter(([command]) => command === 'SET')
+        .map(([, key]) => key);
       assert.deepEqual(sets, [KEYS.spp, META_KEYS.spp]);
     });
   });
@@ -545,51 +558,37 @@ describe('seed-bis-extended parser', () => {
     }
   });
 
-  it('dsrAfterPublish writes seed-meta:economic:bis-dsr only after a successful canonical DSR publish', async () => {
-    // Regression for the ordering bug: previously seed-meta was written
-    // INSIDE fetchAll() before runSeed/atomicPublish ran. If atomicPublish
-    // then failed (Redis hiccup), seed-meta would already be bumped → health
-    // reports DSR fresh while the canonical key is stale. The fix moves the
-    // write into an afterPublish callback that fires only on successful
-    // canonical publish.
-    const origUrl = process.env.UPSTASH_REDIS_REST_URL;
-    const origTok = process.env.UPSTASH_REDIS_REST_TOKEN;
-    const origFetch = globalThis.fetch;
-    process.env.UPSTASH_REDIS_REST_URL = 'https://mock.upstash.invalid';
-    process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
-    const calls = [];
-    globalThis.fetch = async (_url, opts) => {
-      const body = JSON.parse(opts.body);
-      calls.push(body);
-      return { ok: true, status: 200, json: async () => ({ result: 'OK' }) };
+  it('publishes the DSR payload and dedicated metadata in one transaction', async () => {
+    const payloadValue = {
+      _seed: { fetchedAt: 1 },
+      data: { entries: [{ countryCode: 'US', dsrPct: 10.4 }] },
     };
-    try {
-      // 1. DSR populated → seed-meta IS written (this is the post-publish path).
-      calls.length = 0;
-      await dsrAfterPublish({
-        dsr: { entries: [{ countryCode: 'US', dsrPct: 10.4 }], fetchedAt: 't' },
+    const transactionOk = ({ body }) => ({
+      ok: true,
+      status: 200,
+      json: async () => body.map(() => ({ result: 'OK' })),
+    });
+
+    await withRedisCapture(transactionOk, async (calls) => {
+      await publishBisDsrAtomically({
+        dsr: { entries: [{ countryCode: 'US', dsrPct: 10.4 }] },
         spp: null,
         cpp: null,
+      }, {
+        canonicalKey: KEYS.dsr,
+        payloadValue,
+        ttlSeconds: BIS_TTL_SECONDS,
       });
-      const metaSets = calls.filter(c => c[0] === 'SET' && c[1] === META_KEYS.dsr);
-      assert.equal(metaSets.length, 1, `expected SET on ${META_KEYS.dsr} after successful publish, got ${JSON.stringify(calls)}`);
+      const sets = pipelineCommands(calls).filter(([command]) => command === 'SET');
+      assert.deepEqual(sets.map(([, key]) => key), [KEYS.dsr, META_KEYS.dsr]);
+      assert.deepEqual(JSON.parse(sets[0][2]), payloadValue);
+      assert.equal(JSON.parse(sets[1][2]).recordCount, 1);
+    });
 
-      // 2. DSR null/empty → seed-meta NOT written. atomicPublish would have
-      //    skipped the canonical write in this case anyway (validate=false),
-      //    but this guards against a future caller invoking the hook with an
-      //    empty slice.
-      calls.length = 0;
-      await dsrAfterPublish({ dsr: null, spp: null, cpp: null });
-      assert.equal(calls.length, 0, `expected no Redis calls when DSR slice is empty, got ${JSON.stringify(calls)}`);
-
-      calls.length = 0;
-      await dsrAfterPublish({ dsr: { entries: [] }, spp: null, cpp: null });
-      assert.equal(calls.length, 0, `expected no Redis calls when DSR slice has zero entries`);
-    } finally {
-      globalThis.fetch = origFetch;
-      if (origUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL; else process.env.UPSTASH_REDIS_REST_URL = origUrl;
-      if (origTok === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN; else process.env.UPSTASH_REDIS_REST_TOKEN = origTok;
-    }
+    await assert.rejects(
+      publishBisDsrAtomically({ dsr: { entries: [] }, spp: null, cpp: null }),
+      /non-empty DSR slice/,
+    );
   });
 
   it('selectBestSeriesByCountry ignores series with no usable observations', () => {

--- a/tests/fred-rates-publish.test.mjs
+++ b/tests/fred-rates-publish.test.mjs
@@ -6,6 +6,7 @@ process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
 
 import {
   CANONICAL_KEY,
+  publishFredCohortAtomically,
   runFredRatesSeed,
 } from '../scripts/seed-fred-rates.mjs';
 import {
@@ -45,6 +46,14 @@ const MIN_SERIES_COUNT = Math.ceil(FRED_SEED_SERIES.length * 0.75);
 
 function companionMetaKey(key) {
   return `seed-meta:${key.replace(/:v\d+$/, '')}`;
+}
+
+function msetEntries(command) {
+  assert.equal(command?.[0], 'MSET');
+  return new Map(Array.from({ length: (command.length - 1) / 2 }, (_, index) => [
+    command[index * 2 + 1],
+    command[index * 2 + 2],
+  ]));
 }
 
 function expectedFredSidePreservationTargets() {
@@ -300,70 +309,49 @@ describe('FRED publication gates', () => {
     }
   });
 
-  it('leaves the complete last-good cohort unchanged when a late side publication fails', async () => {
-    const captured = await captureFredSeedOptions();
-    const clock = { now: 1_700_000_000_000 };
-    const entries = primeFredConsumerCohort(clock);
-    const before = new Map([...entries].map(([key, entry]) => [key, clone(entry.value)]));
-    const failedMetaKey = companionMetaKey(`${FRED_KEY_PREFIX}:${FRED_SEED_SERIES[1]}:0`);
+  it('publishes every FRED value and aggregate freshness metadata as one atomic value command', async () => {
     const batch = makeFredBatch(MIN_SERIES_COUNT);
     batch.stress = { components: [{ id: 'A' }], seededAt: '2031-01-01T00:00:00.000Z' };
+    const payloadValue = {
+      _seed: { fetchedAt: 1, recordCount: batch.seriesCount, sourceVersion: 'fred-v1' },
+      data: { seriesCount: batch.seriesCount },
+    };
     const transactions = [];
 
     globalThis.fetch = async (url, init = {}) => {
       const body = init.body ? JSON.parse(init.body) : null;
       if (String(url).endsWith('/multi-exec')) {
         transactions.push(body);
-        return Response.json(body.map((command) => (
-          command[1] === failedMetaKey
-            ? { error: 'ERR simulated late metadata failure' }
-            : { result: 'OK' }
-        )));
-      }
-      if (String(url).endsWith('/pipeline')) {
-        return Response.json(body.map(([, key, ttlSeconds]) => {
-          const entry = entries.get(key);
-          if (!entry) return { result: 0 };
-          entry.expiresAt = clock.now + Number(ttlSeconds) * 1000;
-          return { result: 1 };
-        }));
-      }
-      if (body?.[0] === 'SET') {
-        if (body[1] === failedMetaKey) return new Response('unavailable', { status: 503 });
-        if (entries.has(body[1])) {
-          entries.set(body[1], {
-            value: JSON.parse(body[2]),
-            expiresAt: clock.now + Number(body[4] ?? FRED_TTL) * 1000,
-          });
-        }
+        return Response.json(body.map((command) => command[0] === 'MSET'
+          ? { error: 'ERR simulated cohort value failure' }
+          : { result: 1 }));
       }
       return Response.json({ result: 'OK' });
     };
 
     await assert.rejects(
-      runSeed(
-        captured.domain,
-        captured.resource,
-        captured.canonicalKey,
-        async () => batch,
-        captured.options,
-      ),
-      /seed-meta|metadata|command result/i,
+      publishFredCohortAtomically(batch, {
+        payload: JSON.stringify(payloadValue),
+        payloadValue,
+      }),
+      /command result/i,
     );
 
-    for (const [key, value] of before) {
-      assert.deepEqual(entries.get(key)?.value, value, `${key} must remain on the prior cohort`);
-    }
-    const publishedKeys = transactions[0].map(([, key]) => key);
-    assert.deepEqual(publishedKeys, [
+    const published = msetEntries(transactions[0][0]);
+    assert.deepEqual([...published.keys()], [
       ...batch.seriesIds.flatMap((seriesId) => {
         const key = `${FRED_KEY_PREFIX}:${seriesId}:0`;
         return [key, companionMetaKey(key)];
       }),
       STRESS_INDEX_KEY,
       companionMetaKey(STRESS_INDEX_KEY),
+      'seed-meta:economic:fred-rates',
       CANONICAL_KEY,
     ]);
+    const aggregateMeta = JSON.parse(published.get('seed-meta:economic:fred-rates'));
+    assert.equal(aggregateMeta.fetchedAt, payloadValue._seed.fetchedAt);
+    assert.equal(aggregateMeta.recordCount, batch.seriesCount);
+    assert.equal(aggregateMeta.sourceVersion, 'fred-v1');
   });
 
   it('publishes every consumer key and activation after a retained source failure recovers', async () => {

--- a/tests/fred-rates-publish.test.mjs
+++ b/tests/fred-rates-publish.test.mjs
@@ -10,11 +10,13 @@ import {
 } from '../scripts/seed-fred-rates.mjs';
 import {
   FRED_SEED_SERIES,
+  FRED_KEY_PREFIX,
+  FRED_TTL,
   STRESS_INDEX_KEY,
   STRESS_INDEX_TTL,
 } from '../scripts/_fred-seeder.mjs';
 import { upstashCommand } from '../scripts/_upstash-rest.mjs';
-import { writeSeedMeta } from '../scripts/_seed-utils.mjs';
+import { GRACEFUL_FETCH_FAILURE_EXIT_CODE, runSeed, writeSeedMeta } from '../scripts/_seed-utils.mjs';
 
 const originalFetch = globalThis.fetch;
 const originalRetryDelay = process.env.WM_SEED_RETRY_DELAY_MS;
@@ -36,6 +38,128 @@ function makeSeriesMap(count) {
       observations: [{ date: '2031-01-01', value: index + 1 }],
     }]),
   );
+}
+
+const SEED_META_TTL = 7 * 24 * 60 * 60;
+const MIN_SERIES_COUNT = Math.ceil(FRED_SEED_SERIES.length * 0.75);
+
+function companionMetaKey(key) {
+  return `seed-meta:${key.replace(/:v\d+$/, '')}`;
+}
+
+function expectedFredSidePreservationTargets() {
+  return [
+    { key: 'seed-meta:economic:fred-rates', ttlSeconds: SEED_META_TTL },
+    ...FRED_SEED_SERIES.flatMap((seriesId) => {
+      const key = `${FRED_KEY_PREFIX}:${seriesId}:0`;
+      return [
+        { key, ttlSeconds: FRED_TTL },
+        { key: companionMetaKey(key), ttlSeconds: SEED_META_TTL },
+      ];
+    }),
+    { key: STRESS_INDEX_KEY, ttlSeconds: STRESS_INDEX_TTL },
+    { key: companionMetaKey(STRESS_INDEX_KEY), ttlSeconds: SEED_META_TTL },
+  ];
+}
+
+async function captureFredSeedOptions() {
+  let captured;
+  await runFredRatesSeed({
+    runSeedImpl: async (...args) => {
+      captured = args;
+    },
+  });
+  return {
+    domain: captured[0],
+    resource: captured[1],
+    canonicalKey: captured[2],
+    options: captured[4],
+  };
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function trapSeedExit(fn) {
+  const originalExit = process.exit;
+  const originalListeners = new Set(process.rawListeners('SIGTERM'));
+  process.exit = (code) => {
+    const error = new Error(`__fred_seed_exit__:${code}`);
+    error.exitCode = code;
+    throw error;
+  };
+  try {
+    await fn();
+    return null;
+  } catch (error) {
+    if (!String(error.message).startsWith('__fred_seed_exit__:')) throw error;
+    return error.exitCode;
+  } finally {
+    process.exit = originalExit;
+    for (const listener of process.rawListeners('SIGTERM')) {
+      if (!originalListeners.has(listener)) process.removeListener('SIGTERM', listener);
+    }
+  }
+}
+
+function installExpiryAwareRedis(clock, entries, pipelines) {
+  globalThis.fetch = async (url, init = {}) => {
+    const body = init.body ? JSON.parse(init.body) : null;
+    if (String(url).endsWith('/pipeline')) {
+      const result = body.map((command) => {
+        const [, key, ttlSeconds] = command;
+        const entry = entries.get(key);
+        if (!entry || entry.expiresAt <= clock.now) {
+          entries.delete(key);
+          return { result: 0 };
+        }
+        entry.expiresAt = clock.now + Number(ttlSeconds) * 1000;
+        return { result: 1 };
+      });
+      pipelines.push({ at: clock.now, commands: clone(body) });
+      return Response.json(result);
+    }
+    return Response.json({ result: 'OK' });
+  };
+}
+
+function primeFredConsumerCohort(clock) {
+  const entries = new Map();
+  const put = (key, value, ttlSeconds) => entries.set(key, {
+    value: clone(value),
+    expiresAt: clock.now + ttlSeconds * 1000,
+  });
+  put(CANONICAL_KEY, { seeded: 'batch' }, FRED_TTL);
+  put('seed-meta:economic:fred-rates', { fetchedAt: 1, recordCount: 24 }, SEED_META_TTL);
+  for (const seriesId of FRED_SEED_SERIES) {
+    const key = `${FRED_KEY_PREFIX}:${seriesId}:0`;
+    put(key, { series: { seriesId, observations: [{ date: '2031-01-01', value: 1 }] } }, FRED_TTL);
+    put(companionMetaKey(key), { fetchedAt: 1, recordCount: 1 }, SEED_META_TTL);
+  }
+  put(STRESS_INDEX_KEY, { seededAt: '2031-01-01T00:00:00.000Z', components: [] }, STRESS_INDEX_TTL);
+  put(companionMetaKey(STRESS_INDEX_KEY), { fetchedAt: 1, recordCount: 0 }, SEED_META_TTL);
+  return entries;
+}
+
+function assertCohortContentAndTtl(entries, before, clock) {
+  for (const [key, value] of before) {
+    assert.deepEqual(entries.get(key)?.value, value, `${key} content must not be rewritten by retention`);
+    assert.ok(entries.get(key)?.expiresAt > clock.now, `${key} must survive failed refreshes`);
+  }
+}
+
+function makeFredBatch(count) {
+  const seriesById = makeSeriesMap(count);
+  const seriesIds = Object.keys(seriesById);
+  return {
+    fetchedAt: '2031-01-01T00:00:00.000Z',
+    seriesCount: count,
+    seriesIds,
+    missingSeriesIds: FRED_SEED_SERIES.filter((seriesId) => !seriesById[seriesId]),
+    seriesById,
+    stress: null,
+  };
 }
 
 function makeRunSeedHarness(events) {
@@ -63,6 +187,114 @@ function makeRunSeedHarness(events) {
 }
 
 describe('FRED publication gates', () => {
+  it('retains every FRED consumer payload and its unchanged companion metadata across repeated source failures', async () => {
+    const captured = await captureFredSeedOptions();
+    assert.equal(captured.domain, 'economic');
+    assert.equal(captured.resource, 'fred-rates');
+    assert.equal(captured.canonicalKey, CANONICAL_KEY);
+    assert.deepEqual(captured.options.preserveKeyTtls, expectedFredSidePreservationTargets());
+    assert.equal(captured.options.emptyDataIsFailure, true);
+
+    const clock = { now: 1_700_000_000_000 };
+    const entries = primeFredConsumerCohort(clock);
+    const missingKey = `${FRED_KEY_PREFIX}:${FRED_SEED_SERIES.at(-1)}:0`;
+    const missingMetaKey = companionMetaKey(missingKey);
+    entries.delete(missingKey);
+    entries.delete(missingMetaKey);
+    const before = new Map([...entries].map(([key, entry]) => [key, clone(entry.value)]));
+    const pipelines = [];
+    installExpiryAwareRedis(clock, entries, pipelines);
+
+    for (const advanceMs of [0, 5, 10, 15, 20, 25, 30].map((hours) => hours * 60 * 60 * 1000)) {
+      clock.now = 1_700_000_000_000 + advanceMs;
+      const exitCode = await trapSeedExit(() => runSeed(
+        captured.domain,
+        captured.resource,
+        captured.canonicalKey,
+        async () => {
+          throw Object.assign(new Error('FRED upstream unavailable'), { nonRetryable: true });
+        },
+        captured.options,
+      ));
+      assert.equal(exitCode, GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+    }
+
+    assertCohortContentAndTtl(entries, before, clock);
+    assert.equal(entries.has(missingKey), false, 'retention must not recreate a missing FRED payload');
+    assert.equal(entries.has(missingMetaKey), false, 'retention must not recreate metadata for a missing FRED payload');
+
+    const latestGroups = new Map(
+      pipelines.slice(-3).map(({ commands }) => [
+        commands[0][2],
+        commands.map(([, key]) => key).sort(),
+      ]),
+    );
+    assert.deepEqual(latestGroups, new Map([
+      [FRED_TTL, [
+        CANONICAL_KEY,
+        ...FRED_SEED_SERIES.map((seriesId) => `${FRED_KEY_PREFIX}:${seriesId}:0`),
+      ].sort()],
+      [STRESS_INDEX_TTL, [STRESS_INDEX_KEY]],
+      [SEED_META_TTL, [
+        'seed-meta:economic:fred-rates',
+        ...FRED_SEED_SERIES.map((seriesId) => companionMetaKey(`${FRED_KEY_PREFIX}:${seriesId}:0`)),
+        companionMetaKey(STRESS_INDEX_KEY),
+      ].sort()],
+    ]));
+  });
+
+  it('retains the FRED cohort without rewriting metadata on validation or beforePublish failure', async () => {
+    const captured = await captureFredSeedOptions();
+    assert.deepEqual(captured.options.preserveKeyTtls, expectedFredSidePreservationTargets());
+    assert.equal(captured.options.emptyDataIsFailure, true);
+
+    const cases = [
+      {
+        name: 'partial validation failure',
+        run: async () => {
+          const exitCode = await trapSeedExit(() => runSeed(
+            captured.domain,
+            captured.resource,
+            captured.canonicalKey,
+            async () => makeFredBatch(MIN_SERIES_COUNT - 1),
+            captured.options,
+          ));
+          assert.equal(exitCode, 1);
+        },
+      },
+      {
+        name: 'beforePublish failure',
+        run: async () => assert.rejects(
+          runSeed(
+            captured.domain,
+            captured.resource,
+            captured.canonicalKey,
+            async () => makeFredBatch(MIN_SERIES_COUNT),
+            {
+              ...captured.options,
+              beforePublish: async () => {
+                throw new Error('FRED side publication failed');
+              },
+            },
+          ),
+          /FRED side publication failed/,
+        ),
+      },
+    ];
+
+    for (const failure of cases) {
+      const clock = { now: 1_700_000_000_000 };
+      const entries = primeFredConsumerCohort(clock);
+      const before = new Map([...entries].map(([key, entry]) => [key, clone(entry.value)]));
+      const pipelines = [];
+      installExpiryAwareRedis(clock, entries, pipelines);
+
+      await failure.run();
+      assertCohortContentAndTtl(entries, before, clock);
+      assert.equal(pipelines.length, 3, `${failure.name} must extend each TTL cohort once`);
+    }
+  });
+
   it('rejects 17/24 before side writes or activation', async () => {
     const events = [];
     const writes = [];

--- a/tests/fred-rates-publish.test.mjs
+++ b/tests/fred-rates-publish.test.mjs
@@ -78,7 +78,7 @@ async function captureFredSeedOptions() {
 }
 
 function clone(value) {
-  return JSON.parse(JSON.stringify(value));
+  return structuredClone(value);
 }
 
 async function trapSeedExit(fn) {

--- a/tests/fred-rates-publish.test.mjs
+++ b/tests/fred-rates-publish.test.mjs
@@ -295,6 +295,46 @@ describe('FRED publication gates', () => {
     }
   });
 
+  it('publishes every consumer key and activation after a retained source failure recovers', async () => {
+    const captured = await captureFredSeedOptions();
+    const clock = { now: 1_700_000_000_000 };
+    const entries = primeFredConsumerCohort(clock);
+    installExpiryAwareRedis(clock, entries, []);
+    const exitCode = await trapSeedExit(() => runSeed(
+      captured.domain,
+      captured.resource,
+      captured.canonicalKey,
+      async () => {
+        throw Object.assign(new Error('FRED upstream unavailable'), { nonRetryable: true });
+      },
+      captured.options,
+    ));
+    assert.equal(exitCode, GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+
+    const events = [];
+    const writtenKeys = [];
+    await runFredRatesSeed({
+      runSeedImpl: makeRunSeedHarness(events),
+      fetchFredSeriesImpl: async () => makeSeriesMap(FRED_SEED_SERIES.length),
+      fetchGscpiFromRedisImpl: async () => null,
+      computeStressIndexImpl: () => ({ components: [{ id: 'stress' }] }),
+      writeExtraKeyWithMetaImpl: async (key) => {
+        writtenKeys.push(key);
+        return true;
+      },
+      markFredRatesActivatedImpl: async () => {
+        events.push('activation');
+      },
+    });
+
+    assert.deepEqual(
+      writtenKeys.slice(0, -1),
+      FRED_SEED_SERIES.map((seriesId) => `${FRED_KEY_PREFIX}:${seriesId}:0`),
+    );
+    assert.equal(writtenKeys.at(-1), STRESS_INDEX_KEY);
+    assert.equal(events.at(-1), 'activation');
+  });
+
   it('rejects 17/24 before side writes or activation', async () => {
     const events = [];
     const writes = [];

--- a/tests/fred-rates-publish.test.mjs
+++ b/tests/fred-rates-publish.test.mjs
@@ -179,7 +179,12 @@ function makeRunSeedHarness(events) {
     }
 
     events.push('validated');
-    await options.beforePublish(batch, { canonicalKey: key });
+    await options.publishAtomically(batch, {
+      canonicalKey: key,
+      payload: JSON.stringify(canonical),
+      payloadValue: canonical,
+      ttlSeconds: FRED_TTL,
+    });
     events.push('canonical');
     await options.afterPublish(batch, { canonicalKey: key });
     return { skipped: false, batch, canonical };
@@ -243,7 +248,7 @@ describe('FRED publication gates', () => {
     ]));
   });
 
-  it('retains the FRED cohort without rewriting metadata on validation or beforePublish failure', async () => {
+  it('retains the FRED cohort without rewriting metadata on validation or atomic publication failure', async () => {
     const captured = await captureFredSeedOptions();
     assert.deepEqual(captured.options.preserveKeyTtls, expectedFredSidePreservationTargets());
     assert.equal(captured.options.emptyDataIsFailure, true);
@@ -263,7 +268,7 @@ describe('FRED publication gates', () => {
         },
       },
       {
-        name: 'beforePublish failure',
+        name: 'atomic publication failure',
         run: async () => assert.rejects(
           runSeed(
             captured.domain,
@@ -272,12 +277,12 @@ describe('FRED publication gates', () => {
             async () => makeFredBatch(MIN_SERIES_COUNT),
             {
               ...captured.options,
-              beforePublish: async () => {
-                throw new Error('FRED side publication failed');
+              publishAtomically: async () => {
+                throw new Error('FRED cohort publication failed');
               },
             },
           ),
-          /FRED side publication failed/,
+          /FRED cohort publication failed/,
         ),
       },
     ];
@@ -301,10 +306,14 @@ describe('FRED publication gates', () => {
     const entries = primeFredConsumerCohort(clock);
     const before = new Map([...entries].map(([key, entry]) => [key, clone(entry.value)]));
     const failedMetaKey = companionMetaKey(`${FRED_KEY_PREFIX}:${FRED_SEED_SERIES[1]}:0`);
+    const batch = makeFredBatch(MIN_SERIES_COUNT);
+    batch.stress = { components: [{ id: 'A' }], seededAt: '2031-01-01T00:00:00.000Z' };
+    const transactions = [];
 
     globalThis.fetch = async (url, init = {}) => {
       const body = init.body ? JSON.parse(init.body) : null;
       if (String(url).endsWith('/multi-exec')) {
+        transactions.push(body);
         return Response.json(body.map((command) => (
           command[1] === failedMetaKey
             ? { error: 'ERR simulated late metadata failure' }
@@ -336,7 +345,7 @@ describe('FRED publication gates', () => {
         captured.domain,
         captured.resource,
         captured.canonicalKey,
-        async () => makeFredBatch(MIN_SERIES_COUNT),
+        async () => batch,
         captured.options,
       ),
       /seed-meta|metadata|command result/i,
@@ -345,6 +354,16 @@ describe('FRED publication gates', () => {
     for (const [key, value] of before) {
       assert.deepEqual(entries.get(key)?.value, value, `${key} must remain on the prior cohort`);
     }
+    const publishedKeys = transactions[0].map(([, key]) => key);
+    assert.deepEqual(publishedKeys, [
+      ...batch.seriesIds.flatMap((seriesId) => {
+        const key = `${FRED_KEY_PREFIX}:${seriesId}:0`;
+        return [key, companionMetaKey(key)];
+      }),
+      STRESS_INDEX_KEY,
+      companionMetaKey(STRESS_INDEX_KEY),
+      CANONICAL_KEY,
+    ]);
   });
 
   it('publishes every consumer key and activation after a retained source failure recovers', async () => {
@@ -370,9 +389,9 @@ describe('FRED publication gates', () => {
       fetchFredSeriesImpl: async () => makeSeriesMap(FRED_SEED_SERIES.length),
       fetchGscpiFromRedisImpl: async () => null,
       computeStressIndexImpl: () => ({ components: [{ id: 'stress' }] }),
-      writeExtraKeyWithMetaImpl: async (key) => {
-        writtenKeys.push(key);
-        return true;
+      publishFredCohortImpl: async (batch) => {
+        writtenKeys.push(...batch.seriesIds.map((seriesId) => `${FRED_KEY_PREFIX}:${seriesId}:0`));
+        if (batch.stress) writtenKeys.push(STRESS_INDEX_KEY);
       },
       markFredRatesActivatedImpl: async () => {
         events.push('activation');
@@ -401,9 +420,8 @@ describe('FRED publication gates', () => {
       },
       fetchGscpiFromRedisImpl: async () => null,
       computeStressIndexImpl: () => null,
-      writeExtraKeyWithMetaImpl: async (...args) => {
+      publishFredCohortImpl: async (...args) => {
         writes.push(args);
-        return true;
       },
       markFredRatesActivatedImpl: async () => {
         activations += 1;
@@ -430,10 +448,9 @@ describe('FRED publication gates', () => {
       },
       fetchGscpiFromRedisImpl: async () => null,
       computeStressIndexImpl: () => null,
-      writeExtraKeyWithMetaImpl: async (...args) => {
-        events.push(`side:${args[0]}`);
+      publishFredCohortImpl: async (...args) => {
+        events.push('cohort');
         writes.push(args);
-        return true;
       },
       markFredRatesActivatedImpl: async () => {
         events.push('activation');
@@ -452,17 +469,16 @@ describe('FRED publication gates', () => {
     ]);
     assert.equal('seriesById' in result.canonical, false);
     assert.equal('stress' in result.canonical, false);
-    assert.equal(writes.length, 18);
+    assert.equal(writes.length, 1);
     const canonicalIndex = events.indexOf('canonical');
-    assert.ok(events.filter((event) => event.startsWith('side:')).every((event) => events.indexOf(event) < canonicalIndex));
+    assert.ok(events.indexOf('cohort') < canonicalIndex);
     assert.equal(events.at(-1), 'activation');
   });
 
-  it('retries component metadata locally without refetching upstream', async () => {
+  it('publishes one atomic cohort without refetching upstream', async () => {
     const events = [];
     let upstreamCalls = 0;
-    let firstKeyAttempts = 0;
-    const firstKey = `economic:fred:v1:${FRED_SEED_SERIES[0]}:0`;
+    let cohortCalls = 0;
     const result = await runFredRatesSeed({
       runSeedImpl: makeRunSeedHarness(events),
       fetchFredSeriesImpl: async () => {
@@ -471,22 +487,20 @@ describe('FRED publication gates', () => {
       },
       fetchGscpiFromRedisImpl: async () => null,
       computeStressIndexImpl: () => null,
-      writeExtraKeyWithMetaImpl: async (key) => {
-        if (key !== firstKey) return true;
-        firstKeyAttempts += 1;
-        return firstKeyAttempts >= 3;
+      publishFredCohortImpl: async () => {
+        cohortCalls += 1;
       },
       markFredRatesActivatedImpl: async () => {},
     });
 
     assert.equal(result.skipped, false);
-    assert.equal(firstKeyAttempts, 3);
+    assert.equal(cohortCalls, 1);
     assert.equal(upstreamCalls, 1);
   });
 
-  it('publishes a computed stress index in beforePublish', async () => {
+  it('includes a computed stress index in the atomic cohort', async () => {
     const events = [];
-    const writes = [];
+    let publishedBatch;
     const stress = {
       compositeScore: 42,
       label: 'Elevated',
@@ -498,18 +512,14 @@ describe('FRED publication gates', () => {
       fetchFredSeriesImpl: async () => makeSeriesMap(18),
       fetchGscpiFromRedisImpl: async () => null,
       computeStressIndexImpl: () => stress,
-      writeExtraKeyWithMetaImpl: async (...args) => {
-        writes.push(args);
-        return true;
+      publishFredCohortImpl: async (batch) => {
+        publishedBatch = batch;
       },
       markFredRatesActivatedImpl: async () => {},
     });
 
-    const stressWrite = writes.find(([key]) => key === STRESS_INDEX_KEY);
-    assert.ok(stressWrite);
-    assert.equal(stressWrite[1], stress);
-    assert.equal(stressWrite[2], STRESS_INDEX_TTL);
-    assert.equal(stressWrite[3], 2);
+    assert.equal(publishedBatch.stress, stress);
+    assert.equal(publishedBatch.stress.components.length, 2);
   });
 
   it('keeps stress computation failure non-fatal', async () => {
@@ -522,9 +532,9 @@ describe('FRED publication gates', () => {
       computeStressIndexImpl: () => {
         throw new Error('missing stress component');
       },
-      writeExtraKeyWithMetaImpl: async (key) => {
-        writtenKeys.push(key);
-        return true;
+      publishFredCohortImpl: async (batch) => {
+        writtenKeys.push(...batch.seriesIds.map((seriesId) => `${FRED_KEY_PREFIX}:${seriesId}:0`));
+        if (batch.stress) writtenKeys.push(STRESS_INDEX_KEY);
       },
       markFredRatesActivatedImpl: async () => {},
     });
@@ -534,7 +544,7 @@ describe('FRED publication gates', () => {
     assert.equal(writtenKeys.includes(STRESS_INDEX_KEY), false);
   });
 
-  it('fails before canonical publication when stress metadata cannot be confirmed', async () => {
+  it('does not activate when the atomic cohort publication fails', async () => {
     const events = [];
     let upstreamCalls = 0;
     let stressAttempts = 0;
@@ -546,18 +556,17 @@ describe('FRED publication gates', () => {
       },
       fetchGscpiFromRedisImpl: async () => null,
       computeStressIndexImpl: () => ({ components: [{ id: 'A' }] }),
-      writeExtraKeyWithMetaImpl: async (key) => {
-        if (key !== STRESS_INDEX_KEY) return true;
+      publishFredCohortImpl: async () => {
         stressAttempts += 1;
-        return false;
+        throw new Error('FRED atomic publication returned an invalid command result');
       },
       markFredRatesActivatedImpl: async () => {
         events.push('activation');
       },
-    }), /FRED stress-index seed-meta write failed/);
+    }), /FRED atomic publication returned an invalid command result/);
 
     assert.equal(upstreamCalls, 1);
-    assert.equal(stressAttempts, 3);
+    assert.equal(stressAttempts, 1);
     assert.equal(events.includes('canonical'), false);
     assert.equal(events.includes('activation'), false);
   });

--- a/tests/fred-rates-publish.test.mjs
+++ b/tests/fred-rates-publish.test.mjs
@@ -352,6 +352,16 @@ describe('FRED publication gates', () => {
     assert.equal(aggregateMeta.fetchedAt, payloadValue._seed.fetchedAt);
     assert.equal(aggregateMeta.recordCount, batch.seriesCount);
     assert.equal(aggregateMeta.sourceVersion, 'fred-v1');
+    const ttlByKey = new Map(transactions[0].slice(1).map(([, key, ttl]) => [key, ttl]));
+    for (const seriesId of batch.seriesIds) {
+      const key = `${FRED_KEY_PREFIX}:${seriesId}:0`;
+      assert.equal(ttlByKey.get(key), FRED_TTL);
+      assert.equal(ttlByKey.get(companionMetaKey(key)), SEED_META_TTL);
+    }
+    assert.equal(ttlByKey.get(STRESS_INDEX_KEY), STRESS_INDEX_TTL);
+    assert.equal(ttlByKey.get(companionMetaKey(STRESS_INDEX_KEY)), SEED_META_TTL);
+    assert.equal(ttlByKey.get('seed-meta:economic:fred-rates'), SEED_META_TTL);
+    assert.equal(ttlByKey.get(CANONICAL_KEY), FRED_TTL);
   });
 
   it('publishes every consumer key and activation after a retained source failure recovers', async () => {

--- a/tests/fred-rates-publish.test.mjs
+++ b/tests/fred-rates-publish.test.mjs
@@ -295,6 +295,58 @@ describe('FRED publication gates', () => {
     }
   });
 
+  it('leaves the complete last-good cohort unchanged when a late side publication fails', async () => {
+    const captured = await captureFredSeedOptions();
+    const clock = { now: 1_700_000_000_000 };
+    const entries = primeFredConsumerCohort(clock);
+    const before = new Map([...entries].map(([key, entry]) => [key, clone(entry.value)]));
+    const failedMetaKey = companionMetaKey(`${FRED_KEY_PREFIX}:${FRED_SEED_SERIES[1]}:0`);
+
+    globalThis.fetch = async (url, init = {}) => {
+      const body = init.body ? JSON.parse(init.body) : null;
+      if (String(url).endsWith('/multi-exec')) {
+        return Response.json(body.map((command) => (
+          command[1] === failedMetaKey
+            ? { error: 'ERR simulated late metadata failure' }
+            : { result: 'OK' }
+        )));
+      }
+      if (String(url).endsWith('/pipeline')) {
+        return Response.json(body.map(([, key, ttlSeconds]) => {
+          const entry = entries.get(key);
+          if (!entry) return { result: 0 };
+          entry.expiresAt = clock.now + Number(ttlSeconds) * 1000;
+          return { result: 1 };
+        }));
+      }
+      if (body?.[0] === 'SET') {
+        if (body[1] === failedMetaKey) return new Response('unavailable', { status: 503 });
+        if (entries.has(body[1])) {
+          entries.set(body[1], {
+            value: JSON.parse(body[2]),
+            expiresAt: clock.now + Number(body[4] ?? FRED_TTL) * 1000,
+          });
+        }
+      }
+      return Response.json({ result: 'OK' });
+    };
+
+    await assert.rejects(
+      runSeed(
+        captured.domain,
+        captured.resource,
+        captured.canonicalKey,
+        async () => makeFredBatch(MIN_SERIES_COUNT),
+        captured.options,
+      ),
+      /seed-meta|metadata|command result/i,
+    );
+
+    for (const [key, value] of before) {
+      assert.deepEqual(entries.get(key)?.value, value, `${key} must remain on the prior cohort`);
+    }
+  });
+
   it('publishes every consumer key and activation after a retained source failure recovers', async () => {
     const captured = await captureFredSeedOptions();
     const clock = { now: 1_700_000_000_000 };

--- a/tests/fred-rates-rollout-health.test.mjs
+++ b/tests/fred-rates-rollout-health.test.mjs
@@ -47,6 +47,29 @@ function classify({ now, activated = false, rolloutUntil = UNTIL, recordCount } 
   );
 }
 
+function classifyRetained(name, { now, recordCount, fetchedAt }) {
+  const key = BOOTSTRAP_KEYS[name] ?? STANDALONE_KEYS[name];
+  return classifyKey(
+    name,
+    key,
+    { allowOnDemand: false },
+    {
+      keyStrens: new Map([[key, 128]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([[
+        SEED_META[name].key,
+        JSON.stringify({ fetchedAt, recordCount }),
+      ]]),
+      keyMetaErrors: new Map(),
+      activationStates: new Map(
+        Object.keys(ACTIVATION_MARKERS).map((markerName) => [markerName, false]),
+      ),
+      rolloutPendingUntilMs: new Map(),
+      now,
+    },
+  );
+}
+
 test('FRED rollout registers one versioned activation marker and a 24h duration', () => {
   assert.equal(ACTIVATION_MARKERS[NAME], FRED_RATES_ACTIVATION_KEY);
   assert.equal(SEED_META[NAME].key, 'seed-meta:economic:fred-rates');
@@ -57,6 +80,23 @@ test('FRED rollout registers one versioned activation marker and a 24h duration'
 test('fresh FRED coverage is partial at 18 records and OK at all 24 records', () => {
   assert.equal(classify({ now: DEPLOYED_AT, recordCount: 18 }).status, 'COVERAGE_PARTIAL');
   assert.equal(classify({ now: DEPLOYED_AT, recordCount: 24 }).status, 'OK');
+});
+
+test('retained FRED data becomes STALE_SEED at each unchanged health budget', () => {
+  const now = DEPLOYED_AT;
+  for (const { name, recordCount, maxStaleMin } of [
+    { name: 'fredRatesSeeder', recordCount: 24, maxStaleMin: 180 },
+    { name: 'fredBatch', recordCount: 1, maxStaleMin: 1500 },
+    { name: 'economicStress', recordCount: 1, maxStaleMin: 180 },
+  ]) {
+    const entry = classifyRetained(name, {
+      now,
+      recordCount,
+      fetchedAt: now - (maxStaleMin + 1) * 60_000,
+    });
+    assert.equal(entry.status, 'STALE_SEED', name);
+    assert.equal(entry.maxStaleMin, maxStaleMin, name);
+  }
 });
 
 test('a delayed production deployment claims its own durable deadline', () => {

--- a/tests/fred-series-batch.test.mts
+++ b/tests/fred-series-batch.test.mts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { getCachedJsonBatch } from '../server/_shared/redis';
 import { sidecarCacheSet } from '../server/_shared/sidecar-cache';
 import { getFredSeriesBatch } from '../server/worldmonitor/economic/v1/get-fred-series-batch';
+import { runFredRatesSeed } from '../scripts/seed-fred-rates.mjs';
 
 const ORIGINAL_ENV = {
   UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
@@ -68,9 +69,20 @@ function stubPipelineFetch(results: Array<{ result?: string }>): Array<{ url: st
   return calls;
 }
 
+async function fredPreserveKeyTtls(): Promise<Map<string, number>> {
+  let options: { preserveKeyTtls?: Array<{ key: string; ttlSeconds: number }> } | undefined;
+  await runFredRatesSeed({
+    runSeedImpl: async (...args: unknown[]) => {
+      options = args[4] as typeof options;
+    },
+  });
+  return new Map(options?.preserveKeyTtls?.map(({ key, ttlSeconds }) => [key, ttlSeconds]));
+}
+
 describe('getFredSeriesBatch', () => {
   it('reads seeded FRED series through one raw Redis pipeline request', async () => {
     configureRemoteRedis();
+    const retainedTtls = await fredPreserveKeyTtls();
 
     const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -96,6 +108,9 @@ describe('getFredSeriesBatch', () => {
     assert.equal(response.requested, 2);
     assert.equal(response.fetched, 2);
     assert.deepEqual(Object.keys(response.results), ['CPIAUCSL', 'FEDFUNDS']);
+    for (const [, key] of JSON.parse(String(calls[0]!.init?.body))) {
+      assert.ok(retainedTtls.has(key), `FRED consumer GET key ${key} must be retained on a failed seed`);
+    }
     assert.deepEqual(response.results.FEDFUNDS?.observations, [
       { date: '2026-05-01', value: 2 },
       { date: '2026-06-01', value: 3 },


### PR DESCRIPTION
## Summary

Failed FRED and BIS refreshes now keep complete last-good consumer cohorts instead of overwriting good payloads or allowing them to expire. Existing payloads and freshness records retain their independent TTLs without changing observation dates or success markers, while missing keys remain missing.

Successful recovery publishes consumer payloads, companion metadata, aggregate freshness, and canonical data as one atomic value cohort. BIS residential and commercial property slices remain independent, so a healthy slice can publish while another source is unavailable. Existing health thresholds are unchanged.

Fixes #7846.

## Validation

- `node --test tests/fred-rates-publish.test.mjs tests/fred-rates-rollout-health.test.mjs tests/bis-extended-seed.test.mjs` — 53 passed
- `node --import tsx --test tests/fred-series-batch.test.mts` — 6 passed
- Pre-push gates passed: browser and API typechecks, Unicode safety, focused seed tests, changed-file tests, and version sync
- `npm run lint:boundaries` — passed
- One broad `npm run test:data` run passed 30,994 tests with no failures before the final atomic hardening. The later load-heavy rerun passed 30,991 tests and hit five unrelated process-timeout failures; four passed when isolated, while `ai-search-product-facts` still exceeded its own 45-second subprocess timeout on this host.

No production seeder or Redis write was run.

## Post-Deploy Monitoring & Validation

- Owner: deployer or on-call engineer
- Window: the first two hourly FRED runs and the first two scheduled BIS runs after deployment
- Search logs for `economic:fred-rates Seed`, `economic:bis-extended Seed`, `FETCH FAILED`, `atomic publication failed`, `Extended TTL`, and `seed_complete`
- Watch `/api/health?compact=1` for `fredRatesSeeder`, `bisDsr`, `bisPropertyResidential`, and `bisPropertyCommercial`
- Healthy: failed upstream runs extend only existing last-good keys; recovery advances payload and freshness records together; healthy BIS property slices publish independently
- Failure: any affected key becomes `EMPTY` or `REDIS_PARTIAL`, freshness advances after a rejected refresh, or payload and metadata timestamps diverge across one completed cycle
- Mitigation: roll back the deployment if a failure signal persists through one scheduled cycle; do not repair Redis keys manually

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
