### PR TITLE
docs(solutions): retention that outlives its own alarm decays a warning into silence

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -738,6 +738,19 @@ platform will run the seeder again: a standalone seeder whose newest build has
 failed is ticking its previous Active Deployment, and there the same non-zero
 exit ends its schedule outright.
 
+Because the skip's whole alarm rests on freshness monitoring rather than on the
+exit status, extending last-good has a second obligation that is easy to miss:
+the freshness marker must be kept alive alongside the data it reports on. Only
+the marker's *value* is untouchable — advancing a success clock on a failed run
+would claim a success that never happened — while its lifetime must be extended
+with the data's. A skip that re-arms the payload every tick makes that payload's
+effective lifetime unbounded; if the marker keeps its own fixed lifetime it
+expires first, and a present payload with no marker is indistinguishable from a
+healthy one, so a sustained failure decays from warn back to green with frozen
+data behind it. The general form: whichever of the two expires first decides
+what is reported, so the reporting signal must outlive the value it reports on.
+See also: Seed-Owned Key, Content Clock.
+
 ### Starved Tick
 
 A tick that completed no member while deferring due work — it published nothing

--- a/docs/solutions/logic-errors/retention-that-outlives-its-own-alarm.md
+++ b/docs/solutions/logic-errors/retention-that-outlives-its-own-alarm.md
@@ -1,0 +1,118 @@
+---
+title: Retention that outlives its own alarm decays a warning into silence
+date: 2026-09-07
+category: logic-errors
+module: scripts/seed-internet-outages.mjs
+problem_type: logic_error
+component: background_job
+severity: high
+symptoms:
+  - "A sustained upstream outage reported STALE_SEED (warn) for seven days, then flipped back to OK while still serving a week-old frozen payload."
+  - "No health signal distinguished a source that was being actively retained from one that was genuinely fresh."
+root_cause: logic_error
+resolution_type: code_fix
+related_components: [api/health.js, scripts/_seed-utils.mjs]
+tags: [seed-meta, last-good, retention, ttl, freshness-tracking, health, alarm-design, redis]
+---
+
+# Retention that outlives its own alarm decays a warning into silence
+
+## Problem
+
+A seeder's failure path retains last-good data by extending the payload key's TTL. If it extends *only* the payload and lets the freshness marker that reports on that payload expire on its own schedule, the alarm dies before the outage does — and the stale payload keeps being served behind a green health check.
+
+Found while reviewing [PR #7862](https://github.com/koala73/worldmonitor/pull/7862) (issue [#7845](https://github.com/koala73/worldmonitor/issues/7845)), in the fix's own first draft, before merge.
+
+## Symptoms
+
+- A Cloudflare Radar companion source fails every tick. For ~7 days `/api/health` correctly reports `STALE_SEED` (warn).
+- On day 8 the same unchanged failure reports `OK`. The panel still renders the payload frozen at the last successful publish.
+- Nothing in the seeder's logs changes at the transition — the failure and its retention warning are identical on day 8 and day 6.
+
+## What Didn't Work
+
+The failure path looked correct in isolation, and each half of it was independently right:
+
+```js
+// Retain last-good, but do NOT touch seed-meta — rewriting fetchedAt would
+// claim a success that never happened.
+const retained = await extendExistingTtl([companion.key], companion.ttlSeconds);
+```
+
+Not rewriting `fetchedAt` is the correct instinct and the house rule — a failed run must never advance a success clock. The mistake was reading "don't touch seed-meta" as "don't touch the seed-meta *key*," when only its **value** must be left alone. Its **TTL** still needed extending.
+
+Reasoning about the two keys separately is what hides this. The payload's retention is visibly bounded (`ttlSeconds`), so "the data expires eventually" feels true — but re-arming it every tick makes its *effective* lifetime unbounded, while the marker's lifetime stays fixed. Whichever expires first decides what health reports, and the fixed one loses.
+
+## Solution
+
+Extend the marker at its own floor alongside the payload, still without rewriting `fetchedAt`:
+
+```js
+// Two calls, not one pipeline: EXPIRE sets a TTL absolutely, so the payload
+// and its meta must each be extended at their own value.
+const [dataRetained, metaRetained] = await Promise.all([
+  extendExistingTtl([companion.key], companion.ttlSeconds),
+  extendExistingTtl([companionMetaKey(companion)], SEED_META_MIN_TTL_SECONDS),
+]);
+const retained = dataRetained && metaRetained;
+```
+
+`EXPIRE` sets a TTL absolutely rather than adding to it, so the two keys cannot share one call — extending the marker at the payload's TTL would *shorten* it from seven days to one hour. Extending it at `SEED_META_MIN_TTL_SECONDS` ([`scripts/_seed-utils.mjs:1071`](../../../scripts/_seed-utils.mjs), `86400 * 7`) can only extend or hold, because that floor is already the longest TTL the marker is ever written with (see `resolveSeedMetaTtl`, same file).
+
+The same cohort is declared to `runSeed` so the fetch-failure, SIGTERM and validation-skip paths retain it too:
+
+```js
+preserveKeyTtls: [
+  ...COMPANIONS.map((c) => ({ key: c.key, ttlSeconds: c.ttlSeconds })),
+  ...COMPANIONS.map((c) => ({ key: companionMetaKey(c), ttlSeconds: SEED_META_MIN_TTL_SECONDS })),
+],
+```
+
+## Why This Works
+
+`classifyKey` in `api/health.js` derives staleness *entirely* from the seed-meta record. With the marker gone, there is no fault to report and no clock to call stale:
+
+- `readSeedMeta` returns `hasMeta: false, seedStale: null, metaCount: null` ([`api/health.js:2325`](../../../api/health.js)).
+- `const records = hasData ? (metaCount ?? 1) : 0` ([`api/health.js:2742`](../../../api/health.js)) yields `1` — the payload is present, so the key does not look empty either.
+- Every fault and staleness branch requires a signal that is now `null`, so classification falls through to `else status = 'OK'` ([`api/health.js:2912`](../../../api/health.js)).
+
+`hasData && !hasMeta` is therefore indistinguishable from healthy. Keeping the marker alive keeps `seedStale` computable, so the warn persists exactly as long as the failure does.
+
+Note what is *not* fixed by this: the payload is still served. That is intended — retention exists so readers keep seeing last-good. The bug was never that stale data was served; it was that serving it stopped being *reported*.
+
+## Prevention
+
+**The rule: if you extend a value's lifetime on failure, extend the lifetime of the signal that reports on that value — or the alarm expires before the problem does.**
+
+This is the same invariant the fleet already guards from the other direction. [`tests/seed-ttl-outlives-staleness-fleet.test.mjs`](../../../tests/seed-ttl-outlives-staleness-fleet.test.mjs) enforces `ttlSeconds > maxStaleMin * 60` so a merely-late seeder degrades `STALE_SEED` → `EMPTY` in that order rather than reporting a crit for a source that is only running behind (issue #5309; the same family was fixed for reference data in [PR #7847](https://github.com/koala73/worldmonitor/pull/7847), merged). Both directions say one thing: **the reporting signal must outlive the value it reports on.**
+
+Two reasons that fleet test cannot catch this variant, which is why it needs its own guard:
+
+1. It compares *declared* constants — a seeder's `ttlSeconds` against its `maxStaleMin`. A retention path that re-arms a TTL every tick makes the payload's effective lifetime unbounded at runtime, and no declared constant expresses that.
+2. It compares the payload TTL against the *staleness gate*, not against the *marker's own TTL*. Here both declared values are fine in isolation; only their interaction under sustained retention is wrong.
+
+Concrete checks when writing or reviewing a retention path:
+
+- Ask "what expires first — the data, or the thing that tells me the data is stale?" If the data can be re-armed indefinitely, the marker must be too.
+- Assert the retention TTLs, not just the resulting payload. The regression test in `tests/cloudflare-radar-companion-publication.test.mjs` captures the actual `EXPIRE` commands and asserts the marker is extended at the 7-day floor, never at the data TTL:
+
+  ```js
+  assert.deepEqual(
+    expireCommandsFor(run.redisCommands, TRAFFIC_META_KEY).map((c) => c[2]),
+    [SEED_META_MIN_TTL_SECONDS],
+    'the seed-meta key is extended at its own 7-day floor, never at the data TTL',
+  );
+  assert.equal(
+    JSON.parse(run.store.get(TRAFFIC_META_KEY)).fetchedAt, NOW - 30 * 60_000,
+    'extending the clock key must not rewrite the clock',
+  );
+  ```
+
+  The second assertion is the one that keeps the fix honest: extending the marker's TTL is required, rewriting its `fetchedAt` is still forbidden. A fix that "kept the alarm alive" by re-stamping the clock would pass the first assertion and reintroduce the original silent-freeze.
+- Remember `EXPIRE` is absolute, not additive. Batching keys with different lifetimes into one TTL call silently shortens the longer-lived one.
+
+## See Also
+
+- [`bootstrap-key-health-missing-payload.md`](./bootstrap-key-health-missing-payload.md) — the opposite half of the same `classifyKey` pairing: `hasMeta && !hasData` also falsely reported `OK`. Together these cover both ways a half-present key can read as healthy.
+- [`multi-source-freshness-clock-must-reduce-with-min.md`](../design-patterns/multi-source-freshness-clock-must-reduce-with-min.md) — the closest prior alarm-design precedent: a freshness clock that fails to fire because of how two signals are combined.
+- [`sentry-resolve-by-shipping-permanently-mutes-issues.md`](../workflow-issues/sentry-resolve-by-shipping-permanently-mutes-issues.md) — the mirror image at the process layer: there a signal outlives its accuracy, here it dies before the state it reports on.

--- a/docs/solutions/logic-errors/retention-that-outlives-its-own-alarm.md
+++ b/docs/solutions/logic-errors/retention-that-outlives-its-own-alarm.md
@@ -23,6 +23,8 @@ A seeder's failure path retains last-good data by extending the payload key's TT
 
 Found while reviewing [PR #7862](https://github.com/koala73/worldmonitor/pull/7862) (issue [#7845](https://github.com/koala73/worldmonitor/issues/7845)), in the fix's own first draft, before merge.
 
+> **Status: the fix is open in [#7862](https://github.com/koala73/worldmonitor/pull/7862), not yet merged.** Every code and test excerpt below is quoted from that branch, so `COMPANIONS`, `companionMetaKey`, the `preserveKeyTtls` declaration and `tests/cloudflare-radar-companion-publication.test.mjs` do **not** exist on `main` until it lands. The *lesson* holds regardless of that PR's fate; the *citations* resolve only once it merges.
+
 ## Symptoms
 
 - A Cloudflare Radar companion source fails every tick. For ~7 days `/api/health` correctly reports `STALE_SEED` (warn).
@@ -52,19 +54,21 @@ Extend the marker at its own floor alongside the payload, still without rewritin
 // and its meta must each be extended at their own value.
 const [dataRetained, metaRetained] = await Promise.all([
   extendExistingTtl([companion.key], companion.ttlSeconds),
-  extendExistingTtl([companionMetaKey(companion)], SEED_META_MIN_TTL_SECONDS),
+  extendExistingTtl([companionMetaKey(companion)], resolveSeedMetaTtl(undefined, companion.ttlSeconds)),
 ]);
 const retained = dataRetained && metaRetained;
 ```
 
-`EXPIRE` sets a TTL absolutely rather than adding to it, so the two keys cannot share one call — extending the marker at the payload's TTL would *shorten* it from seven days to one hour. Extending it at `SEED_META_MIN_TTL_SECONDS` ([`scripts/_seed-utils.mjs:1071`](../../../scripts/_seed-utils.mjs), `86400 * 7`) can only extend or hold, because that floor is already the longest TTL the marker is ever written with (see `resolveSeedMetaTtl`, same file).
+`EXPIRE` sets a TTL absolutely rather than adding to it, so the two keys cannot share one call — extending the marker at the payload's TTL would *shorten* it from seven days to one hour.
+
+**Resolve the marker's TTL through the same function that wrote it; do not hardcode the floor.** `resolveSeedMetaTtl(metaTtlSeconds, dataTtlSeconds)` returns `metaTtlSeconds ?? Math.max(SEED_META_MIN_TTL_SECONDS, dataTtlSeconds || 0)` ([`scripts/_seed-utils.mjs:1089`](../../../scripts/_seed-utils.mjs)). The seven-day floor is a *minimum*, not a maximum: a key whose data TTL exceeds seven days has its marker written at the **data** TTL, and a caller may pass a longer explicit one. Re-arming such a marker at the floor would shorten it — the same alarm-before-data failure this page is about, reintroduced by the fix for it. The two companions here (3h and 1h) both resolve to the floor, which is exactly why hardcoding it looked safe.
 
 The same cohort is declared to `runSeed` so the fetch-failure, SIGTERM and validation-skip paths retain it too:
 
 ```js
 preserveKeyTtls: [
   ...COMPANIONS.map((c) => ({ key: c.key, ttlSeconds: c.ttlSeconds })),
-  ...COMPANIONS.map((c) => ({ key: companionMetaKey(c), ttlSeconds: SEED_META_MIN_TTL_SECONDS })),
+  ...COMPANIONS.map((c) => ({ key: companionMetaKey(c), ttlSeconds: resolveSeedMetaTtl(undefined, c.ttlSeconds) })),
 ],
 ```
 
@@ -94,13 +98,13 @@ Two reasons that fleet test cannot catch this variant, which is why it needs its
 Concrete checks when writing or reviewing a retention path:
 
 - Ask "what expires first — the data, or the thing that tells me the data is stale?" If the data can be re-armed indefinitely, the marker must be too.
-- Assert the retention TTLs, not just the resulting payload. The regression test in `tests/cloudflare-radar-companion-publication.test.mjs` captures the actual `EXPIRE` commands and asserts the marker is extended at the 7-day floor, never at the data TTL:
+- Assert the retention TTLs, not just the resulting payload — and derive the expected value the same way the writer does, so the assertion cannot outlive a TTL change:
 
   ```js
   assert.deepEqual(
     expireCommandsFor(run.redisCommands, TRAFFIC_META_KEY).map((c) => c[2]),
-    [SEED_META_MIN_TTL_SECONDS],
-    'the seed-meta key is extended at its own 7-day floor, never at the data TTL',
+    [resolveSeedMetaTtl(undefined, ANOMALIES_TTL)],
+    'the seed-meta key is extended at its own resolved TTL, never at the data TTL',
   );
   assert.equal(
     JSON.parse(run.store.get(TRAFFIC_META_KEY)).fetchedAt, NOW - 30 * 60_000,
@@ -109,7 +113,7 @@ Concrete checks when writing or reviewing a retention path:
   ```
 
   The second assertion is the one that keeps the fix honest: extending the marker's TTL is required, rewriting its `fetchedAt` is still forbidden. A fix that "kept the alarm alive" by re-stamping the clock would pass the first assertion and reintroduce the original silent-freeze.
-- Remember `EXPIRE` is absolute, not additive. Batching keys with different lifetimes into one TTL call silently shortens the longer-lived one.
+- Remember `EXPIRE` is absolute, not additive. Batching keys with different lifetimes into one TTL call silently shortens the longer-lived one — and so does re-arming a single key at a constant that is only *usually* its longest TTL.
 
 ## See Also
 


### PR DESCRIPTION
Documents one learning caught while reviewing #7862 — in that fix's own first draft, before merge. Separate from #7862 so the PR under review stays code-only.

## The learning

A seeder failure path retained last-good by extending the payload key's TTL and deliberately not touching `seed-meta`. Not advancing a success clock on a failed run is correct and is the house rule. The mistake was reading *"don't touch seed-meta"* as *"don't touch the seed-meta key"* — only its **value** is untouchable; its **TTL** still needed extending.

Re-arming the payload every tick makes its effective lifetime unbounded while the marker keeps a fixed 7-day floor, so the marker expires first. `classifyKey` then sees `hasData && !hasMeta`: `seedStale` is null, no fault branch fires, `records` resolves to 1, and it falls through to `else status = 'OK'` (`api/health.js:2912`). A week-long outage decays from STALE_SEED back to green with a frozen payload still being served — the silent freeze the work existed to remove, deferred by seven days.

**The rule the corpus didn't have:** if you extend a value's lifetime on failure, extend the lifetime of the signal that reports on it — whichever expires first decides what is reported.

## Why it needs its own doc

`tests/seed-ttl-outlives-staleness-fleet.test.mjs` already guards the same invariant from the other direction (`ttlSeconds > maxStaleMin * 60`, #5309; same family fixed for reference data in #7847). It cannot catch this variant for two reasons the doc spells out:

1. It compares **declared constants**. A retention path that re-arms a TTL at runtime makes the effective lifetime unbounded, and no declared constant expresses that.
2. It compares the payload TTL against the **staleness gate**, not against the **marker's own TTL**. Here both declared values are fine in isolation; only their interaction under sustained retention is wrong.

## Contents

- `docs/solutions/logic-errors/retention-that-outlives-its-own-alarm.md` — new. Cross-links `bootstrap-key-health-missing-payload.md` (the opposite half of the same `classifyKey` pairing — `hasMeta && !hasData` also read as OK), the closest prior alarm-design precedent, and the mirror-direction sibling #7847.
- `CONCEPTS.md` — refines the existing **Graceful Skip** entry rather than adding a term. That entry's claim that *"real staleness is caught by freshness monitoring on the published data"* is exactly what this failure mode silently voids, so the obligation belongs there.

Every cited path, link, and line number was validated against this branch's tree (`validate-frontmatter.py` and `validate-doc-claims.py` both clean: 4 paths, 6 links, 0 flags).

https://claude.ai/code/session_01EPiX2vBMqvhBBDQpqiAgtj
