### PR TITLE
docs(sdk): clarify Go and Python package discovery

### DIFF
--- a/docs/sdks.mdx
+++ b/docs/sdks.mdx
@@ -12,7 +12,17 @@ World Monitor ships official client libraries in four language ecosystems. All o
 | Go | [`github.com/koala73/worldmonitor/sdk/go` on pkg.go.dev](https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go) | `go get github.com/koala73/worldmonitor/sdk/go` | [`sdk/go/`](https://github.com/koala73/worldmonitor/tree/main/sdk/go) |
 | JavaScript / CLI | [`worldmonitor` on npm](https://www.npmjs.com/package/worldmonitor) | `npm install worldmonitor` | [`cli/`](https://github.com/koala73/worldmonitor/tree/main/cli) |
 
-Every package sets its homepage to a `worldmonitor.app` URL (the npm CLI package uses `worldmonitor.app/docs/cli`) — that is how you (or your agent) verify it is the official SDK and not a look-alike.
+## Find and verify the official packages
+
+Use the exact package names in the table. npm, PyPI, and RubyGems link to `worldmonitor.app` in their project metadata; compare those links with the source repositories listed here. The Python package is `worldmonitor-sdk`. The PyPI package named `worldmonitor` is an unrelated project.
+
+The Go SDK is the module `github.com/koala73/worldmonitor/sdk/go`, with package name `worldmonitor`. Go modules have no registry homepage field. Verify its module path against the official repository linked above and its product links on pkg.go.dev.
+
+- [Search pkg.go.dev for worldmonitor](https://pkg.go.dev/search?q=worldmonitor).
+- [Read the Go module proxy's latest release metadata](https://proxy.golang.org/github.com/koala73/worldmonitor/sdk/go/@latest).
+- Install with `go get github.com/koala73/worldmonitor/sdk/go` from your Go project.
+
+Go publishes versions through repository tags (`sdk/go/vX.Y.Z`) and the module proxy. A successful proxy lookup confirms release availability; pkg.go.dev search confirms search visibility. See [how pkg.go.dev adds packages](https://pkg.go.dev/about#adding-a-package).
 
 ## Shared design
 
@@ -75,10 +85,10 @@ import run from 'worldmonitor/run';
 
 ## Releasing (maintainers)
 
-Each SDK versions and publishes independently via OIDC trusted publishing — no long-lived registry tokens (see the [CLI release runbook](/releasing-cli) for the npm flow):
+Each SDK versions independently. npm, Python, and Ruby use OIDC trusted publishing; Go uses repository tags and the public module proxy. No long-lived registry tokens are needed (see the [CLI release runbook](/releasing-cli) for the npm flow):
 
 - **Python:** bump `version` in `sdk/python/pyproject.toml` **and** `__version__` in `sdk/python/src/worldmonitor_sdk/__init__.py`, then tag `py-vX.Y.Z` (workflow `publish-python.yml`).
 - **Ruby:** bump `WorldMonitor::VERSION` in `sdk/ruby/lib/worldmonitor/version.rb`, then tag `gem-vX.Y.Z` (workflow `publish-ruby.yml`).
 - **Go:** bump `Version` in `sdk/go/worldmonitor.go`, then tag `sdk/go/vX.Y.Z` (workflow `publish-go.yml` validates and warms the module proxy).
 
-`tests/sdk-packages.test.mjs` guards the version sync and the `worldmonitor.app` homepage metadata on every package.
+`tests/sdk-packages.test.mjs` checks package identity, version declarations, registry metadata, and release workflow wiring.

--- a/docs/zh/sdks.mdx
+++ b/docs/zh/sdks.mdx
@@ -12,7 +12,17 @@ World Monitor 在四个语言生态中提供官方客户端库。它们都是**�
 | Go | [pkg.go.dev 上的 `github.com/koala73/worldmonitor/sdk/go`](https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go) | `go get github.com/koala73/worldmonitor/sdk/go` | [`sdk/go/`](https://github.com/koala73/worldmonitor/tree/main/sdk/go) |
 | JavaScript / CLI | [npm 上的 `worldmonitor`](https://www.npmjs.com/package/worldmonitor) | `npm install worldmonitor` | [`cli/`](https://github.com/koala73/worldmonitor/tree/main/cli) |
 
-每个软件包都将其主页设为 `worldmonitor.app`——你（或你的智能体）正是据此验证它是官方 SDK 而非仿冒品。
+## 查找并验证官方软件包
+
+请使用表格中的完整包名。npm、PyPI 和 RubyGems 的项目元数据包含指向 `worldmonitor.app` 的链接；请将这些链接与上方列出的源码仓库进行比对。Python 包名是 `worldmonitor-sdk`。PyPI 上名为 `worldmonitor` 的包属于无关项目。
+
+Go SDK 的模块路径是 `github.com/koala73/worldmonitor/sdk/go`，包名是 `worldmonitor`。Go 模块没有注册表主页字段。请通过上方链接的官方仓库核对模块路径，并检查 pkg.go.dev 页面上的产品链接。
+
+- [在 pkg.go.dev 搜索 worldmonitor](https://pkg.go.dev/search?q=worldmonitor)。
+- [查看 Go 模块代理上的最新发布元数据](https://proxy.golang.org/github.com/koala73/worldmonitor/sdk/go/@latest)。
+- 在 Go 项目中运行 `go get github.com/koala73/worldmonitor/sdk/go` 安装。
+
+Go 通过仓库标签（`sdk/go/vX.Y.Z`）和模块代理发布版本。代理查询成功表示版本可用；pkg.go.dev 搜索结果表示该包可以被搜索到。参见 [pkg.go.dev 如何添加软件包](https://pkg.go.dev/about#adding-a-package)。
 
 ## 共享设计
 
@@ -75,10 +85,10 @@ import run from 'worldmonitor/run';
 
 ## 发布（维护者）
 
-每个 SDK 通过 OIDC 可信发布独立进行版本管理和发布——无需长期有效的注册表令牌（npm 流程请参见 [CLI 发布手册](/zh/releasing-cli)）：
+各 SDK 独立管理版本。npm、Python 和 Ruby 使用 OIDC 可信发布；Go 使用仓库标签和公共模块代理。它们均无需长期有效的注册表令牌（npm 流程请参见 [CLI 发布手册](/zh/releasing-cli)）：
 
 - **Python：** 在 `sdk/python/pyproject.toml` 中提升 `version`，**并**在 `sdk/python/src/worldmonitor_sdk/__init__.py` 中提升 `__version__`，然后打上 `py-vX.Y.Z` 标签（工作流 `publish-python.yml`）。
 - **Ruby：** 在 `sdk/ruby/lib/worldmonitor/version.rb` 中提升 `WorldMonitor::VERSION`，然后打上 `gem-vX.Y.Z` 标签（工作流 `publish-ruby.yml`）。
 - **Go：** 在 `sdk/go/worldmonitor.go` 中提升 `Version`，然后打上 `sdk/go/vX.Y.Z` 标签（工作流 `publish-go.yml` 会验证并预热模块代理）。
 
-`tests/sdk-packages.test.mjs` 会在每个软件包上守护版本同步和 `worldmonitor.app` 主页元数据。
+`tests/sdk-packages.test.mjs` 检查包身份、版本声明、注册表元数据和发布工作流配置。

--- a/public/agent-view.json
+++ b/public/agent-view.json
@@ -34,23 +34,34 @@
     },
     "sdks": {
       "javascript": {
+        "package": "worldmonitor",
+        "registry": "npm",
         "install": "npm install worldmonitor",
         "url": "https://www.npmjs.com/package/worldmonitor"
       },
       "python": {
+        "package": "worldmonitor-sdk",
+        "registry": "PyPI",
         "install": "pip install worldmonitor-sdk",
         "url": "https://pypi.org/project/worldmonitor-sdk/"
       },
       "ruby": {
+        "package": "worldmonitor",
+        "registry": "RubyGems",
         "install": "gem install worldmonitor",
         "url": "https://rubygems.org/gems/worldmonitor"
       },
       "go": {
+        "package": "github.com/koala73/worldmonitor/sdk/go",
+        "registry": "Go modules",
         "install": "go get github.com/koala73/worldmonitor/sdk/go",
-        "url": "https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go"
+        "url": "https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go",
+        "searchUrl": "https://pkg.go.dev/search?q=worldmonitor",
+        "moduleProxyUrl": "https://proxy.golang.org/github.com/koala73/worldmonitor/sdk/go/@latest",
+        "source": "https://github.com/koala73/worldmonitor/tree/main/sdk/go"
       },
       "guide": "https://www.worldmonitor.app/docs/sdks",
-      "note": "Official zero-dependency SDK packages; every registry entry sets its homepage to worldmonitor.app for provenance."
+      "note": "Use the exact package names above. npm, PyPI and RubyGems link to worldmonitor.app in their project metadata. Go modules have no homepage field: verify the module path in the official koala73/worldmonitor repository and its product links on pkg.go.dev. The Python package is worldmonitor-sdk; the PyPI package named worldmonitor is unrelated."
     },
     "docsMcp": {
       "url": "https://www.worldmonitor.app/docs/mcp",

--- a/public/sdks.md
+++ b/public/sdks.md
@@ -6,7 +6,7 @@ canonical: "https://www.worldmonitor.app/sdks.md"
 
 # World Monitor SDKs
 
-Last updated: July 7, 2026
+Last updated: September 8, 2026
 
 World Monitor ships official client libraries in four language ecosystems so you can script country briefs, risk scores, market data, and every registered [MCP tool](https://www.worldmonitor.app/mcp-server.md) without writing an HTTP integration. All of them are **zero-dependency**, MCP-first mirrors of the [`worldmonitor` npm CLI](https://www.worldmonitor.app/docs/cli), with a small REST escape hatch for host-relative and self-hosted use.
 
@@ -19,7 +19,17 @@ World Monitor ships official client libraries in four language ecosystems so you
 | Go | [`github.com/koala73/worldmonitor/sdk/go` on pkg.go.dev](https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go) | `go get github.com/koala73/worldmonitor/sdk/go` | [`sdk/go/`](https://github.com/koala73/worldmonitor/tree/main/sdk/go) |
 | JavaScript / CLI | [`worldmonitor` on npm](https://www.npmjs.com/package/worldmonitor) | `npm install worldmonitor` | [`cli/`](https://github.com/koala73/worldmonitor/tree/main/cli) |
 
-Every package sets its homepage to `worldmonitor.app` — that is how you (or your agent) verify it is the official SDK and not a look-alike.
+## Find and verify the official packages
+
+Use the exact package names in the table. npm, PyPI, and RubyGems link to `worldmonitor.app` in their project metadata; compare those links with the source repositories listed here. The Python package is `worldmonitor-sdk`. The PyPI package named `worldmonitor` is an unrelated project.
+
+The Go SDK is the module `github.com/koala73/worldmonitor/sdk/go`, with package name `worldmonitor`. Go modules have no registry homepage field. Verify its module path against the official repository linked above and its product links on pkg.go.dev.
+
+- [Search pkg.go.dev for worldmonitor](https://pkg.go.dev/search?q=worldmonitor).
+- [Read the Go module proxy's latest release metadata](https://proxy.golang.org/github.com/koala73/worldmonitor/sdk/go/@latest).
+- Install with `go get github.com/koala73/worldmonitor/sdk/go` from your Go project.
+
+Go publishes versions through repository tags (`sdk/go/vX.Y.Z`) and the module proxy. A successful proxy lookup confirms release availability; pkg.go.dev search confirms search visibility. See [how pkg.go.dev adds packages](https://pkg.go.dev/about#adding-a-package).
 
 ## Shared design
 


### PR DESCRIPTION
Ora's 2026-09-07 scan reports SDKs only in npm and RubyGems, although the Go module is searchable and downloadable and the Python SDK is published as `worldmonitor-sdk`. Our own SDK guides also incorrectly tell agents to verify every ecosystem through a registry homepage field, which Go modules do not have.

Add exact package names and ecosystem names to the existing agent JSON, plus Go search, module-proxy, and source links. Update the public SDK page and English/Chinese guides to explain Go identity verification, distinguish the official Python package from the unrelated `worldmonitor` package, and correct the Go release description.

Validation:
- `node --test tests/sdk-packages.test.mjs tests/agent-mode-view.test.mjs`: 24 passed, 1 unrelated built-homepage check skipped.
- `npm run lint:public-docs` and `git diff --check`: passed.
- Checked the new JSON package identifiers and Go URLs against source manifests.
- Live pkg.go.dev HTML search and JSON search return `github.com/koala73/worldmonitor/sdk/go@v0.1.1` for `worldmonitor`; JSON search also finds it for `worldmonitor.app`.
- Downloaded the released Go SDK with `go mod download` through `proxy.golang.org`; PyPI's JSON API confirms `worldmonitor-sdk@0.1.1` and its product-domain Homepage metadata.

Evidence: [Ora SDK finding](https://ora.ai/api/score/worldmonitor.app), [Go search](https://pkg.go.dev/search?q=worldmonitor), [Go release metadata](https://proxy.golang.org/github.com/koala73/worldmonitor/sdk/go/@latest), [Python metadata](https://pypi.org/pypi/worldmonitor-sdk/json).

This repairs first-party discovery guidance. Ora's internal lookup logic is unavailable, so its exact failure mechanism and any score improvement remain unverified. A fresh scan after deployment is a separate acceptance step.
