### PR TITLE
fix(weather): bound ECCC alert pagination

### DIFF
--- a/scripts/_weather-alert-select.mjs
+++ b/scripts/_weather-alert-select.mjs
@@ -33,19 +33,20 @@ export const NWS_ALERTS_URL = 'https://api.weather.gov/alerts/active';
 export const ECCC_HOST = 'api.weather.gc.ca';
 // Live ECCC vocabulary is issued/continued/ended — not 'active'.
 // status_en=active returns an empty collection. CQL IN also returned 0,
-// so issued and continued are fetched as two separate GETs. limit is set
-// high so each national collection returns in one page; GeoMet defaults
-// to 10 without it.
+// so issued and continued are paged separately in stable feature_id order.
 export const ECCC_LIVE_STATUSES = Object.freeze(['issued', 'continued']);
+const ECCC_PAGE_SIZE = 250;
 const ECCC_ALERTS_COLLECTION = 'https://api.weather.gc.ca/collections/weather-alerts/items';
 export const ECCC_ALERTS_URLS = Object.freeze(
-  ECCC_LIVE_STATUSES.map((status) => `${ECCC_ALERTS_COLLECTION}?f=json&status_en=${status}&limit=10000`),
+  ECCC_LIVE_STATUSES.map((status) => `${ECCC_ALERTS_COLLECTION}?f=json&status_en=${status}&limit=${ECCC_PAGE_SIZE}&offset=0&sortby=feature_id`),
 );
 // Issued URL kept as the single-URL handle for existing host-policy tests.
 export const ECCC_ALERTS_URL = ECCC_ALERTS_URLS[0];
 // National GeoJSON exceeds HKO's 256KiB; 4 MiB is the upper end of the
 // deliberate 2–4 MiB ceiling for this collection.
 export const ECCC_MAX_BYTES = 4 * 1024 * 1024;
+const ECCC_MAX_AGGREGATE_BYTES = 8 * 1024 * 1024;
+const ECCC_MAX_PAGES = 8;
 
 export const SWIC_HOST = 'severeweather.wmo.int';
 export const SWIC_ALERTS_URL = 'https://severeweather.wmo.int/json/wmo_all.json';
@@ -702,7 +703,7 @@ export async function fetchSwicAlertCatalog({
   };
 }
 
-async function readResponseLimited(response, maxBytes) {
+async function readResponseLimited(response, maxBytes, byteBudget) {
   const advertisedLength = Number(response.headers?.get?.('content-length'));
   if (Number.isFinite(advertisedLength) && advertisedLength > maxBytes) {
     try { await response.body?.cancel?.(); } catch { /* still reject */ }
@@ -711,7 +712,10 @@ async function readResponseLimited(response, maxBytes) {
   const reader = response.body?.getReader?.();
   if (!reader) {
     const text = await response.text();
-    if (Buffer.byteLength(text, 'utf8') > maxBytes) throw new Error('RESPONSE_TOO_LARGE');
+    const bytes = Buffer.byteLength(text, 'utf8');
+    if (byteBudget) byteBudget.remaining -= bytes;
+    if (bytes > maxBytes) throw new Error('RESPONSE_TOO_LARGE');
+    if (byteBudget?.remaining < 0) throw new Error('ECCC_AGGREGATE_TOO_LARGE');
     return JSON.parse(text);
   }
   const chunks = [];
@@ -721,9 +725,10 @@ async function readResponseLimited(response, maxBytes) {
       const { done, value } = await reader.read();
       if (done) break;
       total += value.byteLength;
-      if (total > maxBytes) {
+      if (byteBudget) byteBudget.remaining -= value.byteLength;
+      if (total > maxBytes || byteBudget?.remaining < 0) {
         await reader.cancel().catch(() => {});
-        throw new Error('RESPONSE_TOO_LARGE');
+        throw new Error(total > maxBytes ? 'RESPONSE_TOO_LARGE' : 'ECCC_AGGREGATE_TOO_LARGE');
       }
       chunks.push(value);
     }
@@ -734,40 +739,66 @@ async function readResponseLimited(response, maxBytes) {
 }
 
 /**
- * Fetch issued + continued as two GETs and concatenate features.
- * One URL failing still returns the other; throws only if both fail.
+ * Fetch complete issued + continued collections within a shared byte/page budget.
+ * One status failing returns a partial result; throws only if both fail.
  */
 export async function fetchEcccAlertFeatures({
   fetchFn = globalThis.fetch,
   userAgent,
   maxBytes = ECCC_MAX_BYTES,
 } = {}) {
-  const results = await Promise.allSettled(
-    ECCC_ALERTS_URLS.map((url) => fetchApprovedWeatherJson(url, {
-      allowedHosts: [ECCC_HOST],
-      maxBytes,
-      fetchFn,
-      userAgent,
-    }).then(requireAlertFeatures)),
-  );
-
+  const byteBudget = { remaining: ECCC_MAX_AGGREGATE_BYTES };
+  let pages = 0;
+  const seenIds = new Set();
   const features = [];
   const failures = [];
   const failedStatuses = [];
-  results.forEach((result, index) => {
-    if (result.status === 'fulfilled') {
-      features.push(...result.value);
-    } else {
-      failures.push(result.reason);
-      failedStatuses.push(ECCC_LIVE_STATUSES[index]);
+  // Sequential paging makes the shared resource limits deterministic.
+  for (const [index, status] of ECCC_LIVE_STATUSES.entries()) {
+    const statusFeatures = [];
+    let matched;
+    try {
+      do {
+        if (pages >= ECCC_MAX_PAGES) throw new Error('ECCC_PAGE_LIMIT');
+        if (byteBudget.remaining <= 0) throw new Error('ECCC_AGGREGATE_TOO_LARGE');
+        const url = new URL(ECCC_ALERTS_URLS[index]);
+        url.searchParams.set('offset', String(statusFeatures.length));
+        pages += 1;
+        const data = await fetchApprovedWeatherJson(url.toString(), {
+          allowedHosts: [ECCC_HOST], maxBytes, fetchFn, userAgent, byteBudget,
+        });
+        const page = requireAlertFeatures(data);
+        if (data.type !== 'FeatureCollection'
+          || !Number.isSafeInteger(data.numberMatched) || data.numberMatched < 0
+          || !Number.isSafeInteger(data.numberReturned) || data.numberReturned !== page.length
+          || page.length > ECCC_PAGE_SIZE) {
+          throw new Error('ECCC_MALFORMED_PAGE');
+        }
+        if (matched !== undefined && data.numberMatched !== matched) throw new Error('ECCC_COUNT_DRIFT');
+        matched = data.numberMatched;
+        if (statusFeatures.length + page.length > matched
+          || (page.length === 0 && statusFeatures.length < matched)) {
+          throw new Error('ECCC_PAGE_PROGRESS');
+        }
+        for (const feature of page) {
+          if (typeof feature?.id !== 'string' || !feature.id.trim()) throw new Error('ECCC_INVALID_ID');
+          if (seenIds.has(feature.id)) throw new Error('ECCC_DUPLICATE_ID');
+          seenIds.add(feature.id);
+        }
+        statusFeatures.push(...page);
+      } while (statusFeatures.length < matched);
+      features.push(...statusFeatures);
+    } catch (err) {
+      failures.push(err);
+      failedStatuses.push(status);
     }
-  });
-  if (failures.length === results.length) {
+  }
+  if (failures.length === ECCC_LIVE_STATUSES.length) {
     const detail = failures.map((err) => err?.message || String(err)).join('; ');
     throw new Error(`ECCC issued and continued fetches both failed: ${detail}`);
   }
   // Returns an OBJECT, not a bare array, so a partial fetch cannot be consumed
-  // as if it were the whole set. `issued` and `continued` are two separate GETs
+  // as if it were the whole set. `issued` and `continued` are separate collections
   // and each carries alerts the other does not: `continued` is where an ONGOING
   // warning lives after its first issue. Returning just the surviving features
   // when one status 500s publishes a silently truncated national alert set —
@@ -792,6 +823,7 @@ export async function fetchApprovedWeatherJson(url, {
   userAgent = CHROME_UA,
   timeoutMs = 15_000,
   accept = 'application/geo+json',
+  byteBudget,
 } = {}) {
   const parsed = new URL(url);
   const allowed = new Set((allowedHosts || []).map((host) => String(host).toLowerCase()));
@@ -804,5 +836,5 @@ export async function fetchApprovedWeatherJson(url, {
     signal: AbortSignal.timeout(timeoutMs),
   });
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  return readResponseLimited(response, maxBytes);
+  return readResponseLimited(response, maxBytes, byteBudget);
 }

--- a/tests/weather-alert-selection.test.mjs
+++ b/tests/weather-alert-selection.test.mjs
@@ -828,3 +828,123 @@ describe('WMO SWIC adapter on weather:alerts:v1', () => {
     );
   });
 });
+
+describe('bounded ECCC pagination', () => {
+  const collection = (features, numberMatched = features.length) => ({
+    type: 'FeatureCollection', numberMatched, numberReturned: features.length, features,
+  });
+  const pagedFetch = (issued, continued = [], requests = []) => async (url) => {
+    const params = new URL(url).searchParams;
+    const status = params.get('status_en');
+    const offset = Number(params.get('offset') || 0);
+    const limit = Number(params.get('limit'));
+    requests.push({ status, offset, limit, sortby: params.get('sortby') });
+    const rows = status === 'issued' ? issued : continued;
+    return Response.json(collection(rows.slice(offset, offset + limit), rows.length));
+  };
+
+  it('recovers a national collection over 4 MiB with complete pages below 4 MiB', async () => {
+    const issued = Array.from({ length: 300 }, (_, i) => ecccFeature({
+      id: `issued-${String(i).padStart(4, '0')}`, overrides: { description_en: 'x'.repeat(15_000) },
+    }));
+    const continued = [ecccFeature({ id: 'continued-1', status_en: 'continued' })];
+    assert.ok(Buffer.byteLength(JSON.stringify(collection(issued))) > ECCC_MAX_BYTES);
+    assert.ok(Buffer.byteLength(JSON.stringify(collection(issued.slice(0, 250), 300))) < ECCC_MAX_BYTES);
+    const requests = [];
+    const result = await fetchEcccAlertFeatures({ fetchFn: pagedFetch(issued, continued, requests) });
+    assert.equal(result.partial, false);
+    assert.deepEqual(result.features.map((f) => f.id), [...issued, ...continued].map((f) => f.id));
+    assert.deepEqual(requests, [
+      { status: 'issued', offset: 0, limit: 250, sortby: 'feature_id' },
+      { status: 'issued', offset: 250, limit: 250, sortby: 'feature_id' },
+      { status: 'continued', offset: 0, limit: 250, sortby: 'feature_id' },
+    ]);
+  });
+  it('accepts complete zero collections and pages both live statuses', async () => {
+    const zero = await fetchEcccAlertFeatures({ fetchFn: pagedFetch([]) });
+    assert.deepEqual(zero.features, []);
+    assert.equal(zero.partial, false);
+    const rows = (status) => Array.from({ length: 251 }, (_, i) => ecccFeature({ id: `${status}-${i}`, status_en: status }));
+    const result = await fetchEcccAlertFeatures({ fetchFn: pagedFetch(rows('issued'), rows('continued')) });
+    assert.equal(result.partial, false);
+    assert.equal(result.features.length, 502);
+  });
+
+  for (const [name, secondPage, reason] of [
+    ['count drift', collection([{ id: 'b' }], 3), 'ECCC_COUNT_DRIFT'],
+    ['repeated page', collection([{ id: 'a' }], 2), 'ECCC_DUPLICATE_ID'],
+    ['no progress', collection([], 2), 'ECCC_PAGE_PROGRESS'],
+    ['count underrun', collection([{ id: 'b' }, { id: 'c' }], 2), 'ECCC_PAGE_PROGRESS'],
+    ['returned mismatch', { ...collection([{ id: 'b' }], 2), numberReturned: 0 }, 'ECCC_MALFORMED_PAGE'],
+    ['missing features', { numberMatched: 2, numberReturned: 1 }, 'features array'],
+    ['missing counts', { type: 'FeatureCollection', features: [{ id: 'b' }] }, 'ECCC_MALFORMED_PAGE'],
+    ['invalid count', collection([{ id: 'b' }], '2'), 'ECCC_MALFORMED_PAGE'],
+    ['invalid collection', { ...collection([{ id: 'b' }], 2), type: 'Feature' }, 'ECCC_MALFORMED_PAGE'],
+    ['missing ID', collection([{}], 2), 'ECCC_INVALID_ID'],
+    ['duplicate IDs within page', collection([{ id: 'b' }, { id: 'b' }], 3), 'ECCC_DUPLICATE_ID'],
+    ['oversized page count', collection(Array.from({ length: 251 }, (_, i) => ({ id: `b${i}` })), 300), 'ECCC_MALFORMED_PAGE'],
+    ['request failure', null, 'HTTP 503'],
+  ]) {
+    it(`rejects ${name} without returning an incomplete status as success`, async () => {
+      const matched = name === 'duplicate IDs within page' ? 3 : name === 'oversized page count' ? 300 : 2;
+      const result = await fetchEcccAlertFeatures({ fetchFn: async (url) => {
+        const p = new URL(url).searchParams;
+        if (p.get('status_en') === 'continued') return Response.json(collection([{ id: 'continued' }]));
+        if (p.get('offset') === '0') return Response.json(collection([{ id: 'a' }], matched));
+        return secondPage ? Response.json(secondPage) : new Response('', { status: 503 });
+      } });
+      assert.equal(result.partial, true);
+      assert.deepEqual(result.failedStatuses, ['issued']);
+      assert.deepEqual(result.features, [{ id: 'continued' }]);
+      assert.ok(result.failureDetail.includes(reason), result.failureDetail);
+    });
+  }
+
+  it('rejects duplicate IDs across statuses', async () => {
+    const result = await fetchEcccAlertFeatures({ fetchFn: pagedFetch([{ id: 'same' }], [{ id: 'same' }]) });
+    assert.equal(result.partial, true);
+    assert.deepEqual(result.failedStatuses, ['continued']);
+    assert.match(result.failureDetail, /ECCC_DUPLICATE_ID/);
+  });
+
+  it('keeps the per-response ceiling with and without content-length', async () => {
+    for (const advertised of [false, true]) {
+      await assert.rejects(fetchEcccAlertFeatures({ fetchFn: async () => new Response('x'.repeat(ECCC_MAX_BYTES + 1), {
+        headers: advertised ? { 'content-length': String(ECCC_MAX_BYTES + 1) } : {},
+      }) }), /RESPONSE_TOO_LARGE/);
+    }
+  });
+
+  it('caps actual aggregate bytes across statuses at 8 MiB, including UTF-8', async () => {
+    let requests = 0;
+    const pad = 'é'.repeat(1_500_000);
+    const result = await fetchEcccAlertFeatures({ fetchFn: async (url) => {
+      requests += 1;
+      const p = new URL(url).searchParams;
+      const issued = p.get('status_en') === 'issued';
+      const body = JSON.stringify(collection([{ id: `${issued}-${p.get('offset')}`, pad }], issued ? 1 : 2));
+      assert.ok(Buffer.byteLength(body) < ECCC_MAX_BYTES);
+      return new Response(body, { headers: { 'content-length': '1' } });
+    } });
+    assert.equal(result.partial, true);
+    assert.deepEqual(result.failedStatuses, ['continued']);
+    assert.match(result.failureDetail, /ECCC_AGGREGATE_TOO_LARGE/);
+    assert.equal(requests, 3);
+  });
+
+  it('permits eight total pages but never requests a ninth', async () => {
+    for (const issuedCount of [7, 8, 9]) {
+      let requests = 0;
+      const result = await fetchEcccAlertFeatures({ fetchFn: async (url) => {
+        requests += 1;
+        const p = new URL(url).searchParams;
+        const issued = p.get('status_en') === 'issued';
+        return Response.json(collection([{ id: `${issued}-${p.get('offset')}` }], issued ? issuedCount : 1));
+      } }).catch((error) => error);
+      assert.equal(requests, 8);
+      if (issuedCount === 7) assert.equal(result.partial, false);
+      else assert.match(result.failureDetail || result.message, /ECCC_PAGE_LIMIT/);
+    }
+  });
+
+});

--- a/tests/weather-source-health.test.mjs
+++ b/tests/weather-source-health.test.mjs
@@ -29,6 +29,7 @@ function harness({ store = new Map() } = {}) {
   let failedWrites = [];
   let nwsDelay = 0;
   let writeDelay = 0;
+  let ecccFetch;
   let expires = new Date(START + 120 * MINUTE).toISOString();
   const logs = [];
   const requests = [];
@@ -54,10 +55,11 @@ function harness({ store = new Map() } = {}) {
         now += nwsDelay;
       }
       if (failed.includes(source)) throw new Error(source === 'nws' ? 'The operation was aborted due to timeout' : 'HTTP 503');
+      if (source === 'eccc' && ecccFetch) return ecccFetch(url, expires);
       if (url === weather.SWIC_MEMBERS_URL) return Response.json([{ members: [{ mid: '1', code: 'GBR' }] }]);
       const count = empty.includes(source) ? 0 : source === 'nws' ? 227 : source === 'eccc' ? (url.includes('continued') ? 0 : 207) : 946;
       const items = Array.from({ length: count }, (_, i) => fixture(source, i, expires));
-      return Response.json(source === 'swic' ? { items } : { features: items });
+      return Response.json(source === 'swic' ? { items } : { type: 'FeatureCollection', numberMatched: count, numberReturned: count, features: items });
     },
     upstashGet: async (key) => clone(store.get(key)),
     upstashSet: async (key, value, ttl) => {
@@ -71,8 +73,9 @@ function harness({ store = new Map() } = {}) {
   const seed = runInNewContext(`${envelopes}\n${weatherLoop}\nseedWeatherAlerts`, context);
   return {
     store, logs, requests, notifications, writes,
-    async run({ at = now, failures = [], emptySources = [], expiry = expires, writeFailures = [], nwsDelayMs = 0, writeDelayMs = 0 } = {}) {
+    async run({ at = now, failures = [], emptySources = [], expiry = expires, writeFailures = [], nwsDelayMs = 0, writeDelayMs = 0, ecccFetchFn } = {}) {
       now = at; failed = failures; empty = emptySources; expires = expiry; failedWrites = writeFailures; nwsDelay = nwsDelayMs; writeDelay = writeDelayMs;
+      ecccFetch = ecccFetchFn;
       await seed();
       assert.ok(!logs.some((line) => line.startsWith('[Weather] Seed error:')), logs.join('\n'));
       return { payload: clone(store.get(KEY)?.data), meta: clone(store.get(META)) };
@@ -319,4 +322,36 @@ test('provider success clocks precede a slower failed source and aggregate publi
   assert.equal(result.meta.sourceHealth.swic.lastSuccessAt, START + 15 * MINUTE);
   assert.equal(result.meta.sourceHealth.nws.firstFailureAt, START + 15 * MINUTE + 15_000);
   assert.equal(result.meta.fetchedAt, START + 15 * MINUTE + 15_000);
+});
+
+
+test('paged ECCC success, late-page failure, recovery and valid zero reach relay health', async () => {
+  const h = harness();
+  const ecccFetch = (fail = false) => async (url, expiry) => {
+    const p = new URL(url).searchParams;
+    const offset = Number(p.get('offset'));
+    const count = p.get('status_en') === 'issued' ? 300 : 0;
+    if (fail && offset > 0) throw new Error('late-page failure');
+    const features = Array.from({ length: Math.min(250, count - offset) }, (_, i) => ({
+      ...fixture('eccc', offset + i, expiry), padding: 'x'.repeat(15_000),
+    }));
+    return Response.json({ type: 'FeatureCollection', numberMatched: count, numberReturned: features.length, features });
+  };
+  const good = await h.run({ ecccFetchFn: ecccFetch() });
+  const ids = (payload) => payload.alerts.filter((a) => a.source === 'eccc').map((a) => a.id);
+  assert.ok(ids(good.payload).length > 0);
+  assert.equal(h.classify().status, 'OK');
+  const failed = await h.run({ at: START + 15 * MINUTE, ecccFetchFn: ecccFetch(true) });
+  assert.deepEqual(ids(failed.payload), ids(good.payload));
+  assert.equal(failed.meta.sourceHealth.eccc.lastSuccessAt, good.meta.sourceHealth.eccc.lastSuccessAt);
+  assert.equal(failed.meta.sourceHealth.nws.lastSuccessAt, START + 15 * MINUTE);
+  assert.equal(failed.meta.sourceState, 'degraded');
+  assert.equal(h.classify().status, 'SEED_ERROR');
+  const recovered = await h.run({ at: START + 30 * MINUTE, ecccFetchFn: ecccFetch() });
+  assert.equal(recovered.meta.sourceHealth.eccc.lastSuccessAt, START + 30 * MINUTE);
+  assert.equal(h.classify().status, 'OK');
+  const zero = await h.run({ at: START + 45 * MINUTE, emptySources: ['eccc'] });
+  assert.deepEqual(ids(zero.payload), []);
+  assert.equal(zero.meta.sourceHealth.eccc.lastSuccessAt, START + 45 * MINUTE);
+  assert.equal(h.classify().status, 'OK');
 });


### PR DESCRIPTION
## Summary

Canadian weather alerts could remain on last-good data when ECCC's national response exceeded the 4 MiB response ceiling. Fetch issued and continued alerts in 250-feature pages so larger complete collections can refresh without raising that ceiling.

The collection has a shared 8 MiB/eight-page budget. Count drift, duplicate IDs, malformed or stalled pages, request failure, and exhausted budgets use the existing partial/last-good path. Confirmed zero still purges prior ECCC alerts. Source clocks, health policy, cadence, keys, selection, notifications, and NWS/SWIC behavior stay unchanged.

## Validation

- Proof first: a 300-feature fixture exceeded 4 MiB as one collection while its 250-feature page stayed below 4 MiB. It failed before the fix (`partial=true`) and passes with every expected ID afterward.
- Weather, relay health, notification and Docker import checks: 131 passed. The real relay writer with in-memory storage and the actual health classifier proves late-page failure retains ECCC coverage and its success clock, then recovery and valid-zero purge work.
- Contract typecheck passed; Railway registry checks: 141 passed; all normal pre-push gates passed.
- Read-only provider check at 2026-09-08 02:34 UTC returned 316 features across three pages, with no partial result. This does not prove production publication or Railway egress.
- Sequential code review found no actionable issues. The separate Claude pass returned no usable result.

## Post-Deploy Monitoring & Validation

Owner: repository operator, after separately authorized merge/deployment. Observe two normal 15-minute relay cycles. Search relay logs for `[Weather] ECCC fetch failed`, `ECCC partial fetch`, `ECCC_COUNT_DRIFT`, `ECCC_PAGE_LIMIT`, and `ECCC_AGGREGATE_TOO_LARGE`. Confirm ECCC's success clock advances in `seed-meta:weather:alerts`, fresh or confirmed-zero Canadian coverage reaches `weather:alerts:v1`, and `weatherAlerts` health meets the unchanged policy. Persistent failures or a stale ECCC clock block acceptance and require investigation before any separately authorized rollback. No deployment, production seeder, Redis write or service configuration change was performed here.

Offset paging cannot detect every count-stable provider replacement; detected drift and duplicates fail closed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
