### PR TITLE
fix(cross-strait): preserve validated MND list coverage

### DIFF
--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2325,7 +2325,7 @@ async function probeJapanProxyControlTunnel(host, {
   tunnel?.destroy?.();
 }
 
-function rotatingRefreshCandidates(previousMnd, excludedUrls, now) {
+function rotatingRefreshCandidates(previousMnd, excludedUrls, now, limit) {
   const eligible = [...new Map(
     previousMnd
       .filter((row) => (
@@ -2344,8 +2344,8 @@ function rotatingRefreshCandidates(previousMnd, excludedUrls, now) {
   ).values()];
   if (eligible.length === 0) return [];
   const offset = (Math.floor(now / MND_REFRESH_ROTATION_INTERVAL_MS)
-    * MND_REFRESH_DETAIL_REQUESTS_PER_RUN) % eligible.length;
-  return Array.from({ length: Math.min(MND_REFRESH_DETAIL_REQUESTS_PER_RUN, eligible.length) },
+    * limit) % eligible.length;
+  return Array.from({ length: Math.min(limit, eligible.length) },
     (_, index) => eligible[(offset + index) % eligible.length]);
 }
 
@@ -2595,8 +2595,15 @@ export async function fetchCrossStraitActivitySnapshot({
 } = {}) {
   const generatedAt = new Date(now).toISOString();
   const previousMnd = (previousSnapshot?.observations ?? [])
-    .filter((row) => row?.sourceId === 'taiwan-mnd');
+    .filter((row) => safePreviousMndObservation(row)
+      && validMndObservation(row)
+      && MND_CATEGORY_KEYS.every((key) => Object.hasOwn(row.categories, key))
+      && typeof row.publicationTime === 'string'
+      && Number.isFinite(Date.parse(row.publicationTime)));
   const previousMndByUrl = new Map(previousMnd.map((row) => [row.sourceUrl, row]));
+  const hasRetainedCoverage = (row) => (
+    previousMndByUrl.get(row.sourceUrl)?.publicationTime.slice(0, 10) === row.publicationDay
+  );
   const needsBackfill = new Set(previousMnd.map((row) => row.reportingDay)).size
     < MND_REQUIRED_REPORTING_DAYS;
   const listPages = needsBackfill ? MND_MAX_LIST_PAGES_PER_BACKFILL_RUN : 1;
@@ -2717,7 +2724,8 @@ export async function fetchCrossStraitActivitySnapshot({
         }
       }
       if (
-        latestCandidates.size + unseenBackfillCandidates.size
+        [...latestCandidates.values()].filter((row) => !hasRetainedCoverage(row)).length
+          + unseenBackfillCandidates.size
         >= MND_MAX_DETAIL_REQUESTS_PER_RUN
       ) {
         break;
@@ -2728,26 +2736,30 @@ export async function fetchCrossStraitActivitySnapshot({
     }
   }
 
-  const primaryPool = [
-    ...latestCandidates.values(),
+  const unchangedCurrent = [...latestCandidates.values()].filter(hasRetainedCoverage);
+  const coveredCurrentUrls = new Set(unchangedCurrent.map((row) => row.sourceUrl));
+  const requiredCurrent = [...latestCandidates.values()]
+    .filter((row) => !coveredCurrentUrls.has(row.sourceUrl));
+  const unresolvedCurrentUrls = new Set(requiredCurrent.map((row) => row.sourceUrl));
+  const primaryCandidates = [
+    ...requiredCurrent,
     ...unseenBackfillCandidates.values(),
   ].slice(0, MND_MAX_DETAIL_REQUESTS_PER_RUN);
-  const refreshCandidates = rotatingRefreshCandidates(
+  const currentRefresh = unchangedCurrent.length === 0 ? [] : [{
+    ...unchangedCurrent[Math.floor(now / MND_REFRESH_ROTATION_INTERVAL_MS) % unchangedCurrent.length],
+    allowPublicationAdvance: true,
+  }];
+  const refreshCandidates = [...currentRefresh, ...rotatingRefreshCandidates(
     previousMnd,
-    new Set(primaryPool.map((row) => row.sourceUrl)),
+    new Set([...latestCandidates.keys(), ...unseenBackfillCandidates.keys()]),
     now,
-  );
-  const primaryCandidates = primaryPool.slice(
-    0,
-    MND_MAX_DETAIL_REQUESTS_PER_RUN - refreshCandidates.length,
-  );
-  const candidates = [...primaryCandidates, ...refreshCandidates]
-    .slice(0, MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    MND_REFRESH_DETAIL_REQUESTS_PER_RUN - currentRefresh.length,
+  )];
   const candidateSchedule = [
     ...primaryCandidates.map((candidate) => ({
       candidate,
       isRefresh: false,
-      reservedRefreshAttempts: refreshCandidates.length,
+      reservedRefreshAttempts: 0,
     })),
     ...refreshCandidates.map((candidate, index) => ({
       candidate,
@@ -2762,7 +2774,11 @@ export async function fetchCrossStraitActivitySnapshot({
   for (const { candidate, isRefresh, reservedRefreshAttempts } of candidateSchedule) {
     const candidateErrors = isRefresh ? mndRefreshErrors : mndErrors;
     if (primaryBudgetExhausted && !isRefresh) continue;
-    const detailAttemptLimit = MND_MAX_DETAIL_REQUESTS_PER_RUN - reservedRefreshAttempts;
+    // Required rows consume capacity first; only optional retries reserve room
+    // for the remaining optional first attempts.
+    const detailAttemptLimit = MND_MAX_DETAIL_REQUESTS_PER_RUN
+      - (isRefresh ? Math.min(reservedRefreshAttempts,
+        Math.max(0, MND_MAX_DETAIL_REQUESTS_PER_RUN - detailRequestCount - 1)) : 0);
     let retryErrorCode = null;
     while (detailRequestCount < detailAttemptLimit) {
       if (!hasMndOutboundBudget({
@@ -2800,6 +2816,7 @@ export async function fetchCrossStraitActivitySnapshot({
           allowPublicationAdvance: candidate.allowPublicationAdvance === true,
           expectedReportingDay: candidate.expectedReportingDay ?? null,
         }));
+        unresolvedCurrentUrls.delete(candidate.sourceUrl);
         mndPreferredFetchFn = requestFetchFn;
         if (retryErrorCode && mndProxyFetchFn) {
           mndRequestDiagnostics.at(-1).recoveredVia = requestFetchFn === mndProxyFetchFn
@@ -2830,10 +2847,13 @@ export async function fetchCrossStraitActivitySnapshot({
   const hasHardMndError = mndErrors.some(
     (code) => code !== 'OUTBOUND_BUDGET_EXHAUSTED',
   );
+  if (unresolvedCurrentUrls.size > 0 && !hasHardMndError) {
+    mndErrors.push('MND_CURRENT_LIST_INCOMPLETE');
+  }
   const mndOutcome = {
     ok: discoveredCount > 0
       && !hasHardMndError
-      && (candidates.length === 0 || parsedMnd.length > 0),
+      && unresolvedCurrentUrls.size === 0,
     requestCount,
     observations: parsedMnd,
     errorCodes: [...new Set(mndErrors)],
@@ -2847,6 +2867,24 @@ export async function fetchCrossStraitActivitySnapshot({
     mndOutcome,
     japanOutcome,
   });
+}
+
+function validMndObservation(row) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(row.reportingDay)
+    && Number.isFinite(Date.parse(row.reportingPeriod?.start))
+    && Number.isFinite(Date.parse(row.reportingPeriod?.end))
+    && Date.parse(row.reportingPeriod.end) > Date.parse(row.reportingPeriod.start)
+    && isAllowedSourceUrl(row.sourceUrl, CROSS_STRAIT_SOURCE_CONTRACTS.taiwanMnd)
+    && Object.values(row.categories ?? {}).length === MND_CATEGORY_KEYS.length
+    && Object.values(row.categories).every(
+      (value) => value == null || (Number.isInteger(value) && value >= 0),
+    )
+    && Array.isArray(row.history)
+    && row.history.length <= MND_MAX_REVISION_VINTAGES_PER_DAY
+    && Number.isInteger(row.revision?.sequence)
+    && row.revision.sequence >= 1
+    && row.provenance?.contractVersion === 'decision-signal-provenance/v1'
+    && row.provenance?.familyId === 'operational_activity_record';
 }
 
 export function validateCrossStraitActivitySnapshot(snapshot) {
@@ -2866,21 +2904,5 @@ export function validateCrossStraitActivitySnapshot(snapshot) {
   ) return false;
   const mnd = snapshot.observations.filter((row) => row?.sourceId === 'taiwan-mnd');
   if (mnd.length === 0) return false;
-  return mnd.every((row) => (
-    /^\d{4}-\d{2}-\d{2}$/.test(row.reportingDay)
-    && Number.isFinite(Date.parse(row.reportingPeriod?.start))
-    && Number.isFinite(Date.parse(row.reportingPeriod?.end))
-    && Date.parse(row.reportingPeriod.end) > Date.parse(row.reportingPeriod.start)
-    && isAllowedSourceUrl(row.sourceUrl, CROSS_STRAIT_SOURCE_CONTRACTS.taiwanMnd)
-    && Object.values(row.categories ?? {}).length === MND_CATEGORY_KEYS.length
-    && Object.values(row.categories).every(
-      (value) => value == null || (Number.isInteger(value) && value >= 0),
-    )
-    && Array.isArray(row.history)
-    && row.history.length <= MND_MAX_REVISION_VINTAGES_PER_DAY
-    && Number.isInteger(row.revision?.sequence)
-    && row.revision.sequence >= 1
-    && row.provenance?.contractVersion === 'decision-signal-provenance/v1'
-    && row.provenance?.familyId === 'operational_activity_record'
-  ));
+  return mnd.every(validMndObservation);
 }

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -9,7 +9,12 @@ import seedHealthHandler from '../api/seed-health.js';
 import { atomicPublish, runSeed } from '../scripts/_seed-utils.mjs';
 import { readSectionFreshness } from '../scripts/_bundle-runner.mjs';
 import { extractRunBundleSectionSource } from './helpers/bundle-section-parser.mjs';
-import { CROSS_STRAIT_ACTIVITY_KEY } from '../scripts/cross-strait-activity/adapters.mjs';
+import {
+  CROSS_STRAIT_ACTIVITY_KEY,
+  buildCrossStraitActivitySnapshot,
+  fetchCrossStraitActivitySnapshot,
+  parseTaiwanMndDetail,
+} from '../scripts/cross-strait-activity/adapters.mjs';
 import {
   CROSS_STRAIT_ACTIVITY_BOOTSTRAP_KEY,
   CROSS_STRAIT_ACTIVITY_BOOTSTRAP_MAX_BYTES,
@@ -24,6 +29,7 @@ import {
   CROSS_STRAIT_ACTIVITY_TTL_SECONDS,
   crossStraitActivityAfterPublish,
   crossStraitActivityBeforePublish,
+  crossStraitActivityContentMeta,
   projectCrossStraitActivityBootstrap,
   writePublicationCompletion,
   writeSourceHealth,
@@ -176,6 +182,57 @@ test('legacy cross-Strait source errors stay actionable without discarding last-
     assert.equal(entry.records, 91, name);
   }
 });
+
+for (const listState of ['unchanged', 'changed-date', 'empty'] as const) {
+  test(`MND ${listState} list coverage reaches published source health without changing document clocks`, async () => {
+    const retrievedAt = '2026-07-25T08:30:00.000Z';
+    const nextRun = Date.parse('2026-07-25T11:30:00.000Z');
+    const original = parseTaiwanMndDetail(read('tests/fixtures/cross-strait-activity/mnd-detail.html'), {
+      sourceUrl: 'https://www.mnd.gov.tw/en/News/PLAAct/90000',
+      retrievedAt, expectedPublicationDay: '2026-07-25',
+    });
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt, previousSnapshot: null,
+      mndOutcome: { ok: true, observations: [original] },
+      japanOutcome: { ok: true, availableDocumentUrls: [] },
+    });
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      now: nextRun, previousSnapshot, mndProxyUrl: '', proxyUrl: '', sleepFn: async () => {},
+      fetchFn: async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('mod.go.jp')) return new Response(read('tests/fixtures/cross-strait-activity/jmod-homepage.html'));
+        if (url.includes('plaactlist')) return new Response(listState === 'empty' ? '<html></html>' : `
+          <div class="wrap-page3"><a class="news_list" href="${original.sourceUrl}">
+          <h5 class="date">${listState === 'changed-date' ? '2026.07.26' : '2026.07.25'}</h5></a></div>`);
+        throw new Error('request timeout');
+      },
+    });
+    const stored = new Map<string, unknown>();
+    const writer = async (key: string, value: unknown) => { stored.set(key, value); };
+    const reader = async (key: string) => stored.get(key) ?? null;
+    await writeSourceHealth(previousSnapshot, writer, reader);
+    await writeSourceHealth(snapshot, writer, reader);
+    const { classifyKey, SEED_META, STANDALONE_KEYS } = __testing__;
+    const name = 'crossStraitActivityTaiwanMnd';
+    const key = STANDALONE_KEYS[name];
+    const metaKey = SEED_META[name].key;
+    const entry = classifyKey(name, key, { allowOnDemand: true }, {
+      keyStrens: new Map([[key, JSON.stringify(stored.get(key)).length]]),
+      keyErrors: new Map(), keyMetaErrors: new Map(),
+      keyMetaValues: new Map([[metaKey, JSON.stringify(stored.get(metaKey))]]), now: nextRun,
+    });
+    assert.equal(entry.status, listState === 'unchanged' ? 'OK' : 'SEED_ERROR');
+    assert.equal(snapshot.sources[0].lastSuccessAt, listState === 'unchanged' ? new Date(nextRun).toISOString() : retrievedAt);
+    assert.deepEqual(snapshot.observations, previousSnapshot.observations);
+    assert.deepEqual(crossStraitActivityContentMeta(snapshot), crossStraitActivityContentMeta(previousSnapshot));
+    assert.equal(projectCrossStraitActivityBootstrap(snapshot).sources[0].transportStatus,
+      listState === 'unchanged' ? 'fresh' : 'error');
+    if (listState === 'unchanged') {
+      assert.deepEqual(snapshot.sources[0].errorCodes, []);
+      assert.deepEqual(snapshot.sources[0].refreshErrorCodes, ['TIMEOUT']);
+    }
+  });
+}
 
 test('MND metadata counts completed source attempts independently of canonical publication', async () => {
   const { classifyKey, healthStatusBucket, SEED_META, STANDALONE_KEYS } = __testing__;

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -2902,7 +2902,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(snapshot.sources[0].requestCount, mndCalls.length);
   });
 
-  it('uses remaining time for correction first attempts after slow list discovery', async () => {
+  it('uses remaining time for required details after slow list discovery', async () => {
     const correctionDetails = new Map([21, 22, 23].map((day) => [
       `https://www.mnd.gov.tw/en/News/PLAAct/${99_000 + day}`,
       fixture('mnd-detail.html')
@@ -2954,16 +2954,16 @@ describe('quantified cross-Strait activity (#5575)', () => {
 
       assert.equal(listCalls, MND_MAX_LIST_PAGES_PER_BACKFILL_RUN);
       assert.equal(detailCalls.length, expectedDetails);
-      assert.ok(detailCalls.every((url) => correctionDetails.has(url)));
+      assert.ok(detailCalls.every((url) => !correctionDetails.has(url)));
       assert.ok(clock <= MND_OUTBOUND_BUDGET_MS);
       assert.equal(mnd?.requestCount, listCalls + detailCalls.length);
-      assert.equal(mnd?.transportStatus, 'fresh');
-      assert.equal(mnd?.lastSuccessAt, retrievedAt);
-      assert.deepEqual(mnd?.errorCodes, ['OUTBOUND_BUDGET_EXHAUSTED']);
+      assert.equal(mnd?.transportStatus, 'error');
+      assert.equal(mnd?.lastSuccessAt, previousSnapshot.sources[0].lastSuccessAt);
+      assert.ok(mnd?.errorCodes.includes('OUTBOUND_BUDGET_EXHAUSTED'));
     }
   });
 
-  it('keeps a partial MND collection fresh when only the outbound budget stops more work', async () => {
+  it('keeps incomplete current-list coverage hard when the outbound budget stops required work', async () => {
     let budgetCheck = 0;
     const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
     const fetchFn = async (input: string | URL | Request) => {
@@ -2984,8 +2984,8 @@ describe('quantified cross-Strait activity (#5575)', () => {
     });
     const mnd = snapshot.sources.find((source: { id: string }) => source.id === 'taiwan-mnd');
 
-    assert.equal(mnd?.transportStatus, 'fresh');
-    assert.ok(mnd?.errorCodes.includes('OUTBOUND_BUDGET_EXHAUSTED'));
+    assert.equal(mnd?.transportStatus, 'error');
+    assert.deepEqual(mnd?.errorCodes, ['OUTBOUND_BUDGET_EXHAUSTED', 'MND_CURRENT_LIST_INCOMPLETE']);
     assert.equal(
       snapshot.observations.filter((row: { sourceId: string }) => row.sourceId === 'taiwan-mnd').length,
       1,
@@ -3025,9 +3025,9 @@ describe('quantified cross-Strait activity (#5575)', () => {
         proxied.length = 0;
         const snapshot = await fetchCrossStraitActivitySnapshot(options);
         const mnd = snapshot.sources.find(source => source.id === 'taiwan-mnd');
-        assert.equal(mnd.transportStatus, 'fresh');
-        assert.deepEqual(mnd.errorCodes, []);
-        assert.equal(mnd.lastSuccessAt, retrievedAt);
+        assert.equal(mnd.transportStatus, failure === 'detail' ? 'error' : 'fresh');
+        assert.deepEqual(mnd.errorCodes, failure === 'detail' ? ['MND_CURRENT_LIST_INCOMPLETE'] : []);
+        assert.equal(mnd.lastSuccessAt, failure === 'detail' ? null : retrievedAt);
         assert.equal(mnd.requestCount, direct.length + proxied.length);
         assert.equal(direct.length, failure === 'none' ? 21 : failure === 'list' ? 1 : 2);
         assert.equal(proxied.length, failure === 'none' ? 0 : failure === 'list' ? 21 : 19);
@@ -3112,7 +3112,8 @@ describe('quantified cross-Strait activity (#5575)', () => {
       'direct:/en/News/PLAAct/90001',
       'direct:/en/News/PLAAct/90002',
     ]);
-    assert.equal(mnd.transportStatus, 'fresh');
+    assert.equal(mnd.transportStatus, 'error');
+    assert.deepEqual(mnd.errorCodes, ['MND_CURRENT_LIST_INCOMPLETE']);
     assert.equal(mnd.requestDiagnostics[1].recoveredVia, 'direct');
   });
 
@@ -3410,8 +3411,8 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(firstUrlAttempts, 2);
     assert.ok(detailCalls.length <= MND_MAX_DETAIL_REQUESTS_PER_RUN);
     assert.equal(mnd?.requestCount, detailCalls.length + 1);
-    assert.equal(mnd?.transportStatus, 'fresh');
-    assert.deepEqual(mnd?.errorCodes, []);
+    assert.equal(mnd?.transportStatus, 'error');
+    assert.deepEqual(mnd?.errorCodes, ['MND_CURRENT_LIST_INCOMPLETE']);
   });
 
   it('retries an MND list timeout once and counts the actual requests', async () => {
@@ -3514,7 +3515,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
         fetchFn: async (input: string | URL | Request) => {
           const url = String(input);
           if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
-          if (url.includes('plaactlist')) return new Response(mndListWithCount(20));
+          if (url.includes('plaactlist')) return new Response(mndListWithCount(purpose === 'refresh' ? 1 : 20));
           if (purpose === 'detail' ? url.endsWith('/90000') : url.includes('/86001')) {
             return new Response(new ReadableStream({
               pull(controller) {
@@ -3619,7 +3620,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
   }
 
   for (const failure of ['metadata', 'timeout']) {
-  it(`preserves reserved correction refreshes when a primary detail needs a ${failure} retry`, async () => {
+  it(`spends the detail cap on required rows before corrections after a ${failure} retry`, async () => {
     const previousSnapshot = buildCrossStraitActivitySnapshot({
       generatedAt: retrievedAt,
       previousSnapshot: null,
@@ -3658,12 +3659,12 @@ describe('quantified cross-Strait activity (#5575)', () => {
 
     const correctionRefreshes = detailCalls.filter((url) => /\/PLAAct\/860\d{2}$/.test(url));
     assert.equal(firstPrimaryAttempts, 2);
-    assert.equal(correctionRefreshes.length, MND_REFRESH_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(correctionRefreshes.length, 0);
     assert.equal(detailCalls.length, MND_MAX_DETAIL_REQUESTS_PER_RUN);
   });
   }
 
-  for (const route of ['direct', 'proxy'] as const) it(`preserves correction refresh wall-clock headroom with a ${route} retry`, async () => {
+  for (const route of ['direct', 'proxy'] as const) it(`spends wall-clock headroom on required rows with a ${route} retry`, async () => {
     const previousSnapshot = buildCrossStraitActivitySnapshot({
       generatedAt: retrievedAt,
       previousSnapshot: null,
@@ -3712,7 +3713,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     const correctionRefreshes = detailCalls.filter((url) => /\/PLAAct\/860\d{2}$/.test(url));
     assert.equal(firstPrimaryAttempts, 2);
     assert.equal(proxyCalls > 0, route === 'proxy');
-    assert.equal(correctionRefreshes.length, MND_REFRESH_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(correctionRefreshes.length, 0);
     assert.ok(detailCalls.length <= MND_MAX_DETAIL_REQUESTS_PER_RUN);
     assert.ok(clock <= MND_OUTBOUND_BUDGET_MS);
   });
@@ -3724,11 +3725,11 @@ describe('quantified cross-Strait activity (#5575)', () => {
       mndOutcome: {
         ok: true,
         requestCount: 0,
-        observations: Array.from({ length: 28 }, (_, index) => mndObservationForDay(index + 1)),
+        observations: Array.from({ length: MND_REQUIRED_REPORTING_DAYS }, (_, index) => mndObservationForDay(index + 1)),
       },
       japanOutcome: { ok: true, requestCount: 0, availableDocumentUrls: [] },
     });
-    const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    const list = mndListWithCount(1);
     const detailCalls: string[] = [];
     let firstCorrectionUrl = '';
     let clock = 0;
@@ -3739,7 +3740,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
       detailCalls.push(url);
       const isCorrection = /\/PLAAct\/860\d{2}$/.test(url);
       if (isCorrection && firstCorrectionUrl === '') firstCorrectionUrl = url;
-      clock += url === firstCorrectionUrl ? 15_000 : 13_000;
+      clock += isCorrection ? (url === firstCorrectionUrl ? 15_000 : 13_000) : 130_000;
       return new Response(
         url === firstCorrectionUrl
           ? mndDetailWithoutPublicationMetadata()
@@ -3762,10 +3763,212 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.ok(detailCalls.length <= MND_MAX_DETAIL_REQUESTS_PER_RUN);
     assert.ok(clock <= MND_OUTBOUND_BUDGET_MS);
     assert.equal(mnd?.transportStatus, 'fresh');
-    assert.deepEqual(mnd?.errorCodes, ['OUTBOUND_BUDGET_EXHAUSTED']);
+    assert.deepEqual(mnd?.errorCodes, []);
     assert.ok(mnd?.refreshErrorCodes.includes('MND_PUBLICATION_METADATA_MISSING'));
     assert.ok(mnd?.refreshErrorCodes.includes('OUTBOUND_BUDGET_EXHAUSTED'));
   });
+
+  for (const failure of ['timeout', 'budget'] as const) {
+  it(`keeps complete retained current-list coverage through optional refresh ${failure}`, async () => {
+    const original = parseTaiwanMndDetail(fixture('mnd-detail.html'), {
+      sourceUrl: 'https://www.mnd.gov.tw/en/News/PLAAct/90000',
+      retrievedAt,
+      expectedPublicationDay: '2026-07-25',
+    });
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt, previousSnapshot: null,
+      mndOutcome: { ok: true, observations: [original, ...Array.from(
+        { length: MND_REQUIRED_REPORTING_DAYS }, (_, index) => mndObservationForDay(index + 1),
+      )] },
+      japanOutcome: { ok: true, availableDocumentUrls: [] },
+    });
+    const detailCalls: string[] = [];
+    const nextRun = '2026-07-25T11:30:00.000Z';
+    let clock = 0;
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      previousSnapshot, now: Date.parse(nextRun), nowFn: () => clock, sleepFn: async () => {},
+      fetchFn: async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+        if (url.includes('plaactlist')) {
+          if (failure === 'budget') clock = MND_OUTBOUND_BUDGET_MS;
+          return new Response(mndListWithCount(1));
+        }
+        detailCalls.push(url);
+        throw new Error('request timeout');
+      },
+    });
+    const mnd = snapshot.sources[0];
+    assert.equal(mnd.transportStatus, 'fresh');
+    assert.equal(mnd.lastSuccessAt, nextRun);
+    assert.deepEqual(mnd.errorCodes, []);
+    assert.deepEqual(mnd.refreshErrorCodes, [failure === 'timeout' ? 'TIMEOUT' : 'OUTBOUND_BUDGET_EXHAUSTED']);
+    if (failure === 'timeout') assert.equal(detailCalls[0], original.sourceUrl);
+    assert.equal(new Set(detailCalls).size, failure === 'timeout' ? MND_REFRESH_DETAIL_REQUESTS_PER_RUN : 0);
+    assert.ok(mnd.requestDiagnostics.every((row: { purpose: string }) => row.purpose === 'refresh'));
+    assert.deepEqual(snapshot.observations, previousSnapshot.observations);
+  });
+  }
+
+  for (const invalid of ['changed-date', 'different-url', 'period', 'counts', 'category-keys', 'revision', 'provenance', 'publication'] as const) {
+    it(`requires current detail work for retained ${invalid} evidence`, async () => {
+      const original = parseTaiwanMndDetail(fixture('mnd-detail.html'), {
+        sourceUrl: 'https://www.mnd.gov.tw/en/News/PLAAct/90000',
+        retrievedAt, expectedPublicationDay: '2026-07-25',
+      });
+      const previousSnapshot = buildCrossStraitActivitySnapshot({
+        generatedAt: retrievedAt, previousSnapshot: null,
+        mndOutcome: { ok: true, observations: [original] },
+        japanOutcome: { ok: true, availableDocumentUrls: [] },
+      });
+      const row = previousSnapshot.observations[0];
+      if (invalid === 'different-url') row.sourceUrl += '1';
+      if (invalid === 'period') row.reportingPeriod.end = row.reportingPeriod.start;
+      if (invalid === 'counts') row.categories.planShips = -1;
+      if (invalid === 'category-keys') {
+        delete row.categories.planShips;
+        row.categories.unknown = 1;
+      }
+      if (invalid === 'revision') row.revision.sequence = 0;
+      if (invalid === 'provenance') row.provenance.familyId = 'unknown';
+      if (invalid === 'publication') row.publicationTime = 'invalid';
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        previousSnapshot, now: Date.parse('2026-07-26T08:30:00.000Z'), sleepFn: async () => {},
+        fetchFn: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+          if (url.includes('plaactlist')) return new Response(invalid === 'changed-date'
+            ? mndListWithCount(1).replaceAll('2026.07.25', '2026.07.26') : mndListWithCount(1));
+          throw new Error('request timeout');
+        },
+      });
+      assert.equal(snapshot.sources[0].transportStatus, 'error');
+      assert.equal(snapshot.sources[0].lastSuccessAt, retrievedAt);
+      assert.ok(snapshot.sources[0].errorCodes.includes('TIMEOUT'));
+      assert.ok(snapshot.sources[0].requestDiagnostics.some(d => d.purpose === 'detail' && d.path.endsWith('/90000')));
+    });
+  }
+
+  it('fetches a required row beyond twenty covered list entries before deterministic current corrections', async () => {
+    const retained = Array.from({ length: MND_REQUIRED_REPORTING_DAYS }, (_, index) => mndObservationForDay(index + 1));
+    const current = retained.slice(0, 21);
+    const knownList = current.map(row => `<a class="news_list" href="${row.sourceUrl}">
+      <h5 class="date">${row.publicationTime.slice(0, 10).replaceAll('-', '.')}</h5></a>`).join('');
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt, previousSnapshot: null,
+      mndOutcome: { ok: true, observations: retained },
+      japanOutcome: { ok: true, availableDocumentUrls: [] },
+    });
+    const run = async (now: number) => {
+      const calls: string[] = [];
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        now, previousSnapshot, sleepFn: async () => {},
+        fetchFn: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+          if (url.includes('plaactlist')) return new Response(`<div class="wrap-page3">${knownList}</div>${mndListWithCount(1)}`);
+          calls.push(url);
+          if (url.endsWith('/90000')) return new Response(fixture('mnd-detail.html'));
+          throw new Error('request timeout');
+        },
+      });
+      assert.equal(calls[0], 'https://www.mnd.gov.tw/en/News/PLAAct/90000');
+      assert.equal(new Set(calls).size, 1 + MND_REFRESH_DETAIL_REQUESTS_PER_RUN);
+      assert.equal(snapshot.sources[0].transportStatus, 'fresh');
+      assert.deepEqual(snapshot.sources[0].errorCodes, []);
+      const expected = current[Math.floor(now / (3 * 60 * 60_000)) % current.length].sourceUrl;
+      assert.equal(calls[1], expected);
+      return calls;
+    };
+    const now = Date.parse(retrievedAt);
+    assert.deepEqual(await run(now), await run(now));
+    assert.notEqual((await run(now + 3 * 60 * 60_000))[1], (await run(now))[1]);
+  });
+
+  it('continues staged backfill discovery when twenty current rows already have retained coverage', async () => {
+    const retained = Array.from({ length: 20 }, (_, index) => mndObservationForDay(index + 1));
+    const knownList = `<div class="wrap-page3">${retained.map(row => `<a href="${row.sourceUrl}">
+      <h5 class="date">${row.publicationTime.slice(0, 10).replaceAll('-', '.')}</h5></a>`).join('')}</div>`;
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt, previousSnapshot: null,
+      mndOutcome: { ok: true, observations: retained },
+      japanOutcome: { ok: true, availableDocumentUrls: [] },
+    });
+    const details: string[] = [];
+    await fetchCrossStraitActivitySnapshot({
+      previousSnapshot, now: Date.parse(retrievedAt), sleepFn: async () => {},
+      fetchFn: async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+        if (url.endsWith('/plaactlist')) return new Response(knownList);
+        if (url.includes('plaactlist')) return new Response(mndListWithCount(20));
+        details.push(url);
+        return new Response(fixture('mnd-detail.html'));
+      },
+    });
+    assert.equal(details.length, MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    assert.ok(details.every(url => /\/900\d{2}$/.test(url)));
+  });
+
+  it('rotates through every historical report when a current correction uses one of three slots', async () => {
+    const currentUrl = 'https://www.mnd.gov.tw/en/News/PLAAct/90000';
+    const current = parseTaiwanMndDetail(fixture('mnd-detail.html'), {
+      sourceUrl: currentUrl, retrievedAt, expectedPublicationDay: '2026-07-25',
+    });
+    const historical = [1, 2, 3].map(day => mndObservationForDay(day));
+    const previousSnapshot = buildCrossStraitActivitySnapshot({
+      generatedAt: retrievedAt, previousSnapshot: null,
+      mndOutcome: { ok: true, observations: [current, ...historical] },
+      japanOutcome: { ok: true, availableDocumentUrls: [] },
+    });
+    const refreshed = new Set<string>();
+    for (let run = 0; run < 3; run += 1) {
+      await fetchCrossStraitActivitySnapshot({
+        previousSnapshot, now: Date.parse(retrievedAt) + run * 3 * 60 * 60_000, sleepFn: async () => {},
+        fetchFn: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+          if (url.includes('plaactlist')) return new Response(mndListWithCount(1));
+          if (url !== currentUrl) refreshed.add(url);
+          throw new Error('request timeout');
+        },
+      });
+    }
+    assert.deepEqual(refreshed, new Set(historical.map(row => row.sourceUrl)));
+  });
+
+  for (const correction of ['unchanged-day', 'advanced-day'] as const) {
+    it(`merges a successful current correction with ${correction} through the existing revision path`, async () => {
+      const sourceUrl = 'https://www.mnd.gov.tw/en/News/PLAAct/90000';
+      const original = parseTaiwanMndDetail(fixture('mnd-detail.html'), {
+        sourceUrl, retrievedAt, expectedPublicationDay: '2026-07-25',
+      });
+      const previousSnapshot = buildCrossStraitActivitySnapshot({
+        generatedAt: retrievedAt, previousSnapshot: null,
+        mndOutcome: { ok: true, observations: [original] },
+        japanOutcome: { ok: true, availableDocumentUrls: [] },
+      });
+      const corrected = fixture('mnd-detail-corrected.html');
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        previousSnapshot, now: Date.parse('2026-07-26T09:00:00.000Z'), sleepFn: async () => {},
+        fetchFn: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.includes('mod.go.jp')) return new Response(fixture('jmod-homepage.html'));
+          if (url.includes('plaactlist')) return new Response(correction === 'advanced-day'
+            ? mndListWithCount(1).replaceAll('2026.07.25', '2026.07.26') : mndListWithCount(1));
+          return new Response(correction === 'advanced-day' ? corrected : corrected.replace('2026.07.26', '2026.07.25'));
+        },
+      });
+      const row = snapshot.observations[0];
+      assert.equal(snapshot.sources[0].transportStatus, 'fresh');
+      assert.equal(row.categories.plaAircraftSorties, 30);
+      assert.equal(row.reportingDay, original.reportingDay);
+      assert.equal(row.revision.sequence, 2);
+      assert.equal(row.history.length, 1);
+      assert.equal(row.history[0].revision.vintageId, original.revision.vintageId);
+      assert.equal(row.provenance.familyId, original.provenance.familyId);
+    });
+  }
 
   it('keeps current MND health fresh when an optional correction stays malformed after retry', async () => {
     const previousSnapshot = buildCrossStraitActivitySnapshot({
@@ -4097,7 +4300,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     );
     assert.equal(knownUrlRows.length, 1);
     assert.equal(knownUrlRows[0].reportingDay, '2026-07-25');
-    assert.ok(snapshot.sources[0].errorCodes.includes('MND_REPORTING_DAY_MISMATCH'));
+    assert.ok(snapshot.sources[0].refreshErrorCodes.includes('MND_REPORTING_DAY_MISMATCH'));
   });
 
   it('publishes long-lived history with freshness anchored to the latest reporting window', () => {


### PR DESCRIPTION
## Summary

MND source health can report a whole-source error even when its current official list is fully covered by retained reports: optional correction requests time out and no newly parsed report is available. This change accepts that coverage only when every current row has a validated retained report with the exact URL and publication day, or its required detail fetch succeeds.

Required new/changed detail work uses capacity first. Up to three optional corrections then cover one rotating current report and the remaining historical rotation. Unresolved current rows, unsafe retained evidence, and failed or empty lists remain errors. Document clocks, correction history, staged backfill, request/time limits, proxy retries, schedules, keys, schemas, and health thresholds retain their contracts.

## Validation

- Characterization failed before implementation: complete retained coverage plus timed-out details returned `error` instead of `fresh`.
- 183 adapter and shipping tests pass. These include exact URL/date matching, invalid retained records, required-work priority/caps, optional time-budget expiry, historical rotation, staged backfill, and correction revisions.
- Producer-to-reader fixtures run the real collector, source-health writer, and health classifier: unchanged coverage yields `OK`; changed-date and empty lists yield `SEED_ERROR`; document clocks stay unchanged.
- Contract typecheck, scoped Biome lint, 141 Railway registry tests, and diff hygiene pass.
- Sequential code review found and repaired rotation starvation and premature backfill termination. No remaining actionable findings. The separate Claude review attempt returned no usable result.

## Post-Deploy Monitoring & Validation

Post-merge acceptance remains pending. After an authorized deployment, the owning maintainer should observe two consecutive natural Cross-Strait runs. Inspect `[cross-strait] MND request failures`, Taiwan MND source `requestDiagnostics`, `refreshErrorCodes`, `errorCodes`, `lastAttemptAt`, `lastSuccessAt`, and the `crossStraitActivityTaiwanMnd` health entry. Confirm the deployed commit includes this change; complete retained coverage stays fresh despite optional errors; new required reports advance actual document clocks; unresolved required rows remain visible errors. Request counts must remain within 20 detail and 11 list attempts and the 200-second outbound budget. Any false fresh result for incomplete required coverage is a mitigation/rollback trigger. No production mutation or natural-run validation was performed for this PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
