### PR TITLE
test(e2e): close the map disclosure race left open by #7848

### DIFF
--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -829,18 +829,35 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
         (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayMarkerStress(perFeed),
       STRESS_PER_FEED,
     );
+    // The seeded feeds truncate layer by layer, so a poll that returns the moment
+    // ONE layer is trimmed hands back a snapshot the renderer is still growing
+    // past. Reading the budget state in one call and the disclosure in the next
+    // then compares two different instants, and the assertion below pins the
+    // first against the second: measured 2 failures in 4 whole-spec runs at 4
+    // workers (#7837), every one of them a state snapshot of `300/2000` against a
+    // summary that already read `798/6000`.
+    //
+    // Sampling both inside the SAME page evaluation closes the gap they drifted
+    // across, and polling that pair waits for the seed to finish propagating
+    // without pinning how many layers it ends up trimming.
     await expect
       .poll(
         async () =>
-          page.evaluate(() =>
-            Object.keys(
-              (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState()
-                .truncated,
-            ).length,
-          ),
+          page.evaluate(() => {
+            const budget = (
+              window as HarnessWindow
+            ).__mobileMapIntegrationHarness!.getOverlayBudgetState();
+            const counts = Object.values(budget.truncated);
+            const actual = document.querySelector('.map-truncation-summary')?.textContent ?? null;
+            if (counts.length === 0) return `no layer trimmed yet (summary: ${actual})`;
+            const shownNow = counts.reduce((sum, entry) => sum + entry.shown, 0);
+            const totalNow = counts.reduce((sum, entry) => sum + entry.total, 0);
+            const expected = `${shownNow}/${totalNow} markers`;
+            return expected === actual ? 'disclosed' : `state ${expected} != summary ${actual}`;
+          }),
         { timeout: 15000 },
       )
-      .toBeGreaterThan(0);
+      .toBe('disclosed');
 
     const state = await page.evaluate(() =>
       (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState(),
@@ -856,12 +873,13 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
 
     // Honest private state is necessary but not sufficient: the person looking at
     // the embed must be able to SEE that the map is partial. With no toggle rail
-    // to badge, the compact summary is the only disclosure surface there is.
+    // to badge, the compact summary is the only disclosure surface there is. That
+    // the summary carries the state's own numbers is asserted by the poll above,
+    // which is the only place the two can be compared without a gap between them.
     const summary = page.locator('.map-truncation-summary');
     await expect(summary).toHaveCount(1);
     const shown = Object.values(state.truncated).reduce((sum, counts) => sum + counts.shown, 0);
     const total = Object.values(state.truncated).reduce((sum, counts) => sum + counts.total, 0);
-    await expect(summary).toHaveText(`${shown}/${total} markers`);
     expect(shown).toBeLessThan(total);
     await expect(summary).toBeVisible();
 


### PR DESCRIPTION
## Summary

`reports every trimmed layer as undisclosed when the map has no toggle rail` is
racy on the merged tree, and #7848 did not touch it. It polls until at least one
layer is trimmed, then reads the budget state in one call and compares it with
the summary node in the next. The seeded feeds truncate layer by layer, so the
poll returns while the renderer is still growing past the snapshot, and the two
calls sample different instants.

This reads both inside the same page evaluation and polls that pair, so the two
values can no longer drift apart, and the wait ends when the seed has finished
propagating rather than when the first layer is cut. The now-redundant
`toHaveText` against the stale snapshot is dropped.

No production code, ceiling, retry setting, or worker count changes.

Refs #7837

## Evidence

Measured on `2543c0f18e` (the merged #7848 tree), 4 workers, `--retries=0`,
whole-spec contention:

| Tree | Result |
| --- | --- |
| `2543c0f18e` | 2 failures in 4 runs, both `Expected "300/2000 markers"` / `Received "798/6000 markers"` |
| this branch | 56/56 |

The state snapshot said one layer at `300/2000` while the summary node had
already reached three layers at `798/6000` — the two instants, not a wrong value.

Negative control: mutating the expected string to `${shownNow}/${totalNow} MUTANT`
reddens the poll with `state 798/6000 MUTANT != summary 798/6000 markers`, so the
assertion is not vacuous.

## Findings recorded on #7837, not fixed here

Investigating the cold-load metric flake turned up two things worth writing down.
Neither changes this diff.

**The deferred Sentry SDK doubles `JSEventListeners`.** `@sentry/browser`'s
breadcrumbs integration wraps `EventTarget.prototype.addEventListener` and, for
`click` and `keypress`, registers its own extra listener on the node before
delegating to the caller's. `src/bootstrap/sentry-defer.ts` defers init behind
`SENTRY_AUDIT_WINDOW_DELAY_MS = 10_000`, so whether a cold load pays that cost
depends on whether the page finishes before the timer. Measured on a fully
hydrated dashboard: 1,071 listeners when the markers win the race, 1,490 to 1,618
when Sentry does, on a byte-identical page, and forced GC does not reduce it
because both listeners are real and reachable. Bind stacks confirmed it — both
binds for a node shared an identical app frame and differed only in the Sentry
wrapper line. This does not bite the merged gate today: it samples at SVG map
first paint, measured 2,617-3,236 ms locally, well inside the 10 s timer, with
534-693 listeners against the 1,500 ceiling. It would bite if first paint ever
crossed 10 s on a loaded runner, where ~690 doubles to ~1,380.

**The merged gate samples the pre-hydration shell.** Gating on SVG map first
paint measures 6,612-9,410 post-GC renderer nodes. Waiting instead for real
quiescence (element count stable with no fetch in flight) measures 14,851-14,956
across 18 cold loads, so the settled dashboard sits 44 counts under the 15,000
ceiling. That is a deliberate tradeoff in #7848 — determinism through headroom —
but it means the guardrail no longer covers the hydrated page where the overlay
markers it was created for actually live, and it hides how little budget is
actually left. Raising it here would be re-litigating a just-merged design, so it
is written up for a decision rather than changed.

## Validation

- `npx playwright test e2e/map-overlay-marker-budget.spec.ts --workers=4 --retries=0 --repeat-each=4` — 56/56.
- Full `test:e2e:ci-smoke:1` shard, 4 workers, `--retries=0` — 60/60 on a quiet machine.
- `npx biome lint ./e2e/map-overlay-marker-budget.spec.ts` — clean.

## Known residuals

- The `Object with guid response@... was not bound in the connection` signature is
  untouched and unreproduced locally. It remains the diagnostic gap #7848 recorded.
- Late in this session my machine started failing unrelated specs
  (`bootstrap-hydration-request-budget`, `country-brief`) with Redis timeouts, on a
  pristine tree as well. Those are local, not attributable to this change; CI is
  the arbiter.

https://claude.ai/code/session_01KtzhNLp9p261EjRDdYRbiy
