### PR TITLE
fix: preserve docs canonicals across copied deployments

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -35,6 +35,36 @@ open http://localhost:3000
 
 The dashboard works out of the box with public data sources (earthquakes, weather, conflicts, etc.). API keys unlock additional data feeds.
 
+## Documentation indexing
+
+The bundled documentation identifies `https://www.worldmonitor.app/docs` as its
+original location. `docs/docs.json` sets this canonical base for Mintlify, and
+`src/config/docs-locale-seo.ts` uses `DOCS_PUBLIC_ORIGIN` to produce an absolute,
+page-specific canonical and language links.
+
+Deployments that run `middleware.ts` also return `X-Robots-Tag: noindex` for docs
+HTML on hosts other than the configured public host. This includes preview
+hosts. The policy also applies to HEAD and 304 responses, and preserves existing
+robots restrictions. It does not stop people from reading the docs. Static
+exports and proxies that bypass this middleware must set their own indexing
+headers; they retain the canonical metadata only if they preserve it.
+
+Inspect canonical URLs before publishing a static export. The pinned Mintlify
+CLI currently includes `/src/_props` in local preview and export canonicals;
+that local output does not establish the hosted provider's URL behavior.
+
+For a fork that publishes its own documentation, deliberately update the
+canonical base in `docs/docs.json`, `DOCS_PUBLIC_ORIGIN`, and the docs upstream and
+reverse-proxy routes (`DOCS_UPSTREAM_ORIGIN` and `vercel.json`) together. Configure
+the provider's base path to match. Check the resulting canonical URLs, language
+links, structured data, sitemap, and indexing headers before requesting indexing.
+Do not derive the canonical origin from the incoming request or a forwarded-host
+header. Keep shared caches separated by host and preserve the response's `Vary`
+selectors.
+
+Canonical metadata is a search-engine signal, not a guarantee. A proxy can rewrite
+or remove it, and older deployed copies will not receive changes to this repo.
+
 ## 🔐 Required Environment Variables
 
 These must be set before `docker compose up -d`, or one of the containers will exit on boot.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,6 +11,7 @@
   "favicon": "/favicon.png",
   "seo": {
     "metatags": {
+      "canonical": "https://www.worldmonitor.app/docs",
       "og:image": "https://www.worldmonitor.app/favico/og-image.png",
       "og:site_name": "World Monitor Documentation",
       "og:type": "website",

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { isKnownPublicPagePath, originNotFoundResponse } from './src/config/agent-not-found';
 import {
+  DOCS_PUBLIC_ORIGIN,
   DOCS_UPSTREAM_ORIGIN,
   DOCS_UPSTREAM_TIMEOUT_MS,
   isDocsFullDocumentRequest,
@@ -271,7 +272,7 @@ export default function middleware(request: Request) {
     // for /docs/zh/* (issue #7378). Proxy full-document HTML only — leave RSC
     // flights and static assets on the direct Mintlify rewrite.
     if (isDocsHtmlDocumentPath(path) && isDocsFullDocumentRequest(request)) {
-      return proxyDocsLocaleHtml(request, url);
+      return proxyDocsLocaleHtml(request, url, host);
     }
 
     // Real HTTP 404 for unknown pages. Agents get markdown (orank
@@ -391,7 +392,23 @@ export default function middleware(request: Request) {
   }
 }
 
-async function proxyDocsLocaleHtml(request: Request, url: URL): Promise<Response> {
+function docsResponseHeaders(upstream: Response, host: string): Headers {
+  const headers = new Headers(upstream.headers);
+  if (host !== new URL(DOCS_PUBLIC_ORIGIN).hostname) {
+    const robots = headers.get('x-robots-tag');
+    headers.set('x-robots-tag', robots ? `noindex, ${robots}` : 'noindex');
+  }
+  const varyParts = new Set(
+    (headers.get('vary') ?? '').split(',').map((part) => part.trim().toLowerCase()).filter(Boolean),
+  );
+  for (const name of ['host', 'accept', 'rsc', 'next-router-state-tree', 'next-router-prefetch']) {
+    varyParts.add(name);
+  }
+  headers.set('vary', [...varyParts].join(', '));
+  return headers;
+}
+
+async function proxyDocsLocaleHtml(request: Request, url: URL, host: string): Promise<Response> {
   const upstreamUrl = `${DOCS_UPSTREAM_ORIGIN}${url.pathname}${url.search}`;
   const forwardHeaders = new Headers();
   for (const name of ['accept', 'accept-language', 'user-agent', 'if-none-match', 'if-modified-since']) {
@@ -412,17 +429,18 @@ async function proxyDocsLocaleHtml(request: Request, url: URL): Promise<Response
       signal: AbortSignal.timeout(DOCS_UPSTREAM_TIMEOUT_MS),
     });
 
-    // Pass through redirects / not-modified without rewriting.
-    if (upstream.status >= 300 && upstream.status < 400) {
+    const contentType = upstream.headers.get('content-type');
+    if (upstream.status !== 304 && (
+      upstream.status !== 200 || !shouldTransformDocsUpstreamHtml(url.pathname, contentType)
+    )) {
       return upstream;
     }
     if (upstream.status === 304 || request.method === 'HEAD') {
-      return upstream;
-    }
-
-    const contentType = upstream.headers.get('content-type');
-    if (!shouldTransformDocsUpstreamHtml(url.pathname, contentType)) {
-      return upstream;
+      return new Response(null, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: docsResponseHeaders(upstream, host),
+      });
     }
 
     html = await upstream.text();
@@ -431,25 +449,13 @@ async function proxyDocsLocaleHtml(request: Request, url: URL): Promise<Response
   }
 
   const rewritten = rewriteDocsLocaleHtml(html, url.pathname);
-  const headers = new Headers(upstream.headers);
+  const headers = docsResponseHeaders(upstream, host);
   // Fetch already decoded the body; hop-by-hop / recomputed framing must not
   // be forwarded onto the rewritten string response (Mintlify serves br).
   for (const name of ['content-encoding', 'content-length', 'transfer-encoding', 'connection']) {
     headers.delete(name);
   }
   headers.set('x-wm-docs-locale-seo', '1');
-  // Ensure shared caches vary on the headers that select this proxy path.
-  const vary = headers.get('vary');
-  const varyParts = new Set(
-    (vary ? vary.split(',') : [])
-      .map((part) => part.trim())
-      .filter(Boolean)
-      .map((part) => part.toLowerCase()),
-  );
-  varyParts.add('accept');
-  varyParts.add('rsc');
-  headers.set('vary', [...varyParts].join(', '));
-
   return new Response(rewritten, {
     status: upstream.status,
     statusText: upstream.statusText,

--- a/scripts/verify-sitemaps.mjs
+++ b/scripts/verify-sitemaps.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { XMLValidator } from 'fast-xml-parser';
 
-import { getHtmlAttribute } from './discover-content-corpus-pages.mjs';
+import { decodeHtmlEntities } from './_html-entities.mjs';
 
 const DEFAULT_ORIGIN = 'https://www.worldmonitor.app';
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -66,42 +66,99 @@ export function classifySitemapUrl(value) {
   return 'other';
 }
 
+function getHtmlAttribute(tag, name) {
+  for (const match of tag.matchAll(/\s+([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g)) {
+    if (match[1].toLowerCase() === name) return decodeHtmlEntities(match[2] ?? match[3] ?? match[4]);
+  }
+  return null;
+}
+
 export function inspectIndexability({ url, headers, body }) {
   const headerRobots = headers.get('x-robots-tag') ?? '';
   const linkHeader = headers.get('link') ?? '';
-  const headerCanonical = linkHeader.match(
-    /<([^>]+)>\s*;\s*rel=(?:"canonical"|'canonical'|canonical)/i,
-  )?.[1] ?? null;
   const contentType = headers.get('content-type') ?? '';
+  const isHtml = /text\/html|application\/xhtml\+xml/i.test(contentType);
+  const isDocs = classifySitemapUrl(url) === 'docs';
+  const canonicalDeclarations = [];
+  const canonicalErrors = [];
+  const metaRobots = [];
 
-  let htmlCanonical = null;
-  let metaRobots = '';
-  if (/text\/html|application\/xhtml\+xml/i.test(contentType)) {
-    const linkTags = String(body).match(/<link\b[^>]*>/gi) ?? [];
-    for (const tag of linkTags) {
-      const rel = getHtmlAttribute(tag, 'rel')?.toLowerCase().split(/\s+/) ?? [];
-      if (rel.includes('canonical')) {
-        htmlCanonical = getHtmlAttribute(tag, 'href');
-        break;
+  const addCanonical = (source, href) => {
+    let resolved = null;
+    if (!href?.trim()) {
+      canonicalErrors.push(`${source} canonical has missing href`);
+    } else {
+      try {
+        const target = new URL(href, url);
+        if (!/^https?:$/.test(target.protocol) || target.username || target.password || target.hash) {
+          throw new Error('invalid canonical URL');
+        }
+        resolved = target.href;
+        if (isDocs && !/^https?:\/\//i.test(href)) {
+          canonicalErrors.push(`${source} docs canonical must be absolute: ${href}`);
+        }
+      } catch {
+        canonicalErrors.push(`${source} canonical has invalid URL: ${href}`);
       }
     }
+    canonicalDeclarations.push({ source, href, url: resolved });
+  };
 
-    const metaTags = String(body).match(/<meta\b[^>]*>/gi) ?? [];
-    for (const tag of metaTags) {
-      if (getHtmlAttribute(tag, 'name')?.toLowerCase() === 'robots') {
-        metaRobots = getHtmlAttribute(tag, 'content') ?? '';
-        break;
+  for (const entry of linkHeader.match(/(?:<[^>]*>|"(?:\\.|[^"\\])*"|'[^']*'|[^,])+/g) ?? []) {
+    const target = entry.match(/^\s*<([^>]*)>([\s\S]*)$/);
+    const rel = [...(target?.[2] ?? entry).matchAll(/;\s*([\w-]+)\s*=\s*(?:"((?:\\.|[^"\\])*)"|'([^']*)'|([^;\s,]+))/g)]
+      .find((parameter) => parameter[1].toLowerCase() === 'rel');
+    if (!(rel?.[2] ?? rel?.[3] ?? rel?.[4] ?? '').toLowerCase().split(/\s+/).includes('canonical')) continue;
+    addCanonical('http', target?.[1] ?? null);
+  }
+
+  if (isHtml) {
+    const markup = String(body).replace(/<!--[\s\S]*?-->|<(script|style|template)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+    const head = /<head\b[^>]*>([\s\S]*?)<\/head\s*>/i.exec(markup);
+    for (const match of markup.matchAll(/<(?:link|meta)\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi)) {
+      const tag = match[0];
+      const inHead = head && match.index >= head.index && match.index < head.index + head[0].length;
+      if (/^<link\b/i.test(tag)) {
+        const rel = getHtmlAttribute(tag, 'rel')?.toLowerCase().split(/\s+/) ?? [];
+        if (!rel.includes('canonical')) continue;
+        if (!inHead) {
+          canonicalErrors.push('HTML canonical is outside the head');
+          continue;
+        }
+        const href = getHtmlAttribute(tag, 'href');
+        addCanonical('html', href);
+      } else if (inHead && ['robots', 'googlebot'].includes(getHtmlAttribute(tag, 'name')?.toLowerCase())) {
+        metaRobots.push(getHtmlAttribute(tag, 'content') ?? '');
       }
     }
   }
 
-  let canonical = null;
-  if (headerCanonical) canonical = new URL(headerCanonical, url).href;
-  else if (htmlCanonical) canonical = new URL(htmlCanonical, url).href;
+  for (const source of ['html', 'http']) {
+    const count = canonicalDeclarations.filter(entry => entry.source === source).length;
+    if (count > 1) canonicalErrors.push(`duplicate ${source} canonical declarations: ${count}`);
+    if (source === 'html' && isHtml && isDocs && count === 0) {
+      canonicalErrors.push('missing HTML canonical in docs head');
+    }
+  }
+  const targets = new Set(canonicalDeclarations.map(entry => entry.url).filter(Boolean));
+  if (targets.size > 1) canonicalErrors.push(`conflicting canonical targets: ${[...targets].join(', ')}`);
+  if (canonicalDeclarations.length === 0) canonicalErrors.push('missing canonical');
+
+  let robot = '*';
+  const effectiveRobots = [...metaRobots];
+  for (const part of headerRobots.split(',')) {
+    const scope = /^\s*([\w-]+):\s*(.*)$/.exec(part);
+    if (scope && !/^(?:unavailable_after|max-image-preview|max-snippet|max-video-preview)$/i.test(scope[1])) {
+      robot = scope[1].toLowerCase();
+    }
+    if (robot === '*' || robot === 'googlebot') effectiveRobots.push(scope?.[2] ?? part);
+  }
   return {
-    canonical,
-    indexable: !/\bnoindex\b/i.test(`${headerRobots},${metaRobots}`),
-    robots: [headerRobots, metaRobots].filter(Boolean).join(', ') || null,
+    canonical: canonicalErrors.length === 0 ? [...targets][0] ?? null : null,
+    canonicalDeclarations,
+    canonicalErrors,
+    indexable: !/\b(?:noindex|none)\b/i.test(effectiveRobots.join(', ')),
+    robots: [headerRobots, ...metaRobots].filter(Boolean).join(', ') || null,
   };
 }
 
@@ -318,9 +375,10 @@ function selectSamples(urls, samplePerFamily) {
   for (const url of [...urls].sort()) {
     const family = classifySitemapUrl(url);
     const count = counts.get(family) ?? 0;
-    if (count >= samplePerFamily) continue;
+    const ciiDocs = /^\/docs\/(?:zh\/)?country-instability-index$/.test(new URL(url).pathname);
+    if (count >= samplePerFamily && !ciiDocs) continue;
     selected.add(url);
-    counts.set(family, count + 1);
+    if (count < samplePerFamily) counts.set(family, count + 1);
   }
   return selected;
 }
@@ -393,11 +451,12 @@ export async function verifyProductionSitemaps({
       const inspection = sampled
         ? inspectIndexability({ url, headers: response.headers, body })
         : null;
-      const canonicalMatches = !sampled || inspection.canonical === url;
+      const canonicalMatches = !sampled || (inspection.canonical === url && inspection.canonicalErrors.length === 0);
       const indexable = !sampled || inspection.indexable;
       if (!direct) errors.push(`${url} returned ${response.status}, expected direct HTTP 200`);
       if (!canonicalMatches) {
         errors.push(`${url} canonical mismatch: ${inspection.canonical ?? '(missing)'}`);
+        errors.push(...inspection.canonicalErrors.map(error => `${url} ${error}`));
       }
       if (!indexable) errors.push(`${url} is noindex`);
 
@@ -409,6 +468,8 @@ export async function verifyProductionSitemaps({
         status: response.status,
         location: response.headers.get('location'),
         canonical: inspection?.canonical ?? null,
+        canonicalDeclarations: inspection?.canonicalDeclarations ?? null,
+        canonicalErrors: inspection?.canonicalErrors ?? null,
         indexable: inspection?.indexable ?? null,
         robots: inspection?.robots ?? null,
         ok: direct && canonicalMatches && indexable,

--- a/src/config/docs-locale-seo.ts
+++ b/src/config/docs-locale-seo.ts
@@ -132,6 +132,27 @@ function stripExistingDocsHreflang(html: string): string {
   );
 }
 
+function replaceDocsCanonical(html: string, pathname: string): string {
+  const href = docsAbsoluteUrl(pathname).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  const canonical = `<link rel="canonical" href="${href}" />`;
+  return html.replace(/(<head\b[^>]*>)([\s\S]*?)(<\/head>)/i, (_match, open, head: string, close) => {
+    let replaced = false;
+    const rewritten = head.replace(
+      /<!--[\s\S]*?-->|<script\b[^>]*>[\s\S]*?<\/script\s*>|<link\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi,
+      (tag) => {
+        if (!/^<link\b/i.test(tag)) return tag;
+        const rel = [...tag.matchAll(/\s+([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g)]
+          .find((attribute) => attribute[1]?.toLowerCase() === 'rel');
+        if (!(rel?.[2] ?? rel?.[3] ?? rel?.[4] ?? '').toLowerCase().split(/\s+/).includes('canonical')) return tag;
+        if (replaced) return '';
+        replaced = true;
+        return canonical;
+      },
+    );
+    return `${open}${rewritten}${replaced ? '' : canonical}${close}`;
+  });
+}
+
 function injectAfterCanonical(html: string, linkTags: string[]): string {
   if (linkTags.length === 0) return html;
   const block = linkTags.join('');
@@ -468,7 +489,7 @@ export function rewriteDocsLocaleHtml(html: string, pathname: string): string {
   const pair = resolveDocsLocalePair(pathname);
   if (!pair) return html;
 
-  let next = stripExistingDocsHreflang(html);
+  let next = replaceDocsCanonical(stripExistingDocsHreflang(html), pathname);
   if (pair.active === 'zh') {
     next = replaceHtmlLang(next, DOCS_ZH_HREFLANG);
     next = replaceOgLocale(next, 'zh_CN');

--- a/tests/docs-locale-seo.test.mts
+++ b/tests/docs-locale-seo.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -86,6 +86,31 @@ describe('docs locale pair + hreflang cluster', () => {
 });
 
 describe('rewriteDocsLocaleHtml', () => {
+  it('pins Mintlify page metadata to the same public docs base', () => {
+    const config = JSON.parse(readFileSync(join(repoRoot, 'docs/docs.json'), 'utf8'));
+    assert.equal(config.seo.metatags.canonical, `${DOCS_PUBLIC_ORIGIN}/docs`);
+  });
+
+  it('replaces missing, relative, foreign and duplicate canonicals in either locale', () => {
+    for (const pathname of ['/docs/country-instability-index', '/docs/zh/country-instability-index']) {
+      for (const links of [
+        '',
+        '<link href="/wm-proxy/docs/about" rel="canonical">',
+        "<link rel='canonical' href='https://copy.example/docs/about'>",
+        '<link rel="canonical" href="https://copy.example/a"><link rel="canonical" href="https://copy.example/b">',
+      ]) {
+        const seed = `<!DOCTYPE html><html><head>${links}<title>CII</title></head><body>CII</body></html>`;
+        const html = rewriteDocsLocaleHtml(seed, pathname);
+        const head = html.match(/<head>([\s\S]*?)<\/head>/)?.[1] ?? '';
+        assert.deepEqual(head.match(/<link\b[^>]*rel="canonical"[^>]*>/g), [
+          `<link rel="canonical" href="${DOCS_PUBLIC_ORIGIN}${pathname}" />`,
+        ]);
+        assert.equal(rewriteDocsLocaleHtml(html, pathname), html, 'rewriting is idempotent');
+        assert.match(html, /<body>CII<\/body>/);
+      }
+    }
+  });
+
   const zhSeed = `<!DOCTYPE html><html lang="en" class="x"><head>
 <meta name="og:locale" content="en_US"/>
 <link rel="canonical" href="https://www.worldmonitor.app/docs/zh/about"/>

--- a/tests/middleware-docs-locale-seo.test.mts
+++ b/tests/middleware-docs-locale-seo.test.mts
@@ -17,6 +17,86 @@ function docsHtmlRequest(): Request {
 }
 
 describe('middleware docs locale SEO proxy', () => {
+  it('keeps the official canonical and excludes copied deployments from indexing', async () => {
+    const originalFetch = globalThis.fetch;
+    mock.method(globalThis, 'fetch', async () => new Response(
+      '<html><head><link rel="canonical" href="https://copy.example/docs/zh/about"></head><body>关于</body></html>',
+      { headers: { 'content-type': 'text/html', 'x-robots-tag': 'bingbot: noarchive', vary: 'Accept-Encoding' } },
+    ));
+    try {
+      for (const [host, noindex] of [
+        ['www.worldmonitor.app', false],
+        ['WWW.WORLDMONITOR.APP:443', false],
+        ['copy.example', true],
+        ['worldmonitor-preview.vercel.app', true],
+        ['www.worldmonitor.app.copy.example', true],
+      ] as const) {
+        const request = new Request('https://copy.example/docs/zh/about?ref=test', {
+          headers: { accept: 'text/html', host, 'x-forwarded-host': 'www.worldmonitor.app' },
+        });
+        const response = await middleware(request);
+        assert.ok(response instanceof Response);
+        assert.equal(response.headers.get('x-robots-tag'), noindex ? 'noindex, bingbot: noarchive' : 'bingbot: noarchive');
+        assert.match(response.headers.get('vary') ?? '', /host/);
+        assert.match(response.headers.get('vary') ?? '', /accept-encoding/);
+        const body = await response.text();
+        assert.match(body, /rel="canonical" href="https:\/\/www\.worldmonitor\.app\/docs\/zh\/about"/);
+        assert.doesNotMatch(body, /copy\.example/);
+      }
+      assert.equal(globalThis.fetch.mock.calls.length, 5, 'one upstream fetch per document');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('applies the same indexing policy to HEAD and conditional 304 responses without reading a body', async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      for (const status of [200, 304]) {
+        for (const host of ['www.worldmonitor.app', 'copy.example']) {
+          const upstream = new Response(null, {
+            status,
+            headers: { ...(status === 200 ? { 'content-type': 'text/html' } : {}), etag: '"docs"' },
+          });
+          mock.method(upstream, 'text', () => { throw new Error('must not read body'); });
+          mock.method(globalThis, 'fetch', async (_url: string, init: RequestInit) => {
+            assert.equal(new Headers(init.headers).get('if-none-match'), '"docs"');
+            return upstream;
+          });
+          const response = await middleware(new Request(`https://${host}/docs/zh/about`, {
+            method: status === 200 ? 'HEAD' : 'GET',
+            headers: { accept: 'text/html', 'if-none-match': '"docs"' },
+          }));
+          assert.ok(response instanceof Response);
+          assert.equal(response.status, status);
+          assert.equal(response.headers.get('x-robots-tag'), host === 'copy.example' ? 'noindex' : null);
+          assert.equal(response.headers.get('etag'), '"docs"');
+          assert.match(response.headers.get('vary') ?? '', /host/);
+          assert.equal(upstream.text.mock.calls.length, 0);
+          assert.equal(await response.text(), '');
+        }
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('preserves redirects, errors and non-HTML responses on copied deployments', async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      for (const [status, contentType] of [[308, 'text/html'], [404, 'text/html'], [500, 'text/html'], [200, 'text/plain']] as const) {
+        const upstream = new Response('<html><head></head><body>unchanged</body></html>', {
+          status, headers: { 'content-type': contentType, location: '/docs/about' },
+        });
+        mock.method(globalThis, 'fetch', async () => upstream);
+        const response = await middleware(new Request('https://copy.example/docs/zh/about', { headers: { accept: 'text/html' } }));
+        assert.equal(response, upstream);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('rewrites Chinese docs HTML lang and injects reciprocal hreflang', async () => {
     const upstreamHtml = `<!DOCTYPE html><html lang="en"><head>
 <meta name="og:locale" content="en_US"/>

--- a/tests/sitemap-verifier.test.mjs
+++ b/tests/sitemap-verifier.test.mjs
@@ -86,6 +86,96 @@ describe('production sitemap verifier helpers', () => {
     assert.equal(markdown.indexable, false);
   });
 
+  it('rejects conflicting canonical signals instead of giving the HTTP header priority', () => {
+    const url = 'https://www.worldmonitor.app/docs/zh/country-instability-index';
+    const inspect = (htmlHref) => inspectIndexability({
+      url,
+      headers: new Headers({
+        'content-type': 'text/html',
+        link: `</docs/llms.txt>; rel="llms-txt", <${url}>; title="CII, documentation"; rel="canonical"`,
+      }),
+      body: `<html><head><link href="${htmlHref}" rel="canonical"></head></html>`,
+    });
+    const conflict = inspect('https://mirror.example/wm-proxy/docs/zh/country-instability-index');
+    assert.equal(conflict.canonical, null);
+    assert.match(conflict.canonicalErrors.join('\n'), /conflicting/i);
+    assert.equal(conflict.canonicalDeclarations.length, 2);
+    const agreement = inspect(url);
+    assert.equal(agreement.canonical, url);
+    assert.deepEqual(agreement.canonicalErrors, []);
+  });
+
+  it('reports duplicate, missing, invalid, relative and body-only docs canonicals', () => {
+    const url = 'https://www.worldmonitor.app/docs/about';
+    for (const [head, body, error] of [
+      [`<link rel="canonical" href="${url}"><link rel="canonical" href="${url}">`, '', /duplicate/i],
+      ['<link rel="canonical">', '', /missing.*href/i],
+      ['<link rel="canonical" href="https://[broken">', '', /invalid/i],
+      ['<link rel="canonical" href="/docs/about">', '', /absolute/i],
+      [`<link data-rel="canonical" href="${url}">`, '', /missing/i],
+      [`<link title="rel='canonical'" href="${url}">`, '', /missing/i],
+      [`<link rel="canonical" data-href="${url}">`, '', /missing.*href/i],
+      ['', `<link rel="canonical" href="${url}">`, /outside.*head/i],
+      [`<!-- <link rel="canonical" href="${url}"> --><script>const example = '<link rel="canonical" href="${url}">';</script>`, '', /missing/i],
+    ]) {
+      const result = inspectIndexability({
+        url, headers: new Headers({ 'content-type': 'text/html' }),
+        body: `<html><head>${head}</head><body>${body}</body></html>`,
+      });
+      assert.match(result.canonicalErrors.join('\n'), error);
+    }
+  });
+
+  it('does not lose earlier robots restrictions or apply another bot scope to Googlebot', () => {
+    const inspect = (meta, header = '') => inspectIndexability({
+      url: 'https://www.worldmonitor.app/docs/about',
+      headers: new Headers({ 'content-type': 'text/html', 'x-robots-tag': header }),
+      body: `<html><head>${meta}</head></html>`,
+    });
+    assert.equal(inspect('<meta name="robots" content="noindex"><meta name="robots" content="index">').indexable, false);
+    assert.equal(inspect('<meta name="googlebot" content="none">').indexable, false);
+    assert.equal(inspect('', 'googlebot: noindex, follow').indexable, false);
+    assert.equal(inspect('', 'otherbot: noindex, googlebot: index').indexable, true);
+  });
+
+  it('parses each HTTP canonical without treating quoted Link parameters as declarations', () => {
+    const url = 'https://www.worldmonitor.app/docs/about';
+    const inspect = (link) => inspectIndexability({
+      url, headers: new Headers({ 'content-type': 'text/html', link }),
+      body: `<html><head><link rel="canonical" href="${url}"></head></html>`,
+    });
+    assert.match(inspect(`<${url}>; rel="canonical", <${url}>; rel="canonical"`).canonicalErrors.join('\n'), /duplicate http/);
+    assert.match(inspect(`<${url}>; rel="canonical", invalid; rel="canonical"`).canonicalErrors.join('\n'), /missing href/);
+    assert.deepEqual(inspect(`<${url}>; title="example, <not-a-link>; rel='canonical'"; rel="alternate"`).canonicalErrors, []);
+  });
+
+  it('GET-checks both CII locales and fails the overall audit on a conflicting canonical', async () => {
+    const origin = 'https://www.worldmonitor.app';
+    const pages = ['/', '/blog/', '/docs/about', '/docs/country-instability-index', '/docs/zh/country-instability-index'];
+    const documents = new Map([
+      [`${origin}/robots.txt`, `Sitemap: ${origin}/sitemap.xml\nSitemap: ${origin}/blog/sitemap-index.xml\nSitemap: ${origin}/docs/sitemap.xml`],
+      [`${origin}/sitemap.xml`, `<sitemapindex>${['/sitemap-main.xml', '/blog/sitemap-index.xml', '/docs/sitemap.xml'].map(path => `<sitemap><loc>${origin}${path}</loc></sitemap>`).join('')}</sitemapindex>`],
+      ...[['/sitemap-main.xml', pages.slice(0, 1)], ['/blog/sitemap-index.xml', pages.slice(1, 2)], ['/docs/sitemap.xml', pages.slice(2)]].map(([path, paths]) => [
+        `${origin}${path}`, `<urlset>${paths.map(page => `<url><loc>${origin}${page}</loc></url>`).join('')}</urlset>`,
+      ]),
+    ]);
+    const fetches = [];
+    const fetchImpl = async (url, { method }) => {
+      fetches.push({ url, method });
+      if (documents.has(url)) return new Response(documents.get(url), { headers: { 'content-type': 'application/xml' } });
+      const href = url.includes('/zh/') ? 'https://mirror.example/docs/zh/country-instability-index' : url;
+      return new Response(`<html><head><link rel="canonical" href="${href}"></head></html>`, {
+        headers: { 'content-type': 'text/html', link: `<${url}>; rel="canonical"` },
+      });
+    };
+    const result = await verifyProductionSitemaps({ fetchImpl });
+    assert.equal(result.passed, false);
+    assert.match(result.errors.join('\n'), /conflicting/i);
+    for (const path of pages.slice(3)) {
+      assert.ok(fetches.some(entry => entry.url === `${origin}${path}` && entry.method === 'GET'), path);
+    }
+  });
+
   it('accepts the canonical apex MCP URL in the root sitemap inventory', async () => {
     const mcpUrl = 'https://worldmonitor.app/mcp';
     const rootSitemap = 'https://www.worldmonitor.app/sitemap.xml';


### PR DESCRIPTION
## Summary

Copied documentation can compete with the official site for Google's chosen canonical. Unchanged Mintlify deployments now carry a fixed WorldMonitor docs base, and our middleware emits one absolute canonical for the requested page and language. Copies and previews running this middleware receive `X-Robots-Tag: noindex`; the official host preserves upstream indexing rules. This also covers HEAD and 304 responses.

The sitemap verifier now rejects duplicate, malformed, misplaced, relative docs, and conflicting canonical declarations, aggregates robots restrictions, and always GET-checks both CII locales. It no longer lets an HTTP canonical hide conflicting HTML. The optional extra HTTP canonical was not retained: the proxy experiment produced a conflict when HTML was rewritten, not reliable protection. Proxies can still remove or rewrite these signals, and existing deployments do not inherit repository updates.

## Validation

- 153 focused docs, sitemap, middleware, bot-gate, and root-redirect tests pass. New failure cases were observed before their fixes. TypeScript, project lint, boundary checks, and `git diff --check` pass.
- Pinned Mintlify validation/export pass: 507 pages and 5,981 resolved anchors. The CLI emits `/src/_props` in local preview/export canonicals, so that output is excluded from canonical acceptance and documented for self-hosters. The installed vendor canonical function with actual hosted page metadata and the new base produces the exact official English/Chinese URLs.
- Actual middleware served through a local HTTP harness: alternating official/copy/official Host headers returned 200 each, with noindex only on the copy and host/RSC selectors retained in Vary. Both CII pages retain one official canonical after browser hydration; sidebar navigation updates it to each locale's destination canonical. The local harness also emitted a React hydration warning; an error-free hosted rollout is not claimed.
- Local median rewrite cost: Chinese 1.180 → 1.240 ms; English 1.300 → 1.361 ms (300 samples each). No extra upstream request or browser script; the 8-second upstream timeout remains.
- Sequential manual review covered origins, escaping, header parsing, cache policy, errors, and RSC passthrough. No external review automation was invoked. Raw page evidence remains local.

## Post-Deploy Monitoring & Validation

Owner: maintainer approving the rollout. During the first 24 hours after deployment, inspect both `/docs/country-instability-index` and `/docs/zh/country-instability-index`, plus an internal client navigation. Expect direct 200, one exact official HTML canonical, matching locale/structured-data URLs, no official noindex, and working RSC navigation. Inspect middleware logs for `Docs upstream unavailable`, docs 5xx/timeouts, and browser hydration/navigation errors; verify a copied/preview host gets noindex and cannot affect the official host's cached response. If canonicals contain `/src/_props`, duplicate `/docs`, disagree across signals, or the official host receives noindex, roll back this change and clear affected caches. Hosted provider config and Vercel CDN behavior still require this rollout check.

Then run `npm run verify:sitemaps`, request indexing for the affected URLs in Search Console, and inspect the Google-selected canonical after a new crawl. Google acceptance is separate from build and deployment success; no selection or timing guarantee is made.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
