### PR TITLE
fix(md): share rendered homepage content with AI crawlers

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -244,7 +244,7 @@ export default function middleware(request: Request) {
   const accept = request.headers.get('accept');
   const markdownQuality = acceptQuality(accept, 'text/markdown') ?? 0;
   const wantsHomepageMarkdown = /(?:^|,)\s*text\/markdown\s*(?:;|,|$)/i.test(accept ?? '') &&
-    markdownQuality > 0 && markdownQuality >= (acceptQuality(accept, 'text/html') ?? 0);
+    markdownQuality > 0 && markdownQuality >= (acceptQuality(accept, 'text/html', true) ?? 0);
 
   if (
     path === '/' &&

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { isKnownPublicPagePath, originNotFoundResponse } from './src/config/agent-not-found';
+import { acceptQuality, isKnownPublicPagePath, originNotFoundResponse } from './src/config/agent-not-found';
 import {
   DOCS_PUBLIC_ORIGIN,
   DOCS_UPSTREAM_ORIGIN,
@@ -241,18 +241,23 @@ export default function middleware(request: Request) {
     return new Response(null, { status: 308, headers: uaConditionedRedirectHeaders(dashboardUrl) });
   }
 
+  const accept = request.headers.get('accept');
+  const markdownQuality = acceptQuality(accept, 'text/markdown') ?? 0;
+  const wantsHomepageMarkdown = /(?:^|,)\s*text\/markdown\s*(?:;|,|$)/i.test(accept ?? '') &&
+    markdownQuality > 0 && markdownQuality >= (acceptQuality(accept, 'text/html') ?? 0);
+
   if (
     path === '/' &&
     (host === 'www.worldmonitor.app' || host === 'worldmonitor.app') &&
     (request.method === 'GET' || request.method === 'HEAD') &&
     url.searchParams.get('mode') !== 'agent' &&
-    AGENT_UA.test(ua)
+    (AGENT_UA.test(ua) || wantsHomepageMarkdown)
   ) {
     return new Response(null, {
       headers: {
-        'x-middleware-rewrite': new URL('/home.md', url).toString(),
+        'x-middleware-rewrite': new URL('/pro/home.md', url).toString(),
         'Content-Type': 'text/markdown; charset=utf-8',
-        Vary: 'User-Agent',
+        Vary: 'User-Agent, Accept',
         'Cache-Control': 'private, no-store',
         'CDN-Cache-Control': 'no-store',
         'Vercel-CDN-Cache-Control': 'no-store',

--- a/pro-test/prerender.mjs
+++ b/pro-test/prerender.mjs
@@ -182,7 +182,9 @@ async function renderWelcomeRoot() {
   });
   try {
     const { renderWelcomeApp } = await server.ssrLoadModule('/src/welcome-prerender.tsx');
-    return rewriteBuiltAssetUrls(await renderWelcomeApp());
+    const { htmlToMarkdown } = await server.ssrLoadModule('../api/_md-url-twin.ts');
+    const html = rewriteBuiltAssetUrls(await renderWelcomeApp());
+    return { html, markdown: htmlToMarkdown(html, 'World Monitor') };
   } finally {
     await server.close();
   }
@@ -230,7 +232,7 @@ function rewriteBuiltAssetUrls(markup) {
   return rewritten;
 }
 
-const welcomeContent = await renderWelcomeRoot();
+const { html: welcomeContent, markdown: welcomeMarkdown } = await renderWelcomeRoot();
 
 // GitHub star InteractionCounter: populated from the committed freeze
 // snapshot, never hardcoded and never fetched at build time (offline builds
@@ -295,3 +297,15 @@ for (const { file, content, rootAttributes } of PAGES) {
   writeFileSync(htmlPath, html, 'utf-8');
   console.log(`[prerender] Injected critical CSS and visible content into public/pro/${file}`);
 }
+
+// Both homepage markdown selectors use the rendered HTML's content. Keep the
+// curated authentication and discovery guidance as a supplement, not a second
+// independently maintained copy of the homepage's measured statistics.
+const agentContext = readFileSync(resolve(__dirname, '../public/home.md'), 'utf8');
+const metadata = agentContext.match(/^---\n[\s\S]*?\n---\n/);
+if (!metadata) throw new Error('Homepage agent context must have document metadata');
+writeFileSync(
+  resolve(__dirname, '../public/pro/home.md'),
+  `${metadata[0].replace('https://www.worldmonitor.app/home.md', 'https://www.worldmonitor.app/')}\n${welcomeMarkdown}\n\n${agentContext.slice(metadata[0].length).trim()}\n`,
+  'utf8',
+);

--- a/src/config/agent-not-found.ts
+++ b/src/config/agent-not-found.ts
@@ -110,7 +110,7 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
-function acceptQuality(header: string | null | undefined, type: string): number | null {
+export function acceptQuality(header: string | null | undefined, type: string): number | null {
   if (header == null) return null;
   const trimmed = header.trim();
   if (!trimmed) return null;

--- a/src/config/agent-not-found.ts
+++ b/src/config/agent-not-found.ts
@@ -110,7 +110,8 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
-export function acceptQuality(header: string | null | undefined, type: string): number | null {
+// Catch-all ranges are opt-in: the agent 404 treats curl's */* as no HTML preference.
+export function acceptQuality(header: string | null | undefined, type: string, includeWildcard = false): number | null {
   if (header == null) return null;
   const trimmed = header.trim();
   if (!trimmed) return null;
@@ -122,14 +123,13 @@ export function acceptQuality(header: string | null | undefined, type: string): 
     const tokens = rawPart.split(';').map((part) => part.trim().toLowerCase()).filter(Boolean);
     const media = tokens[0];
     if (!media) continue;
-    // curl's default Accept is */* — do not treat that as text/html.
-    if (media === '*/*') continue;
+    const wildcard = media === '*/*' && includeWildcard;
     const [main, sub] = media.split('/');
-    if (media !== wanted && !(main === wantedMain && sub === '*')) continue;
+    if (media !== wanted && !(main === wantedMain && sub === '*') && !wildcard) continue;
     const qToken = tokens.find((token) => token.startsWith('q='));
     const q = qToken ? Number(qToken.slice(2)) : 1;
     if (!Number.isFinite(q) || q < 0) continue;
-    const matchSpecificity = media === wanted ? 1 : 0;
+    const matchSpecificity = media === wanted ? 2 : wildcard ? 0 : 1;
     if (matchSpecificity > specificity) {
       best = q;
       specificity = matchSpecificity;

--- a/src/config/agent-not-found.ts
+++ b/src/config/agent-not-found.ts
@@ -117,6 +117,7 @@ export function acceptQuality(header: string | null | undefined, type: string): 
   const wanted = type.toLowerCase();
   const [wantedMain] = wanted.split('/');
   let best: number | null = null;
+  let specificity = -1;
   for (const rawPart of trimmed.split(',')) {
     const tokens = rawPart.split(';').map((part) => part.trim().toLowerCase()).filter(Boolean);
     const media = tokens[0];
@@ -128,7 +129,13 @@ export function acceptQuality(header: string | null | undefined, type: string): 
     const qToken = tokens.find((token) => token.startsWith('q='));
     const q = qToken ? Number(qToken.slice(2)) : 1;
     if (!Number.isFinite(q) || q < 0) continue;
-    if (best === null || q > best) best = q;
+    const matchSpecificity = media === wanted ? 1 : 0;
+    if (matchSpecificity > specificity) {
+      best = q;
+      specificity = matchSpecificity;
+    } else if (matchSpecificity === specificity && (best === null || q > best)) {
+      best = q;
+    }
   }
   return best;
 }

--- a/tests/agent-friendly-404.test.mts
+++ b/tests/agent-friendly-404.test.mts
@@ -71,6 +71,11 @@ describe('prefersAgentNotFound (content negotiation)', () => {
     assert.equal(prefersAgentNotFound('text/markdown'), true);
     assert.equal(prefersAgentNotFound('text/html;q=0.8, text/markdown'), true);
   });
+
+  it('uses explicit media qualities before text wildcards', () => {
+    assert.equal(prefersAgentNotFound('text/*;q=0.8, text/markdown;q=0.1, text/html;q=0.5'), false);
+    assert.equal(prefersAgentNotFound('text/*;q=0.8, text/html;q=0.1, text/markdown;q=0.5'), true);
+  });
 });
 
 describe('agent-friendly 404s (orank agent-friendly-404)', () => {

--- a/tests/agent-readiness.test.mts
+++ b/tests/agent-readiness.test.mts
@@ -80,7 +80,11 @@ describe('agent homepage routing', () => {
   });
 
   it('honors explicit markdown media types and preserves HTML preferences', async () => {
-    for (const accept of ['text/markdown', 'TEXT/MARKDOWN; charset=utf-8', 'text/html;q=0.5, text/markdown']) {
+    for (const accept of [
+      'text/markdown', 'TEXT/MARKDOWN; charset=utf-8', 'text/html;q=0.5, text/markdown',
+      'text/markdown;q=0.2, text/html;q=0, */*;q=0.9',
+      'text/markdown;q=0.2, text/*;q=0, */*;q=0.9',
+    ]) {
       for (const method of ['GET', 'HEAD']) {
         const response = await middleware(new Request('https://www.worldmonitor.app/', {
           method, headers: { 'User-Agent': 'Mozilla/5.0', Accept: accept },
@@ -95,6 +99,8 @@ describe('agent homepage routing', () => {
       'text/*, text/markdown;q=0',
       'text/markdown;q=0, text/*',
       'text/*;q=0.8, text/markdown;q=0.1, text/html;q=0.5',
+      'text/markdown;q=0.2, */*;q=0.9',
+      '*/*;q=0.9, text/markdown;q=0.2',
     ]) {
       assert.equal(await middleware(new Request('https://www.worldmonitor.app/', {
         headers: { 'User-Agent': 'Mozilla/5.0', Accept: accept },

--- a/tests/agent-readiness.test.mts
+++ b/tests/agent-readiness.test.mts
@@ -90,7 +90,12 @@ describe('agent homepage routing', () => {
         assert.match(response?.headers.get('cache-control') ?? '', /no-store/);
       }
     }
-    for (const accept of ['text/html', '*/*', 'text/*', 'text/markdown;q=0', 'text/markdown;q=0.2, text/html', 'text/markdown-extra']) {
+    for (const accept of [
+      'text/html', '*/*', 'text/*', 'text/markdown;q=0', 'text/markdown;q=0.2, text/html', 'text/markdown-extra',
+      'text/*, text/markdown;q=0',
+      'text/markdown;q=0, text/*',
+      'text/*;q=0.8, text/markdown;q=0.1, text/html;q=0.5',
+    ]) {
       assert.equal(await middleware(new Request('https://www.worldmonitor.app/', {
         headers: { 'User-Agent': 'Mozilla/5.0', Accept: accept },
       })), undefined);

--- a/tests/agent-readiness.test.mts
+++ b/tests/agent-readiness.test.mts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { load } from 'js-yaml';
 import middleware from '../middleware';
 import agentRequestPolicy from '../shared/agent-request-policy.json';
+import { guardProBuiltOutput, shouldSkipProBuiltOutput } from './_lib/pro-built-output.mjs';
 
 describe('public agent documents', () => {
   // auth.md is intentionally heading-led for scanner compatibility. Its title,
@@ -26,6 +27,7 @@ describe('public agent documents', () => {
 });
 
 describe('agent homepage routing', () => {
+  guardProBuiltOutput();
   for (const agent of agentRequestPolicy.userAgents) {
     it(`${agent} receives the Markdown document even with Accept: text/html`, async () => {
       for (const host of ['worldmonitor.app', 'www.worldmonitor.app']) {
@@ -34,22 +36,75 @@ describe('agent homepage routing', () => {
             method, headers: { 'User-Agent': `${agent}/1.0`, Accept: 'text/html' },
           }));
           assert.ok(response);
-          assert.equal(response.headers.get('x-middleware-rewrite'), `https://${host}/home.md`);
+          assert.equal(response.headers.get('x-middleware-rewrite'), `https://${host}/pro/home.md`);
           assert.match(response.headers.get('content-type')!, /text\/markdown/);
           for (const header of ['Cache-Control', 'CDN-Cache-Control', 'Vercel-CDN-Cache-Control']) {
             assert.match(response.headers.get(header)!, /no-store/);
           }
-          assert.equal(response.headers.get('vary'), 'User-Agent');
+          assert.equal(response.headers.get('vary'), 'User-Agent, Accept');
         }
       }
     });
   }
+
+  it('serves the same complete homepage for crawler and Accept negotiation', { skip: shouldSkipProBuiltOutput() }, async () => {
+    const html = readFileSync(new URL('../public/pro/welcome.html', import.meta.url), 'utf8');
+    const depth = JSON.parse(readFileSync(new URL('../pro-test/src/generated/depth-stats.json', import.meta.url), 'utf8'));
+    const { htmlToMarkdown } = await import('../api/_md-url-twin');
+    const sections = [...html.matchAll(/<section\b[^>]*>[\s\S]*?<\/section>/g)]
+      .map(section => htmlToMarkdown(section[0], 'World Monitor').replace(/^# World Monitor\n\n/, ''));
+    assert.ok(sections.length > 0, 'the proof must exercise rendered homepage sections');
+    let canonicalMarkdown: string | undefined;
+    for (const headers of [
+      { 'User-Agent': 'Mozilla/5.0', Accept: 'text/markdown' },
+      ...agentRequestPolicy.userAgents.map(ua => ({ 'User-Agent': `${ua}/1.0`, Accept: 'text/html' })),
+    ]) {
+      const response = await middleware(new Request('https://www.worldmonitor.app/', { headers }));
+      assert.ok(response, 'explicit markdown requests must be routed');
+      const destination = new URL(response.headers.get('x-middleware-rewrite')!);
+      const markdown = readFileSync(new URL(`../public${destination.pathname}`, import.meta.url), 'utf8');
+      canonicalMarkdown ??= markdown;
+      assert.equal(markdown, canonicalMarkdown);
+      assert.match(markdown, /Under the hood/);
+      assert.match(markdown, /^canonical: "https:\/\/www\.worldmonitor\.app\/"$/m);
+      for (const value of Object.values(depth)) {
+        const token = new RegExp(`\\b${value}\\b`);
+        assert.match(html, token);
+        assert.match(markdown, token);
+      }
+      // Compare each rendered teaser section, including its values and capture date.
+      for (const section of sections) {
+        assert.ok(markdown.includes(section), 'all rendered homepage sections must survive');
+      }
+    }
+  });
+
+  it('honors explicit markdown media types and preserves HTML preferences', async () => {
+    for (const accept of ['text/markdown', 'TEXT/MARKDOWN; charset=utf-8', 'text/html;q=0.5, text/markdown']) {
+      for (const method of ['GET', 'HEAD']) {
+        const response = await middleware(new Request('https://www.worldmonitor.app/', {
+          method, headers: { 'User-Agent': 'Mozilla/5.0', Accept: accept },
+        }));
+        assert.equal(response?.headers.get('x-middleware-rewrite'), 'https://www.worldmonitor.app/pro/home.md');
+        assert.equal(response?.headers.get('vary'), 'User-Agent, Accept');
+        assert.match(response?.headers.get('cache-control') ?? '', /no-store/);
+      }
+    }
+    for (const accept of ['text/html', '*/*', 'text/*', 'text/markdown;q=0', 'text/markdown;q=0.2, text/html', 'text/markdown-extra']) {
+      assert.equal(await middleware(new Request('https://www.worldmonitor.app/', {
+        headers: { 'User-Agent': 'Mozilla/5.0', Accept: accept },
+      })), undefined);
+    }
+  });
 
   it('preserves JSON agent mode, browsers, search crawlers, variants, and other paths', async () => {
     for (const [url, ua] of [
       ['https://www.worldmonitor.app/?mode=agent', 'ClaudeBot/1.0'],
       ['https://www.worldmonitor.app/', 'Mozilla/5.0'],
       ['https://www.worldmonitor.app/', 'Googlebot/2.1'],
+      ['https://www.worldmonitor.app/', 'OAI-SearchBot/1.0'],
+      ['https://www.worldmonitor.app/', 'Claude-SearchBot/1.0'],
+      ['https://www.worldmonitor.app/', 'Bingbot/2.0'],
       ['https://www.worldmonitor.app/', 'NotClaudeBot/1.0'],
       ['https://www.worldmonitor.app/dashboard', 'ClaudeBot/1.0'],
       ['https://tech.worldmonitor.app/', 'ClaudeBot/1.0'],


### PR DESCRIPTION
## Summary

AI crawlers previously received a short homepage document that omitted the published coverage numbers. Crawler requests and explicit `Accept: text/markdown` requests now receive the same document, generated from the rendered HTML homepage at build time, with the existing authentication and discovery guidance retained as a supplement. Browser and search-crawler defaults, JSON agent mode, and legacy map redirects retain their existing behavior.

Fixes #7863.

## Validation

- Homepage build passed. The regression first failed against the original routing, then passed with all 15 depth statistics and every rendered homepage section, including dated teaser values, present in the selected markdown document.
- 185 related middleware, content, converter, and product-facts tests passed with no skips. The final 28-test homepage suite also passed after strengthening canonical metadata and content checks.
- Review follow-up: 136 middleware and negotiation tests passed after correcting media-range specificity. Explicit Markdown exclusions now override text wildcards; the shared 404 negotiation path is covered too. Both new regression cases were observed failing before the correction.
- `npm run typecheck`, `npm run typecheck:api`, `npm run lint:boundaries`, focused Biome lint, JavaScript syntax checking, and `git diff --check` passed.
- Local diff review completed. Deployed Vercel/Cloudflare behavior remains unverified; local tests exercise the real middleware and built assets.

## Post-Deploy Monitoring & Validation

Owner: PR author, during the first 30 minutes after an authorized deployment. Fetch `/` with GPTBot, ClaudeBot, PerplexityBot, Google-Extended, and a browser UA with `Accept: text/markdown`; expect HTTP 200, identical markdown bodies, all generated depth statistics, dated teaser content, `Vary: User-Agent, Accept`, and no-store cache headers. Also check browser and OAI-SearchBot requests still return HTML. Inspect Vercel request logs for `/` and `/pro/home.md` 404/5xx responses and Cloudflare cache headers for a cached wrong representation. A missing document, missing statistics, or HTML/markdown cache mix-up is a rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
