### PR TITLE
fix(natural-events): parse NHC advisory timestamps

### DIFF
--- a/scripts/seed-natural-events.mjs
+++ b/scripts/seed-natural-events.mjs
@@ -34,6 +34,25 @@ const NHC_FAILURE_CODES = new Set([
 ]);
 const NHC_POINT_GEOMETRY_TYPES = new Set(['Point']);
 const NHC_CONE_GEOMETRY_TYPES = new Set(['Polygon', 'MultiPolygon']);
+const NHC_ADVISORY_TIMEZONE_OFFSETS_MIN = {
+  UTC: 0,
+  GMT: 0,
+  AST: -4 * 60,
+  ADT: -3 * 60,
+  EST: -5 * 60,
+  EDT: -4 * 60,
+  CST: -6 * 60,
+  CDT: -5 * 60,
+  MST: -7 * 60,
+  MDT: -6 * 60,
+  PST: -8 * 60,
+  PDT: -7 * 60,
+  AKST: -9 * 60,
+  AKDT: -8 * 60,
+  HST: -10 * 60,
+};
+const NHC_ADVISORY_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const NHC_ADVISORY_WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 const DAYS = 30;
 const WILDFIRE_MAX_AGE_MS = 48 * 60 * 60 * 1000;
@@ -123,6 +142,30 @@ function classifyWind(kt) {
   if (kt >= 64) return { category: 1, classification: 'Category 1' };
   if (kt >= 34) return { category: 0, classification: 'Tropical Storm' };
   return { category: 0, classification: 'Tropical Depression' };
+}
+
+function parseNhcAdvisoryDate(value) {
+  if (typeof value !== 'string') return new Date(value).getTime();
+
+  const match = value.match(/^(\d{1,2})(\d{2}) (AM|PM) ([A-Z]{3,4}) (Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{1,2}) (\d{4})$/);
+  if (!match) return new Date(value).getTime();
+
+  const [, hourText, minuteText, meridiem, timezone, weekday, monthText, dayText, yearText] = match;
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const month = NHC_ADVISORY_MONTHS.indexOf(monthText);
+  const day = Number(dayText);
+  const year = Number(yearText);
+  const timezoneOffsetMin = NHC_ADVISORY_TIMEZONE_OFFSETS_MIN[timezone];
+  const calendarDate = new Date(Date.UTC(year, month, day));
+  if (hour < 1 || hour > 12 || minute > 59 || timezoneOffsetMin === undefined
+    || calendarDate.getUTCFullYear() !== year || calendarDate.getUTCMonth() !== month
+    || calendarDate.getUTCDate() !== day || calendarDate.getUTCDay() !== NHC_ADVISORY_WEEKDAYS.indexOf(weekday)) {
+    return Number.NaN;
+  }
+
+  const hour24 = hour % 12 + (meridiem === 'PM' ? 12 : 0);
+  return Date.UTC(year, month, day, hour24, minute) - timezoneOffsetMin * 60_000;
 }
 
 function parseGdacsTcFields(props) {
@@ -393,13 +436,7 @@ async function fetchNhc(fetchFn = globalThis.fetch) {
     }
 
     const p = currentPt.properties;
-    const timeFirstAdvDate = typeof p.advdate === 'string'
-      ? p.advdate.match(/^(\d{1,2})(\d{2}) (AM|PM) ([A-Z]{3,4}) ((?:Sun|Mon|Tue|Wed|Thu|Fri|Sat) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{2} \d{4})$/)
-      : null;
-    const normalizedAdvDate = timeFirstAdvDate
-      ? `${timeFirstAdvDate[5]} ${timeFirstAdvDate[1]}:${timeFirstAdvDate[2]} ${timeFirstAdvDate[3]} ${timeFirstAdvDate[4]}`
-      : p.advdate;
-    const advDate = p.advdate ? new Date(normalizedAdvDate).getTime() : Number.NaN;
+    const advDate = p.advdate ? parseNhcAdvisoryDate(p.advdate) : Number.NaN;
     if (typeof p.stormname !== 'string' || p.stormname.trim().length === 0
       || !Number.isInteger(p.stormnum) || p.stormnum < 1 || p.stormnum > 99
       || !['string', 'number'].includes(typeof p.advisnum) || String(p.advisnum).trim().length === 0

--- a/scripts/seed-natural-events.mjs
+++ b/scripts/seed-natural-events.mjs
@@ -393,7 +393,13 @@ async function fetchNhc(fetchFn = globalThis.fetch) {
     }
 
     const p = currentPt.properties;
-    const advDate = p.advdate ? new Date(p.advdate).getTime() : Number.NaN;
+    const timeFirstAdvDate = typeof p.advdate === 'string'
+      ? p.advdate.match(/^(\d{1,2})(\d{2}) (AM|PM) ([A-Z]{3,4}) ((?:Sun|Mon|Tue|Wed|Thu|Fri|Sat) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{2} \d{4})$/)
+      : null;
+    const normalizedAdvDate = timeFirstAdvDate
+      ? `${timeFirstAdvDate[5]} ${timeFirstAdvDate[1]}:${timeFirstAdvDate[2]} ${timeFirstAdvDate[3]} ${timeFirstAdvDate[4]}`
+      : p.advdate;
+    const advDate = p.advdate ? new Date(normalizedAdvDate).getTime() : Number.NaN;
     if (typeof p.stormname !== 'string' || p.stormname.trim().length === 0
       || !Number.isInteger(p.stormnum) || p.stormnum < 1 || p.stormnum > 99
       || !['string', 'number'].includes(typeof p.advisnum) || String(p.advisnum).trim().length === 0

--- a/tests/natural-events-nhc-recovery.test.mjs
+++ b/tests/natural-events-nhc-recovery.test.mjs
@@ -295,6 +295,7 @@ test('accepts time-first advisory dates across NHC time zones', async () => {
     ['800 AM PDT Mon Sep 07 2026', '2026-09-07T15:00:00.000Z'],
     ['800 AM AST Mon Sep 07 2026', '2026-09-07T12:00:00.000Z'],
     ['800 AM HST Mon Sep 07 2026', '2026-09-07T18:00:00.000Z'],
+    ['1230 PM AST Mon Sep 07 2026', '2026-09-07T16:30:00.000Z'],
   ]) {
     const mariePoint = {
       ...currentStormPoint,
@@ -324,6 +325,9 @@ test('accepts time-first advisory dates across NHC time zones', async () => {
 test('rejects malformed time-first NHC advisory dates', async () => {
   for (const advdate of [
     '1299 AM PDT Mon Sep 07 2026',
+    '0000 AM PDT Mon Sep 07 2026',
+    '1300 AM PDT Mon Sep 07 2026',
+    '800 AM XYZ Mon Sep 07 2026',
     '800 AM PDT Mon Feb 31 2026',
     '800 AM PDT Tue Sep 07 2026',
   ]) {

--- a/tests/natural-events-nhc-recovery.test.mjs
+++ b/tests/natural-events-nhc-recovery.test.mjs
@@ -290,29 +290,55 @@ test('optional cone and past-point failures do not remove a point-confirmed stor
   assert.equal(payload._nhcSnapshot.consecutiveFailures, 0);
 });
 
-test('accepts the time-first advisory date returned by NHC ArcGIS layers', async () => {
-  const mariePoint = {
-    ...currentStormPoint,
-    geometry: { type: 'Point', coordinates: [-124.4, 24.7] },
-    properties: {
-      ...currentStormPoint.properties,
-      stormname: 'Marie',
-      stormnum: 13,
-      advisnum: '26',
-      maxwind: 55,
-      advdate: '800 AM PDT Mon Sep 07 2026',
-    },
-  };
-  const payload = await runNhc({
-    previous: null,
-    nhc: async (_input, id) => Response.json(collection(id === 188 ? [mariePoint] : [])),
-  });
+test('accepts time-first advisory dates across NHC time zones', async () => {
+  for (const [advdate, expectedDate] of [
+    ['800 AM PDT Mon Sep 07 2026', '2026-09-07T15:00:00.000Z'],
+    ['800 AM AST Mon Sep 07 2026', '2026-09-07T12:00:00.000Z'],
+    ['800 AM HST Mon Sep 07 2026', '2026-09-07T18:00:00.000Z'],
+  ]) {
+    const mariePoint = {
+      ...currentStormPoint,
+      geometry: { type: 'Point', coordinates: [-124.4, 24.7] },
+      properties: {
+        ...currentStormPoint.properties,
+        stormname: 'Marie',
+        stormnum: 13,
+        advisnum: '26',
+        maxwind: 55,
+        advdate,
+      },
+    };
+    const payload = await runNhc({
+      previous: null,
+      nhc: async (_input, id) => Response.json(collection(id === 188 ? [mariePoint] : [])),
+    });
 
-  const storm = payload.events.find(event => event.sourceName === 'NHC');
-  assert.ok(storm);
-  assert.equal(storm.id, 'nhc-EP13-26');
-  assert.equal(storm.date, Date.parse('2026-09-07T15:00:00.000Z'));
-  assert.equal(payload._nhcSnapshot.errorCode, null);
+    const storm = payload.events.find(event => event.sourceName === 'NHC');
+    assert.ok(storm, advdate);
+    assert.equal(storm.id, 'nhc-EP13-26');
+    assert.equal(storm.date, Date.parse(expectedDate));
+    assert.equal(payload._nhcSnapshot.errorCode, null);
+  }
+});
+
+test('rejects malformed time-first NHC advisory dates', async () => {
+  for (const advdate of [
+    '1299 AM PDT Mon Sep 07 2026',
+    '800 AM PDT Mon Feb 31 2026',
+    '800 AM PDT Tue Sep 07 2026',
+  ]) {
+    const invalidPoint = {
+      ...currentStormPoint,
+      properties: { ...currentStormPoint.properties, advdate },
+    };
+    const payload = await runNhc({
+      now: NOW + MIN,
+      nhc: async (_input, id) => Response.json(collection(id === 6 ? [invalidPoint] : [])),
+    });
+
+    assert.deepEqual(payload.events.filter(event => event.sourceName === 'NHC'), [retainedStorm], advdate);
+    assert.equal(payload._nhcSnapshot.errorCode, 'NHC_POINT_RESPONSE_INVALID', advdate);
+  }
 });
 
 test('invalid optional past-point properties do not remove a point-confirmed storm', async () => {

--- a/tests/natural-events-nhc-recovery.test.mjs
+++ b/tests/natural-events-nhc-recovery.test.mjs
@@ -290,6 +290,31 @@ test('optional cone and past-point failures do not remove a point-confirmed stor
   assert.equal(payload._nhcSnapshot.consecutiveFailures, 0);
 });
 
+test('accepts the time-first advisory date returned by NHC ArcGIS layers', async () => {
+  const mariePoint = {
+    ...currentStormPoint,
+    geometry: { type: 'Point', coordinates: [-124.4, 24.7] },
+    properties: {
+      ...currentStormPoint.properties,
+      stormname: 'Marie',
+      stormnum: 13,
+      advisnum: '26',
+      maxwind: 55,
+      advdate: '800 AM PDT Mon Sep 07 2026',
+    },
+  };
+  const payload = await runNhc({
+    previous: null,
+    nhc: async (_input, id) => Response.json(collection(id === 188 ? [mariePoint] : [])),
+  });
+
+  const storm = payload.events.find(event => event.sourceName === 'NHC');
+  assert.ok(storm);
+  assert.equal(storm.id, 'nhc-EP13-26');
+  assert.equal(storm.date, Date.parse('2026-09-07T15:00:00.000Z'));
+  assert.equal(payload._nhcSnapshot.errorCode, null);
+});
+
 test('invalid optional past-point properties do not remove a point-confirmed storm', async () => {
   const payload = await runNhc({
     previous: null,


### PR DESCRIPTION
## Why

Natural-events health stayed in `WARNING` with retained records because the live NHC ArcGIS layer returned an advisory timestamp such as `800 AM PDT Mon Sep 07 2026`. Node 24 rejected that valid provider format, so each natural run recorded `NHC_POINT_RESPONSE_INVALID` instead of recovering the NHC source.

## Scope

Parse the NHC time-first format with explicit NOAA time-zone offsets. Validate the clock, calendar date, and weekday before accepting it. Existing date formats keep their prior parsing path, and malformed provider values still fail closed with last-good NHC retention.

Related: #7844

## Blast Radius

This changes only `advdate` conversion for active NHC forecast points. It does not change health budgets, run schedules, source-state policy, EONET, GDACS, or western-Pacific cyclone ingestion.

## Verification

- Reproduced the production format as a failing NHC ingestion test before the fix.
- Passed 22 NHC recovery tests, including PDT, AST, HST, PM, invalid clock, impossible date, wrong weekday, and unknown-zone cases.
- Passed 7 adjacent natural-events tests and the TypeScript consumer test.
- Passed `typecheck`, `typecheck:api`, `lint:boundaries`, `git diff --check`, and the repository pre-push gate.
- Completed correctness, testing, maintainability, reliability, project-standard, agent-parity, learnings, and adversarial review. All validated findings are fixed.

## Post-Deploy Monitoring & Validation

Observe the first two eligible natural seeder runs after the merged commit is deployed. Do not call the seeder manually. Acceptance requires the NHC snapshot to report no error, reset its consecutive-failure count to zero, keep the active storm with the expected UTC advisory time, and remove `naturalEvents` from production health problems. Treat another `NHC_POINT_RESPONSE_INVALID` after the deployed run as a failed acceptance and inspect the exact upstream timestamp before changing any health threshold.

CI and PR readiness do not prove deployment or production recovery.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
