### PR TITLE
feat(compare): disclose measurement sources and dated snapshots

### DIFF
--- a/scripts/build-comparison-pages.mjs
+++ b/scripts/build-comparison-pages.mjs
@@ -16,12 +16,13 @@ import { join } from 'node:path';
 import { CHOKEPOINT_REGISTRY } from '../src/config/chokepoint-registry.ts';
 import {
   COMPARE_HUB_NARRATIVE,
+  COMPARISON_MEASUREMENTS,
   COMPARISON_NARRATIVES,
 } from './comparison-page-narratives.mjs';
 import { computeStats } from './docs-stats.mjs';
 
 /** Bump when hub or child copy changes so lastmod advances without touching every sibling. */
-export const COMPARISONS_CONTENT_VERSION = '2026-09-06';
+export const COMPARISONS_CONTENT_VERSION = '2026-09-08';
 
 /**
  * Universal comparison-matrix columns. Engines lift these cells verbatim, so
@@ -573,7 +574,23 @@ function comparisonWebPageLd({ name, description, url, lastmod, faqId, baseUrl }
   };
 }
 
-function renderComparePage(page, { tpl, baseUrl, lastmod }) {
+function renderMeasurement(slug, snapshotDate, escapeHtml) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(snapshotDate ?? '')) {
+    throw new Error('Comparison measurement requires the captured snapshot date');
+  }
+  const paragraphs = COMPARISON_MEASUREMENTS[slug];
+  if (!paragraphs?.length) throw new Error(slug + ' needs a World Monitor measurement explanation');
+  const maritime = slug === 'chokepoint-monitoring-tools';
+  const snapshotPath = maritime ? '/chokepoints/status.json' : '/country-instability-index/cii-ranking.json';
+  return [
+    '      <h2>How World Monitor measures this</h2>',
+    ...renderParagraphs(paragraphs, escapeHtml),
+    '      <p>Coverage: the <a href="/sources/">source catalog</a> lists ' + escapeHtml(formatCount(WORLD_MONITOR_PROVIDER_COUNT)) + ' active providers across the product, not per metric. Availability varies by source and location.</p>',
+    '      <p data-measurement-snapshot><a href="' + snapshotPath + '">Published ' + (maritime ? 'chokepoint status' : 'country instability') + ' snapshot</a>, captured <time datetime="' + escapeHtml(snapshotDate) + '">' + escapeHtml(snapshotDate) + '</time>. This reference remains dated when live values change.</p>',
+  ];
+}
+
+function renderComparePage(page, { tpl, baseUrl, lastmod, snapshotDate }) {
   const { escapeHtml, breadcrumbLd, pageDocument } = tpl;
   const pageUrl = new URL(page.path, baseUrl).href;
   const description = page.h1
@@ -622,6 +639,8 @@ function renderComparePage(page, { tpl, baseUrl, lastmod }) {
     '',
     '      <h2>Comparison matrix</h2>',
     renderMatrix(page.matrixRows, escapeHtml),
+    '',
+    ...renderMeasurement(page.slug, snapshotDate, escapeHtml),
     '',
     '      <h2>When to choose them instead</h2>',
     '      <p>' + escapeHtml(page.concessionIntro) + '</p>',
@@ -715,7 +734,7 @@ export function comparisonDiscoveryEntries(baseUrl) {
   return [hub, ...pages];
 }
 
-function renderCompareHub({ tpl, baseUrl, lastmod }) {
+function renderCompareHub({ tpl, baseUrl, lastmod, snapshotDate }) {
   const { escapeHtml, breadcrumbLd, pageDocument } = tpl;
   const path = COMPARE_HUB_PATH;
   const description = COMPARE_HUB_DESCRIPTION;
@@ -737,6 +756,8 @@ function renderCompareHub({ tpl, baseUrl, lastmod }) {
     '',
     '      <h2>Master comparison matrix</h2>',
     renderMatrix(COMPARISON_HUB_MATRIX_ROWS, escapeHtml),
+    '',
+    ...renderMeasurement('hub', snapshotDate, escapeHtml),
     '',
     ...renderHeadingSection(
       COMPARE_HUB_NARRATIVE.concessions.heading,
@@ -784,17 +805,17 @@ function renderCompareHub({ tpl, baseUrl, lastmod }) {
   });
 }
 
-export function writeComparisonPages({ outDir, baseUrl, tpl, lastmod = COMPARISONS_CONTENT_VERSION }) {
+export function writeComparisonPages({ outDir, baseUrl, tpl, snapshotDate, lastmod = COMPARISONS_CONTENT_VERSION }) {
   mkdirSync(join(outDir, 'compare'), { recursive: true });
   writeFileSync(
     join(outDir, 'compare', 'index.html'),
-    renderCompareHub({ tpl, baseUrl, lastmod }),
+    renderCompareHub({ tpl, baseUrl, lastmod, snapshotDate }),
   );
   for (const page of COMPARISON_PAGES) {
     mkdirSync(join(outDir, 'compare', page.slug), { recursive: true });
     writeFileSync(
       join(outDir, 'compare', page.slug, 'index.html'),
-      renderComparePage(page, { tpl, baseUrl, lastmod }),
+      renderComparePage(page, { tpl, baseUrl, lastmod, snapshotDate }),
     );
   }
 }

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -537,8 +537,9 @@ export function sourcePageLastmod({
 export function comparisonPageLastmod({
   contentVersion = COMPARISONS_CONTENT_VERSION,
   pathLastmods = [],
+  snapshotDate,
 } = {}) {
-  return laterDate(contentVersion, ...pathLastmods);
+  return laterDate(contentVersion, ...pathLastmods, snapshotDate);
 }
 
 function normalizeBaseUrl(baseUrl) {
@@ -1743,6 +1744,7 @@ export async function loadCorpusData({ rootDir = DEFAULT_ROOT, livePulseSnapshot
   const comparisonsLastmod = comparisonPageLastmod({
     contentVersion: COMPARISONS_CONTENT_VERSION,
     pathLastmods: COMPARISON_PAGE_LASTMOD_PATHS.map((path) => gitFileLastmod(rootDir, path)),
+    snapshotDate: livePulse.capturedAt,
   });
   const attributionManifest = readJson(rootDir, SOURCE_ATTRIBUTION_MANIFEST_PATH);
   // Production generators share the validated attribution predicate and stats.
@@ -5292,6 +5294,7 @@ export async function buildCorpus({
     outDir,
     baseUrl,
     lastmod: data.lastmod.comparisons,
+    snapshotDate: data.livePulse.capturedAt,
     tpl: { escapeHtml, absoluteUrl, breadcrumbLd, withUtmSource, pageDocument },
   });
 

--- a/scripts/comparison-page-narratives.mjs
+++ b/scripts/comparison-page-narratives.mjs
@@ -15,6 +15,65 @@ const CHOKEPOINT_COUNT = CHOKEPOINT_REGISTRY.length;
 // count (#6038 / #7744).
 const PROVIDER_COUNT = computeStats().sourceAttribution.providerCount.toLocaleString('en-US');
 
+// Source contracts: conflict/v1/list-acled-events.ts (15-minute cache),
+// seed-gdelt-bulk-materializer.mjs (15-minute batches), seed-ucdp-events.mjs
+// (annual GED and monthly Candidate releases), seed-bundle-portwatch.mjs
+// (6-hour transit refresh), and supply-chain/v1/get-chokepoint-status.ts.
+export const COMPARISON_MEASUREMENTS = {
+  hub: [
+    'World Monitor combines separate measurements rather than treating every map marker as the same kind of evidence. GDELT supplies news and event data in 15-minute batches; UCDP supplies coded conflict events from annual GED and monthly Candidate releases; AISStream supplies streaming vessel positions. These sources answer different questions: reported attention, recorded violence, and observed traffic. Their timestamps and geographic coverage can differ even when they appear together on the dashboard.',
+    'ACLED event requests use a 15-minute cache, which does not make ACLED publish new events every 15 minutes. Maritime monitoring covers ' + CHOKEPOINT_COUNT + ' maritime chokepoints from the shared registry. Check the country snapshot below for dated risk context; it is not a simultaneous capture of every feed.',
+  ],
+  'liveuamap-alternatives': [
+    'World Monitor places UCDP coded violence and ACLED conflict events alongside GDELT news context. UCDP distinguishes state-based, non-state, and one-sided violence. ACLED requests select event dates and countries, while GDELT provides reported developments. A headline and a coded event can describe the same incident, so adding their totals would not produce a reliable count of unique attacks.',
+    'GDELT ingestion follows 15-minute batches. ACLED responses are cached for 15 minutes; source publication can lag that interval. UCDP annual GED and monthly Candidate releases provide slower historical evidence. The linked country snapshot shows the risk context available at capture time. It does not certify frontline positions or make every report independently verified.',
+  ],
+  'best-geopolitical-risk-dashboards': [
+    'World Monitor presents country instability alongside the evidence that gives a score context. GDELT supplies news and event data, UCDP supplies coded violence, and IMF PortWatch supplies daily vessel-transit history for maritime monitoring. These series measure different activity: news volume is not a count of casualties, and a shipping slowdown is not a probability of conflict. Read the published country score with its method version and observation time.',
+    'GDELT batches arrive on a 15-minute cycle. World Monitor refreshes PortWatch history every 6 hours, while UCDP Candidate releases are monthly. Faster dashboard access cannot remove those source delays. The dated country snapshot below supports a reproducible comparison; missing or partial evidence must remain visible when interpreting a country ranking.',
+  ],
+  'worldmonitor-vs-liveuamap': [
+    'World Monitor builds its conflict view from sources including ACLED and UCDP, then adds GDELT reporting and AISStream vessel observations as separate context. ACLED records events such as battles and violence against civilians. UCDP provides coded violence categories. AIS positions describe reported vessel movements, not confirmation that a nearby conflict caused a disruption. This separation matters when comparing a multi-domain dashboard with a conflict-event map.',
+    'ACLED responses use a 15-minute cache; GDELT ingestion follows 15-minute batches; AISStream sends vessel messages as they arrive. None of these intervals guarantees immediate reporting of an incident. The linked country snapshot records dated risk context, so a reader can distinguish the captured assessment from later live developments.',
+  ],
+  'worldmonitor-vs-acled': [
+    'World Monitor uses ACLED as an upstream conflict source rather than reproducing its coding operation. The event handler requests battles, explosions and remote violence, and violence against civilians, with date and country filters. UCDP supplies a separate coded-violence series. GDELT adds news context. These inputs retain different definitions and publication delays; their presence on one dashboard does not make them a single interchangeable event dataset.',
+    'World Monitor caches ACLED requests for 15 minutes. That is a retrieval interval, not a promise that ACLED releases new records at that speed. UCDP combines annual GED and monthly Candidate releases. The dated country snapshot below documents downstream risk context; it is not an ACLED archive or a substitute for the original event records and license.',
+  ],
+  'worldmonitor-vs-gdelt': [
+    'World Monitor ingests GDELT bulk event and Global Knowledge Graph batches to prepare country news and topic views. The materializer checks that event and GKG batches cover matching time intervals before publishing them. This turns the upstream stream into bounded dashboard results, rather than exposing the complete GDELT archive. A country news count describes reporting activity; it cannot by itself establish how many distinct incidents occurred.',
+    'The ingestion schedule follows 15-minute GDELT batches, and source gaps can delay publication. UCDP coded violence remains a separate source with annual GED and monthly Candidate releases. The linked country snapshot provides a dated downstream reference. Its capture date must not be mistaken for the event date of each GDELT article.',
+  ],
+  'worldmonitor-vs-dataminr': [
+    'World Monitor derives its public monitoring context from named feeds, including GDELT news and event batches, ACLED conflict events, and USGS earthquake observations. The earthquake pipeline also reads Natural Resources Canada. These streams provide reported developments and measured hazards; they do not establish access to a proprietary social-data firehose. A displayed report should be checked against its original source before a team treats it as an operational alert.',
+    'GDELT ingestion runs on a 15-minute cycle, ACLED responses use a 15-minute cache, and the earthquake worker is scheduled every 5 minutes. These are collection schedules, not guaranteed detection times. The dated country snapshot below gives reproducible risk context for comparison with live alerting products, without implying an alert-delivery SLA.',
+  ],
+  'worldmonitor-vs-recorded-future': [
+    'World Monitor uses feeds including abuse.ch Feodo Tracker and URLhaus for cyber indicators, with GDELT reporting and UCDP conflict events providing separate geopolitical context. Feodo identifies reported command-and-control infrastructure; URLhaus supplies reported malicious URLs and requires configured access. An indicator location is not proof of an attacker\'s location or attribution. These feeds do not constitute a complete enterprise investigation record.',
+    'The cyber worker is scheduled every 2 hours; GDELT ingestion follows 15-minute batches and UCDP Candidate releases are monthly. Results depend on source access and successful refresh. Check the observation time on each indicator. The linked country snapshot is dated geopolitical context, not a frozen cyber-indicator archive or a claim about enterprise threat coverage.',
+  ],
+  'worldmonitor-vs-deepstatemap': [
+    'World Monitor uses UCDP coded violence, ACLED conflict events, and GDELT reporting to place Ukraine developments in wider country and regional context. UCDP event locations describe coded incidents; they are not a continuously surveyed front line. News locations likewise indicate where reporting concerns an event, rather than verified control of each settlement. Readers should keep that distinction when comparing event markers with analyst-maintained territorial geometry.',
+    'GDELT ingestion follows 15-minute batches and ACLED requests use a 15-minute cache. UCDP annual GED and monthly Candidate releases have longer publication delays. The dated country snapshot below supports review of the captured instability context. It cannot confirm current unit positions, tactical movement, or territorial control at the time a reader opens this page.',
+  ],
+  'mcp-servers-for-geopolitical-data': [
+    'World Monitor\'s MCP interface exposes source-backed datasets rather than making the language model the original observer. Maritime results draw on AISStream vessel observations and IMF PortWatch transit history; conflict context includes UCDP and ACLED; news views use GDELT. A tool response must be interpreted with the dataset\'s observation time and availability fields. Calling a tool now does not mean that every upstream measurement was made now.',
+    'GDELT ingestion follows 15-minute batches, ACLED requests use a 15-minute cache, and PortWatch transit history refreshes every 6 hours. Coverage differs by tool and source, even though they share an interface. The dated country snapshot below is a reproducible example of published risk context, not a guarantee that every MCP result has the same timestamp.',
+  ],
+  'chokepoint-monitoring-tools': [
+    'World Monitor combines IMF PortWatch daily transit history, AISStream vessel crossings over a rolling 24-hour window, and NGA navigational warnings. Its shared registry defines ' + CHOKEPOINT_COUNT + ' maritime chokepoints. PortWatch supports week-on-week traffic comparisons; AISStream supplies observed crossings; NGA adds safety notices. The disruption score combines traffic anomalies, nearby warnings, AIS disruptions, and threat baselines. A high score signals risk, not verified closure.',
+    'World Monitor refreshes PortWatch history every 6 hours. AISStream messages arrive continuously, while the combined status response uses a 5-minute cache. Upstream reporting can lag those schedules, and missing AIS coverage is not proof of zero traffic. The snapshot below preserves the captured status and source availability for each monitored waterway; it is not a vessel-level archive.',
+  ],
+  'free-geopolitical-risk-dashboards': [
+    'World Monitor\'s free dashboard displays measurements from named public sources, including GDELT news and events, UCDP coded violence, and USGS earthquakes. The earthquake pipeline also uses Natural Resources Canada. Free access does not make every source equally complete: reported news, coded conflict, and instrument-detected seismic events have different observation methods and geographic gaps. A quiet map alone cannot establish that a country has no risk.',
+    'GDELT ingestion follows 15-minute batches and the earthquake worker runs every 5 minutes. UCDP annual GED and monthly Candidate releases provide slower conflict evidence. The dated country snapshot below lets readers inspect published risk context without relying on the current screen. Check its observation times and the source coverage before treating a displayed ranking as current.',
+  ],
+  'travel-risk-intelligence-vs-assistance': [
+    'World Monitor provides travel-risk context from country advisories, conflict reporting, and observed hazards. GDELT supplies news and event data, ACLED supplies conflict events, and the earthquake pipeline reads USGS and Natural Resources Canada. These observations can help a traveler identify a development that needs investigation. They do not establish whether a particular road, hotel, airport, or evacuation route is safe.',
+    'GDELT ingestion follows 15-minute batches, ACLED requests use a 15-minute cache, and earthquake collection runs every 5 minutes. Official advisory publication follows the issuing authority\'s schedule. The dated country snapshot below records captured instability context. Check current official advice before travel; World Monitor does not dispatch assistance, arrange medical evacuation, or manage an emergency case.',
+  ],
+};
+
 function methodology(
   focus,
   recheck = 'Vendors change SKUs, so re-check the linked vendor page before you buy.',

--- a/tests/compare-page-product-facts.test.mjs
+++ b/tests/compare-page-product-facts.test.mjs
@@ -80,9 +80,10 @@ const tpl = {
 function renderedComparePages() {
   const lastmod = '2026-09-05';
   const baseUrl = 'https://www.worldmonitor.app';
+  const snapshotDate = '2026-09-04';
   return [
-    ['hub', __test.renderCompareHub({ tpl, baseUrl, lastmod })],
-    ...COMPARISON_PAGES.map((page) => [page.slug, __test.renderComparePage(page, { tpl, baseUrl, lastmod })]),
+    ['hub', __test.renderCompareHub({ tpl, baseUrl, lastmod, snapshotDate })],
+    ...COMPARISON_PAGES.map((page) => [page.slug, __test.renderComparePage(page, { tpl, baseUrl, lastmod, snapshotDate })]),
   ];
 }
 

--- a/tests/comparison-pages-narrative.test.mjs
+++ b/tests/comparison-pages-narrative.test.mjs
@@ -15,6 +15,8 @@ import {
   COMPARISON_PAGES,
   writeComparisonPages,
 } from '../scripts/build-comparison-pages.mjs';
+import { CHOKEPOINT_REGISTRY } from '../src/config/chokepoint-registry.ts';
+import { computeStats } from '../scripts/docs-stats.mjs';
 
 /** Empty keyword H2s were 0 following characters. A real paragraph clears this. */
 const MIN_H2_FOLLOWING_CHARS = 80;
@@ -170,6 +172,7 @@ describe('comparison page narrative depth (#7743)', () => {
       outDir,
       baseUrl: 'https://www.worldmonitor.app',
       tpl: stubTpl,
+      snapshotDate: '2026-01-17',
     });
     hubHtml = readFileSync(join(outDir, 'compare', 'index.html'), 'utf8');
     for (const page of COMPARISON_PAGES) {
@@ -192,6 +195,36 @@ describe('comparison page narrative depth (#7743)', () => {
         VS_SLUGS.has(page.slug) || MULTI_SLUGS.has(page.slug),
         page.slug + ' must be classified as vs-* or multi-product',
       );
+    }
+  });
+
+  it('discloses a topic-specific method, coverage, cadence and dated snapshot on all 13 pages (#7868)', () => {
+    const providerCount = computeStats().sourceAttribution.providerCount.toLocaleString('en-US');
+    const methods = new Set();
+    for (const [slug, html] of [['hub', hubHtml], ...pages]) {
+      const main = mainEl(html);
+      const sections = h2Sections(main).filter(({ heading }) => heading === 'How World Monitor measures this');
+      assert.equal(sections.length, 1, `${slug} needs exactly one measurement section`);
+      const copy = sections[0].following;
+      assert.ok(wordCount(copy) >= 120 && wordCount(copy) <= 180, `${slug}: ${wordCount(copy)} method words`);
+      assert.match(copy, /GDELT|UCDP|AISStream|Feodo|USGS/, `${slug} must name upstream feeds`);
+      assert.match(copy, /minute|hour|daily|weekly|monthly|stream/i, `${slug} must describe cadence`);
+      assert.ok(copy.includes(`${providerCount} active providers`), `${slug} must use reconciled coverage`);
+      const heading = [...main.querySelectorAll('h2')].find((node) => node.textContent === sections[0].heading);
+      const firstParagraph = heading.nextElementSibling.textContent;
+      assert.ok(!methods.has(firstParagraph), `${slug} must have its own method explanation`);
+      methods.add(firstParagraph);
+      const snapshot = main.querySelector('[data-measurement-snapshot]');
+      assert.equal(snapshot?.querySelector('time')?.getAttribute('datetime'), '2026-01-17');
+      assert.match(snapshot.textContent, /2026-01-17/, `${slug} must show the capture date, not publication date`);
+      const expectedPath = slug === 'chokepoint-monitoring-tools' ? '/chokepoints/status.json' : '/country-instability-index/cii-ranking.json';
+      assert.equal(snapshot.querySelector('a').getAttribute('href'), expectedPath);
+      assert.ok(main.querySelector('a[href="/sources/"]'), `${slug} must link the source catalog`);
+      if (slug === 'chokepoint-monitoring-tools') {
+        for (const source of ['AISStream', 'IMF PortWatch', 'NGA']) assert.ok(copy.includes(source));
+        assert.ok(copy.includes(`${CHOKEPOINT_REGISTRY.length} maritime chokepoints`));
+        assert.match(copy, /6 hours/);
+      }
     }
   });
 

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -4851,8 +4851,9 @@ describe('crawlable corpus generator', () => {
       comparisonPageLastmod({
         contentVersion: COMPARISONS_CONTENT_VERSION,
         pathLastmods: COMPARISON_PAGE_LASTMOD_PATHS.map((path) => gitFileLastmod(repoRoot, path)),
+        snapshotDate: data.livePulse.capturedAt,
       }),
-      'comparisons lastmod must fold the generator, narratives, attribution manifest, and chokepoint registry',
+      'comparisons lastmod must fold the copy, registries, and referenced snapshot',
     );
     assert.equal(
       data.crises.length,
@@ -5044,6 +5045,8 @@ describe('live-pulse snapshot injection (#7533)', () => {
         CII_RANKING_PAGE_CONTENT_VERSION,
         CHOKEPOINT_PAGE_CONTENT_VERSION,
         CRISIS_PAGE_CONTENT_VERSION,
+        COMPARISONS_CONTENT_VERSION,
+        ...COMPARISON_PAGE_LASTMOD_PATHS.map((path) => gitFileLastmod(repoRoot, path)),
       ].filter(Boolean).sort().at(-1);
       const pulseDate = !latestOther || latestOther < today ? today : dayAfter(latestOther);
       if (pulseDate !== today) {
@@ -5063,6 +5066,16 @@ describe('live-pulse snapshot injection (#7533)', () => {
           livePulseSnapshotPath: join(pulseDir, `crawlable-live-pulse-${pulseDate}.json`),
         });
         const pageFor = (route) => `${route.slice(1)}index.html`;
+        for (const route of [manifest.sections.comparisons.index, ...manifest.sections.comparisons.routes]) {
+          const document = htmlDocument(read(outDir, pageFor(route)), `https://www.worldmonitor.app${route}`);
+          const reference = document.querySelector('[data-measurement-snapshot]');
+          assert.ok(reference, `${route} needs a snapshot reference`);
+          assert.equal(reference.querySelector('time').getAttribute('datetime'), pulseDate);
+          const downloadPath = reference.querySelector('a').getAttribute('href').slice(1);
+          const download = JSON.parse(read(outDir, downloadPath));
+          assert.equal(download.capturedAt, pulseDate, `${route} must link the actual referenced snapshot`);
+          assert.equal(data.lastmod.comparisons, pulseDate, 'new snapshot must advance comparison lastmod');
+        }
         const countriesLastmod = laterDate(
           data.resilience.capturedAt,
           pulseDate,
@@ -5142,6 +5155,7 @@ describe('live-pulse snapshot injection (#7533)', () => {
             comparisonPageLastmod({
               contentVersion: COMPARISONS_CONTENT_VERSION,
               pathLastmods: COMPARISON_PAGE_LASTMOD_PATHS.map((path) => gitFileLastmod(repoRoot, path)),
+              snapshotDate: pulseDate,
             }),
             pageFor(manifest.sections.comparisons.index),
           ]],


### PR DESCRIPTION
## Summary

Readers of all 13 comparison pages can now see how World Monitor obtains its own measurements: named upstream feeds, collection and publication schedules, reconciled coverage, and a dated snapshot download. Each page has a topic-specific 120–180 word “How World Monitor measures this” section. Snapshot dates come from the same capture as the published datasets and advance the comparison sitemap metadata when the capture changes.

This improves method disclosure. It does not establish indexing, ranking, or AI citation outcomes.

Fixes #7868

## Validation

- 138 comparison and corpus tests pass. The new section test failed before implementation; the full corpus test then caught a wrong snapshot URL, which was corrected and verified against the generated JSON downloads.
- `npm run build:crawlable-corpus`, `npm run lint:boundaries`, `npm run lint:safe-html`, scoped Biome lint, and `git diff --check` pass. Biome reports one pre-existing unused-parameter warning and four pre-existing informational diagnostics.
- Local browser preview: chokepoint method at 1280px and 390px; hub at 390px. Text wraps without page overflow. The capture date displays as 2026-09-04.
- Local sequential code review completed. No external review automation invoked.

## Claim evidence

| Published claim | Repository source |
| --- | --- |
| Provider and chokepoint coverage | `computeStats().sourceAttribution.providerCount`; `src/config/chokepoint-registry.ts` |
| GDELT 15-minute batches | `scripts/seed-gdelt-bulk-materializer.mjs`; `scripts/railway-services.json` |
| ACLED 15-minute response cache and selected conflict types | `server/worldmonitor/conflict/v1/list-acled-events.ts` |
| UCDP annual GED and monthly Candidate releases | `scripts/seed-ucdp-events.mjs` |
| PortWatch 6-hour refresh, AIS crossing window, NGA warnings, combined 5-minute cache | `scripts/seed-bundle-portwatch.mjs`; `scripts/ais-relay.cjs`; `server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts`; `server/worldmonitor/maritime/v1/list-navigational-warnings.ts` |
| Cyber indicators and 2-hour schedule | `scripts/seed-cyber-threats.mjs` |
| USGS/NRCan earthquake sources and 5-minute schedule | `scripts/seed-earthquakes.mjs`; `scripts/railway-services.json` |
| Dated country and maritime context | Existing `/country-instability-index/cii-ranking.json` and `/chokepoints/status.json` downloads, generated from the committed live-pulse capture |

## Post-Deploy Monitoring & Validation

Owner: PR author, during the first deployment after an authorized merge. Check `/compare/` and `/compare/chokepoint-monitoring-tools/` for the method heading, then confirm that each snapshot link returns JSON with the displayed capture date. Healthy: all 13 routes include the section and the sitemap date reflects the newest content or capture. Investigate missing sections, 404 downloads, or date mismatch; revert this change if the deployed corpus is invalid. Search build logs for `Comparison measurement requires` or `needs a World Monitor measurement explanation` if generation fails. Search indexing and citation changes require a separate later observation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-Codex-000000)
