### PR TITLE
fix: tighten docs sitemap and robots verification

### DIFF
--- a/scripts/verify-sitemaps.mjs
+++ b/scripts/verify-sitemaps.mjs
@@ -8,6 +8,7 @@ import { decodeHtmlEntities } from './_html-entities.mjs';
 
 const DEFAULT_ORIGIN = 'https://www.worldmonitor.app';
 const DEFAULT_TIMEOUT_MS = 15_000;
+const REQUIRED_DOCS_PATHS = ['/docs/country-instability-index', '/docs/zh/country-instability-index'];
 const EXPECTED_PAGE_HOSTS = new Set([
   'worldmonitor.app',
   'www.worldmonitor.app',
@@ -148,16 +149,15 @@ export function inspectIndexability({ url, headers, body }) {
   const effectiveRobots = [...metaRobots];
   for (const part of headerRobots.split(',')) {
     const scope = /^\s*([\w-]+):\s*(.*)$/.exec(part);
-    if (scope && !/^(?:unavailable_after|max-image-preview|max-snippet|max-video-preview)$/i.test(scope[1])) {
-      robot = scope[1].toLowerCase();
-    }
-    if (robot === '*' || robot === 'googlebot') effectiveRobots.push(scope?.[2] ?? part);
+    const scoped = scope && !/^(?:unavailable_after|max-image-preview|max-snippet|max-video-preview)$/i.test(scope[1]);
+    if (scoped) robot = scope[1].toLowerCase();
+    if (robot === '*' || robot === 'googlebot') effectiveRobots.push(scoped ? scope[2] : part);
   }
   return {
     canonical: canonicalErrors.length === 0 ? [...targets][0] ?? null : null,
     canonicalDeclarations,
     canonicalErrors,
-    indexable: !/\b(?:noindex|none)\b/i.test(effectiveRobots.join(', ')),
+    indexable: !effectiveRobots.some(value => value.split(',').some(directive => /^(?:noindex|none)$/i.test(directive.trim()))),
     robots: [headerRobots, ...metaRobots].filter(Boolean).join(', ') || null,
   };
 }
@@ -375,7 +375,7 @@ function selectSamples(urls, samplePerFamily) {
   for (const url of [...urls].sort()) {
     const family = classifySitemapUrl(url);
     const count = counts.get(family) ?? 0;
-    const ciiDocs = /^\/docs\/(?:zh\/)?country-instability-index$/.test(new URL(url).pathname);
+    const ciiDocs = REQUIRED_DOCS_PATHS.includes(new URL(url).pathname);
     if (count >= samplePerFamily && !ciiDocs) continue;
     selected.add(url);
     if (count < samplePerFamily) counts.set(family, count + 1);
@@ -424,6 +424,10 @@ export async function verifyProductionSitemaps({
   );
   errors.push(...inventoryErrors);
   const allUrls = [...urls.keys()];
+  for (const path of REQUIRED_DOCS_PATHS) {
+    const requiredUrl = `${normalizedOrigin}${path}`;
+    if (!urls.has(requiredUrl)) errors.push(`required docs page missing from sitemap: ${requiredUrl}`);
+  }
   const samples = selectSamples(allUrls, samplePerFamily);
   errors.push(...ownershipOverlaps.map(
     ({ url, sitemaps }) => `${url} is owned by multiple sitemap documents: ${sitemaps.join(', ')}`,

--- a/tests/sitemap-verifier.test.mjs
+++ b/tests/sitemap-verifier.test.mjs
@@ -136,6 +136,11 @@ describe('production sitemap verifier helpers', () => {
     assert.equal(inspect('<meta name="googlebot" content="none">').indexable, false);
     assert.equal(inspect('', 'googlebot: noindex, follow').indexable, false);
     assert.equal(inspect('', 'otherbot: noindex, googlebot: index').indexable, true);
+    assert.equal(inspect('<meta name="robots" content="max-image-preview:none">').indexable, true);
+    assert.equal(inspect('', 'max-image-preview: none').indexable, true);
+    assert.equal(inspect('', 'googlebot: max-image-preview:none').indexable, true);
+    assert.equal(inspect('', 'none').indexable, false);
+    assert.equal(inspect('', 'max-image-preview:none, noindex').indexable, false);
   });
 
   it('parses each HTTP canonical without treating quoted Link parameters as declarations', () => {
@@ -149,7 +154,7 @@ describe('production sitemap verifier helpers', () => {
     assert.deepEqual(inspect(`<${url}>; title="example, <not-a-link>; rel='canonical'"; rel="alternate"`).canonicalErrors, []);
   });
 
-  it('GET-checks both CII locales and fails the overall audit on a conflicting canonical', async () => {
+  it('GET-checks both CII locales and rejects conflicting canonicals or missing locales', async () => {
     const origin = 'https://www.worldmonitor.app';
     const pages = ['/', '/blog/', '/docs/about', '/docs/country-instability-index', '/docs/zh/country-instability-index'];
     const documents = new Map([
@@ -160,10 +165,11 @@ describe('production sitemap verifier helpers', () => {
       ]),
     ]);
     const fetches = [];
+    let conflicting = true;
     const fetchImpl = async (url, { method }) => {
       fetches.push({ url, method });
       if (documents.has(url)) return new Response(documents.get(url), { headers: { 'content-type': 'application/xml' } });
-      const href = url.includes('/zh/') ? 'https://mirror.example/docs/zh/country-instability-index' : url;
+      const href = conflicting && url.includes('/zh/') ? 'https://mirror.example/docs/zh/country-instability-index' : url;
       return new Response(`<html><head><link rel="canonical" href="${href}"></head></html>`, {
         headers: { 'content-type': 'text/html', link: `<${url}>; rel="canonical"` },
       });
@@ -173,6 +179,15 @@ describe('production sitemap verifier helpers', () => {
     assert.match(result.errors.join('\n'), /conflicting/i);
     for (const path of pages.slice(3)) {
       assert.ok(fetches.some(entry => entry.url === `${origin}${path}` && entry.method === 'GET'), path);
+    }
+    conflicting = false;
+    assert.equal((await verifyProductionSitemaps({ fetchImpl })).passed, true);
+    const sitemap = documents.get(`${origin}/docs/sitemap.xml`);
+    for (const path of pages.slice(3)) {
+      documents.set(`${origin}/docs/sitemap.xml`, sitemap.replace(`<url><loc>${origin}${path}</loc></url>`, ''));
+      const missingLocale = await verifyProductionSitemaps({ fetchImpl });
+      assert.equal(missingLocale.passed, false);
+      assert.ok(missingLocale.errors.includes(`required docs page missing from sitemap: ${origin}${path}`));
     }
   });
 
@@ -199,10 +214,15 @@ describe('production sitemap verifier helpers', () => {
       ['https://www.worldmonitor.app/docs/', '<html><head><link rel="canonical" href="https://www.worldmonitor.app/docs/"></head></html>'],
       [mcpUrl, '# World Monitor MCP'],
     ]);
+    for (const path of ['/docs/country-instability-index', '/docs/zh/country-instability-index']) {
+      const url = `https://www.worldmonitor.app${path}`;
+      responses.set(docsSitemap, responses.get(docsSitemap).replace('</urlset>', `<url><loc>${url}</loc></url></urlset>`));
+      responses.set(url, `<html><head><link rel="canonical" href="${url}"></head></html>`);
+    }
     const fetchImpl = async (url) => {
       const value = String(url);
       const isMcp = value === mcpUrl;
-      const isPage = value.endsWith('/') || isMcp;
+      const isPage = value.endsWith('/') || value.endsWith('/country-instability-index') || isMcp;
       return new Response(responses.get(value), {
         status: responses.has(value) ? 200 : 404,
         headers: isMcp


### PR DESCRIPTION
## Summary

The sitemap audit could reject an indexable page with `max-image-preview:none`, and could pass if a CII locale disappeared from the sitemap. It now treats only standalone `none`/`noindex` directives as indexing restrictions and requires both English and Chinese CII URLs before sampling.

Related: #7854

## Validation

Both failures were reproduced before the fixes. All 14 sitemap verifier tests pass, including valid preview restrictions, standalone indexing restrictions, conflicting canonicals, and omission of either locale. The fixes were reviewed against current main after #7854 merged.

## Post-Deploy Monitoring & Validation

Owner: maintainer approving the rollout. On the first sitemap audit after rollout, run `npm run verify:sitemaps`. Both CII locales must be present and GET-checked; preview-only robots restrictions must remain indexable. Investigate `required docs page missing from sitemap`, canonical conflicts, or noindex reports. Revert this follow-up if it introduces false audit failures. This changes the audit only; page-serving behavior is unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
