### PR TITLE
fix(radar): publish authoritative empty companions

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1444,7 +1444,7 @@ const SEED_META = {
   },
   emberElectricity:     { key: 'seed-meta:energy:ember',                maxStaleMin: 2880 }, // daily cron (08:00 UTC); 2880min = 48h = 2x interval
   cryptoSectors:        { key: 'seed-meta:market:crypto-sectors',             maxStaleMin: 120 }, // relay loop every ~30min; 120min = 2h = 4x interval
-  ddosAttacks:          { key: 'seed-meta:cf:radar:ddos',                    maxStaleMin: 60 }, // written by seed-internet-outages afterPublish; outages cron ~15min; 60 = 4x interval
+  ddosAttacks:          { key: 'seed-meta:cf:radar:ddos',                    maxStaleMin: 60 }, // atomically published by seed-internet-outages; outages cron ~15min; 60 = 4x interval
   economicStress:       { key: 'seed-meta:economic:stress-index',            maxStaleMin: 180 }, // computed in seed-economy afterPublish; cron ~1h; 180min = 3x interval
   marketImplications:   {
     key: 'seed-meta:intelligence:market-implications',
@@ -1466,7 +1466,7 @@ const SEED_META = {
       failureCodePattern: /^MARKET_IMPLICATIONS_(LLM_NO_RESPONSE|NO_PARSEABLE_CARDS|VALIDATION|UNKNOWN)$/,
     },
   },
-  trafficAnomalies:     { key: 'seed-meta:cf:radar:traffic-anomalies',       maxStaleMin: 60 }, // written by seed-internet-outages afterPublish; outages cron ~15min; 60 = 4x interval
+  trafficAnomalies:     { key: 'seed-meta:cf:radar:traffic-anomalies',       maxStaleMin: 60 }, // atomically published by seed-internet-outages; outages cron ~15min; 60 = 4x interval
   chokepointExposure:   { key: 'seed-meta:supply_chain:chokepoint-exposure', maxStaleMin: 2880 }, // daily cron; 2880min = 48h = 2x interval
   recoveryFiscalSpace:     { key: 'seed-meta:resilience:recovery:fiscal-space',     maxStaleMin: 129600 }, // monthly cron; 129600min = 90d = 3x interval (bumped from 86400/60d = 2x in PR #3669 for month-2 hiccup margin)
   recoveryReserveAdequacy: { key: 'seed-meta:resilience:recovery:reserve-adequacy', maxStaleMin: 86400 }, // monthly cron; 86400min = 60d = 2x interval
@@ -2040,9 +2040,9 @@ const ZERO_RECORD_DATA_OK_KEYS = new Set([
   // are sparse — most 28d windows publish an empty {outages:[]} envelope with
   // recordCount=0 (hasData=true). NARROW set, not EMPTY_DATA_OK_KEYS: the
   // seeder always publishes the array, so a MISSING canonical key is a real
-  // publish failure → still EMPTY (crit). Siblings ddosAttacks/trafficAnomalies
-  // sit in the broad set because their data key can be wholly absent on quiet
-  // (writeSeedMeta-only path).
+  // publish failure → still EMPTY (crit). ddosAttacks and trafficAnomalies use
+  // the same present-payload contract. Their EMPTY_DATA_OK_KEYS membership only
+  // preserves pre-first-publish grace.
   'outages',
   // Official disclosure categories are sparse. The canonical snapshot always
   // exists after a successful query, but a quiet 90-day window can validly

--- a/api/health.js
+++ b/api/health.js
@@ -1967,9 +1967,9 @@ const EMPTY_DATA_OK_KEYS = new Set([
 ]);
 
 // These compact projections must leave a payload on every successful publish.
-// This is deliberately narrower than EMPTY_DATA_OK_KEYS: DDoS, traffic, and
-// weather refresh only their seed metadata during quiet periods, so an absent
-// payload is valid for those sources. Every entry here must also be in
+// This is deliberately narrower than EMPTY_DATA_OK_KEYS: weather refreshes
+// only its seed metadata during quiet periods, so an absent payload is valid
+// for that source. Every entry here must also be in
 // EMPTY_DATA_OK_KEYS so a pre-first-publish absence remains STALE_SEED rather
 // than a false-critical EMPTY; tests/health-empty-data-ok.test.mjs enforces it.
 const MISSING_DATA_IS_FAILURE_KEYS = new Set([
@@ -1977,6 +1977,8 @@ const MISSING_DATA_IS_FAILURE_KEYS = new Set([
   // successful cycle, including valid zero-record cycles. Fresh metadata
   // therefore cannot excuse a vanished data key.
   'cableHealth',
+  'ddosAttacks',
+  'trafficAnomalies',
   'notamClosures',
   'thermalEscalationBootstrap',
   'ucdpEventsBootstrap',

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1170,25 +1170,52 @@ export async function writeExtraKeyWithMetaAtomically({
     ['SET', key, JSON.stringify(data), 'EX', dataTtl],
     ['SET', metaKey, JSON.stringify(buildSeedMeta(recordCount, coverage, extra, fetchedAt)), 'EX', metaTtl],
   ];
-  const resp = await fetch(`${url}/multi-exec`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
-    body: JSON.stringify(commands),
-    signal: AbortSignal.timeout(5_000),
-  });
-  if (!resp.ok) {
-    throw new Error(`Atomic extra-key publish failed: HTTP ${resp.status}`);
-  }
+  // This runs after the provider fetches have settled. Retrying this bounded
+  // Redis transaction therefore recovers a transient publication failure
+  // without replaying the provider requests or exposing half the pair.
+  return withRetry(async () => {
+    const resp = await fetch(`${url}/multi-exec`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+      body: JSON.stringify(commands),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!resp.ok) {
+      const err = new Error(`Atomic extra-key publish failed: HTTP ${resp.status}`);
+      if (PERMANENT_4XX_STATUSES.has(resp.status)) {
+        err.nonRetryable = true;
+      } else if (resp.status === 429) {
+        const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp.headers, 'Retry-After'));
+        if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+      }
+      err.httpStatus = resp.status;
+      throw err;
+    }
 
-  const results = await resp.json();
-  if (!Array.isArray(results)) {
-    throw new Error(`Atomic extra-key publish failed: ${results?.error || 'invalid transaction response'}`);
-  }
-  const failures = results.filter((result) => result?.error || result?.result === 'ERR');
-  if (failures.length > 0 || results.length !== commands.length) {
-    throw new Error(`Atomic extra-key publish failed: ${failures.length || 'missing'} command result(s)`);
-  }
-  return true;
+    let results;
+    try {
+      results = await resp.json();
+    } catch (cause) {
+      throw Object.assign(new Error('Atomic extra-key publish failed: invalid transaction response'), {
+        cause,
+        nonRetryable: true,
+      });
+    }
+    if (!Array.isArray(results)) {
+      throw Object.assign(
+        new Error(`Atomic extra-key publish failed: ${results?.error || 'invalid transaction response'}`),
+        { nonRetryable: true },
+      );
+    }
+    const failures = results.filter((result) => result?.error || result?.result === 'ERR');
+    if (failures.length > 0 || results.length !== commands.length) {
+      throw Object.assign(
+        new Error(`Atomic extra-key publish failed: ${failures.length || 'missing'} command result(s)`),
+        { nonRetryable: true },
+      );
+    }
+    return true;
+  }, SEED_REDIS_RETRY_ATTEMPTS - 1, SEED_REDIS_RETRY_BASE_MS);
 }
 
 // Detailed counterpart to extendExistingTtl. Results stay aligned to the input

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1181,13 +1181,8 @@ export async function writeExtraKeyWithMetaAtomically({
       signal: AbortSignal.timeout(5_000),
     });
     if (!resp.ok) {
-      const err = new Error(`Atomic extra-key publish failed: HTTP ${resp.status}`);
-      if (PERMANENT_4XX_STATUSES.has(resp.status)) {
-        err.nonRetryable = true;
-      } else if (resp.status === 429) {
-        const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp.headers, 'Retry-After'));
-        if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
-      }
+      const err = httpRetryError(resp);
+      err.message = `Atomic extra-key publish failed: HTTP ${resp.status}`;
       err.httpStatus = resp.status;
       throw err;
     }

--- a/scripts/seed-internet-outages.mjs
+++ b/scripts/seed-internet-outages.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, writeSeedMeta } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMetaAtomically } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -66,6 +66,36 @@ function toEpochMs(value) {
   return Number.isNaN(d.getTime()) ? 0 : d.getTime();
 }
 
+function requireRadarResult(data, source) {
+  if (
+    !data
+    || data.configured === false
+    || data.success !== true
+    || (data.errors != null && (!Array.isArray(data.errors) || data.errors.length > 0))
+    || !data.result
+    || typeof data.result !== 'object'
+    || Array.isArray(data.result)
+  ) {
+    throw new Error(`Cloudflare Radar ${source} returned an invalid success envelope`);
+  }
+  return data.result;
+}
+
+function requireRadarArray(result, field, source) {
+  if (!Array.isArray(result[field])) {
+    throw new Error(`Cloudflare Radar ${source} response is missing result.${field}`);
+  }
+  return result[field];
+}
+
+function requireRadarObject(result, field, source) {
+  const value = result[field];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Cloudflare Radar ${source} response is missing result.${field}`);
+  }
+  return value;
+}
+
 async function fetchOutages() {
   const token = process.env.CLOUDFLARE_API_TOKEN;
   if (!token) {
@@ -82,13 +112,11 @@ async function fetchOutages() {
   });
   if (!resp.ok) throw new Error(`Cloudflare Radar API error: ${resp.status}`);
 
-  const data = await resp.json();
-  if (data.configured === false || !data.success || data.errors?.length) {
-    throw new Error(`Cloudflare Radar error: ${JSON.stringify(data.errors || [])}`);
-  }
+  const result = requireRadarResult(await resp.json(), 'outage annotations');
+  const annotations = requireRadarArray(result, 'annotations', 'outage annotations');
 
   const outages = [];
-  for (const raw of data.result?.annotations || []) {
+  for (const raw of annotations) {
     if (!raw.locations?.length) continue;
     const countryCode = raw.locations[0];
     if (!countryCode) continue;
@@ -131,25 +159,45 @@ async function fetchDdosData(token) {
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
   };
 
-  const [protocolResp, vectorResp, targetResp] = await Promise.all([
+  const fetchOptionalTargets = async () => {
+    try {
+      const resp = await fetch(`${CF_RADAR_BASE}/radar/attacks/layer3/top/locations/target?dateRange=7d`, { headers, signal: AbortSignal.timeout(15_000) });
+      if (!resp.ok) {
+        console.warn(`  CF Radar DDoS target locations fetch failed: HTTP ${resp.status}`);
+        return [];
+      }
+      const result = requireRadarResult(await resp.json(), 'DDoS target locations');
+      return requireRadarArray(result, 'top_0', 'DDoS target locations')
+        .filter((item) => item && typeof item === 'object' && !Array.isArray(item));
+    } catch (error) {
+      console.warn(`  CF Radar DDoS target locations fetch failed: ${error?.message || error}`);
+      return [];
+    }
+  };
+
+  const [protocolResp, vectorResp, targetLocations] = await Promise.all([
     fetch(`${CF_RADAR_BASE}/radar/attacks/layer3/summary/protocol?dateRange=7d`, { headers, signal: AbortSignal.timeout(15_000) }),
     fetch(`${CF_RADAR_BASE}/radar/attacks/layer3/summary/vector?dateRange=7d`, { headers, signal: AbortSignal.timeout(15_000) }),
-    fetch(`${CF_RADAR_BASE}/radar/attacks/layer3/top/locations/target?dateRange=7d`, { headers, signal: AbortSignal.timeout(15_000) }),
+    fetchOptionalTargets(),
   ]);
 
   if (!protocolResp.ok || !vectorResp.ok) {
     throw new Error(`CF Radar DDoS API error: protocol=${protocolResp.status} vector=${vectorResp.status}`);
   }
 
-  const [protocolData, vectorData] = await Promise.all([protocolResp.json(), vectorResp.json()]);
-  const targetData = targetResp.ok ? await targetResp.json() : null;
+  const [protocolResult, vectorResult] = await Promise.all([
+    protocolResp.json().then((data) => requireRadarResult(data, 'DDoS protocol')),
+    vectorResp.json().then((data) => requireRadarResult(data, 'DDoS vector')),
+  ]);
 
   function toEntries(summary) {
-    return Object.entries(summary || {}).map(([label, pct]) => ({ label, percentage: parseFloat(pct) || 0 }))
+    return Object.entries(summary).map(([label, pct]) => ({ label, percentage: parseFloat(pct) || 0 }))
       .sort((a, b) => b.percentage - a.percentage);
   }
 
-  const topTargetLocations = (targetData?.result?.top_0 || []).map((item) => {
+  // Protocol and vector are required summaries. Target locations are an
+  // optional detail slice: a failure there leaves a valid summary publishable.
+  const topTargetLocations = targetLocations.map((item) => {
     const code = item.clientCountryAlpha2 || '';
     const coords = COUNTRY_COORDS[code] || null;
     return {
@@ -161,10 +209,10 @@ async function fetchDdosData(token) {
     };
   }).filter((item) => item.latitude !== 0 || item.longitude !== 0);
 
-  const meta = protocolData.result?.meta;
+  const meta = protocolResult.meta;
   return {
-    protocol: toEntries(protocolData.result?.summary_0),
-    vector: toEntries(vectorData.result?.summary_0),
+    protocol: toEntries(requireRadarObject(protocolResult, 'summary_0', 'DDoS protocol')),
+    vector: toEntries(requireRadarObject(vectorResult, 'summary_0', 'DDoS vector')),
     dateRangeStart: meta?.dateRange?.[0]?.startTime || '',
     dateRangeEnd: meta?.dateRange?.[0]?.endTime || '',
     topTargetLocations,
@@ -184,8 +232,8 @@ async function fetchTrafficAnomalies(token) {
   });
   if (!resp.ok) throw new Error(`CF Radar traffic anomalies API error: ${resp.status}`);
 
-  const data = await resp.json();
-  const raw = data.result?.trafficAnomalies || [];
+  const result = requireRadarResult(await resp.json(), 'traffic anomalies');
+  const raw = requireRadarArray(result, 'trafficAnomalies', 'traffic anomalies');
 
   const anomalies = raw.map((item) => {
     const coords = COUNTRY_COORDS[item.locationDetails?.code] || null;
@@ -218,22 +266,41 @@ async function fetchAll() {
     fetchTrafficAnomalies(token),
   ]);
 
-  if (outagesResult.status === 'rejected') throw outagesResult.reason;
-  if (ddosResult.status === 'rejected') console.warn(`  CF Radar DDoS fetch failed: ${ddosResult.reason?.message || ddosResult.reason}`);
-  if (anomaliesResult.status === 'rejected') console.warn(`  CF Radar traffic anomalies fetch failed: ${anomaliesResult.reason?.message || anomaliesResult.reason}`);
-
-  const ddos = ddosResult.status === 'fulfilled' ? ddosResult.value : null;
-  const anomalies = anomaliesResult.status === 'fulfilled' ? anomaliesResult.value : null;
-
-  if (ddos && (ddos.protocol.length > 0 || ddos.vector.length > 0)) {
-    await writeExtraKeyWithMeta(DDOS_KEY, ddos, DDOS_TTL, ddos.protocol.length + ddos.vector.length);
-  } else if (ddos) {
-    await writeSeedMeta(DDOS_KEY, 0);
+  const companionPublishes = [];
+  if (ddosResult.status === 'fulfilled') {
+    companionPublishes.push(
+      writeExtraKeyWithMetaAtomically({
+        key: DDOS_KEY,
+        data: ddosResult.value,
+        ttlSeconds: DDOS_TTL,
+        recordCount: ddosResult.value.protocol.length + ddosResult.value.vector.length,
+      }),
+    );
   }
-  if (anomalies && anomalies.anomalies.length > 0) {
-    await writeExtraKeyWithMeta(TRAFFIC_ANOMALIES_KEY, anomalies, ANOMALIES_TTL, anomalies.totalCount);
-  } else if (anomalies) {
-    await writeSeedMeta(TRAFFIC_ANOMALIES_KEY, 0);
+  if (anomaliesResult.status === 'fulfilled') {
+    companionPublishes.push(
+      writeExtraKeyWithMetaAtomically({
+        key: TRAFFIC_ANOMALIES_KEY,
+        data: anomaliesResult.value,
+        ttlSeconds: ANOMALIES_TTL,
+        recordCount: anomaliesResult.value.totalCount,
+      }),
+    );
+  }
+  const publicationResults = await Promise.allSettled(companionPublishes);
+
+  const failures = [
+    outagesResult,
+    ddosResult,
+    anomaliesResult,
+    ...publicationResults,
+  ].filter((result) => result.status === 'rejected');
+  if (failures.length > 0) {
+    const error = new Error(`Cloudflare Radar update failed: ${failures.map((result) => result.reason?.message || result.reason).join('; ')}`);
+    // All provider work settled above. Retrying fetchAll would replay healthy
+    // Radar requests after their companion publication has already completed.
+    error.nonRetryable = true;
+    throw error;
   }
 
   return outagesResult.value;
@@ -253,6 +320,10 @@ runSeed('infra', 'outages', CANONICAL_KEY, fetchAll, {
   sourceVersion: 'cloudflare-radar-28d',
 
   declareRecords,
+  preserveKeyTtls: [
+    { key: DDOS_KEY, ttlSeconds: DDOS_TTL },
+    { key: TRAFFIC_ANOMALIES_KEY, ttlSeconds: ANOMALIES_TTL },
+  ],
   // CF Radar curated outage annotations are sparse (~1-2/wk, clustered, with
   // multi-day gaps). Zero mappable outages is the NORMAL state, not a fetch
   // failure — without this, runSeed takes the contract RETRY path on every

--- a/src/services/infrastructure/index.ts
+++ b/src/services/infrastructure/index.ts
@@ -27,6 +27,22 @@ const emptyStatusFallback: ListServiceStatusesResponse = { statuses: [] };
 const emptyDdosFallback: ListInternetDdosAttacksResponse = { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '', topTargetLocations: [] };
 const emptyAnomaliesFallback: ListInternetTrafficAnomaliesResponse = { anomalies: [], totalCount: 0 };
 
+function isDdosResponse(value: unknown): value is ListInternetDdosAttacksResponse {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const response = value as Partial<ListInternetDdosAttacksResponse>;
+  return Array.isArray(response.protocol)
+    && Array.isArray(response.vector)
+    && typeof response.dateRangeStart === 'string'
+    && typeof response.dateRangeEnd === 'string'
+    && Array.isArray(response.topTargetLocations);
+}
+
+function isTrafficAnomaliesResponse(value: unknown): value is ListInternetTrafficAnomaliesResponse {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const response = value as Partial<ListInternetTrafficAnomaliesResponse>;
+  return Array.isArray(response.anomalies) && typeof response.totalCount === 'number';
+}
+
 // ---- Proto enum -> legacy string adapters ----
 
 const SEVERITY_REVERSE: Record<string, 'partial' | 'major' | 'total'> = {
@@ -117,14 +133,16 @@ export function getOutagesStatus(): string {
 
 export async function fetchDdosAttacks(): Promise<ListInternetDdosAttacksResponse> {
   const hydrated = getHydratedData('ddosAttacks') as ListInternetDdosAttacksResponse | undefined;
-  if (hydrated?.protocol?.length || hydrated?.vector?.length) {
+  if (isDdosResponse(hydrated)) {
     ddosBreaker.recordSuccess(hydrated);
     return hydrated;
   }
 
   return ddosBreaker.execute(async () => {
-    return client.listInternetDdosAttacks({});
-  }, emptyDdosFallback, { shouldCache: (r) => r.protocol.length > 0 || r.vector.length > 0 });
+    const response = await client.listInternetDdosAttacks({});
+    if (!isDdosResponse(response)) throw new Error('Invalid DDoS attacks response');
+    return response;
+  }, emptyDdosFallback, { shouldCache: isDdosResponse });
 }
 
 // ========================================================================
@@ -133,16 +151,21 @@ export async function fetchDdosAttacks(): Promise<ListInternetDdosAttacksRespons
 
 export async function fetchTrafficAnomalies(country?: string): Promise<ListInternetTrafficAnomaliesResponse> {
   const hydrated = getHydratedData('trafficAnomalies') as ListInternetTrafficAnomaliesResponse | undefined;
-  if (hydrated?.anomalies !== undefined && !country) {
-    if (hydrated.anomalies.length > 0) trafficAnomaliesBreaker.recordSuccess(hydrated);
+  if (!country && isTrafficAnomaliesResponse(hydrated)) {
+    trafficAnomaliesBreaker.recordSuccess(hydrated);
     return hydrated;
   }
 
   return trafficAnomaliesBreaker.execute(async () => {
-    return client.listInternetTrafficAnomalies({ country: country || '' });
+    const response = await client.listInternetTrafficAnomalies({ country: country || '' });
+    if (!isTrafficAnomaliesResponse(response)) throw new Error('Invalid traffic anomalies response');
+    return response;
   }, emptyAnomaliesFallback, {
     cacheKey: country,
-    shouldCache: (r) => r.anomalies.length > 0,
+    // Global empty data is authoritative, but preserve the existing
+    // country-specific retry behavior for an empty filtered result.
+    shouldCache: (response) => isTrafficAnomaliesResponse(response)
+      && (!country || response.anomalies.length > 0),
   });
 }
 

--- a/tests/bootstrap-hydration-reuse.test.mts
+++ b/tests/bootstrap-hydration-reuse.test.mts
@@ -422,6 +422,26 @@ describe('bootstrap hydration reuse (#7048)', () => {
     );
   });
 
+  it('malformed live DDoS and traffic responses use their fallbacks', async () => {
+    const requests = bootstrapStub({}, (url) => {
+      if (url.includes('list-internet-ddos-attacks')) {
+        return { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '', topTargetLocations: null };
+      }
+      if (url.includes('list-internet-traffic-anomalies')) return { anomalies: [], totalCount: '0' };
+      return { anomalies: [], totalCount: 0 };
+    });
+    await harness.fetchBootstrapData();
+
+    const [firstDdos, firstTraffic] = await Promise.all([
+      harness.fetchDdosAttacks(),
+      harness.fetchTrafficAnomalies(),
+    ]);
+
+    assert.deepEqual(firstDdos, { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '', topTargetLocations: [] });
+    assert.deepEqual(firstTraffic, { anomalies: [], totalCount: 0 });
+    assert.equal(rpcUrlCount(requests), 2, 'each malformed live response must reach its runtime guard');
+  });
+
   it('malformed DDoS and traffic hydration falls through instead of warming the global cache', async () => {
     const requests = bootstrapStub({
       ddosAttacks: { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '' },

--- a/tests/bootstrap-hydration-reuse.test.mts
+++ b/tests/bootstrap-hydration-reuse.test.mts
@@ -21,6 +21,13 @@ type Harness = {
   fetchAllFires: () => Promise<{ totalCount: number; regions?: Record<string, unknown[]>; skipped?: boolean }>;
   fetchEarthquakes: () => Promise<Array<{ id: string }>>;
   fetchFlightDelays: () => Promise<Array<{ id: string; updatedAt: Date }>>;
+  fetchDdosAttacks: () => Promise<{
+    protocol: Array<{ label: string }>;
+    vector: Array<{ label: string }>;
+    dateRangeStart: string;
+    dateRangeEnd: string;
+    topTargetLocations: Array<{ countryCode: string }>;
+  }>;
   fetchTrafficAnomalies: (country?: string) => Promise<{ anomalies: Array<{ id: string }>; totalCount: number }>;
   fetchSocialVelocity: () => Promise<{ posts: Array<{ id: string }>; fetchedAt: number }>;
   fetchDiseaseOutbreaks: () => Promise<{ outbreaks: Array<{ id: string }>; fetchedAt: number }>;
@@ -110,6 +117,10 @@ const FLIGHT_DELAY = {
 };
 const SOCIAL_POST = { id: 'post-1', title: 'headline', velocity: 42 };
 const OUTBREAK = { id: 'out-1', disease: 'Cholera', country: 'YY', cases: 10 };
+const DDOS_ATTACK = {
+  protocol: [{ label: 'TCP', percentage: 80 }], vector: [],
+  dateRangeStart: '2026-09-01T00:00:00Z', dateRangeEnd: '2026-09-08T00:00:00Z', topTargetLocations: [],
+};
 
 function bootstrapStub(
   payload: Record<string, unknown>,
@@ -186,6 +197,7 @@ before(async () => {
         "export { fetchAllFires } from './src/services/wildfires/index.ts';",
         "export { fetchEarthquakes } from './src/services/earthquakes.ts';",
         "export { fetchFlightDelays } from './src/services/aviation/index.ts';",
+        "export { fetchDdosAttacks } from './src/services/infrastructure/index.ts';",
         "export { fetchTrafficAnomalies } from './src/services/infrastructure/index.ts';",
         "export { fetchSocialVelocity } from './src/services/social-velocity.ts';",
         "export { fetchDiseaseOutbreaks } from './src/services/disease-outbreaks.ts';",
@@ -410,6 +422,41 @@ describe('bootstrap hydration reuse (#7048)', () => {
     );
   });
 
+  it('malformed DDoS and traffic hydration falls through instead of warming the global cache', async () => {
+    const requests = bootstrapStub({
+      ddosAttacks: { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '' },
+      trafficAnomalies: { anomalies: [], totalCount: '0' },
+    }, (url) => {
+      if (url.includes('list-internet-ddos-attacks')) return DDOS_ATTACK;
+      if (url.includes('list-internet-traffic-anomalies')) return { anomalies: [{ id: 'live-traffic' }], totalCount: 1 };
+      return { anomalies: [], totalCount: 0 };
+    });
+    await harness.fetchBootstrapData();
+
+    const [ddos, traffic] = await Promise.all([
+      harness.fetchDdosAttacks(),
+      harness.fetchTrafficAnomalies(),
+    ]);
+
+    assert.equal(ddos.protocol[0]?.label, 'TCP');
+    assert.equal(traffic.anomalies[0]?.id, 'live-traffic');
+    assert.equal(rpcUrlCount(requests), 2, 'each malformed global hydration must use its live RPC fallback');
+  });
+
+  it('DDoS: authoritative empty hydration replaces stale global cache data', async () => {
+    const requests = bootstrapStub({
+      ddosAttacks: { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '', topTargetLocations: [] },
+    });
+    await harness.fetchBootstrapData();
+
+    const first = await harness.fetchDdosAttacks();
+    const second = await harness.fetchDdosAttacks();
+
+    assert.deepEqual(first, { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '', topTargetLocations: [] });
+    assert.deepEqual(second, first, 'the empty global DDoS snapshot replaces the previous cached response');
+    assert.equal(rpcUrlCount(requests), 0, 'valid empty DDoS hydration must stay in the breaker cache');
+  });
+
   it('traffic anomalies: global hydration never satisfies a country-specific cache key', async () => {
     const requests = bootstrapStub({
       trafficAnomalies: { anomalies: [{ id: 'global-1' }], totalCount: 1 },
@@ -422,6 +469,23 @@ describe('bootstrap hydration reuse (#7048)', () => {
     assert.equal(global.anomalies[0]?.id, 'global-1');
     assert.deepEqual(filtered.anomalies, []);
     assert.equal(rpcUrlCount(requests), 1, 'the filtered read must use its own RPC/cache key');
+  });
+
+  it('traffic anomalies: authoritative empty global hydration replaces cache but empty country results remain retryable', async () => {
+    const requests = bootstrapStub({
+      trafficAnomalies: { anomalies: [], totalCount: 0 },
+    });
+    await harness.fetchBootstrapData();
+
+    const globalFirst = await harness.fetchTrafficAnomalies();
+    const globalSecond = await harness.fetchTrafficAnomalies();
+    assert.deepEqual(globalFirst, { anomalies: [], totalCount: 0 });
+    assert.deepEqual(globalSecond, globalFirst, 'the empty global snapshot replaces the previous cached response');
+    assert.equal(rpcUrlCount(requests), 0, 'valid empty global traffic hydration must stay in the breaker cache');
+
+    await harness.fetchTrafficAnomalies('US');
+    await harness.fetchTrafficAnomalies('US');
+    assert.equal(rpcUrlCount(requests), 2, 'empty country-filtered results retain their existing retry behavior');
   });
 
   it('socialVelocity (no breaker): the hydration handoff answers recurring reads', async () => {

--- a/tests/cloudflare-radar-seed-flow.test.mjs
+++ b/tests/cloudflare-radar-seed-flow.test.mjs
@@ -1,0 +1,274 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+import { __testing__ as health } from '../api/health.js';
+
+const DDoS_KEY = 'cf:radar:ddos:v1';
+const TRAFFIC_KEY = 'cf:radar:traffic-anomalies:v1';
+const DDoS_META_KEY = 'seed-meta:cf:radar:ddos';
+const TRAFFIC_META_KEY = 'seed-meta:cf:radar:traffic-anomalies';
+const NOW = Date.parse('2026-09-07T12:00:00Z');
+
+function runFixture(initial, mode = 'ok', now = NOW) {
+  const result = spawnSync(
+    process.execPath,
+    ['--input-type=module', '--eval', `(${seedProcess.toString()})(${JSON.stringify(initial)}, ${now}, ${JSON.stringify(mode)})`],
+    {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: {
+        PATH: process.env.PATH,
+        CLOUDFLARE_API_TOKEN: 'fixture-token',
+        NODE_TEST_CONTEXT: 'child',
+        TEST_SEED_URL: new URL('../scripts/seed-internet-outages.mjs', import.meta.url).href,
+        UPSTASH_REDIS_REST_URL: 'https://redis.cloudflare-radar.test',
+        UPSTASH_REDIS_REST_TOKEN: 'fixture-token',
+        WM_SEED_ENV_FILE: '/dev/null',
+      },
+    },
+  );
+  const output = result.stdout + result.stderr;
+  const fixture = output.match(/FIXTURE_RESULT=(.+)/);
+  assert.ok(fixture, output);
+  return {
+    ...JSON.parse(fixture[1]),
+    output,
+    status: result.status,
+  };
+}
+
+async function seedProcess(initial, now, mode) {
+  Date.now = () => now;
+  const store = new Map(initial);
+  const calls = [];
+
+  const redisCommand = (command) => {
+    const [name, key, value] = command;
+    if (name === 'SET') {
+      store.set(key, value);
+      return 'OK';
+    }
+    if (name === 'DEL') return Number(store.delete(key));
+    if (name === 'EXPIRE' || name === 'EVAL') return 1;
+    throw new Error(`unexpected Redis command ${name}`);
+  };
+
+  globalThis.fetch = async (input, init = {}) => {
+    const url = new URL(input);
+    calls.push(url.pathname);
+    if (url.origin === 'https://redis.cloudflare-radar.test') {
+      if (url.pathname.startsWith('/get/')) {
+        return Response.json({ result: store.get(decodeURIComponent(url.pathname.slice(5))) ?? null });
+      }
+      const command = JSON.parse(init.body);
+      if (url.pathname === '/multi-exec') {
+        if (mode === 'traffic-write-fail' && command.some((entry) => entry[1] === 'cf:radar:traffic-anomalies:v1')) {
+          return Response.json([{ error: 'READONLY injected failure' }, { result: 'OK' }]);
+        }
+        for (const entry of command) redisCommand(entry);
+        return Response.json(command.map(() => ({ result: 'OK' })));
+      }
+      return Response.json({ result: redisCommand(command) });
+    }
+
+    if (url.hostname !== 'api.cloudflare.com') throw new Error(`unexpected request ${url}`);
+    if (url.pathname.endsWith('/annotations/outages')) {
+      if (mode === 'annotations-fail' || mode === 'total-failure') return new Response('', { status: 503 });
+      return Response.json({ success: true, result: { annotations: [] } });
+    }
+    if (url.pathname.endsWith('/summary/protocol') || url.pathname.endsWith('/summary/vector')) {
+      if (mode === 'ddos-fail' || mode === 'success-false' || mode === 'total-failure') {
+        return Response.json({ success: false, errors: [{ code: 7000 }] });
+      }
+      if (mode === 'malformed-errors') {
+        return Response.json({ success: true, errors: { code: 7000 }, result: { summary_0: {}, meta: { dateRange: [] } } });
+      }
+      if (['target-fail', 'target-invalid', 'target-malformed'].includes(mode)) {
+        const summary = url.pathname.endsWith('/summary/protocol') ? { TCP: '70' } : { SYN: '30' };
+        return Response.json({ success: true, result: { summary_0: summary, meta: { dateRange: [] } } });
+      }
+      return Response.json({ success: true, result: { summary_0: {}, meta: { dateRange: [] } } });
+    }
+    if (url.pathname.endsWith('/top/locations/target')) {
+      if (mode === 'target-fail') return new Response('', { status: 503 });
+      if (mode === 'target-invalid') return Response.json({ success: false, errors: [{ code: 7000 }] });
+      if (mode === 'target-malformed') return Response.json({ success: true, result: { top_0: [null] } });
+      return Response.json({ success: true, result: { top_0: [] } });
+    }
+    if (url.pathname.endsWith('/traffic_anomalies')) {
+      if (mode === 'traffic-fail' || mode === 'success-false' || mode === 'total-failure') {
+        return Response.json({ success: false, errors: [{ code: 7000 }] });
+      }
+      if (mode === 'malformed-errors') {
+        return Response.json({ success: true, errors: { code: 7000 }, result: { trafficAnomalies: [] } });
+      }
+      return Response.json({ success: true, result: { trafficAnomalies: [] } });
+    }
+    throw new Error(`unexpected Radar request ${url}`);
+  };
+
+  process.on('exit', () => {
+    console.log(`FIXTURE_RESULT=${JSON.stringify({ calls, store: [...store] })}`);
+  });
+  await import(process.env.TEST_SEED_URL);
+}
+
+function initialLastGood() {
+  const oldMeta = JSON.stringify({ fetchedAt: NOW - 30 * 60_000, recordCount: 1 });
+  return [
+    [DDoS_KEY, JSON.stringify({ protocol: [{ label: 'old', percentage: 100 }], vector: [], topTargetLocations: [] })],
+    [TRAFFIC_KEY, JSON.stringify({ anomalies: [{ uuid: 'old-event' }], totalCount: 1 })],
+    [DDoS_META_KEY, oldMeta],
+    [TRAFFIC_META_KEY, oldMeta],
+  ];
+}
+
+function radarCallCounts(calls) {
+  return calls.filter((path) => path.startsWith('/client/v4/radar/')).sort();
+}
+
+async function readCompanionsThroughRpc(store) {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+  const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.cloudflare-radar.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'fixture-token';
+  globalThis.fetch = async (input) => {
+    const url = new URL(input);
+    assert.equal(url.origin, 'https://redis.cloudflare-radar.test');
+    return Response.json({ result: store.get(decodeURIComponent(url.pathname.slice(5))) ?? null });
+  };
+  try {
+    const [{ listInternetDdosAttacks }, { listInternetTrafficAnomalies }] = await Promise.all([
+      import('../server/worldmonitor/infrastructure/v1/list-ddos-attacks.ts'),
+      import('../server/worldmonitor/infrastructure/v1/list-traffic-anomalies.ts'),
+    ]);
+    return {
+      ddos: await listInternetDdosAttacks({}, {}),
+      traffic: await listInternetTrafficAnomalies({}, {}),
+    };
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+    if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+  }
+}
+
+function classifyCompanion(name, key, metaKey, store) {
+  return health.classifyKey(name, key, { allowOnDemand: false }, {
+    keyStrens: new Map([[key, Buffer.byteLength(store.get(key) ?? '')]]),
+    keyErrors: new Map(),
+    keyMetaErrors: new Map(),
+    keyMetaValues: new Map([[metaKey, store.get(metaKey)]]),
+    now: NOW + 1_000,
+  });
+}
+
+test('a confirmed empty Radar response replaces old companion payloads', () => {
+  const result = runFixture(initialLastGood());
+
+  assert.equal(result.status, 0, result.output);
+  const store = new Map(result.store);
+  assert.deepEqual(
+    JSON.parse(store.get(DDoS_KEY)),
+    { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '', topTargetLocations: [] },
+    'a valid empty DDoS response must clear the old protocol summary',
+  );
+  assert.deepEqual(
+    JSON.parse(store.get(TRAFFIC_KEY)),
+    { anomalies: [], totalCount: 0 },
+    'a valid empty traffic response must clear the old anomaly event',
+  );
+  assert.equal(classifyCompanion('ddosAttacks', DDoS_KEY, DDoS_META_KEY, store).status, 'OK');
+  assert.equal(classifyCompanion('trafficAnomalies', TRAFFIC_KEY, TRAFFIC_META_KEY, store).status, 'OK');
+});
+
+test('real companion RPC readers no longer serve old records after a confirmed empty response', async () => {
+  const store = new Map(runFixture(initialLastGood()).store);
+  const result = await readCompanionsThroughRpc(store);
+  assert.deepEqual(result.ddos.protocol, []);
+  assert.deepEqual(result.ddos.vector, []);
+  assert.deepEqual(result.traffic.anomalies, []);
+  assert.equal(result.traffic.totalCount, 0);
+});
+
+test('HTTP-200 invalid envelopes retain last-good companion payloads and success clocks', () => {
+  for (const mode of ['success-false', 'malformed-errors']) {
+    const initial = initialLastGood();
+    const result = runFixture(initial, mode);
+    const store = new Map(result.store);
+    const before = new Map(initial);
+    assert.notEqual(result.status, 0, `${mode}: ${result.output}`);
+    for (const key of [DDoS_KEY, TRAFFIC_KEY, DDoS_META_KEY, TRAFFIC_META_KEY]) {
+      assert.equal(store.get(key), before.get(key), `${mode}: ${key} must retain its last-good value`);
+    }
+    assert.equal(radarCallCounts(result.calls).length, 5, `${mode}: sources must not replay after settlement`);
+  }
+});
+
+test('empty data stays authoritative through a source error and recovery', () => {
+  const empty = new Map(runFixture(initialLastGood()).store);
+  const failed = new Map(runFixture([...empty], 'traffic-fail', NOW + 60_000).store);
+  const recovered = new Map(runFixture([...failed], 'ok', NOW + 120_000).store);
+
+  assert.equal(failed.get(TRAFFIC_KEY), empty.get(TRAFFIC_KEY));
+  assert.equal(failed.get(TRAFFIC_META_KEY), empty.get(TRAFFIC_META_KEY));
+  assert.deepEqual(JSON.parse(recovered.get(TRAFFIC_KEY)), { anomalies: [], totalCount: 0 });
+  assert.equal(JSON.parse(recovered.get(TRAFFIC_META_KEY)).fetchedAt, NOW + 120_000);
+});
+
+test('annotations and one companion can fail without discarding a healthy companion update', () => {
+  for (const [mode, updatedKey, preservedKey] of [
+    ['annotations-fail', TRAFFIC_KEY, null],
+    ['ddos-fail', TRAFFIC_KEY, DDoS_KEY],
+    ['traffic-fail', DDoS_KEY, TRAFFIC_KEY],
+  ]) {
+    const initial = initialLastGood();
+    const result = runFixture(initial, mode);
+    const store = new Map(result.store);
+    const before = new Map(initial);
+    assert.notEqual(result.status, 0, `${mode}: ${result.output}`);
+    assert.equal(radarCallCounts(result.calls).length, 5, `${mode}: sources must not replay after settlement`);
+    assert.notEqual(store.get(updatedKey), before.get(updatedKey), `${mode}: healthy companion must publish`);
+    if (preservedKey) assert.equal(store.get(preservedKey), before.get(preservedKey), `${mode}: failed companion must retain last-good data`);
+  }
+});
+
+test('a failed or malformed optional DDoS target slice does not discard required summaries', () => {
+  for (const mode of ['target-fail', 'target-invalid', 'target-malformed']) {
+    const result = runFixture(initialLastGood(), mode);
+    const store = new Map(result.store);
+    assert.equal(result.status, 0, `${mode}: ${result.output}`);
+    const ddos = JSON.parse(store.get(DDoS_KEY));
+    assert.deepEqual(ddos.protocol, [{ label: 'TCP', percentage: 70 }], mode);
+    assert.deepEqual(ddos.vector, [{ label: 'SYN', percentage: 30 }], mode);
+    assert.deepEqual(ddos.topTargetLocations, [], mode);
+  }
+});
+
+test('an atomic companion write failure leaves its payload and success clock unchanged', () => {
+  const initial = initialLastGood();
+  const result = runFixture(initial, 'traffic-write-fail');
+  const store = new Map(result.store);
+  const before = new Map(initial);
+  assert.notEqual(result.status, 0, result.output);
+  assert.equal(store.get(TRAFFIC_KEY), before.get(TRAFFIC_KEY));
+  assert.equal(store.get(TRAFFIC_META_KEY), before.get(TRAFFIC_META_KEY));
+  assert.notEqual(store.get(DDoS_KEY), before.get(DDoS_KEY), 'the healthy DDoS companion must still publish');
+  assert.equal(radarCallCounts(result.calls).length, 5, 'a cache write failure must not replay provider requests');
+});
+
+test('a total Radar failure keeps all companion last-good values', () => {
+  const initial = initialLastGood();
+  const result = runFixture(initial, 'total-failure');
+  const store = new Map(result.store);
+  const before = new Map(initial);
+  assert.notEqual(result.status, 0, result.output);
+  for (const key of [DDoS_KEY, TRAFFIC_KEY, DDoS_META_KEY, TRAFFIC_META_KEY]) {
+    assert.equal(store.get(key), before.get(key), `${key} must survive total source failure`);
+  }
+  assert.equal(radarCallCounts(result.calls).length, 5, 'total failure must make one bounded provider pass');
+});

--- a/tests/cloudflare-radar-seed-flow.test.mjs
+++ b/tests/cloudflare-radar-seed-flow.test.mjs
@@ -42,6 +42,7 @@ async function seedProcess(initial, now, mode) {
   Date.now = () => now;
   const store = new Map(initial);
   const calls = [];
+  const ttlExtensions = [];
 
   const redisCommand = (command) => {
     const [name, key, value] = command;
@@ -68,6 +69,12 @@ async function seedProcess(initial, now, mode) {
         }
         for (const entry of command) redisCommand(entry);
         return Response.json(command.map(() => ({ result: 'OK' })));
+      }
+      if (url.pathname === '/pipeline') {
+        for (const entry of command) {
+          if (entry[0] === 'EXPIRE') ttlExtensions.push([entry[1], entry[2]]);
+        }
+        return Response.json(command.map((entry) => ({ result: redisCommand(entry) })));
       }
       return Response.json({ result: redisCommand(command) });
     }
@@ -109,7 +116,7 @@ async function seedProcess(initial, now, mode) {
   };
 
   process.on('exit', () => {
-    console.log(`FIXTURE_RESULT=${JSON.stringify({ calls, store: [...store] })}`);
+    console.log(`FIXTURE_RESULT=${JSON.stringify({ calls, store: [...store], ttlExtensions })}`);
   });
   await import(process.env.TEST_SEED_URL);
 }
@@ -126,6 +133,17 @@ function initialLastGood() {
 
 function radarCallCounts(calls) {
   return calls.filter((path) => path.startsWith('/client/v4/radar/')).sort();
+}
+
+function assertCompanionTtlRetention(result, label) {
+  const companions = result.ttlExtensions
+    .filter(([key]) => key === DDoS_KEY || key === TRAFFIC_KEY)
+    .sort(([left], [right]) => left.localeCompare(right));
+  assert.deepEqual(
+    companions,
+    [[DDoS_KEY, 10_800], [TRAFFIC_KEY, 3_600]],
+    `${label}: failed runs must preserve each companion at its declared TTL`,
+  );
 }
 
 async function readCompanionsThroughRpc(store) {
@@ -206,6 +224,7 @@ test('HTTP-200 invalid envelopes retain last-good companion payloads and success
       assert.equal(store.get(key), before.get(key), `${mode}: ${key} must retain its last-good value`);
     }
     assert.equal(radarCallCounts(result.calls).length, 5, `${mode}: sources must not replay after settlement`);
+    assertCompanionTtlRetention(result, mode);
   }
 });
 
@@ -234,6 +253,7 @@ test('annotations and one companion can fail without discarding a healthy compan
     assert.equal(radarCallCounts(result.calls).length, 5, `${mode}: sources must not replay after settlement`);
     assert.notEqual(store.get(updatedKey), before.get(updatedKey), `${mode}: healthy companion must publish`);
     if (preservedKey) assert.equal(store.get(preservedKey), before.get(preservedKey), `${mode}: failed companion must retain last-good data`);
+    assertCompanionTtlRetention(result, mode);
   }
 });
 
@@ -259,6 +279,7 @@ test('an atomic companion write failure leaves its payload and success clock unc
   assert.equal(store.get(TRAFFIC_META_KEY), before.get(TRAFFIC_META_KEY));
   assert.notEqual(store.get(DDoS_KEY), before.get(DDoS_KEY), 'the healthy DDoS companion must still publish');
   assert.equal(radarCallCounts(result.calls).length, 5, 'a cache write failure must not replay provider requests');
+  assertCompanionTtlRetention(result, 'traffic-write-fail');
 });
 
 test('a total Radar failure keeps all companion last-good values', () => {
@@ -271,4 +292,5 @@ test('a total Radar failure keeps all companion last-good values', () => {
     assert.equal(store.get(key), before.get(key), `${key} must survive total source failure`);
   }
   assert.equal(radarCallCounts(result.calls).length, 5, 'total failure must make one bounded provider pass');
+  assertCompanionTtlRetention(result, 'total-failure');
 });

--- a/tests/health-empty-data-ok.test.mjs
+++ b/tests/health-empty-data-ok.test.mjs
@@ -22,14 +22,14 @@ const STRICT_PROJECTIONS = [...MISSING_DATA_IS_FAILURE_KEYS];
 // These sources intentionally refresh only metadata on quiet cycles, so a missing
 // payload with fresh metadata remains healthy rather than generating a false alarm.
 const QUIET_META_ONLY_KEYS = [
-  'ddosAttacks',
-  'trafficAnomalies',
   'weatherAlerts',
   'newsThreatSummary',
 ];
 
 const AUDITED_PRESENT_PAYLOAD_KEYS = [
   'cableHealth',
+  'ddosAttacks',
+  'trafficAnomalies',
   'notamClosures',
   // canadaRoads does NOT refresh metadata only on quiet cycles: the seeder
   // publishes an explicit {records: []} envelope on every successful tick

--- a/tests/seed-utils-meta-ttl-outlives-data.test.mjs
+++ b/tests/seed-utils-meta-ttl-outlives-data.test.mjs
@@ -204,12 +204,12 @@ test('writeExtraKeyWithMetaAtomically: retries a transient transaction failure w
   assert.deepEqual(transactions[1], transactions[0], 'every attempt sends the complete atomic pair');
 });
 
-test('writeExtraKeyWithMetaAtomically: permanent transaction failures do not retry', async () => {
+test('writeExtraKeyWithMetaAtomically: every permanent transaction failure does not retry', async () => {
   let calls = 0;
   globalThis.fetch = async (url) => {
     calls += 1;
     assert.match(String(url), /\/multi-exec$/);
-    return new Response('forbidden', { status: 403 });
+    return new Response('method not allowed', { status: 405 });
   };
 
   await assert.rejects(
@@ -221,7 +221,7 @@ test('writeExtraKeyWithMetaAtomically: permanent transaction failures do not ret
       metaKey: 'seed-meta:conflict:humanitarian',
       metaTtlSeconds: 259_200,
     }),
-    /HTTP 403/,
+    /HTTP 405/,
   );
   assert.equal(calls, 1, 'a permanent Redis client error must fail fast');
 });

--- a/tests/seed-utils-meta-ttl-outlives-data.test.mjs
+++ b/tests/seed-utils-meta-ttl-outlives-data.test.mjs
@@ -34,6 +34,7 @@ const {
   await import('../scripts/_seed-utils.mjs');
 
 const originalFetch = globalThis.fetch;
+const originalRetryDelayMs = process.env.WM_SEED_RETRY_DELAY_MS;
 
 /** seed-economy.mjs CRUDE_INVENTORIES_TTL / NAT_GAS_TTL / SPR_TTL / REFINERY_INPUTS_TTL. */
 const EIA_WEEKLY_DATA_TTL = 1_814_400; // 21 days
@@ -51,6 +52,9 @@ function ttlOf(command) {
 beforeEach(() => {
   sets = [];
   transactions = [];
+  // Keep the production retry count and error policy, but do not sleep through
+  // the real Redis backoff in this focused unit suite.
+  process.env.WM_SEED_RETRY_DELAY_MS = '0';
   globalThis.fetch = async (url, opts = {}) => {
     const command = opts?.body ? JSON.parse(opts.body) : null;
     if (String(url).endsWith('/multi-exec')) {
@@ -64,6 +68,8 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  if (originalRetryDelayMs === undefined) delete process.env.WM_SEED_RETRY_DELAY_MS;
+  else process.env.WM_SEED_RETRY_DELAY_MS = originalRetryDelayMs;
 });
 
 test('writeExtraKeyWithMeta: seed-meta outlives the data key it vouches for', async () => {
@@ -173,12 +179,37 @@ test('writeExtraKeyWithMetaAtomically: marker and health provenance use one Redi
   });
 });
 
-test('writeExtraKeyWithMetaAtomically: a failed transaction cannot report marker-only success', async () => {
+test('writeExtraKeyWithMetaAtomically: retries a transient transaction failure without splitting the pair', async () => {
+  let calls = 0;
+  globalThis.fetch = async (url, opts) => {
+    calls += 1;
+    assert.match(String(url), /\/multi-exec$/);
+    const commands = JSON.parse(opts.body);
+    transactions.push(commands);
+    if (calls === 1) return new Response('unavailable', { status: 503 });
+    return Response.json(commands.map(() => ({ result: 'OK' })));
+  };
+
+  await writeExtraKeyWithMetaAtomically({
+    key: 'conflict:humanitarian:v1',
+    data: { sourceChannel: 'hapi-api' },
+    ttlSeconds: 259_200,
+    recordCount: 41,
+    metaKey: 'seed-meta:conflict:humanitarian',
+    metaTtlSeconds: 259_200,
+    extra: { sourceChannel: 'hapi-api', sourceState: 'degraded' },
+  });
+
+  assert.equal(calls, 2, 'a transient Redis failure gets one retry before the transaction succeeds');
+  assert.deepEqual(transactions[1], transactions[0], 'every attempt sends the complete atomic pair');
+});
+
+test('writeExtraKeyWithMetaAtomically: permanent transaction failures do not retry', async () => {
   let calls = 0;
   globalThis.fetch = async (url) => {
     calls += 1;
     assert.match(String(url), /\/multi-exec$/);
-    return new Response('unavailable', { status: 503 });
+    return new Response('forbidden', { status: 403 });
   };
 
   await assert.rejects(
@@ -189,18 +220,21 @@ test('writeExtraKeyWithMetaAtomically: a failed transaction cannot report marker
       recordCount: 41,
       metaKey: 'seed-meta:conflict:humanitarian',
       metaTtlSeconds: 259_200,
-      extra: { sourceChannel: 'hapi-api', sourceState: 'degraded' },
     }),
-    /HTTP 503/,
+    /HTTP 403/,
   );
-  assert.equal(calls, 1, 'the atomic pair is one failure unit');
+  assert.equal(calls, 1, 'a permanent Redis client error must fail fast');
 });
 
 test('writeExtraKeyWithMetaAtomically: a command error rejects the whole publication result', async () => {
-  globalThis.fetch = async () => Response.json([
-    { result: 'OK' },
-    { error: 'ERR simulated seed-meta failure' },
-  ]);
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return Response.json([
+      { result: 'OK' },
+      { error: 'ERR simulated seed-meta failure' },
+    ]);
+  };
 
   await assert.rejects(
     writeExtraKeyWithMetaAtomically({
@@ -213,6 +247,7 @@ test('writeExtraKeyWithMetaAtomically: a command error rejects the whole publica
     }),
     /1 command result/,
   );
+  assert.equal(calls, 1, 'a command-level failure is explicit and must not be retried');
 });
 
 test('resolveSeedMetaTtl: floor, clamp, and explicit override', () => {


### PR DESCRIPTION
## Summary

- Publish explicit empty DDoS and traffic companion payloads when Cloudflare Radar confirms no records.
- Preserve last-good companion data and success metadata on failed or invalid responses without replaying healthy provider requests.
- Treat a fresh companion marker without its required payload as a failed publication in health.

## Validation

- `node --import tsx --test tests/cloudflare-radar-seed-flow.test.mjs tests/health-empty-data-ok.test.mjs` (13 passed)
- `npm run typecheck:api`
- Repository pre-push safety gate, including full type checks and boundary checks
- `git diff --check origin/main...HEAD`

Fixes #7845.

---

[![Compound Engineering](https://img.shields.io/badge/Compound%20Engineering-000000)](https://github.com/compound-engineering)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
