### PR TITLE
fix(md-twin): serve the sibling's markdown instead of soft-404 stubs

### DIFF
--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -10,7 +10,9 @@
  * answers, and reports that response's status. A path with no page behind it
  * therefore 404s. Only a served document gets a canonical, and it points at
  * the sibling — never at the `.md` URL, which would set a stub competing with
- * the page it summarises (#7860).
+ * the page it summarises (#7860). That rule is scoped to generated twins: the
+ * curated `.md` files under public/ are the only representation of their own
+ * content, have no HTML sibling to defer to, and self-canonicalise correctly.
  *
  * Loop-prevention: sibling fetches send x-wm-md-twin so a .md handler never
  * fetches another .md handler.
@@ -49,7 +51,7 @@ const REWRITE_SYNTHETIC_PARAMS = ['path', 'mdPath'] as const;
  * Corpus pages answer 308 from `/x` to `/x/`. Following that hop is what turns
  * a soft-404 stub into the real document — or into the origin's honest 404.
  */
-const MAX_SIBLING_REDIRECTS = 3;
+export const MAX_SIBLING_REDIRECTS = 3;
 const FORWARDED_RESPONSE_HEADERS = [
   'allow',
   'location',
@@ -172,9 +174,31 @@ function jsonToMarkdown(raw: string, heading: string): string {
 }
 
 function withMarkdownMetadata(markdown: string, canonical: string): string {
-  if (markdown.startsWith('---\n')) return markdown;
+  if (markdown.startsWith('---\n')) return withCanonicalFrontMatter(markdown, canonical);
   const title = markdown.match(/^# (.+)$/m)?.[1] ?? headingFromPath(new URL(canonical).pathname);
   return `---\ntitle: ${JSON.stringify(title)}\ncanonical: ${JSON.stringify(canonical)}\n---\n\n${markdown}`;
+}
+
+/**
+ * The sibling's negotiated markdown arrives with front matter of its own
+ * (title, description, image) and no canonical, so returning it untouched
+ * would ship a document whose body never names the page it represents — the
+ * Link header would carry the canonical and the body would contradict it by
+ * omission. Set the key here instead, keeping every field the origin wrote.
+ * Only a top-level `canonical:` is replaced; an indented one belongs to some
+ * other key's mapping and is left alone.
+ */
+function withCanonicalFrontMatter(markdown: string, canonical: string): string {
+  const terminator = markdown.indexOf('\n---', 4);
+  // Unterminated front matter is not front matter — leave the body untouched
+  // rather than guessing where the block was meant to end.
+  if (terminator === -1) return markdown;
+  const fields = markdown
+    .slice(4, terminator)
+    .split('\n')
+    .filter((line) => !/^canonical\s*:/.test(line))
+    .join('\n');
+  return `---\n${fields}\ncanonical: ${JSON.stringify(canonical)}${markdown.slice(terminator)}`;
 }
 
 /**
@@ -205,6 +229,19 @@ function markdownHeaders(
     Link: links,
     ...extra,
   };
+}
+
+/**
+ * A 404 or 410 is a property of the URL, so a shared cache can absorb the
+ * repeats — which matters precisely because the `.md` space is unbounded and
+ * crawlers probe it: `noindex` keeps those paths out of the index, and this
+ * keeps each re-probe from costing an origin round trip. Every other failure
+ * status describes this attempt rather than the URL (an upstream blip, a rate
+ * limit, an auth state), and caching one would pin a real page to a wrong
+ * answer for the whole TTL.
+ */
+function failureCacheControl(status: number): string {
+  return status === 404 || status === 410 ? 'public, max-age=0, s-maxage=300' : 'no-store';
 }
 
 /** Headers for a twin with no indexable document behind it. */
@@ -334,13 +371,17 @@ export async function buildMarkdownTwinResponse(
   let siblingUrl = siblingRequestUrl(req, sibling);
   let siblingRes: Response;
   let followed = 0;
+  // One deadline for the whole chain, not one per hop. A fresh timeout inside
+  // the loop would multiply the budget by the hop count, so a chain of slow but
+  // individually-passing hops could outlive the edge function itself.
+  const siblingDeadline = AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS);
   for (;;) {
     try {
       siblingRes = await fetchImpl(siblingUrl, {
         method: req.method,
         headers: outbound,
         redirect: 'manual',
-        signal: AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS),
+        signal: siblingDeadline,
       });
     } catch {
       return new Response(
@@ -363,11 +404,13 @@ export async function buildMarkdownTwinResponse(
     // documents it rather than fetching another site on the caller's behalf.
     if (!target || target.origin !== siblingUrl.origin) {
       void siblingRes.body?.cancel().catch(() => {});
+      // A redirect notice, not a representation of the sibling, so it gets no
+      // canonical in either the headers or the body — `noindex` is the whole
+      // signal. Pairing the two would contradict each other.
       const body = `# ${headingFromPath(sibling)}\n\nThis resource redirects to [${location}](${location}).\n`;
-      const canonical = new URL(sibling, req.url).href;
-      return new Response(req.method === 'HEAD' ? null : withMarkdownMetadata(body, canonical), {
+      return new Response(req.method === 'HEAD' ? null : body, {
         status: 200,
-        headers: markdownHeaders(canonical, { 'X-Robots-Tag': 'noindex' }),
+        headers: nonDocumentHeaders(),
       });
     }
 
@@ -392,7 +435,9 @@ export async function buildMarkdownTwinResponse(
   const isFailure = !siblingRes.ok;
   const siblingStatus = isFailure ? siblingRes.status : 200;
   const responseHeaders: Record<string, string> = {
-    ...(isFailure ? { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' } : {}),
+    ...(isFailure
+      ? { 'Cache-Control': failureCacheControl(siblingStatus), 'X-Robots-Tag': 'noindex' }
+      : {}),
     ...forwardedResponseHeaders(siblingRes),
   };
   const documentHeaders = (extra: Record<string, string>) =>
@@ -440,7 +485,10 @@ export async function buildMarkdownTwinResponse(
     });
   }
 
-  return new Response(withMarkdownMetadata(markdown, canonical), {
+  // The metadata block names the page this document represents, so it belongs
+  // only on a served document. Emitting it on a failure would have the body
+  // claim a canonical the headers deliberately withhold.
+  return new Response(isFailure ? markdown : withMarkdownMetadata(markdown, canonical), {
     status: siblingStatus,
     headers: documentHeaders(responseHeaders),
   });

--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -25,11 +25,18 @@ import { appendDeprecationPolicyLinkToRecord, DEPRECATION_POLICY_LINK } from '..
 export const MD_TWIN_LOOP_HEADER = 'x-wm-md-twin';
 /**
  * The ceiling has to clear the real corpus, not just the old stubs. Once the
- * twin asks for `text/markdown` (#7860) it receives whole documents: measured
- * across all 273 sitemap URLs on 2026-09-08 the largest is `/sources/` at
+ * twin asks for `text/markdown` (#7860) it receives whole documents: sweeping
+ * all 273 sitemap URLs on 2026-09-08, the largest page is `/sources/` at
  * 132,497 bytes, then `/countries/` at 105,932. At the previous 80 KB cap both
  * would have answered 502 where they used to answer a stub. 256 KB keeps ~2x
  * headroom over the largest page while still bounding what the edge buffers.
+ *
+ * One sitemap URL is larger and stays over the cap: `/llms-full.txt` (264,615
+ * bytes), whose twin therefore answers 502. That is deliberate, not an
+ * oversight — it is a plain-text agent file that is already its own best
+ * representation, so a markdown twin of it is redundant, and it was over the
+ * previous cap too. Raising the ceiling to buffer it would cost every request
+ * headroom to serve one URL nobody needs.
  */
 export const MAX_TWIN_BYTES = 256_000;
 const MAX_TWIN_CHARS = MAX_TWIN_BYTES;

--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -5,6 +5,13 @@
  * text/markdown (or a heading-led non-HTML body). Static files under public/
  * win. Everything else is generated from the sibling URL.
  *
+ * The twin mirrors the sibling and never invents a page. It asks the origin
+ * for `text/markdown`, follows same-origin redirects to whatever finally
+ * answers, and reports that response's status. A path with no page behind it
+ * therefore 404s. Only a served document gets a canonical, and it points at
+ * the sibling — never at the `.md` URL, which would set a stub competing with
+ * the page it summarises (#7860).
+ *
  * Loop-prevention: sibling fetches send x-wm-md-twin so a .md handler never
  * fetches another .md handler.
  */
@@ -14,10 +21,35 @@ import { getPublicCorsHeaders } from './_cors.js';
 import { appendDeprecationPolicyLinkToRecord, DEPRECATION_POLICY_LINK } from '../server/_shared/deprecation-policy';
 
 export const MD_TWIN_LOOP_HEADER = 'x-wm-md-twin';
-const MAX_TWIN_CHARS = 80_000;
-const MAX_TWIN_BYTES = 80_000;
+/**
+ * The ceiling has to clear the real corpus, not just the old stubs. Once the
+ * twin asks for `text/markdown` (#7860) it receives whole documents: measured
+ * across all 273 sitemap URLs on 2026-09-08 the largest is `/sources/` at
+ * 132,497 bytes, then `/countries/` at 105,932. At the previous 80 KB cap both
+ * would have answered 502 where they used to answer a stub. 256 KB keeps ~2x
+ * headroom over the largest page while still bounding what the edge buffers.
+ */
+export const MAX_TWIN_BYTES = 256_000;
+const MAX_TWIN_CHARS = MAX_TWIN_BYTES;
 const SIBLING_FETCH_TIMEOUT_MS = 8_000;
 const SIBLING_USER_AGENT = 'WorldMonitor-MarkdownTwin/1.0';
+/**
+ * `text/markdown` leads because the origin negotiates a real markdown variant
+ * of every corpus page under that Accept; the rest are the fallbacks the
+ * converters below can still turn into a heading-led document (#7860).
+ */
+const SIBLING_ACCEPT =
+  'text/markdown, text/html;q=0.9, application/json;q=0.8, text/plain;q=0.7, */*;q=0.1';
+/**
+ * Vercel's `/:mdPath((?!api/).+).md` rewrite injects these. They are routing
+ * artifacts, never caller intent, so they must not reach the sibling.
+ */
+const REWRITE_SYNTHETIC_PARAMS = ['path', 'mdPath'] as const;
+/**
+ * Corpus pages answer 308 from `/x` to `/x/`. Following that hop is what turns
+ * a soft-404 stub into the real document — or into the origin's honest 404.
+ */
+const MAX_SIBLING_REDIRECTS = 3;
 const FORWARDED_RESPONSE_HEADERS = [
   'allow',
   'location',
@@ -145,8 +177,21 @@ function withMarkdownMetadata(markdown: string, canonical: string): string {
   return `---\ntitle: ${JSON.stringify(title)}\ncanonical: ${JSON.stringify(canonical)}\n---\n\n${markdown}`;
 }
 
-function markdownHeaders(req: Request, markdownPath: string, extra: Record<string, string> = {}): Record<string, string> {
-  const origin = new URL(req.url).origin;
+/**
+ * `canonical` is the HTML sibling the twin represents, or null when the twin
+ * has no document behind it. A twin never canonicalises to itself: a 248-byte
+ * `.md` stub claiming to be the canonical representation of a country page is
+ * exactly what made this route a soft-404 farm (#7860). Pass null for anything
+ * that is not a served document; those responses carry `X-Robots-Tag: noindex`
+ * instead, so an unbounded `.md` space costs no crawl budget.
+ */
+function markdownHeaders(
+  canonical: string | null,
+  extra: Record<string, string> = {},
+): Record<string, string> {
+  const links = canonical
+    ? `<${canonical}>; rel="canonical", ${DEPRECATION_POLICY_LINK}`
+    : DEPRECATION_POLICY_LINK;
   return {
     'Content-Type': 'text/markdown; charset=utf-8',
     'X-Content-Type-Options': 'nosniff',
@@ -157,9 +202,30 @@ function markdownHeaders(req: Request, markdownPath: string, extra: Record<strin
     // no other variance needs declaring.
     Vary: MD_TWIN_LOOP_HEADER,
     ...getPublicCorsHeaders('GET, HEAD, OPTIONS'),
-    Link: `<${origin}${markdownPath}>; rel="canonical", ${DEPRECATION_POLICY_LINK}`,
+    Link: links,
     ...extra,
   };
+}
+
+/** Headers for a twin with no indexable document behind it. */
+function nonDocumentHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return markdownHeaders(null, { 'X-Robots-Tag': 'noindex', ...extra });
+}
+
+/**
+ * The sibling URL to fetch, with the rewrite's synthetic params removed. A
+ * caller's own query string still rides along — `/countries/iran.md?window=7d`
+ * must reach the same page state the HTML request would.
+ */
+function siblingRequestUrl(req: Request, sibling: string): URL {
+  const requestUrl = new URL(req.url);
+  const search = new URLSearchParams(requestUrl.search);
+  if (requestUrl.pathname === '/api/md-twin' || requestUrl.pathname === '/api/md-twin/') {
+    for (const name of REWRITE_SYNTHETIC_PARAMS) search.delete(name);
+  }
+  const siblingUrl = new URL(sibling, req.url);
+  siblingUrl.search = search.toString();
+  return siblingUrl;
 }
 
 function headingFromPath(pathname: string): string {
@@ -238,14 +304,14 @@ export async function buildMarkdownTwinResponse(
   if (req.method !== 'GET' && req.method !== 'HEAD') {
     return new Response('# Method not allowed\n', {
       status: 405,
-      headers: markdownHeaders(req, markdownPath, { Allow: 'GET, HEAD, OPTIONS' }),
+      headers: nonDocumentHeaders({ Allow: 'GET, HEAD, OPTIONS' }),
     });
   }
 
   if (req.headers.get(MD_TWIN_LOOP_HEADER) === '1') {
     return new Response('# Not found\n', {
       status: 404,
-      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+      headers: nonDocumentHeaders({ 'Cache-Control': 'no-store' }),
     });
   }
 
@@ -253,60 +319,96 @@ export async function buildMarkdownTwinResponse(
   if (!sibling) {
     return new Response('# Not found\n', {
       status: 404,
-      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+      headers: nonDocumentHeaders({ 'Cache-Control': 'no-store' }),
     });
   }
-
-  const siblingUrl = new URL(sibling, req.url);
-  siblingUrl.search = new URL(req.url).search;
 
   const outbound = new Headers();
   outbound.set('user-agent', SIBLING_USER_AGENT);
   outbound.set(MD_TWIN_LOOP_HEADER, '1');
-  outbound.set('accept', 'text/html, application/json;q=0.9, text/plain;q=0.8, */*;q=0.1');
+  outbound.set('accept', SIBLING_ACCEPT);
 
+  // Resolve the sibling by hand rather than with `redirect: 'follow'` so a
+  // cross-origin hop stays a document instead of being fetched, and so the
+  // canonical tracks the URL that actually answered.
+  let siblingUrl = siblingRequestUrl(req, sibling);
   let siblingRes: Response;
-  try {
-    siblingRes = await fetchImpl(siblingUrl, {
-      method: req.method,
-      headers: outbound,
-      redirect: 'manual',
-      signal: AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS),
-    });
-  } catch {
-    return new Response(`# ${headingFromPath(sibling)}\n\nThe sibling page at \`${sibling}\` could not be fetched.\n`, {
-      status: 502,
-      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
-    });
+  let followed = 0;
+  for (;;) {
+    try {
+      siblingRes = await fetchImpl(siblingUrl, {
+        method: req.method,
+        headers: outbound,
+        redirect: 'manual',
+        signal: AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS),
+      });
+    } catch {
+      return new Response(
+        `# ${headingFromPath(sibling)}\n\nThe sibling page at \`${sibling}\` could not be fetched.\n`,
+        { status: 502, headers: nonDocumentHeaders({ 'Cache-Control': 'no-store' }) },
+      );
+    }
+
+    const location = siblingRes.headers.get('location');
+    if (siblingRes.status < 300 || siblingRes.status >= 400 || !location) break;
+
+    let target: URL | null = null;
+    try {
+      target = new URL(location, siblingUrl);
+    } catch {
+      target = null;
+    }
+
+    // A cross-origin hop is the destination, not a step towards one — the twin
+    // documents it rather than fetching another site on the caller's behalf.
+    if (!target || target.origin !== siblingUrl.origin) {
+      void siblingRes.body?.cancel().catch(() => {});
+      const body = `# ${headingFromPath(sibling)}\n\nThis resource redirects to [${location}](${location}).\n`;
+      const canonical = new URL(sibling, req.url).href;
+      return new Response(req.method === 'HEAD' ? null : withMarkdownMetadata(body, canonical), {
+        status: 200,
+        headers: markdownHeaders(canonical, { 'X-Robots-Tag': 'noindex' }),
+      });
+    }
+
+    if (followed >= MAX_SIBLING_REDIRECTS) {
+      // An unresolvable chain has no document behind it. Answering 404 keeps
+      // the `.md` space bounded instead of minting another cacheable 200.
+      void siblingRes.body?.cancel().catch(() => {});
+      return new Response(`# ${headingFromPath(sibling)}\n\nNot found.\n`, {
+        status: 404,
+        headers: nonDocumentHeaders({ 'Cache-Control': 'no-store' }),
+      });
+    }
+
+    void siblingRes.body?.cancel().catch(() => {});
+    siblingUrl = target;
+    followed += 1;
   }
 
-  const location = siblingRes.headers.get('location');
-  if (siblingRes.status >= 300 && siblingRes.status < 400 && location) {
-    const body = `# ${headingFromPath(sibling)}\n\nThis resource redirects to [${location}](${location}).\n`;
-    return new Response(req.method === 'HEAD' ? null : withMarkdownMetadata(body, new URL(markdownPath, req.url).href), {
-      status: 200,
-      headers: markdownHeaders(req, markdownPath),
-    });
-  }
-
+  // Whatever finally answered is the page this twin represents, so it — never
+  // the `.md` URL — is the canonical (#7860).
+  const canonical = new URL(siblingUrl.pathname, req.url).href;
   const isFailure = !siblingRes.ok;
   const siblingStatus = isFailure ? siblingRes.status : 200;
   const responseHeaders: Record<string, string> = {
-    ...(isFailure ? { 'Cache-Control': 'no-store' } : {}),
+    ...(isFailure ? { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' } : {}),
     ...forwardedResponseHeaders(siblingRes),
   };
+  const documentHeaders = (extra: Record<string, string>) =>
+    isFailure ? nonDocumentHeaders(extra) : markdownHeaders(canonical, extra);
 
   if (req.method === 'HEAD') {
     return new Response(null, {
       status: siblingStatus,
-      headers: markdownHeaders(req, markdownPath, responseHeaders),
+      headers: documentHeaders(responseHeaders),
     });
   }
 
   if (siblingStatus === 304) {
     return new Response(null, {
       status: siblingStatus,
-      headers: markdownHeaders(req, markdownPath, responseHeaders),
+      headers: documentHeaders(responseHeaders),
     });
   }
 
@@ -334,12 +436,12 @@ export async function buildMarkdownTwinResponse(
   } catch {
     return new Response(`# ${heading}\n\nThe sibling page at \`${sibling}\` could not be read.\n`, {
       status: 502,
-      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+      headers: nonDocumentHeaders({ 'Cache-Control': 'no-store' }),
     });
   }
 
-  return new Response(withMarkdownMetadata(markdown, new URL(markdownPath, req.url).href), {
+  return new Response(withMarkdownMetadata(markdown, canonical), {
     status: siblingStatus,
-    headers: markdownHeaders(req, markdownPath, responseHeaders),
+    headers: documentHeaders(responseHeaders),
   });
 }

--- a/api/md-twin.ts
+++ b/api/md-twin.ts
@@ -28,6 +28,7 @@ export default async function handler(req: Request): Promise<Response> {
       headers: {
         'Content-Type': 'text/markdown; charset=utf-8',
         'Cache-Control': 'no-store',
+        'X-Robots-Tag': 'noindex',
         'Access-Control-Allow-Origin': '*',
       },
     });

--- a/api/md-twin.ts
+++ b/api/md-twin.ts
@@ -3,8 +3,14 @@
  *
  * Vercel afterFiles rewrites unmatched `/{page}.md` (except static files,
  * /docs/*, /index.md, and /api/*) here. The handler fetches the sibling page
- * and returns heading-led text/markdown so agent-readiness scanners that
- * probe arbitrary content URLs get a .md twin, not a JSON/HTML 404.
+ * and returns its markdown, so agent-readiness scanners that probe content
+ * URLs get a real .md twin rather than a JSON/HTML body.
+ *
+ * The rewrite's path space is unbounded, so the twin only ever mirrors what
+ * the sibling actually answers: a path with no page behind it returns the
+ * origin's 404, and no twin canonicalises to itself. Returning cheap,
+ * cacheable, self-canonical 200 stubs for invented paths made this route a
+ * soft-404 farm against an already-binding crawl budget (#7860).
  */
 
 import {

--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -87,7 +87,9 @@ A second, separate MCP server for the documentation itself (card at `/.well-know
 
 ### Markdown twins — `<any-page>.md`
 
-Every page on the site has an agent-readable markdown twin: append `.md` to the path (`/pricing.md`, `/countries/tw.md`, `/home.md` for the front page). Curated twins are static and cached `public, max-age=3600` with `Access-Control-Allow-Origin: *`; everything else is rendered on demand by the twin service (HTML becomes heading-led markdown, JSON becomes a fenced block, output capped at 80 KB) with a `Link: <sibling>; rel="canonical"` header. `GET`/`HEAD` on `.md` twins bypasses the API bot gate, so plain `curl` works without a browser User-Agent.
+Every published page on the site has an agent-readable markdown twin: append `.md` to the path (`/pricing.md`, `/countries/tw.md`, `/home.md` for the front page). Curated twins are static and cached `public, max-age=3600` with `Access-Control-Allow-Origin: *`; everything else is rendered on demand by the twin service, which fetches the sibling page as markdown and falls back to converting HTML into heading-led markdown or JSON into a fenced block, with output capped at 256 KB. A served twin carries a `Link: <sibling>; rel="canonical"` header pointing at the HTML page, never at the `.md` URL itself.
+
+The twin mirrors its sibling rather than inventing a page, so a `.md` path with no page behind it answers the sibling's own status — a made-up path returns `404`, not an empty stub. Anything that is not a served document (a `404`, an upstream failure, a redirect notice) carries `X-Robots-Tag: noindex` and no canonical. `GET`/`HEAD` on `.md` twins bypasses the API bot gate, so plain `curl` works without a browser User-Agent.
 
 ## Agent walkthroughs
 

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -3716,6 +3716,13 @@ describe('agent readiness: generic markdown URL-fallback rewrite', () => {
     assert.equal(shadow, undefined, 'do not add /api/:path* → /api/not-found; it shadows [rpc].ts gateways (#4724)');
   });
 
+  // The rewrite is deliberate, but it opens an unbounded `.md` space: any path
+  // ending `.md` outside /api/ lands on the generator. What keeps that space
+  // from becoming a soft-404 farm is the handler contract — a path with no
+  // page behind it must answer 404 with X-Robots-Tag: noindex, and no twin may
+  // ever canonicalise to itself. That contract is asserted in
+  // tests/md-url-twin.test.mjs ('api/md-twin.ts soft-404 farm (#7860)');
+  // widening this rewrite without re-reading it reopens #7860.
   it('sends content-page .md twins to the generator, not the dashboard shell', () => {
     assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/dashboard.md' })?.destination, '/api/md-twin?path=:mdPath');
     assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/stocks/AAPL.md' })?.destination, '/api/md-twin?path=:mdPath');

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -536,9 +536,11 @@ describe('api/md-twin.ts soft-404 farm (#7860)', () => {
   });
 
   // Asking the sibling for markdown means whole documents come back, not
-  // 248-byte stubs. `/sources/` is the largest page in the sitemap — measured
-  // at 132,497 bytes on 2026-09-08 — and it must survive the twin's byte cap,
-  // or the fix trades a soft 200 for a hard 502 on the biggest corpus pages.
+  // 248-byte stubs. `/sources/` is the largest corpus *page* in the sitemap —
+  // measured at 132,497 bytes on 2026-09-08 — and it must survive the twin's
+  // byte cap, or the fix trades a soft 200 for a hard 502 on the biggest
+  // pages. (`/llms-full.txt` is larger still and stays a deliberate 502; see
+  // the MAX_TWIN_BYTES comment.)
   it('serves the largest real corpus page rather than rejecting it as oversized', async () => {
     const sourcesMarkdown = `# Sources\n\n${'World Monitor tracks this source. '.repeat(4_000)}`;
     assert.ok(sourcesMarkdown.length > 132_497, 'fixture must be at least as large as the live /sources/ page');

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -4,6 +4,7 @@ import { load } from 'js-yaml';
 
 import handler from '../api/md-twin.ts';
 import {
+  MAX_TWIN_BYTES,
   MD_TWIN_LOOP_HEADER,
   buildMarkdownTwinResponse,
   htmlToMarkdown,
@@ -63,21 +64,26 @@ describe('api/md-twin.ts vary coverage (#7616 U4)', () => {
 });
 
 describe('api/md-twin.ts', () => {
-  it('includes metadata when a sibling redirects to its canonical page', async () => {
+  it('follows a same-origin redirect and carries the resolved page as canonical', async () => {
     const response = await buildMarkdownTwinResponse(
       new Request('https://www.worldmonitor.app/countries.md'),
       '/countries.md',
-      async () => new Response(null, { status: 308, headers: { Location: '/countries/' } }),
+      async (input) =>
+        new URL(String(input)).pathname === '/countries'
+          ? new Response(null, { status: 308, headers: { Location: '/countries/' } })
+          : new Response('<h1>Countries</h1><p>All monitored countries.</p>', {
+              headers: { 'Content-Type': 'text/html' },
+            }),
     );
     assert.equal(response.status, 200);
     const document = await response.text();
     const block = document.match(/^---\n([\s\S]*?)\n---\n/);
-    assert.ok(block, 'redirect documents must carry metadata');
+    assert.ok(block, 'resolved documents must carry metadata');
     assert.deepEqual(load(block[1]), {
-      title: 'countries',
-      canonical: 'https://www.worldmonitor.app/countries.md',
+      title: 'Countries',
+      canonical: 'https://www.worldmonitor.app/countries/',
     });
-    assert.match(document, /\[\/countries\/\]\(\/countries\/\)/);
+    assert.match(document, /All monitored countries\./);
   });
 
   it('adds escaped title and canonical metadata to generated documents', async () => {
@@ -93,7 +99,8 @@ describe('api/md-twin.ts', () => {
     assert.ok(block);
     assert.deepEqual(load(block[1]), {
       title: 'Title: "quoted"',
-      canonical: 'https://www.worldmonitor.app/example.md',
+      // The HTML sibling, never the .md twin itself (#7860).
+      canonical: 'https://www.worldmonitor.app/example',
     });
     assert.match(document, /Content\./);
   });
@@ -229,7 +236,7 @@ describe('api/md-twin.ts', () => {
     const res = await buildMarkdownTwinResponse(
       new Request('https://www.worldmonitor.app/dashboard.md'),
       '/dashboard.md',
-      async () => new Response('small', { headers: { 'content-length': '80001' } }),
+      async () => new Response('small', { headers: { 'content-length': String(MAX_TWIN_BYTES + 1) } }),
     );
 
     assert.equal(res.status, 502);
@@ -241,7 +248,7 @@ describe('api/md-twin.ts', () => {
     let canceled = false;
     const body = new ReadableStream({
       start(controller) {
-        controller.enqueue(new Uint8Array(80_001));
+        controller.enqueue(new Uint8Array(MAX_TWIN_BYTES + 1));
       },
       cancel() {
         canceled = true;
@@ -315,5 +322,187 @@ describe('api/md-twin.ts', () => {
     );
     assert.equal(res.status, 404);
     assert.match(await res.text(), /^# /m);
+  });
+});
+
+// Issue #7860: `/api/md-twin` answered an unbounded `.md` space with indexable,
+// self-canonical 200 stubs. Root cause, verified live 2026-09-07: the
+// `/:mdPath((?!api/).+).md` rewrite injects `?path=…&mdPath=…`, the handler
+// copied that whole search onto the sibling fetch, and the extension-less
+// sibling (`/countries/iran`) answers 308 to its trailing-slash form. With
+// `redirect: 'manual'` every corpus page — real or invented — became a
+// self-canonical 200 "This resource redirects to …" stub.
+describe('api/md-twin.ts soft-404 farm (#7860)', () => {
+  const IRAN_MARKDOWN =
+    '---\ntitle: Iran Instability Index\n---\n\n# Iran Country Instability Index\n\nCII is 60/100.\n';
+
+  /** Mirrors production: extension-less corpus paths 308 to their trailing-slash form. */
+  function corpusOrigin({ trailingSlashBody = null } = {}) {
+    const seen = [];
+    const fetchImpl = async (input, init) => {
+      const url = new URL(String(input));
+      seen.push({ url, init });
+      if (!url.pathname.endsWith('/')) {
+        const location = new URL(url);
+        location.pathname += '/';
+        return new Response(null, {
+          status: 308,
+          headers: { location: location.pathname + location.search },
+        });
+      }
+      if (trailingSlashBody === null) {
+        return new Response('# Not found\n', {
+          status: 404,
+          headers: { 'content-type': 'text/markdown' },
+        });
+      }
+      return new Response(trailingSlashBody, {
+        status: 200,
+        headers: { 'content-type': 'text/markdown; charset=utf-8' },
+      });
+    };
+    return { seen, fetchImpl };
+  }
+
+  it('serves the real markdown for a corpus page instead of a redirect stub', async () => {
+    const { fetchImpl } = corpusOrigin({ trailingSlashBody: IRAN_MARKDOWN });
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Firan&mdPath=countries%2Firan'),
+      '/countries/iran.md',
+      fetchImpl,
+    );
+
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /Iran Country Instability Index/);
+    assert.doesNotMatch(body, /This resource redirects to/);
+  });
+
+  it('returns 404 for a .md path whose sibling page does not exist', async () => {
+    const { fetchImpl } = corpusOrigin();
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Fdoes-not-exist-xyz'),
+      '/countries/does-not-exist-xyz.md',
+      fetchImpl,
+    );
+
+    assert.equal(res.status, 404);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+  });
+
+  it('never declares a stub the canonical representation of itself', async () => {
+    const { fetchImpl } = corpusOrigin();
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Fdoes-not-exist-xyz'),
+      '/countries/does-not-exist-xyz.md',
+      fetchImpl,
+    );
+
+    assert.doesNotMatch(res.headers.get('link') ?? '', /does-not-exist-xyz\.md>; rel="canonical"/);
+    assert.doesNotMatch(await res.text(), /canonical:.*does-not-exist-xyz\.md/);
+  });
+
+  it('points the canonical at the HTML sibling, not at the .md twin', async () => {
+    const { fetchImpl } = corpusOrigin({ trailingSlashBody: IRAN_MARKDOWN });
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Firan'),
+      '/countries/iran.md',
+      fetchImpl,
+    );
+
+    const link = res.headers.get('link') ?? '';
+    assert.match(link, /<https:\/\/www\.worldmonitor\.app\/countries\/iran\/>; rel="canonical"/);
+    assert.doesNotMatch(link, /iran\.md>; rel="canonical"/);
+  });
+
+  it('asks the sibling for markdown so the negotiated body is what gets served', async () => {
+    const { seen, fetchImpl } = corpusOrigin({ trailingSlashBody: IRAN_MARKDOWN });
+    await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Firan'),
+      '/countries/iran.md',
+      fetchImpl,
+    );
+
+    assert.ok(seen.length > 0, 'the sibling must be fetched');
+    for (const { init } of seen) {
+      assert.match(new Headers(init?.headers).get('accept') ?? '', /text\/markdown/);
+    }
+  });
+
+  it('does not leak the rewrite-injected path/mdPath params onto the sibling', async () => {
+    const { seen, fetchImpl } = corpusOrigin({ trailingSlashBody: IRAN_MARKDOWN });
+    await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Firan&mdPath=countries%2Firan'),
+      '/countries/iran.md',
+      fetchImpl,
+    );
+
+    for (const { url } of seen) {
+      assert.equal(url.searchParams.get('path'), null, `path leaked into ${url}`);
+      assert.equal(url.searchParams.get('mdPath'), null, `mdPath leaked into ${url}`);
+    }
+  });
+
+  it('forwards a caller query string that is not a rewrite artifact', async () => {
+    const { seen, fetchImpl } = corpusOrigin({ trailingSlashBody: IRAN_MARKDOWN });
+    await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries/iran.md?window=7d'),
+      '/countries/iran.md',
+      fetchImpl,
+    );
+
+    assert.equal(seen[0].url.searchParams.get('window'), '7d');
+  });
+
+  it('stops following same-origin redirects instead of looping forever', async () => {
+    let hops = 0;
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/loop.md'),
+      '/loop.md',
+      async () => {
+        hops += 1;
+        return new Response(null, { status: 308, headers: { location: `/loop-${hops}` } });
+      },
+    );
+
+    assert.ok(hops <= 4, `redirect chain must be bounded, saw ${hops} hops`);
+    assert.equal(res.status, 404);
+    assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+  });
+
+  // Asking the sibling for markdown means whole documents come back, not
+  // 248-byte stubs. `/sources/` is the largest page in the sitemap — measured
+  // at 132,497 bytes on 2026-09-08 — and it must survive the twin's byte cap,
+  // or the fix trades a soft 200 for a hard 502 on the biggest corpus pages.
+  it('serves the largest real corpus page rather than rejecting it as oversized', async () => {
+    const sourcesMarkdown = `# Sources\n\n${'World Monitor tracks this source. '.repeat(4_000)}`;
+    assert.ok(sourcesMarkdown.length > 132_497, 'fixture must be at least as large as the live /sources/ page');
+
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/sources.md'),
+      '/sources.md',
+      async () =>
+        new Response(sourcesMarkdown, { headers: { 'content-type': 'text/markdown; charset=utf-8' } }),
+    );
+
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /^# Sources/m);
+  });
+
+  it('keeps documenting a cross-origin redirect but marks it noindex', async () => {
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/download.md'),
+      '/api/download.md',
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://github.com/koala73/worldmonitor/releases/latest' },
+        }),
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+    assert.match(await res.text(), /github\.com\/koala73\/worldmonitor\/releases\/latest/);
   });
 });

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -4,6 +4,7 @@ import { load } from 'js-yaml';
 
 import handler from '../api/md-twin.ts';
 import {
+  MAX_SIBLING_REDIRECTS,
   MAX_TWIN_BYTES,
   MD_TWIN_LOOP_HEADER,
   buildMarkdownTwinResponse,
@@ -387,8 +388,24 @@ describe('api/md-twin.ts soft-404 farm (#7860)', () => {
     );
 
     assert.equal(res.status, 404);
-    assert.equal(res.headers.get('cache-control'), 'no-store');
     assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+    // Shared-cacheable on purpose. The `.md` space is unbounded and crawlers
+    // probe it, so an uncacheable 404 would make every re-probe cost an origin
+    // round trip — and each one fans out across the redirect chain.
+    assert.equal(res.headers.get('cache-control'), 'public, max-age=0, s-maxage=300');
+  });
+
+  it('keeps a transient upstream failure out of the shared cache', async () => {
+    for (const status of [500, 502, 503, 429]) {
+      const res = await buildMarkdownTwinResponse(
+        new Request('https://www.worldmonitor.app/countries/iran.md'),
+        '/countries/iran.md',
+        async () => new Response('upstream failure', { status }),
+      );
+
+      assert.equal(res.status, status);
+      assert.equal(res.headers.get('cache-control'), 'no-store', `${status} must not be cached`);
+    }
   });
 
   it('never declares a stub the canonical representation of itself', async () => {
@@ -399,8 +416,10 @@ describe('api/md-twin.ts soft-404 farm (#7860)', () => {
       fetchImpl,
     );
 
-    assert.doesNotMatch(res.headers.get('link') ?? '', /does-not-exist-xyz\.md>; rel="canonical"/);
-    assert.doesNotMatch(await res.text(), /canonical:.*does-not-exist-xyz\.md/);
+    assert.doesNotMatch(res.headers.get('link') ?? '', /rel="canonical"/);
+    // Not just "no self-canonical": a 404 names no canonical at all, or the
+    // body would claim a page the headers deliberately withhold.
+    assert.doesNotMatch(await res.text(), /^canonical:/m);
   });
 
   it('points the canonical at the HTML sibling, not at the .md twin', async () => {
@@ -424,9 +443,13 @@ describe('api/md-twin.ts soft-404 farm (#7860)', () => {
       fetchImpl,
     );
 
-    assert.ok(seen.length > 0, 'the sibling must be fetched');
+    assert.ok(seen.length > 1, 'the redirect hop and the resolved fetch must both be seen');
     for (const { init } of seen) {
-      assert.match(new Headers(init?.headers).get('accept') ?? '', /text\/markdown/);
+      const headers = new Headers(init?.headers);
+      assert.match(headers.get('accept') ?? '', /text\/markdown/);
+      // The guard has to ride every hop, not just the first: a followed
+      // redirect that lands back on a `.md` path would otherwise recurse.
+      assert.equal(headers.get(MD_TWIN_LOOP_HEADER), '1');
     }
   });
 
@@ -444,15 +467,23 @@ describe('api/md-twin.ts soft-404 farm (#7860)', () => {
     }
   });
 
+  // Stripping the rewrite's params must not become "strip the query string":
+  // a caller's own params still have to reach the page, while the canonical
+  // stays query-free so two parameterisations do not compete as documents.
   it('forwards a caller query string that is not a rewrite artifact', async () => {
     const { seen, fetchImpl } = corpusOrigin({ trailingSlashBody: IRAN_MARKDOWN });
-    await buildMarkdownTwinResponse(
-      new Request('https://www.worldmonitor.app/countries/iran.md?window=7d'),
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Firan&window=7d'),
       '/countries/iran.md',
       fetchImpl,
     );
 
     assert.equal(seen[0].url.searchParams.get('window'), '7d');
+    assert.equal(seen[0].url.searchParams.get('path'), null);
+    assert.match(
+      res.headers.get('link') ?? '',
+      /<https:\/\/www\.worldmonitor\.app\/countries\/iran\/>; rel="canonical"/,
+    );
   });
 
   it('stops following same-origin redirects instead of looping forever', async () => {
@@ -466,9 +497,42 @@ describe('api/md-twin.ts soft-404 farm (#7860)', () => {
       },
     );
 
-    assert.ok(hops <= 4, `redirect chain must be bounded, saw ${hops} hops`);
+    // Exact, not an upper bound: a budget that silently shrank to zero hops
+    // would still satisfy `<= 4` while breaking every corpus page, all of
+    // which need one hop to reach their trailing-slash form.
+    assert.equal(hops, MAX_SIBLING_REDIRECTS + 1);
     assert.equal(res.status, 404);
     assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+  });
+
+  it('does not throw on a Location header that will not parse', async () => {
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries/iran.md'),
+      '/countries/iran.md',
+      async () => new Response(null, { status: 308, headers: { location: 'http://[' } }),
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+    assert.match(await res.text(), /redirects to/);
+  });
+
+  it('serves a body sitting exactly on the byte cap', async () => {
+    const body = `# Cap\n${'x'.repeat(MAX_TWIN_BYTES - '# Cap\n'.length)}`;
+    assert.equal(new TextEncoder().encode(body).byteLength, MAX_TWIN_BYTES);
+
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/cap.md'),
+      '/cap.md',
+      async () =>
+        new Response(body, {
+          headers: { 'content-type': 'text/markdown', 'content-length': String(MAX_TWIN_BYTES) },
+        }),
+    );
+
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /^# Cap/m);
   });
 
   // Asking the sibling for markdown means whole documents come back, not
@@ -490,6 +554,85 @@ describe('api/md-twin.ts soft-404 farm (#7860)', () => {
     assert.match(await res.text(), /^# Sources/m);
   });
 
+  // The sibling's negotiated markdown carries front matter of its own and no
+  // canonical. Before the fix `withMarkdownMetadata` returned any `---`-led
+  // document untouched, so exactly where documents became real, the body
+  // stopped naming the page it represents.
+  it('sets the canonical in front matter the origin already wrote', async () => {
+    const negotiated = '---\ndescription: Iran CII is 60/100.\ntitle: Iran\nimage: /og.png\n---\n\n# Iran\n';
+    const { fetchImpl } = corpusOrigin({ trailingSlashBody: negotiated });
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Firan'),
+      '/countries/iran.md',
+      fetchImpl,
+    );
+
+    const block = (await res.text()).match(/^---\n([\s\S]*?)\n---\n/);
+    assert.ok(block, 'the negotiated document must still carry front matter');
+    assert.deepEqual(load(block[1]), {
+      description: 'Iran CII is 60/100.',
+      title: 'Iran',
+      image: '/og.png',
+      canonical: 'https://www.worldmonitor.app/countries/iran/',
+    });
+  });
+
+  it('replaces a stale canonical rather than emitting the key twice', async () => {
+    const stale = '---\ntitle: Iran\ncanonical: "https://www.worldmonitor.app/countries/iran.md"\n---\n\n# Iran\n';
+    const { fetchImpl } = corpusOrigin({ trailingSlashBody: stale });
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/md-twin?path=countries%2Firan'),
+      '/countries/iran.md',
+      fetchImpl,
+    );
+
+    const document = await res.text();
+    const block = document.match(/^---\n([\s\S]*?)\n---\n/);
+    assert.deepEqual(load(block[1]), {
+      title: 'Iran',
+      canonical: 'https://www.worldmonitor.app/countries/iran/',
+    });
+    assert.equal(document.match(/^canonical:/gm)?.length, 1);
+  });
+
+  // One deadline for the chain, not one per hop: a fresh timeout inside the
+  // loop multiplies the budget by the hop count, so slow-but-passing hops can
+  // outlive the edge function itself.
+  it('spends a single deadline across every redirect hop', async () => {
+    const signals = [];
+    await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries/iran.md'),
+      '/countries/iran.md',
+      async (input, init) => {
+        signals.push(init?.signal);
+        return new URL(String(input)).pathname.endsWith('/')
+          ? new Response('# Iran\n', { headers: { 'content-type': 'text/markdown' } })
+          : new Response(null, { status: 308, headers: { location: '/countries/iran/' } });
+      },
+    );
+
+    assert.equal(signals.length, 2, 'expected one redirect hop plus the resolved fetch');
+    assert.ok(signals[0], 'each hop must carry an abort signal');
+    assert.equal(signals[0], signals[1], 'every hop must share one deadline');
+  });
+
+  it('follows a redirect for HEAD without reading a body', async () => {
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries/iran.md', { method: 'HEAD' }),
+      '/countries/iran.md',
+      async (input, init) => {
+        assert.equal(init?.method, 'HEAD');
+        return new URL(String(input)).pathname.endsWith('/')
+          ? new Response(null, { status: 200, headers: { 'content-type': 'text/markdown' } })
+          : new Response(null, { status: 308, headers: { location: '/countries/iran/' } });
+      },
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), '');
+    assert.match(res.headers.get('link') ?? '', /<https:\/\/www\.worldmonitor\.app\/countries\/iran\/>; rel="canonical"/);
+  });
+
   it('keeps documenting a cross-origin redirect but marks it noindex', async () => {
     const res = await buildMarkdownTwinResponse(
       new Request('https://www.worldmonitor.app/api/download.md'),
@@ -503,6 +646,11 @@ describe('api/md-twin.ts soft-404 farm (#7860)', () => {
 
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('x-robots-tag'), 'noindex');
-    assert.match(await res.text(), /github\.com\/koala73\/worldmonitor\/releases\/latest/);
+    // A redirect notice represents no page, so it names no canonical in either
+    // half — `noindex` alongside a canonical would be two contradictory claims.
+    assert.doesNotMatch(res.headers.get('link') ?? '', /rel="canonical"/);
+    const body = await res.text();
+    assert.doesNotMatch(body, /^canonical:/m);
+    assert.match(body, /github\.com\/koala73\/worldmonitor\/releases\/latest/);
   });
 });


### PR DESCRIPTION
## Summary

`/countries/iran.md` answered with a 248-byte stub that declared itself the canonical representation of Iran. So did `/crises.md`, `/sources.md`, every `/compare/*` page — and `/countries/does-not-exist-xyz.md`, a path that has never existed. All 200, all self-canonical, all CDN-cached, none carrying `noindex`. Because `llms.txt` publishes nine intentional `.md` URLs, AI crawlers are actively taught that `.md` siblings exist on this domain, and guessing more of them was rewarded with a 200 every time — an unbounded soft-404 space competing for a crawl budget that is already the binding constraint.

The twin now mirrors its sibling. A real page serves the real markdown: `/countries/iran.md` is 21,055 bytes carrying the CII score and description, which is the token-efficient AI surface the `.md` convention promised. An invented path returns 404. Nothing canonicalises to itself.

Fixes #7860

Related: #7660, #7747

## The root cause

One defect produced all six symptoms in the issue:

```
/countries/iran?path=countries%2Firan   →   308   →   /countries/iran/?path=…
```

`vercel.json` rewrites `/:mdPath((?!api/).+).md` to the handler and injects `?path=…&mdPath=…`. The handler copied that whole query onto its sibling fetch, and the extension-less sibling answers 308 to its trailing-slash form. Under `redirect: 'manual'` that 308 became a 200 "This resource redirects to …" stub — identically for a real page and a made-up one, because both redirect the same way. The real markdown was always one `Accept` header away.

## Design decisions

| Decision | Why |
|---|---|
| Follow **same-origin** redirects only, bounded at 3 | A cross-origin hop is the destination, not a step toward one; the twin documents it rather than fetching another site on a caller's behalf. Real corpus pages need exactly 1 hop. |
| One deadline for the whole chain | A fresh `AbortSignal.timeout` per hop multiplies the budget by the hop count — 8s becomes ~32s against an edge function that must start responding within ~25s. |
| A 404/410 is shared-cacheable; every other failure is `no-store` | A 404 is a property of the URL, so the CDN can absorb re-probes of the unbounded space. A 5xx describes *this attempt*, and caching one would pin a real page to a wrong answer for the whole TTL. |
| Canonical points at the resolved sibling, or nowhere | A served document names its page in both the `Link` header and the body front matter. A 404, an upstream failure, and a redirect notice name no canonical at all and carry `X-Robots-Tag: noindex`. |
| Byte cap 80 KB → 256 KB | Real documents now arrive where 248-byte stubs used to. Across all 273 sitemap URLs the largest *page* is `/sources/` at 132,497 bytes; at the old cap it would have answered 502. |

The rule that a twin never self-canonicalises is scoped to *generated* twins. The curated `.md` files under `public/` are the only representation of their own content, have no HTML sibling to defer to, and self-canonicalise correctly.

## Validation

The risk in this change runs the other way: a route that always answered 200 can now answer 404, and a twin that wrongly 404s a real page fails silently — no test goes red, the page just stops being served to agents. So the load-bearing check was a full sweep, not the unit tests.

- **All 273 sitemap URLs** were re-fetched with the twin's exact outbound headers and a 3-redirect limit. Every one resolves 200 within 0–1 hops. No real page 404s, and none exceeds the cap except `/llms-full.txt` (below).
- **Root cause confirmed against production**, not inferred: the 308 chain, the injected query params, and `/countries/does-not-exist-xyz/` being a genuine 404 were each verified live.
- **37 handler tests** (up from 30). The eight tests for the original defect were written red-first; the three pinning the review fixes were re-run against the pre-fix code to prove they fail for the right reason rather than passing vacuously.
- **Full suite: 31,191 tests, 0 failures.** Typecheck, biome, and the docs volatile-inventory gate clean.

Reviewed across nine independent lenses including a cross-model adversarial pass, which found the per-hop timeout independently and reproduced it at 26,416 ms with no individual timeout firing.

Not yet verified: every probe above ran the handler locally against production siblings. The live `cf-cache-status` check on a deployed `.md` twin — now that bodies are ~132 KB of markdown rather than 248-byte stubs — needs this branch's preview.

## Residual risks

- **The redirect budget has no real page behind it.** Every corpus path resolves in 0–1 hops, so `MAX_SIBLING_REDIRECTS = 3` is exercised only by a synthetic test. A future layer that adds a hop — locale prefix, host canonicalisation, an auth bounce — would turn a live page into a silent 404 with nothing going red.
- **`/llms-full.txt.md` returns 502** (264,615 bytes, over the cap). Deliberate, and not a regression: it was over the previous 80 KB cap too, and a plain-text agent file is already its own best representation.
- **HEAD and GET disagree on oversize pages** — HEAD returns before the body is read, so it answers 200 where GET answers 502.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
