### PR TITLE
docs(solutions): a deferred half pinned by a passing test reads as a decision

### DIFF
--- a/docs/solutions/conventions/an-origin-cache-header-proves-nothing-about-the-layer-that-honours-it.md
+++ b/docs/solutions/conventions/an-origin-cache-header-proves-nothing-about-the-layer-that-honours-it.md
@@ -1,6 +1,7 @@
 ---
 title: "An origin cache header proves nothing about the layer that honours it"
 date: 2026-09-04
+last_updated: 2026-09-08
 category: conventions
 module: crawlable corpus / CDN cache configuration
 problem_type: convention
@@ -12,6 +13,8 @@ applies_when:
   - "Diagnosing cf-cache-status DYNAMIC on a route whose origin headers look correct"
   - "Changing anything about the crawlable corpus' caching, TTFB, or crawl budget"
   - "Reviewing a fix whose only evidence is a green offline config assertion"
+  - "Deferring half of a two-part change and pinning the deferral with a passing test"
+  - "Shipping a claim whose other half is applied by hand outside the repo"
   - "Caching a proxied or content-negotiated route (Accept, RSC) at a shared edge"
 symptoms:
   - "Every corpus route answers with the configured CDN-Cache-Control and Cloudflare still reports cf-cache-status: DYNAMIC"
@@ -180,6 +183,60 @@ What this adds to the convention:
   falls through to the bypass and shows the origin's answer without storing
   anything. Sending the suspect request to the bare URL *is* the poisoning.
 
+## Fifth time: #7869 (2026-09-08) — a deferred half, pinned by a confident test name
+
+The root sitemaps had been reported uncached in two consecutive audit rounds
+before anyone looked at why. The reason turns out to be a new shape of this same
+failure, and the most transferable one yet: **the incomplete half had been
+written down as a decision.**
+
+#7749 gave `/sitemap.xml` and `/sitemap-main.xml` the Vercel half of the pair and
+stopped there, which is a defensible place to stop. What made it durable was the
+test that pinned it:
+
+```
+it('caches root sitemaps at Vercel without changing the Cloudflare bypass (#7749)', ...)
+```
+
+— asserting `CDN-Cache-Control` was `null`. That test is green, confidently
+named, and reads as a deliberate scope boundary rather than an unfinished job. So
+nothing prompted anyone to finish it, and production kept answering
+`cf-cache-status: DYNAMIC` until an external audit re-measured it two rounds
+later. A TODO decays into a decision the moment it is expressed as a passing
+assertion.
+
+**The counter-practice, when a claim's other half lives outside the repo.** The
+Cloudflare rule is only reachable through a manual `--apply`, so nothing in the
+repo can prove it ran. Every in-repo guard here compares `vercel.json` against
+`scripts/cloudflare-cache-rule.mjs` — two constants in the same tree, neither of
+which knows what the zone contains. The fix is not a better offline assertion; it
+is to put the URLs in the live post-deploy probe
+(`tests/live-api-cache-auth-regression.test.mjs`), so *merged but never applied*
+turns the sweep red instead of staying quietly inert. That workflow runs on
+`deployment_status` and on a schedule, not on pull requests, so it cannot block
+the merge — it reports afterwards, which is the correct shape for a claim that
+only becomes true after an operator acts.
+
+Both of these are the same lesson the rest of this document keeps arriving at,
+one level up: **an assertion proves what was declared, and the thing worth
+proving usually lives somewhere the assertion cannot see.** When it does, say so
+in the test's name — a test called "…without changing the Cloudflare bypass"
+should have been called "…pending the Cloudflare claim (#7749)".
+
+### Two measurement traps, restated because both recurred here
+
+- `curl -I` sends HEAD, and the rule's method guard excludes it, so HEAD reports
+  `DYNAMIC` on routes that HIT for real clients. Every cache measurement in this
+  repo must use GET. This is already recorded above and still produced a wrong
+  round-6 measurement.
+- The naive birthday figure is the wrong number for a namespaced key. Sizing the
+  risk of a truncated-digest collision over 748 providers looked like ~1.65%
+  until the namespace was read correctly: an anchor collision needs the slug to
+  match *as well as* the digest, and every slug was distinct, so the path was
+  unreachable rather than a one-in-sixty gamble. Overstating a risk buys the
+  wrong fix; the defect there was a guarantee the code asserted and did not have.
+  (See `docs/solutions/design-patterns/published-citation-anchors-need-identity-based-ids-and-visible-scroll-targets.md`.)
+
 ## Related
 
 - `docs/solutions/design-patterns/pinned-value-allowlist-freezes-a-snapshot-not-the-invariant.md`
@@ -190,3 +247,6 @@ What this adds to the convention:
   (threshold *and* marker list) so it cannot itself go silently missing.
 - `docs/solutions/conventions/ref-param-is-affiliate-attribution-use-utm-for-internal-source-tags.md`
   — why the cache rule deliberately excludes query-bearing corpus URLs.
+- `docs/solutions/design-patterns/published-citation-anchors-need-identity-based-ids-and-visible-scroll-targets.md`
+  — the other half of #7869: what changes once a fragment id becomes published
+  citation data, and why an anchor must read only its own key.


### PR DESCRIPTION
Follow-on to #7881, which merged while this was being written. Documentation only — no code, no behavior change.

## What this records

#7881's sitemap fix was the **fifth** recurrence of the convention already documented in `an-origin-cache-header-proves-nothing-about-the-layer-that-honours-it.md` (after #7590, #7659, #7747, #7804). Rather than add a fourth near-duplicate doc, this updates that one — the overlap is high on every dimension, and two docs describing the same convention would drift.

The new shape is worth recording because it is not "someone forgot the other half":

#7749 gave `/sitemap.xml` and `/sitemap-main.xml` the Vercel half and stopped, which is a defensible place to stop. What made it durable was the test that pinned the stopping point:

```
it('caches root sitemaps at Vercel without changing the Cloudflare bypass (#7749)', ...)
```

— asserting `CDN-Cache-Control` was `null`. Green, confidently named, and indistinguishable from a deliberate scope boundary. So nothing prompted anyone to finish it, and production kept answering `cf-cache-status: DYNAMIC` until an external audit re-measured it two rounds later.

**A TODO decays into a decision the moment it is expressed as a passing assertion.** That test should have been named "…pending the Cloudflare claim (#7749)".

## The counter-practice

The generalizable half: when a claim's other half lives outside the repo — here a Cloudflare zone rule reachable only through a manual `--apply` — no offline assertion can reach it, because every in-repo guard compares two constants in the same tree. The answer is a live post-deploy probe, so *merged but never applied* turns a sweep red instead of staying inert. That workflow runs on `deployment_status` and a schedule rather than on pull requests, which is the right shape for a claim that only becomes true after an operator acts.

## Two measurement traps, restated

Both recurred during #7881:

- `curl -I` sends HEAD, which the rule's method guard excludes, so HEAD reports `DYNAMIC` on routes that HIT for real clients. Already in the doc, and still produced a wrong round-6 measurement.
- The naive birthday figure is the wrong number for a namespaced key. I sized a truncated-digest collision risk at ~1.65% over 748 providers by reading the namespace as the digest alone; an anchor collision needs the slug to match *as well*, and every slug was distinct, so the path was unreachable. **I overstated it roughly a hundredfold.** Recorded because overstating a risk buys the wrong fix — the real defect there was a guarantee the code asserted and did not have.

## Testing

- `tests/mdx-lint.test.mjs` — 903 pass (the gate that caught #7881's last red build; run here *before* pushing this time).
- `npm run docs:check`, frontmatter validator, and the claims validator (9 paths, 0 flags) — all clean.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — documentation only, no runtime surface.

## Note on #7881's operator step

Unrelated to this PR but still open: the Cloudflare half of #7881 is inert until `node scripts/cloudflare-cache-rule.mjs --apply` runs against the zone. Until then `/sitemap.xml` and `/sitemap-main.xml` stay `DYNAMIC`, and the Live API Cache/Auth Sweep will go red on `root sitemap index` / `root sitemap URL set` — which is the probe #7881 added for exactly this purpose, working as intended.

https://claude.ai/code/session_01KzXNMYV3dj5H3eZVEeV2aQ
