### PR TITLE
fix(sentry): align releases while preserving GitHub sync

### DIFF
--- a/docs/solutions/workflow-issues/sentry-resolve-by-shipping-permanently-mutes-issues.md
+++ b/docs/solutions/workflow-issues/sentry-resolve-by-shipping-permanently-mutes-issues.md
@@ -19,6 +19,61 @@ tags: [sentry, resolve-by-shipping, inrelease-pin, github-integration, commit-me
 
 # Resolve-by-shipping silently mutes browser Sentry issues forever
 
+## Release alignment update — 2026-09-08
+
+The owner chose to preserve GitHub/Sentry automation. The older recommendation
+below to disable commit resolution is superseded. No such control was found in
+the installed integration settings; GitHub issue-status synchronization is a
+separate setting. Do not disable the integration or replace it with manual triage.
+
+`shared/sentry-build-metadata.ts` now supplies the deployment SHA as `release`
+for both dashboard and marketing events, matching `api/_sentry-common.js`.
+Both Vite uploaders use that same release and `dist`. `app_version` retains the
+semantic version for searches across deployments; release health is now per SHA.
+Missing or malformed build markers retain the local semver fallback.
+
+The marketing build only uploads artifacts. The production root build owns
+release creation, finalization, and automatic commit association. Preview and
+local builds do not perform those release lifecycle writes. Source-map matching
+still uses debug IDs, and the existing public-map cleanup remains in place.
+Production build finalization is not proof of a successful deployment: a failed
+deployment after the build can still leave a Sentry release behind. This change
+does not introduce a post-deployment finalization service.
+
+### Live acceptance after deployment
+
+Local tests prove identity propagation, not Sentry's hosted regression behavior.
+The release owner must record the following evidence before calling #7838 closed:
+
+1. Read the production build SHA and inspect a new dashboard event and marketing
+   event. Both must carry that SHA as `release` and `dist`, and the expected
+   `app_version` and `build_sha` tags. Inspect each event's full stack to confirm
+   that uploaded source maps still produce original file names and lines.
+2. In an explicitly authorized isolated Sentry test project, reproduce the same
+   error fingerprint in release A, then associate its fixing commit with release
+   B using the GitHub integration. Confirm the resulting resolution from an
+   independent issue read. Use the same configuration and release lifecycle as
+   production; a direct status write does not prove commit resolution works.
+3. Send an event from A after resolution and record whether it stays resolved.
+   Then send the same fingerprint from a later release C and confirm the issue
+   reopens. Include a client still running the old semver bundle in the old-build
+   check. Do not infer release ordering from the lexical order of SHA strings.
+4. Verify preview builds do not associate resolving commits. Audit any historical
+   pin against actual deployed releases; alignment does not repair existing pins
+   or issues with missing release metadata by itself.
+
+Keep the daily pin audit as a strict migration review alarm until these checks
+pass. Its nonzero result means compatibility needs review, not that every pin is
+invalid. Do not automatically clear valid commit/release resolutions. After live
+acceptance, replace the blanket pin gate and old plain-only triage guidance with
+an evidence-based compatibility policy; do not silently disable the audit.
+
+If new events lose build attribution or mapped frames, stop rollout and restore
+the prior build configuration. A rollback restores the old release mismatch, so
+the audit and explicit repair of confirmed incompatible pins remain necessary.
+
+The remaining sections record the original incident and remediation.
+
 ## Problem
 
 WorldMonitor's documented triage doctrine was resolve by shipping. Put a `Fixes` marker naming a Sentry short ID in the commit message or the PR body and let the Sentry GitHub integration close the issue. The integration does not issue a plain resolve. It resolves the issue `inRelease: <commit-sha>`.

--- a/docs/solutions/workflow-issues/sentry-resolve-by-shipping-permanently-mutes-issues.md
+++ b/docs/solutions/workflow-issues/sentry-resolve-by-shipping-permanently-mutes-issues.md
@@ -27,10 +27,17 @@ the installed integration settings; GitHub issue-status synchronization is a
 separate setting. Do not disable the integration or replace it with manual triage.
 
 `shared/sentry-build-metadata.ts` now supplies the deployment SHA as `release`
-for both dashboard and marketing events, matching `api/_sentry-common.js`.
+for production dashboard and marketing events, matching `api/_sentry-common.js`.
 Both Vite uploaders use that same release and `dist`. `app_version` retains the
 semantic version for searches across deployments; release health is now per SHA.
-Missing or malformed build markers retain the local semver fallback.
+Missing or malformed production build markers retain the semver fallback.
+
+Preview and development browser events retain build/version tags but omit release
+and dist, and use environment-specific fingerprints even for custom groups.
+This keeps them out of production release ordering and issue regression state.
+Both uploaders disable automatic release injection; the SDK sets production
+release metadata explicitly. Build-time `create: false` alone is insufficient
+because an event carrying a release can create that release during ingestion.
 
 The marketing build only uploads artifacts. The production root build owns
 release creation, finalization, and automatic commit association. Preview and
@@ -58,7 +65,8 @@ The release owner must record the following evidence before calling #7838 closed
    Then send the same fingerprint from a later release C and confirm the issue
    reopens. Include a client still running the old semver bundle in the old-build
    check. Do not infer release ordering from the lexical order of SHA strings.
-4. Verify preview builds do not associate resolving commits. Audit any historical
+4. Verify preview events have no release and group separately from production,
+   and preview builds do not associate resolving commits. Audit any historical
    pin against actual deployed releases; alignment does not repair existing pins
    or issues with missing release metadata by itself.
 

--- a/pro-test/src/sentry.ts
+++ b/pro-test/src/sentry.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/react';
-import { getSentryBuildMetadata } from '../../shared/sentry-build-metadata';
+import { getSentryBuildMetadata, isolateNonProductionSentryEvent } from '../../shared/sentry-build-metadata';
 
 import { SENTRY_ALLOW_URLS } from './sentry-allow-urls';
 import {
@@ -21,13 +21,14 @@ import { collectRemoveChildEvidence, decorateRemoveChildEvent } from './services
 export function initSentry(): void {
   const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
   const servedLanguage = document.documentElement.getAttribute('lang') ?? 'en';
+  const environment = (location.hostname === 'worldmonitor.app' || location.hostname.endsWith('.worldmonitor.app')) ? 'production'
+    : location.hostname.includes('vercel.app') ? 'preview'
+    : 'development';
 
   Sentry.init({
     dsn: sentryDsn || undefined,
-    ...getSentryBuildMetadata(__APP_VERSION__, __BUILD_HASH__),
-    environment: (location.hostname === 'worldmonitor.app' || location.hostname.endsWith('.worldmonitor.app')) ? 'production'
-      : location.hostname.includes('vercel.app') ? 'preview'
-      : 'development',
+    ...getSentryBuildMetadata(__APP_VERSION__, __BUILD_HASH__, environment),
+    environment,
     enabled: Boolean(sentryDsn) && !location.hostname.startsWith('localhost'),
     allowUrls: SENTRY_ALLOW_URLS,
     tracesSampleRate: 0.1,
@@ -35,6 +36,7 @@ export function initSentry(): void {
     beforeSend: (event) => {
       const filteredEvent = marketingBeforeSend(event);
       if (!filteredEvent) return null;
+      isolateNonProductionSentryEvent(filteredEvent, environment);
       if (filteredEvent.request?.url) {
         const safeRequestUrl = sanitizeMarketingRequestUrl(filteredEvent.request.url);
         filteredEvent.request.url = safeRequestUrl;

--- a/pro-test/src/sentry.ts
+++ b/pro-test/src/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react';
+import { getSentryBuildMetadata } from '../../shared/sentry-build-metadata';
 
 import { SENTRY_ALLOW_URLS } from './sentry-allow-urls';
 import {
@@ -23,6 +24,7 @@ export function initSentry(): void {
 
   Sentry.init({
     dsn: sentryDsn || undefined,
+    ...getSentryBuildMetadata(__APP_VERSION__, __BUILD_HASH__),
     environment: (location.hostname === 'worldmonitor.app' || location.hostname.endsWith('.worldmonitor.app')) ? 'production'
       : location.hostname.includes('vercel.app') ? 'preview'
       : 'development',

--- a/pro-test/src/vite-env.d.ts
+++ b/pro-test/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __BUILD_HASH__: string;

--- a/pro-test/vite.config.ts
+++ b/pro-test/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
           telemetry: false,
           release: {
             name: sentryBuild.release,
+            inject: false,
             dist: sentryBuild.dist,
             // The root build publishes the release after both bundles build.
             create: false,

--- a/pro-test/vite.config.ts
+++ b/pro-test/vite.config.ts
@@ -3,11 +3,14 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vite';
+import pkg from '../package.json';
+import { getSentryBuildMetadata } from '../shared/sentry-build-metadata';
 
 // Mirrors the root config's gate. WORLDMONITOR-11Y and -107 are marketing-bundle
 // events that arrived with zero usable frames, so covering only the dashboard
 // would leave this half of the surface unreadable.
 const uploadSourceMapsToSentry = Boolean(process.env.SENTRY_AUTH_TOKEN);
+const sentryBuild = getSentryBuildMetadata(pkg.version, process.env.VERCEL_GIT_COMMIT_SHA ?? 'dev');
 
 const STATIC_SCRIPT_NONCE = 'wm-static-bootstrap';
 
@@ -21,6 +24,10 @@ function isWelcomeHydrationPreload(dep: string) {
 }
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __BUILD_HASH__: JSON.stringify(process.env.VERCEL_GIT_COMMIT_SHA ?? 'dev'),
+  },
   plugins: [
     react(),
     tailwindcss(),
@@ -30,6 +37,15 @@ export default defineConfig({
           project: 'worldmonitor',
           authToken: process.env.SENTRY_AUTH_TOKEN,
           telemetry: false,
+          release: {
+            name: sentryBuild.release,
+            dist: sentryBuild.dist,
+            // The root build publishes the release after both bundles build.
+            create: false,
+            finalize: false,
+            setCommits: false,
+            deploy: false,
+          },
           sourcemaps: {
             // This bundle emits into ../public/pro, which the root build copies
             // wholesale into dist — a leftover map would ship publicly whatever

--- a/scripts/audit-sentry-resolve-pins.mjs
+++ b/scripts/audit-sentry-resolve-pins.mjs
@@ -1,20 +1,16 @@
 #!/usr/bin/env node
 
 /**
- * Read-only audit for release-pinned Sentry resolutions.
+ * Read-only migration audit for release-pinned Sentry resolutions.
  *
- * WorldMonitor resolves by shipping: a commit body carrying `Fixes
- * WORLDMONITOR-XX` closes the issue. The Sentry GitHub integration acts on
- * that marker by resolving the issue `inRelease: <commit-sha>` rather than
- * issuing a plain resolve. Browser events all carry the static semver release
- * `worldmonitor@2.10.0`, so a browser event can never arrive in a release
- * NEWER than a SHA-named pin, and the issue can therefore never reopen. It
- * reads "resolved" forever while the bug keeps firing. Sentry triage policy is
- * plain resolve only, so any pin is a policy violation and this audit is the
- * backstop that finds one.
- *
- * Nothing here mutates Sentry. The repair is manual and is printed with the
- * findings.
+ * The old stable browser release could not advance past SHA-named pins.
+ * Browser and uploader release alignment addresses that mismatch for new
+ * builds, but does not prove deployed Sentry regression handling or migrate
+ * old tabs. Keep reporting every pin until the live acceptance procedure in
+ * docs/solutions/workflow-issues/sentry-resolve-by-shipping-permanently-mutes-issues.md
+ * passes and a compatibility-aware audit replaces this migration gate.
+ * A pin is a review candidate, not proof that an issue cannot reopen.
+ * Nothing here mutates Sentry or clears valid automatic resolutions.
  *
  * The API traps are encoded here rather than documented elsewhere:
  *
@@ -153,8 +149,8 @@ export function formatReport(result) {
     lines.push(`Sentry resolve pins clean: ${result.checked} resolved issues, all plain resolves.`);
   } else {
     lines.push(
-      `Sentry resolve pins violated: ${result.violations.length} of ${result.checked} `
-        + 'resolved issues are pinned to a release or commit and can never reopen.',
+      `Sentry resolve pins require review: ${result.violations.length} of ${result.checked} `
+        + 'resolved issues are pinned; verify deployed release compatibility before repair.',
     );
     for (const violation of result.violations) {
       lines.push(`  ${violation.shortId ?? violation.id ?? 'unknown issue'}`
@@ -170,11 +166,12 @@ export function formatReport(result) {
 
 export function formatRepairRecipe() {
   return [
-    'Repair each pinned issue by hand, one at a time:',
+    'Only repair a confirmed incompatible pin; preserve valid automatic resolutions.',
+    'Check deployed release identity and recurrence evidence before changing status.',
     '  1. PUT status=unresolved on the issue.',
     '  2. GET the issue and confirm status is unresolved.',
     '  3. PUT status=resolved with no statusDetails.',
-    '  4. GET the issue and confirm statusDetails is {}.',
+    '  4. GET the issue and confirm statusDetails has no release or commit pin keys.',
     'Step 1 is not optional. A resolved-to-resolved write silently no-ops and',
     'leaves the pin in place while reporting success.',
   ].join('\n');
@@ -280,7 +277,7 @@ async function main() {
     for (const violation of result.violations) {
       console.error(
         `::error::${violation.shortId ?? violation.id} is resolved and pinned to `
-          + `${violation.pinValue}, so new events can never reopen it.`,
+          + `${violation.pinValue}; deployed release compatibility needs verification.`,
       );
     }
     console.error(formatRepairRecipe());

--- a/shared/sentry-build-metadata.ts
+++ b/shared/sentry-build-metadata.ts
@@ -1,7 +1,7 @@
 const VERCEL_COMMIT_SHA = /^[0-9a-f]{40}$/i;
 
 interface SentryBuildMetadata {
-  release: string;
+  release?: string;
   dist?: string;
   initialScope?: {
     tags: {
@@ -19,14 +19,15 @@ interface SentryBuildMetadata {
 export function getSentryBuildMetadata(
   appVersion: string,
   buildHash: string,
+  environment = 'production',
 ): SentryBuildMetadata {
   const release = `worldmonitor@${appVersion}`;
   const normalizedBuildHash = buildHash.trim();
-  if (!VERCEL_COMMIT_SHA.test(normalizedBuildHash)) return { release };
+  if (!VERCEL_COMMIT_SHA.test(normalizedBuildHash)) return { release: environment === 'production' ? release : undefined };
 
   return {
-    release: normalizedBuildHash,
-    dist: normalizedBuildHash,
+    release: environment === 'production' ? normalizedBuildHash : undefined,
+    dist: environment === 'production' ? normalizedBuildHash : undefined,
     initialScope: {
       tags: {
         build_sha: normalizedBuildHash,
@@ -34,4 +35,15 @@ export function getSentryBuildMetadata(
       },
     },
   };
+}
+
+/** Environments share a Sentry project, so preview errors need separate groups. */
+export function isolateNonProductionSentryEvent(
+  event: { release?: string; dist?: string; fingerprint?: string[] },
+  environment: string,
+): void {
+  if (environment === 'production') return;
+  delete event.release;
+  delete event.dist;
+  event.fingerprint = [...(event.fingerprint ?? ['{{ default }}']), `worldmonitor:${environment}`];
 }

--- a/shared/sentry-build-metadata.ts
+++ b/shared/sentry-build-metadata.ts
@@ -6,14 +6,15 @@ interface SentryBuildMetadata {
   initialScope?: {
     tags: {
       build_sha: string;
+      app_version: string;
     };
   };
 }
 
 /**
- * Keep the semver release stable while making each Vercel deployment
- * attributable. Sentry's `dist` is the build within a release; the explicit
- * tag keeps the SHA available in issue/event searches and exports.
+ * Match the Edge release and GitHub commit identity. A stable semver release
+ * cannot advance past a commit-based resolution when the app version stays
+ * unchanged. Keep the app version as a tag for cross-deployment searches.
  */
 export function getSentryBuildMetadata(
   appVersion: string,
@@ -24,11 +25,12 @@ export function getSentryBuildMetadata(
   if (!VERCEL_COMMIT_SHA.test(normalizedBuildHash)) return { release };
 
   return {
-    release,
+    release: normalizedBuildHash,
     dist: normalizedBuildHash,
     initialScope: {
       tags: {
         build_sha: normalizedBuildHash,
+        app_version: appVersion,
       },
     },
   };

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -8,7 +8,7 @@
 
 import { isIosLikeUserAgent } from './platform-ua';
 import { SENTRY_ALLOW_URLS } from './sentry-allow-urls';
-import { getSentryBuildMetadata } from '../../shared/sentry-build-metadata';
+import { getSentryBuildMetadata, isolateNonProductionSentryEvent } from '../../shared/sentry-build-metadata';
 
 type SentryNs = typeof import('@sentry/browser');
 
@@ -58,12 +58,13 @@ const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set([
 
 function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
   const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
+  const environment = (location.hostname === 'worldmonitor.app' || location.hostname.endsWith('.worldmonitor.app')) ? 'production'
+    : location.hostname.includes('vercel.app') ? 'preview'
+    : 'development';
   return {
     dsn: sentryDsn || undefined,
-    ...getSentryBuildMetadata(__APP_VERSION__, __BUILD_HASH__),
-    environment: (location.hostname === 'worldmonitor.app' || location.hostname.endsWith('.worldmonitor.app')) ? 'production'
-      : location.hostname.includes('vercel.app') ? 'preview'
-      : 'development',
+    ...getSentryBuildMetadata(__APP_VERSION__, __BUILD_HASH__, environment),
+    environment,
     enabled: Boolean(sentryDsn) && !location.hostname.startsWith('localhost') && !('__TAURI_INTERNALS__' in window),
     allowUrls: SENTRY_ALLOW_URLS,
     sendDefaultPii: true,
@@ -431,6 +432,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /^(?:CollectorTransportError: )?Umami collector beacon transport rejected\b/,
     ],
     beforeSend(event) {
+      isolateNonProductionSentryEvent(event, environment);
       const msg = event.exception?.values?.[0]?.value ?? '';
       if (msg.length <= 3 && /^[a-zA-Z_$]+$/.test(msg)) return null;
       const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -432,7 +432,6 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /^(?:CollectorTransportError: )?Umami collector beacon transport rejected\b/,
     ],
     beforeSend(event) {
-      isolateNonProductionSentryEvent(event, environment);
       const msg = event.exception?.values?.[0]?.value ?? '';
       if (msg.length <= 3 && /^[a-zA-Z_$]+$/.test(msg)) return null;
       const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
@@ -1096,6 +1095,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       if (excType === 'SyntaxError'
           && /^(?:SyntaxError: )?(?:Invalid or unexpected token|Unexpected (?:token|keyword|identifier|EOF|end of script))/.test(msg)
           && frames.some(f => /\/(?:maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
+      isolateNonProductionSentryEvent(event, environment);
       return event;
     },
   };

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -8,7 +8,7 @@
 
 import { isIosLikeUserAgent } from './platform-ua';
 import { SENTRY_ALLOW_URLS } from './sentry-allow-urls';
-import { getSentryBuildMetadata } from './sentry-build-metadata';
+import { getSentryBuildMetadata } from '../../shared/sentry-build-metadata';
 
 type SentryNs = typeof import('@sentry/browser');
 

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isDebugBearRumScriptFrame } from '../src/bootstrap/debugbear-rum.ts';
 import { isIosLikeUserAgent } from '../src/bootstrap/platform-ua.ts';
+import { isolateNonProductionSentryEvent } from '../shared/sentry-build-metadata.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -43,6 +44,7 @@ assert.ok(tpMatch, 'THIRD_PARTY_FETCH_HOST_ALLOWLIST must be defined in src/boot
 // eslint-disable-next-line no-new-func
 const rawBeforeSend = new Function(
   'event', 'isDebugBearRumScriptFrame', 'isIosLikeUserAgent', 'navigator',
+  'isolateNonProductionSentryEvent', 'environment',
   `${tpMatch[0]}\n${fnBody}`,
 );
 
@@ -58,7 +60,7 @@ const IOS_NAVIGATOR = { userAgent: IOS_GOOGLE_APP_UA, maxTouchPoints: 5 };
 const IPADOS_NAVIGATOR = { userAgent: MAC_DESKTOP_UA, maxTouchPoints: 5 };
 
 function beforeSend(event, navigatorStub = DESKTOP_NAVIGATOR) {
-  return rawBeforeSend(event, isDebugBearRumScriptFrame, isIosLikeUserAgent, navigatorStub);
+  return rawBeforeSend(event, isDebugBearRumScriptFrame, isIosLikeUserAgent, navigatorStub, isolateNonProductionSentryEvent, 'production');
 }
 
 // Extract the `ignoreErrors` array literal so tests can assert which messages

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -59,8 +59,8 @@ const IOS_NAVIGATOR = { userAgent: IOS_GOOGLE_APP_UA, maxTouchPoints: 5 };
 /** iPadOS 13+ desktop mode: Macintosh UA, but touch-capable. */
 const IPADOS_NAVIGATOR = { userAgent: MAC_DESKTOP_UA, maxTouchPoints: 5 };
 
-function beforeSend(event, navigatorStub = DESKTOP_NAVIGATOR) {
-  return rawBeforeSend(event, isDebugBearRumScriptFrame, isIosLikeUserAgent, navigatorStub, isolateNonProductionSentryEvent, 'production');
+function beforeSend(event, navigatorStub = DESKTOP_NAVIGATOR, environment = 'production') {
+  return rawBeforeSend(event, isDebugBearRumScriptFrame, isIosLikeUserAgent, navigatorStub, isolateNonProductionSentryEvent, environment);
 }
 
 // Extract the `ignoreErrors` array literal so tests can assert which messages
@@ -1827,6 +1827,25 @@ describe('host-attributed fetch failures are fingerprinted by host (WORLDMONITOR
     { filename: '/assets/widget-store-DbqgxtxV.js', lineno: 0, function: 'Pn.window.fetch' },
     { filename: '/assets/analytics-DdK2NArM.js', lineno: 0, function: 'c' },
   ];
+
+  it('isolates non-production fetch groups after host attribution', () => {
+    for (const environment of ['preview', 'development']) {
+      for (const [host, bucket] of [
+        ['api.worldmonitor.app', 'api.worldmonitor.app'],
+        ['pub-8ace9f6a86d74cb2bd5eb1de5590dd9e.r2.dev', 'pub-8ace9f6a86d74cb2bd5eb1de5590dd9e.r2.dev'],
+        ['foreign.example', 'third-party'],
+      ]) {
+        const input = makeEvent(`Failed to fetch (${host})`, 'TypeError', zgStack);
+        input.release = 'a'.repeat(40);
+        input.dist = 'a'.repeat(40);
+        const event = beforeSend(input, DESKTOP_NAVIGATOR, environment);
+        assert.ok(event !== null);
+        assert.deepEqual(event.fingerprint, ['fetch-failure', bucket, `worldmonitor:${environment}`]);
+        assert.equal(event.release, undefined);
+        assert.equal(event.dist, undefined);
+      }
+    }
+  });
 
   it('gives a first-party origin failure its own fingerprint', () => {
     const event = beforeSend(makeEvent('Failed to fetch (api.worldmonitor.app)', 'TypeError', zgStack));

--- a/tests/sentry-build-metadata.test.mts
+++ b/tests/sentry-build-metadata.test.mts
@@ -1,9 +1,29 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { getSentryBuildMetadata } from '../shared/sentry-build-metadata';
+import { getSentryBuildMetadata, isolateNonProductionSentryEvent } from '../shared/sentry-build-metadata';
 
 describe('Sentry build attribution', () => {
+  it('keeps preview build tags without adding to production release ordering', () => {
+    const sha = 'a'.repeat(40);
+    const metadata = getSentryBuildMetadata('2.10.0', sha, 'preview');
+    assert.equal(metadata.release, undefined);
+    assert.equal(metadata.dist, undefined);
+    assert.equal(metadata.initialScope?.tags.build_sha, sha);
+    assert.equal(metadata.initialScope?.tags.app_version, '2.10.0');
+  });
+
+  it('separates preview fingerprints and removes explicitly supplied releases', () => {
+    const event = { release: 'a'.repeat(40), dist: 'a'.repeat(40), fingerprint: ['custom-group'] };
+    isolateNonProductionSentryEvent(event, 'preview');
+    assert.equal(event.release, undefined);
+    assert.equal(event.dist, undefined);
+    assert.deepEqual(event.fingerprint, ['custom-group', 'worldmonitor:preview']);
+    const production = { release: 'b'.repeat(40), fingerprint: ['custom-group'] };
+    isolateNonProductionSentryEvent(production, 'production');
+    assert.deepEqual(production, { release: 'b'.repeat(40), fingerprint: ['custom-group'] });
+  });
+
   it('uses the deployment SHA as release and keeps version and build attribution', () => {
     const sha = 'aa74d8947a7cd59afef896078a606d31e0bd388b';
 

--- a/tests/sentry-build-metadata.test.mts
+++ b/tests/sentry-build-metadata.test.mts
@@ -1,21 +1,28 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { getSentryBuildMetadata } from '../src/bootstrap/sentry-build-metadata';
+import { getSentryBuildMetadata } from '../shared/sentry-build-metadata';
 
 describe('Sentry build attribution', () => {
-  it('uses the Vercel commit SHA as dist and build_sha without changing release grouping', () => {
+  it('uses the deployment SHA as release and keeps version and build attribution', () => {
     const sha = 'aa74d8947a7cd59afef896078a606d31e0bd388b';
 
     assert.deepEqual(getSentryBuildMetadata('2.10.0', sha), {
-      release: 'worldmonitor@2.10.0',
+      release: sha,
       dist: sha,
       initialScope: {
         tags: {
           build_sha: sha,
+          app_version: '2.10.0',
         },
       },
     });
+  });
+
+  it('changes release on the next deployment even when the app version is unchanged', () => {
+    const first = getSentryBuildMetadata('2.10.0', 'a'.repeat(40));
+    const next = getSentryBuildMetadata('2.10.0', 'b'.repeat(40));
+    assert.notEqual(first.release, next.release);
   });
 
   it('omits build attribution for local and malformed build markers', () => {
@@ -32,6 +39,7 @@ describe('Sentry build attribution', () => {
     const metadata = getSentryBuildMetadata('2.10.0', `  ${sha}\n`);
 
     assert.equal(metadata.dist, sha);
+    assert.equal(metadata.release, sha);
     assert.equal(metadata.initialScope?.tags.build_sha, sha);
   });
 });

--- a/tests/sentry-release-build.test.mts
+++ b/tests/sentry-release-build.test.mts
@@ -1,19 +1,36 @@
 import assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { resolve, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { build } from 'esbuild';
 import { BrowserClient, Scope } from '@sentry/browser';
-import { getSentryBuildMetadata, isolateNonProductionSentryEvent } from '../shared/sentry-build-metadata';
+import type { BrowserOptions, ErrorEvent } from '@sentry/browser';
+import type { Envelope } from '@sentry/core';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
+import type { ConfigEnv, UserConfig } from 'vite';
+import { Window } from 'happy-dom';
 
 const originalEnv = { ...process.env };
 const sha = '0123456789abcdef0123456789abcdef01234567';
 let scratch: string;
-let loadDashboard: Function;
+let loadDashboard: (env: ConfigEnv) => UserConfig;
 let marketingConfigUrl: string;
+const initializers: Array<() => Promise<BrowserOptions>> = [];
+type UploadOptions = NonNullable<Parameters<typeof sentryVitePlugin>[0]>;
+
+function uploadOptions(config: UserConfig): NonNullable<UploadOptions['release']> {
+  const plugins: unknown[] = config.plugins ?? [];
+  const plugin = plugins.flat(Infinity).find(p => p && typeof p === 'object' && 'name' in p && p.name === 'sentry-upload');
+  assert.ok(plugin && typeof plugin === 'object' && 'options' in plugin);
+  const options = plugin.options as UploadOptions;
+  assert.ok(options.release);
+  return options.release;
+}
 
 before(async () => {
+  const { version } = JSON.parse(await readFile(resolve('package.json'), 'utf8'));
+  assert.equal(typeof version, 'string');
   const cache = resolve('pro-test/node_modules/.cache');
   await mkdir(cache, { recursive: true });
   scratch = await mkdtemp(join(cache, 'sentry-release-test-'));
@@ -37,6 +54,26 @@ before(async () => {
   }
   loadDashboard = (await import(pathToFileURL(join(scratch, 'dashboard.mjs')).href)).default;
   marketingConfigUrl = pathToFileURL(join(scratch, 'marketing.mjs')).href;
+  for (const [name, entry, initialize] of [
+    ['dashboard', 'src/bootstrap/sentry-init.ts', 'loadAndInitSentry'],
+    ['marketing', 'pro-test/src/sentry.ts', 'initSentry'],
+  ]) {
+    const outfile = join(scratch, `${name}-init.mjs`);
+    await build({
+      stdin: { contents: `import { ${initialize} } from ${JSON.stringify(resolve(entry))}; import { captured } from 'capture-sdk'; export default async () => { await ${initialize}(); return captured(); };`, resolveDir: resolve('.') },
+      outfile, bundle: true, platform: 'node', format: 'esm', packages: 'external',
+      define: { __APP_VERSION__: JSON.stringify(version), __BUILD_HASH__: JSON.stringify(sha), 'import.meta.env.VITE_SENTRY_DSN': '"https://public@example.invalid/1"' },
+      plugins: [{ name: 'capture-real-initializer', setup(bundler) {
+        bundler.onResolve({ filter: /^(?:@sentry\/(?:browser|react)|capture-sdk)$/ }, () => ({ path: 'sdk', namespace: 'capture' }));
+        bundler.onLoad({ filter: /.*/, namespace: 'capture' }, () => ({ contents: 'let options; export const init = value => { options = value; }; export const captured = () => options;' }));
+        // Locale loading is unrelated to release metadata; retain the real
+        // initializer, filtering and DOM evidence collection.
+        bundler.onResolve({ filter: /^\.\/i18n$/ }, () => ({ path: 'locale', namespace: 'locale' }));
+        bundler.onLoad({ filter: /.*/, namespace: 'locale' }, () => ({ contents: 'export const currentLanguageBase = () => "en";' }));
+      } }],
+    });
+    initializers.push((await import(pathToFileURL(outfile).href)).default);
+  }
 });
 
 afterEach(() => {
@@ -56,45 +93,61 @@ describe('Sentry build and event release contract', () => {
         (await import(`${marketingConfigUrl}?target=${target}`)).default,
       ];
       for (const [index, config] of configs.entries()) {
-        const metadata = getSentryBuildMetadata(
-          JSON.parse(config.define.__APP_VERSION__), JSON.parse(config.define.__BUILD_HASH__),
-          target,
-        );
-        const upload = config.plugins.flat(Infinity).find((p: any) => p?.name === 'sentry-upload').options;
-        assert.equal(metadata.release, target === 'production' ? sha : undefined);
-        assert.equal(upload.release.name, sha);
-        assert.equal(upload.release.dist, sha);
-        assert.equal(upload.release.inject, false);
+        assert.equal(JSON.parse(String(config.define?.__BUILD_HASH__)), sha);
+        const upload = uploadOptions(config);
+        assert.equal(upload.name, sha);
+        assert.equal(upload.dist, sha);
+        assert.equal(upload.inject, false);
         const publishes = index === 0 && target === 'production';
-        assert.equal(upload.release.create, publishes);
-        assert.equal(upload.release.finalize, publishes);
-        assert.equal(upload.release.setCommits, publishes ? undefined : false);
-        assert.equal(upload.release.deploy, publishes ? undefined : false);
+        assert.equal(upload.create, publishes);
+        assert.equal(upload.finalize, publishes);
+        assert.equal(upload.setCommits, publishes ? undefined : false);
+        assert.equal(upload.deploy, publishes ? undefined : false);
 
         // A real SDK client produces the event envelope. Only delivery is
         // replaced; release, dist and scope tags pass through Sentry itself.
-        const envelopes: any[] = [];
-        const client = new BrowserClient({
-          ...metadata, dsn: 'https://public@example.invalid/1',
-          integrations: [], stackParser: () => [],
-          beforeSend: event => { isolateNonProductionSentryEvent(event, target); return event; },
-          transport: () => ({
-            send: async (envelope) => { envelopes.push(envelope); return { statusCode: 200 }; },
-            flush: async () => true,
-          }),
-        });
-        const scope = new Scope();
-        scope.update(metadata.initialScope);
-        client.captureEvent({ message: 'synthetic release contract check' }, {}, scope);
-        await client.flush(1000);
-        assert.equal(envelopes.length, 1);
-        const event = envelopes[0][1][0][1];
-        assert.equal(event.release, target === 'production' ? sha : undefined);
-        assert.equal(event.dist, target === 'production' ? sha : undefined);
-        assert.deepEqual(event.fingerprint, target === 'production' ? undefined : ['{{ default }}', `worldmonitor:${target}`]);
-        assert.equal(event.tags.app_version, JSON.parse(config.define.__APP_VERSION__));
-        assert.equal(event.tags.build_sha, sha);
-        await client.close();
+        const hostname = target === 'production' ? 'worldmonitor.app' : target === 'preview' ? 'worldmonitor-preview.vercel.app' : 'dev.example';
+        const window = new Window({ url: `https://${hostname}/` });
+        const globals = ['window', 'document', 'location', 'navigator'] as const;
+        const descriptors = globals.map(key => Object.getOwnPropertyDescriptor(globalThis, key));
+        for (const key of globals) Object.defineProperty(globalThis, key, { value: key === 'window' ? window : window[key], configurable: true });
+        let client: BrowserClient | undefined;
+        try {
+          const options = await initializers[index]();
+          assert.equal(options.environment, target);
+          assert.equal(options.enabled, true);
+          const envelopes: Envelope[] = [];
+          client = new BrowserClient({
+            ...options,
+            integrations: [], stackParser: () => [],
+            transport: () => ({
+              send: async (envelope) => { envelopes.push(envelope); return { statusCode: 200 }; },
+              flush: async () => true,
+            }),
+          });
+          const scope = new Scope();
+          scope.update(typeof options.initialScope === 'function' ? options.initialScope(scope) : options.initialScope);
+          for (const fingerprint of [undefined, ['custom-group']]) {
+            client.captureEvent({ exception: { values: [{ type: 'Error', value: 'synthetic release contract check' }] }, fingerprint }, {}, scope);
+            await client.flush(1000);
+            const envelope = envelopes.pop();
+            assert.ok(envelope);
+            const event = envelope[1][0][1] as ErrorEvent;
+            assert.equal(event.release, target === 'production' ? sha : undefined);
+            assert.equal(event.dist, target === 'production' ? sha : undefined);
+            assert.deepEqual(event.fingerprint, target === 'production' ? fingerprint : [...(fingerprint ?? ['{{ default }}']), `worldmonitor:${target}`]);
+            assert.equal(event.tags?.app_version, JSON.parse(String(config.define?.__APP_VERSION__)));
+            assert.equal(event.tags?.build_sha, sha);
+          }
+        } finally {
+          await client?.close();
+          for (const [i, key] of globals.entries()) {
+            const descriptor = descriptors[i];
+            if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+            else Reflect.deleteProperty(globalThis, key);
+          }
+          await window.happyDOM.close();
+        }
       }
     });
   }
@@ -104,9 +157,9 @@ describe('Sentry build and event release contract', () => {
     process.env.VERCEL_ENV = 'production';
     delete process.env.VERCEL_GIT_COMMIT_SHA;
     const config = await loadDashboard({ mode: 'production', command: 'build' });
-    const upload = config.plugins.flat(Infinity).find((p: any) => p?.name === 'sentry-upload').options;
-    assert.equal(upload.release.create, false);
-    assert.equal(upload.release.finalize, false);
-    assert.equal(upload.release.setCommits, false);
+    const upload = uploadOptions(config);
+    assert.equal(upload.create, false);
+    assert.equal(upload.finalize, false);
+    assert.equal(upload.setCommits, false);
   });
 });

--- a/tests/sentry-release-build.test.mts
+++ b/tests/sentry-release-build.test.mts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { after, afterEach, before, describe, it } from 'node:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { resolve, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+import { BrowserClient, Scope } from '@sentry/browser';
+import { getSentryBuildMetadata } from '../shared/sentry-build-metadata';
+
+const originalEnv = { ...process.env };
+const sha = '0123456789abcdef0123456789abcdef01234567';
+let scratch: string;
+let loadDashboard: Function;
+let marketingConfigUrl: string;
+
+before(async () => {
+  const cache = resolve('pro-test/node_modules/.cache');
+  await mkdir(cache, { recursive: true });
+  scratch = await mkdtemp(join(cache, 'sentry-release-test-'));
+  // Execute both real configs, replacing only the upload boundary. No token
+  // or network access is needed to observe what we pass to the Sentry plugin.
+  for (const [name, entry] of [['dashboard', 'vite.config.ts'], ['marketing', 'pro-test/vite.config.ts']]) {
+    await build({
+      entryPoints: [entry], outfile: join(scratch, `${name}.mjs`),
+      bundle: true, platform: 'node', format: 'esm', packages: 'external',
+      define: { __dirname: JSON.stringify(resolve(name === 'dashboard' ? '.' : 'pro-test')) },
+      plugins: [{
+        name: 'capture-sentry-upload-options',
+        setup(bundler) {
+          bundler.onResolve({ filter: /^@sentry\/vite-plugin$/ }, () => ({ path: 'sentry-upload', namespace: 'test' }));
+          bundler.onLoad({ filter: /.*/, namespace: 'test' }, () => ({
+            contents: 'export const sentryVitePlugin = options => ({ name: "sentry-upload", options });',
+          }));
+        },
+      }],
+    });
+  }
+  loadDashboard = (await import(pathToFileURL(join(scratch, 'dashboard.mjs')).href)).default;
+  marketingConfigUrl = pathToFileURL(join(scratch, 'marketing.mjs')).href;
+});
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) if (!(key in originalEnv)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+});
+after(async () => { if (scratch) await rm(scratch, { recursive: true, force: true }); });
+
+describe('Sentry build and event release contract', () => {
+  for (const target of ['production', 'preview', 'development']) {
+    it(`aligns both bundles and source-map uploads in ${target}`, async () => {
+      process.env.SENTRY_AUTH_TOKEN = 'test-only-never-sent';
+      process.env.VERCEL_GIT_COMMIT_SHA = sha;
+      process.env.VERCEL_ENV = target;
+      const configs = [
+        await loadDashboard({ mode: 'production', command: 'build' }),
+        (await import(`${marketingConfigUrl}?target=${target}`)).default,
+      ];
+      for (const [index, config] of configs.entries()) {
+        const metadata = getSentryBuildMetadata(
+          JSON.parse(config.define.__APP_VERSION__), JSON.parse(config.define.__BUILD_HASH__),
+        );
+        const upload = config.plugins.flat(Infinity).find((p: any) => p?.name === 'sentry-upload').options;
+        assert.equal(metadata.release, sha);
+        assert.equal(upload.release.name, metadata.release);
+        assert.equal(upload.release.dist, metadata.dist);
+        const publishes = index === 0 && target === 'production';
+        assert.equal(upload.release.create, publishes);
+        assert.equal(upload.release.finalize, publishes);
+        assert.equal(upload.release.setCommits, publishes ? undefined : false);
+        assert.equal(upload.release.deploy, publishes ? undefined : false);
+
+        // A real SDK client produces the event envelope. Only delivery is
+        // replaced; release, dist and scope tags pass through Sentry itself.
+        const envelopes: any[] = [];
+        const client = new BrowserClient({
+          ...metadata, dsn: 'https://public@example.invalid/1',
+          integrations: [], stackParser: () => [],
+          transport: () => ({
+            send: async (envelope) => { envelopes.push(envelope); return { statusCode: 200 }; },
+            flush: async () => true,
+          }),
+        });
+        const scope = new Scope();
+        scope.update(metadata.initialScope);
+        client.captureEvent({ message: 'synthetic release contract check' }, {}, scope);
+        await client.flush(1000);
+        assert.equal(envelopes.length, 1);
+        const event = envelopes[0][1][0][1];
+        assert.equal(event.release, upload.release.name);
+        assert.equal(event.dist, upload.release.dist);
+        assert.equal(event.tags.app_version, JSON.parse(config.define.__APP_VERSION__));
+        assert.equal(event.tags.build_sha, sha);
+        await client.close();
+      }
+    });
+  }
+
+  it('does not publish a production release with a missing deployment SHA', async () => {
+    process.env.SENTRY_AUTH_TOKEN = 'test-only-never-sent';
+    process.env.VERCEL_ENV = 'production';
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+    const config = await loadDashboard({ mode: 'production', command: 'build' });
+    const upload = config.plugins.flat(Infinity).find((p: any) => p?.name === 'sentry-upload').options;
+    assert.equal(upload.release.create, false);
+    assert.equal(upload.release.finalize, false);
+    assert.equal(upload.release.setCommits, false);
+  });
+});

--- a/tests/sentry-release-build.test.mts
+++ b/tests/sentry-release-build.test.mts
@@ -5,7 +5,7 @@ import { resolve, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { build } from 'esbuild';
 import { BrowserClient, Scope } from '@sentry/browser';
-import { getSentryBuildMetadata } from '../shared/sentry-build-metadata';
+import { getSentryBuildMetadata, isolateNonProductionSentryEvent } from '../shared/sentry-build-metadata';
 
 const originalEnv = { ...process.env };
 const sha = '0123456789abcdef0123456789abcdef01234567';
@@ -58,11 +58,13 @@ describe('Sentry build and event release contract', () => {
       for (const [index, config] of configs.entries()) {
         const metadata = getSentryBuildMetadata(
           JSON.parse(config.define.__APP_VERSION__), JSON.parse(config.define.__BUILD_HASH__),
+          target,
         );
         const upload = config.plugins.flat(Infinity).find((p: any) => p?.name === 'sentry-upload').options;
-        assert.equal(metadata.release, sha);
-        assert.equal(upload.release.name, metadata.release);
-        assert.equal(upload.release.dist, metadata.dist);
+        assert.equal(metadata.release, target === 'production' ? sha : undefined);
+        assert.equal(upload.release.name, sha);
+        assert.equal(upload.release.dist, sha);
+        assert.equal(upload.release.inject, false);
         const publishes = index === 0 && target === 'production';
         assert.equal(upload.release.create, publishes);
         assert.equal(upload.release.finalize, publishes);
@@ -75,6 +77,7 @@ describe('Sentry build and event release contract', () => {
         const client = new BrowserClient({
           ...metadata, dsn: 'https://public@example.invalid/1',
           integrations: [], stackParser: () => [],
+          beforeSend: event => { isolateNonProductionSentryEvent(event, target); return event; },
           transport: () => ({
             send: async (envelope) => { envelopes.push(envelope); return { statusCode: 200 }; },
             flush: async () => true,
@@ -86,8 +89,9 @@ describe('Sentry build and event release contract', () => {
         await client.flush(1000);
         assert.equal(envelopes.length, 1);
         const event = envelopes[0][1][0][1];
-        assert.equal(event.release, upload.release.name);
-        assert.equal(event.dist, upload.release.dist);
+        assert.equal(event.release, target === 'production' ? sha : undefined);
+        assert.equal(event.dist, target === 'production' ? sha : undefined);
+        assert.deepEqual(event.fingerprint, target === 'production' ? undefined : ['{{ default }}', `worldmonitor:${target}`]);
         assert.equal(event.tags.app_version, JSON.parse(config.define.__APP_VERSION__));
         assert.equal(event.tags.build_sha, sha);
         await client.close();

--- a/tests/sentry-resolve-pins.test.mjs
+++ b/tests/sentry-resolve-pins.test.mjs
@@ -238,6 +238,8 @@ describe('Sentry resolve-pin audit', () => {
     assert.match(run.stdout, /4 of 6/u);
     assert.match(run.stderr, /PUT status=unresolved/u);
     assert.match(run.stderr, /silently no-ops/u);
+    assert.match(run.stderr, /Only repair a confirmed incompatible pin/u);
+    assert.doesNotMatch(`${run.stdout}${run.stderr}`, /can never reopen/u);
   });
 
   it('never prints the resolver identity Sentry attaches to a pin', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { brotliCompress } from 'zlib';
 import { promisify } from 'util';
 import pkg from './package.json';
+import { getSentryBuildMetadata } from './shared/sentry-build-metadata';
 import { VARIANT_META, type VariantMeta } from './src/config/variant-meta';
 import {
   WEB_DASHBOARD_VARIANTS,
@@ -929,10 +930,10 @@ export default defineConfig(({ mode }) => {
     || process.env.VERCEL_ENV === 'preview';
   // Sentry source-map upload. Gated on the token so a build without it (local,
   // fork, CI) behaves exactly as before rather than failing. Matching is by
-  // debug ID — the plugin stamps the same id into the bundle and its map — so
-  // it does not depend on the browser SDK's static `worldmonitor@x.y.z`
-  // release name, which would otherwise collide across deploys.
+  // debug ID — the plugin stamps the same id into the bundle and its map.
   const uploadSourceMapsToSentry = Boolean(process.env.SENTRY_AUTH_TOKEN);
+  const sentryBuild = getSentryBuildMetadata(pkg.version, process.env.VERCEL_GIT_COMMIT_SHA ?? 'dev');
+  const publishSentryRelease = process.env.VERCEL_ENV === 'production' && Boolean(sentryBuild.dist);
 
   return {
     html: {
@@ -959,6 +960,16 @@ export default defineConfig(({ mode }) => {
             project: 'worldmonitor',
             authToken: process.env.SENTRY_AUTH_TOKEN,
             telemetry: false,
+            release: {
+              name: sentryBuild.release,
+              dist: sentryBuild.dist,
+              // Preview/local uploads must not resolve shared production issues.
+              create: publishSentryRelease,
+              finalize: publishSentryRelease,
+              // Preserve the plugin's Vercel-aware commit detection in production.
+              setCommits: publishSentryRelease ? undefined : false,
+              deploy: publishSentryRelease ? undefined : false,
+            },
             sourcemaps: {
               // Previews deliberately serve public maps (emitPublicSourceMaps);
               // leave those in place and only sweep them when production built

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -962,6 +962,7 @@ export default defineConfig(({ mode }) => {
             telemetry: false,
             release: {
               name: sentryBuild.release,
+              inject: false,
               dist: sentryBuild.dist,
               // Preview/local uploads must not resolve shared production issues.
               create: publishSentryRelease,


### PR DESCRIPTION
## Summary

Browser errors can retain a Sentry resolution tied to a commit release while reporting an unchanged app-version release. This change makes dashboard and marketing events use the deployment SHA, matching source-map uploads and the existing Edge release identity. The app version remains available as a tag, and GitHub–Sentry integration stays enabled.

Only the root production build creates/finalizes releases and uses Sentry's existing commit-association defaults. Preview and marketing builds can upload source maps without lifecycle writes. Preview browser events retain build tags, omit release metadata, and use separate fingerprints so they cannot create unshipped releases or regress production issues. The pin audit remains a strict migration alarm, but its guidance now requires checking compatibility before repairing a pin.

Release finalization still occurs during the build, before deployment success is known. Hosted Sentry resolution and regression behavior needs the documented live acceptance sequence; this PR does not claim to prove that behavior or complete the incident.

Related: #7838

## Validation

- 719 focused tests passed, including actual build configuration and captured SDK envelopes across production, preview, and missing-SHA cases.
- Dashboard and marketing type checks, import boundaries, and both Vite builds passed.
- Eight intercepted Chromium probes exercised both real initializers across production/preview and two deployment SHAs: production release/dist/tags matched, preview release metadata was absent, and default/custom fingerprints were isolated. All had debug IDs and error frames mapped to their original source line. These probes made no Sentry writes and do not prove hosted artifact upload or symbolication.

## Post-Deploy Monitoring & Validation

The deploying maintainer should follow the acceptance sequence in the updated incident document over the next two production releases: verify event release/dist and mapped frames; verify a fixing commit resolves an isolated test issue through the existing GitHub integration; verify an older event does not reopen it and a later-release recurrence does. Also verify preview builds do not associate commits and preview events group separately without a release. A wrong identity, missing source mapping, or recurrence that stays resolved blocks acceptance.

Keep the daily pin audit active until those checks pass. Valid automatic resolutions must not be erased merely because they contain a pin; the audit's permanent compatibility policy remains follow-up work after live evidence.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
