### PR TITLE
fix(md-twin): serve the real document and 404 the empty .md space (#7860)

### DIFF
--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -5,8 +5,16 @@
  * text/markdown (or a heading-led non-HTML body). Static files under public/
  * win. Everything else is generated from the sibling URL.
  *
+ * The sibling is asked for text/markdown first, so a prerendered page comes
+ * back as Vercel's own markdown conversion instead of a scrape of its HTML.
+ * Same-origin redirects are followed (every content URL here 308s /x to /x/)
+ * and the twin inherits the final target's status, so an invented path is a
+ * 404 rather than an indexable stub. The canonical always names the final
+ * HTML page, never the .md twin, and only a response that carries the real
+ * document is left indexable.
+ *
  * Loop-prevention: sibling fetches send x-wm-md-twin so a .md handler never
- * fetches another .md handler.
+ * fetches another .md handler, and a redirect onto a .md path is not followed.
  */
 
 // @ts-expect-error — JS module, no declaration file
@@ -14,8 +22,9 @@ import { getPublicCorsHeaders } from './_cors.js';
 import { appendDeprecationPolicyLinkToRecord, DEPRECATION_POLICY_LINK } from '../server/_shared/deprecation-policy';
 
 export const MD_TWIN_LOOP_HEADER = 'x-wm-md-twin';
-const MAX_TWIN_CHARS = 80_000;
-export const MAX_TWIN_BYTES = 80_000;
+const MAX_TWIN_CHARS = 512_000;
+export const MAX_TWIN_BYTES = 512_000;
+const MAX_SIBLING_REDIRECTS = 3;
 const SIBLING_FETCH_TIMEOUT_MS = 8_000;
 const SIBLING_USER_AGENT = 'WorldMonitor-MarkdownTwin/1.0';
 const FORWARDED_RESPONSE_HEADERS = [
@@ -139,14 +148,35 @@ function jsonToMarkdown(raw: string, heading: string): string {
   return `# ${heading}\n\n\`\`\`json\n${pretty}\n\`\`\``.slice(0, MAX_TWIN_CHARS);
 }
 
-function withMarkdownMetadata(markdown: string, canonical: string): string {
-  if (markdown.startsWith('---\n')) return markdown;
-  const title = markdown.match(/^# (.+)$/m)?.[1] ?? headingFromPath(new URL(canonical).pathname);
-  return `---\ntitle: ${JSON.stringify(title)}\ncanonical: ${JSON.stringify(canonical)}\n---\n\n${markdown}`;
+const FRONT_MATTER = /^---\n([\s\S]*?)\n---(?:\n|$)/;
+
+function withHeading(markdown: string, heading: string): string {
+  if (/^# /m.test(markdown)) return markdown;
+  // Asking the sibling for markdown makes a front-matter-led body the common
+  // case, and a heading prepended above the opening `---` would swallow the
+  // whole block into the document text.
+  const block = markdown.match(FRONT_MATTER)?.[0];
+  return block
+    ? `${block}\n# ${heading}\n\n${markdown.slice(block.length)}`
+    : `# ${heading}\n\n${markdown}`;
 }
 
-function markdownHeaders(req: Request, markdownPath: string, extra: Record<string, string> = {}): Record<string, string> {
-  const origin = new URL(req.url).origin;
+function withMarkdownMetadata(markdown: string, canonical: string | null, fallbackTitle: string): string {
+  const frontMatter = markdown.match(FRONT_MATTER);
+  if (frontMatter) {
+    if (!canonical) return markdown;
+    // Vercel's own front-matter carries title/description/image but no
+    // canonical; keep its lines byte-for-byte and append ours.
+    const lines = (frontMatter[1] ?? '').split('\n').filter((line) => !line.startsWith('canonical:'));
+    lines.push(`canonical: ${JSON.stringify(canonical)}`);
+    return `---\n${lines.join('\n')}\n---\n${markdown.slice(frontMatter[0].length)}`;
+  }
+  const title = markdown.match(/^# (.+)$/m)?.[1] ?? fallbackTitle;
+  const canonicalLine = canonical ? `\ncanonical: ${JSON.stringify(canonical)}` : '';
+  return `---\ntitle: ${JSON.stringify(title)}${canonicalLine}\n---\n\n${markdown}`;
+}
+
+function markdownHeaders(canonical: string | null, extra: Record<string, string> = {}): Record<string, string> {
   return {
     'Content-Type': 'text/markdown; charset=utf-8',
     'X-Content-Type-Options': 'nosniff',
@@ -157,7 +187,7 @@ function markdownHeaders(req: Request, markdownPath: string, extra: Record<strin
     // no other variance needs declaring.
     Vary: MD_TWIN_LOOP_HEADER,
     ...getPublicCorsHeaders('GET, HEAD, OPTIONS'),
-    Link: `<${origin}${markdownPath}>; rel="canonical", ${DEPRECATION_POLICY_LINK}`,
+    Link: canonical ? `<${canonical}>; rel="canonical", ${DEPRECATION_POLICY_LINK}` : DEPRECATION_POLICY_LINK,
     ...extra,
   };
 }
@@ -238,14 +268,14 @@ export async function buildMarkdownTwinResponse(
   if (req.method !== 'GET' && req.method !== 'HEAD') {
     return new Response('# Method not allowed\n', {
       status: 405,
-      headers: markdownHeaders(req, markdownPath, { Allow: 'GET, HEAD, OPTIONS' }),
+      headers: markdownHeaders(null, { Allow: 'GET, HEAD, OPTIONS', 'X-Robots-Tag': 'noindex' }),
     });
   }
 
   if (req.headers.get(MD_TWIN_LOOP_HEADER) === '1') {
     return new Response('# Not found\n', {
       status: 404,
-      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+      headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
     });
   }
 
@@ -253,70 +283,97 @@ export async function buildMarkdownTwinResponse(
   if (!sibling) {
     return new Response('# Not found\n', {
       status: 404,
-      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+      headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
     });
   }
 
-  const siblingUrl = new URL(sibling, req.url);
-  siblingUrl.search = new URL(req.url).search;
+  const heading = headingFromPath(sibling);
+  const requestUrl = new URL(req.url);
+  let siblingUrl = new URL(sibling, requestUrl);
+  siblingUrl.search = requestUrl.search;
+  if (requestUrl.pathname === '/api/md-twin' || requestUrl.pathname === '/api/md-twin/') {
+    // `path`/`mdPath` belong to the afterFiles rewrite, not to the caller.
+    siblingUrl.searchParams.delete('path');
+    siblingUrl.searchParams.delete('mdPath');
+  }
 
   const outbound = new Headers();
   outbound.set('user-agent', SIBLING_USER_AGENT);
   outbound.set(MD_TWIN_LOOP_HEADER, '1');
-  outbound.set('accept', 'text/html, application/json;q=0.9, text/plain;q=0.8, */*;q=0.1');
+  outbound.set('accept', 'text/markdown, text/html;q=0.9, application/json;q=0.8, text/plain;q=0.7, */*;q=0.1');
 
   let siblingRes: Response;
-  try {
-    siblingRes = await fetchImpl(siblingUrl, {
-      method: req.method,
-      headers: outbound,
-      redirect: 'manual',
-      signal: AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS),
-    });
-  } catch {
-    return new Response(`# ${headingFromPath(sibling)}\n\nThe sibling page at \`${sibling}\` could not be fetched.\n`, {
-      status: 502,
-      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
-    });
-  }
+  for (let hops = 0; ; hops += 1) {
+    let redirectTarget: URL | null;
+    try {
+      siblingRes = await fetchImpl(siblingUrl, {
+        method: req.method,
+        headers: outbound,
+        redirect: 'manual',
+        signal: AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS),
+      });
+      const location = siblingRes.headers.get('location');
+      redirectTarget =
+        siblingRes.status >= 300 && siblingRes.status < 400 && location ? new URL(location, siblingUrl) : null;
+    } catch {
+      return new Response(`# ${heading}\n\nThe sibling page at \`${sibling}\` could not be fetched.\n`, {
+        status: 502,
+        headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
+      });
+    }
+    if (!redirectTarget) break;
 
-  const location = siblingRes.headers.get('location');
-  if (siblingRes.status >= 300 && siblingRes.status < 400 && location) {
-    const body = `# ${headingFromPath(sibling)}\n\nThis resource redirects to [${location}](${location}).\n`;
-    return new Response(req.method === 'HEAD' ? null : withMarkdownMetadata(body, new URL(markdownPath, req.url).href), {
-      status: 200,
-      headers: markdownHeaders(req, markdownPath),
-    });
+    if (redirectTarget.origin !== requestUrl.origin) {
+      const body = `# ${heading}\n\nThis resource redirects to [${redirectTarget.href}](${redirectTarget.href}).\n`;
+      return new Response(req.method === 'HEAD' ? null : withMarkdownMetadata(body, null, heading), {
+        status: 200,
+        headers: markdownHeaders(null, { 'X-Robots-Tag': 'noindex' }),
+      });
+    }
+
+    // A .md target would re-enter this handler; the hop budget bounds the
+    // chain even when every hop is a legitimate same-origin redirect.
+    if (hops >= MAX_SIBLING_REDIRECTS || isMarkdownTwinPath(redirectTarget.pathname)) {
+      return new Response('# Not found\n', {
+        status: 404,
+        headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
+      });
+    }
+    siblingUrl = redirectTarget;
   }
 
   const isFailure = !siblingRes.ok;
   const siblingStatus = isFailure ? siblingRes.status : 200;
+  // Query-less, matching what the sibling's own <link rel="canonical"> emits:
+  // /countries/iran/?foo=1 canonicalises to /countries/iran/. Carrying the
+  // query here would chain one canonical into another and let query params
+  // reopen the unbounded twin space this handler exists to close.
+  const canonical = isFailure ? null : `${siblingUrl.origin}${siblingUrl.pathname}`;
   const responseHeaders: Record<string, string> = {
-    ...(isFailure ? { 'Cache-Control': 'no-store' } : {}),
+    ...(isFailure ? { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' } : {}),
     ...forwardedResponseHeaders(siblingRes),
   };
 
   if (req.method === 'HEAD') {
     return new Response(null, {
       status: siblingStatus,
-      headers: markdownHeaders(req, markdownPath, responseHeaders),
+      headers: markdownHeaders(canonical, responseHeaders),
     });
   }
 
   if (siblingStatus === 304) {
     return new Response(null, {
       status: siblingStatus,
-      headers: markdownHeaders(req, markdownPath, responseHeaders),
+      headers: markdownHeaders(canonical, responseHeaders),
     });
   }
 
-  const heading = headingFromPath(sibling);
   let markdown: string;
   try {
     const contentType = siblingRes.headers.get('content-type') ?? '';
     const raw = await readSiblingBody(siblingRes);
 
-    if (/markdown|text\/plain/i.test(contentType) && /^# /m.test(raw)) {
+    if (/markdown|text\/plain/i.test(contentType) && (/^# /m.test(raw) || FRONT_MATTER.test(raw))) {
       markdown = raw.slice(0, MAX_TWIN_CHARS);
     } else if (/json/i.test(contentType) || raw.trim().startsWith('{') || raw.trim().startsWith('[')) {
       markdown = jsonToMarkdown(raw, heading);
@@ -328,18 +385,16 @@ export async function buildMarkdownTwinResponse(
       markdown = /^# /m.test(raw) ? raw.slice(0, MAX_TWIN_CHARS) : `# ${heading}\n\n${raw}`.slice(0, MAX_TWIN_CHARS);
     }
 
-    if (!/^# /m.test(markdown)) {
-      markdown = `# ${heading}\n\n${markdown}`;
-    }
+    markdown = withHeading(markdown, heading);
   } catch {
     return new Response(`# ${heading}\n\nThe sibling page at \`${sibling}\` could not be read.\n`, {
       status: 502,
-      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+      headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
     });
   }
 
-  return new Response(withMarkdownMetadata(markdown, new URL(markdownPath, req.url).href), {
+  return new Response(withMarkdownMetadata(markdown, canonical, heading), {
     status: siblingStatus,
-    headers: markdownHeaders(req, markdownPath, responseHeaders),
+    headers: markdownHeaders(canonical, responseHeaders),
   });
 }

--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -9,9 +9,9 @@
  * back as Vercel's own markdown conversion instead of a scrape of its HTML.
  * Same-origin redirects are followed (every content URL here 308s /x to /x/)
  * and the twin inherits the final target's status, so an invented path is a
- * 404 rather than an indexable stub. The canonical always names the final
- * HTML page, never the .md twin, and only a response that carries the real
- * document is left indexable.
+ * 404 rather than an indexable stub. The canonical names the final HTML page,
+ * never the .md twin and never an /api/ endpoint, and only a response that
+ * carries the real document is left indexable.
  *
  * Loop-prevention: sibling fetches send x-wm-md-twin so a .md handler never
  * fetches another .md handler, and a redirect onto a .md path is not followed.
@@ -25,6 +25,9 @@ export const MD_TWIN_LOOP_HEADER = 'x-wm-md-twin';
 const MAX_TWIN_CHARS = 512_000;
 export const MAX_TWIN_BYTES = 512_000;
 const MAX_SIBLING_REDIRECTS = 3;
+// Every response that is not the sibling's own document carries these: a
+// stub must never be cached as if it were the page, nor indexed as one.
+const NOT_A_DOCUMENT = { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' } as const;
 const SIBLING_FETCH_TIMEOUT_MS = 8_000;
 const SIBLING_USER_AGENT = 'WorldMonitor-MarkdownTwin/1.0';
 const FORWARDED_RESPONSE_HEADERS = [
@@ -141,7 +144,10 @@ export function htmlToMarkdown(html: string, fallbackTitle: string): string {
 function jsonToMarkdown(raw: string, heading: string): string {
   let pretty = raw.trim();
   try {
-    pretty = JSON.stringify(JSON.parse(raw) as unknown, null, 2);
+    const reserialised = JSON.stringify(JSON.parse(raw) as unknown, null, 2);
+    // Indenting can multiply a body that is already at the cap, so keep the
+    // expanded form only when it fits and otherwise fence the raw text.
+    if (reserialised.length <= MAX_TWIN_CHARS) pretty = reserialised;
   } catch {
     // Keep the original text when the body is not JSON.
   }
@@ -149,27 +155,58 @@ function jsonToMarkdown(raw: string, heading: string): string {
 }
 
 const FRONT_MATTER = /^---\n([\s\S]*?)\n---(?:\n|$)/;
+const FRONT_MATTER_KEY = /^([A-Za-z0-9_.-]+):(?:\s|$)/;
+
+/**
+ * `---` opens a thematic break as well as a front-matter block, so a document
+ * that merely starts with a horizontal rule must not have its prose spliced
+ * into metadata. Require the captured block to read as a flat YAML mapping.
+ */
+function frontMatterOf(markdown: string): { block: string; lines: string[] } | null {
+  const match = markdown.match(FRONT_MATTER);
+  if (!match) return null;
+  const lines = (match[1] ?? '').split('\n');
+  const isMapping =
+    lines.some((line) => FRONT_MATTER_KEY.test(line)) &&
+    lines.every((line) => line.trim() === '' || line.startsWith(' ') || FRONT_MATTER_KEY.test(line));
+  return isMapping ? { block: match[0], lines } : null;
+}
+
+/**
+ * Re-emit `key: value` with the value quoted. Vercel's generated front-matter
+ * leaves values bare, and its descriptions routinely contain ": " (live
+ * 2026-09-08 on /dashboard and /chokepoints/strait-of-hormuz/), which a plain
+ * YAML scalar cannot hold — so copying the block through unchanged would ship
+ * a metadata block no consumer can parse, canonical included.
+ */
+function quoteFrontMatterValue(line: string): string {
+  const entry = line.match(/^([A-Za-z0-9_.-]+):\s*(.*)$/);
+  if (!entry) return line;
+  const [, key, value = ''] = entry;
+  if (value === '' || /^(["']).*\1$/.test(value)) return line;
+  return `${key}: ${JSON.stringify(value)}`;
+}
 
 function withHeading(markdown: string, heading: string): string {
   if (/^# /m.test(markdown)) return markdown;
   // Asking the sibling for markdown makes a front-matter-led body the common
   // case, and a heading prepended above the opening `---` would swallow the
   // whole block into the document text.
-  const block = markdown.match(FRONT_MATTER)?.[0];
+  const block = frontMatterOf(markdown)?.block;
   return block
     ? `${block}\n# ${heading}\n\n${markdown.slice(block.length)}`
     : `# ${heading}\n\n${markdown}`;
 }
 
 function withMarkdownMetadata(markdown: string, canonical: string | null, fallbackTitle: string): string {
-  const frontMatter = markdown.match(FRONT_MATTER);
+  const frontMatter = frontMatterOf(markdown);
   if (frontMatter) {
     if (!canonical) return markdown;
-    // Vercel's own front-matter carries title/description/image but no
-    // canonical; keep its lines byte-for-byte and append ours.
-    const lines = (frontMatter[1] ?? '').split('\n').filter((line) => !line.startsWith('canonical:'));
+    const lines = frontMatter.lines
+      .filter((line) => !line.startsWith('canonical:'))
+      .map(quoteFrontMatterValue);
     lines.push(`canonical: ${JSON.stringify(canonical)}`);
-    return `---\n${lines.join('\n')}\n---\n${markdown.slice(frontMatter[0].length)}`;
+    return `---\n${lines.join('\n')}\n---\n${markdown.slice(frontMatter.block.length)}`;
   }
   const title = markdown.match(/^# (.+)$/m)?.[1] ?? fallbackTitle;
   const canonicalLine = canonical ? `\ncanonical: ${JSON.stringify(canonical)}` : '';
@@ -275,7 +312,7 @@ export async function buildMarkdownTwinResponse(
   if (req.headers.get(MD_TWIN_LOOP_HEADER) === '1') {
     return new Response('# Not found\n', {
       status: 404,
-      headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
+      headers: markdownHeaders(null, { ...NOT_A_DOCUMENT }),
     });
   }
 
@@ -283,7 +320,7 @@ export async function buildMarkdownTwinResponse(
   if (!sibling) {
     return new Response('# Not found\n', {
       status: 404,
-      headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
+      headers: markdownHeaders(null, { ...NOT_A_DOCUMENT }),
     });
   }
 
@@ -302,6 +339,11 @@ export async function buildMarkdownTwinResponse(
   outbound.set(MD_TWIN_LOOP_HEADER, '1');
   outbound.set('accept', 'text/markdown, text/html;q=0.9, application/json;q=0.8, text/plain;q=0.7, */*;q=0.1');
 
+  // One deadline for the whole chain, not one per hop: a fresh signal each hop
+  // would multiply the budget by the hop count and overrun the edge runtime's
+  // execution ceiling before any of this handler's own error branches ran.
+  const deadline = AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS);
+
   let siblingRes: Response;
   for (let hops = 0; ; hops += 1) {
     let redirectTarget: URL | null;
@@ -310,7 +352,7 @@ export async function buildMarkdownTwinResponse(
         method: req.method,
         headers: outbound,
         redirect: 'manual',
-        signal: AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS),
+        signal: deadline,
       });
       const location = siblingRes.headers.get('location');
       redirectTarget =
@@ -318,7 +360,7 @@ export async function buildMarkdownTwinResponse(
     } catch {
       return new Response(`# ${heading}\n\nThe sibling page at \`${sibling}\` could not be fetched.\n`, {
         status: 502,
-        headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
+        headers: markdownHeaders(null, { ...NOT_A_DOCUMENT }),
       });
     }
     if (!redirectTarget) break;
@@ -336,7 +378,7 @@ export async function buildMarkdownTwinResponse(
     if (hops >= MAX_SIBLING_REDIRECTS || isMarkdownTwinPath(redirectTarget.pathname)) {
       return new Response('# Not found\n', {
         status: 404,
-        headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
+        headers: markdownHeaders(null, { ...NOT_A_DOCUMENT }),
       });
     }
     siblingUrl = redirectTarget;
@@ -348,9 +390,16 @@ export async function buildMarkdownTwinResponse(
   // /countries/iran/?foo=1 canonicalises to /countries/iran/. Carrying the
   // query here would chain one canonical into another and let query params
   // reopen the unbounded twin space this handler exists to close.
-  const canonical = isFailure ? null : `${siblingUrl.origin}${siblingUrl.pathname}`;
+  //
+  // An /api/ sibling gets none at all. Those endpoints are not canonical web
+  // pages, and many need their query to mean anything, so the query-less form
+  // would name a different, degenerate resource than the one served.
+  const canonical =
+    isFailure || siblingUrl.pathname.startsWith('/api/')
+      ? null
+      : `${siblingUrl.origin}${siblingUrl.pathname}`;
   const responseHeaders: Record<string, string> = {
-    ...(isFailure ? { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' } : {}),
+    ...(isFailure ? NOT_A_DOCUMENT : {}),
     ...forwardedResponseHeaders(siblingRes),
   };
 
@@ -389,7 +438,7 @@ export async function buildMarkdownTwinResponse(
   } catch {
     return new Response(`# ${heading}\n\nThe sibling page at \`${sibling}\` could not be read.\n`, {
       status: 502,
-      headers: markdownHeaders(null, { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }),
+      headers: markdownHeaders(null, { ...NOT_A_DOCUMENT }),
     });
   }
 

--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -15,7 +15,7 @@ import { appendDeprecationPolicyLinkToRecord, DEPRECATION_POLICY_LINK } from '..
 
 export const MD_TWIN_LOOP_HEADER = 'x-wm-md-twin';
 const MAX_TWIN_CHARS = 80_000;
-const MAX_TWIN_BYTES = 80_000;
+export const MAX_TWIN_BYTES = 80_000;
 const SIBLING_FETCH_TIMEOUT_MS = 8_000;
 const SIBLING_USER_AGENT = 'WorldMonitor-MarkdownTwin/1.0';
 const FORWARDED_RESPONSE_HEADERS = [

--- a/api/md-twin.ts
+++ b/api/md-twin.ts
@@ -22,6 +22,7 @@ export default async function handler(req: Request): Promise<Response> {
       headers: {
         'Content-Type': 'text/markdown; charset=utf-8',
         'Cache-Control': 'no-store',
+        'X-Robots-Tag': 'noindex',
         'Access-Control-Allow-Origin': '*',
       },
     });

--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -87,7 +87,7 @@ A second, separate MCP server for the documentation itself (card at `/.well-know
 
 ### Markdown twins — `<any-page>.md`
 
-Every page on the site has an agent-readable markdown twin: append `.md` to the path (`/pricing.md`, `/countries/tw.md`, `/home.md` for the front page). Curated twins are static and cached `public, max-age=3600` with `Access-Control-Allow-Origin: *`; everything else is rendered on demand by the twin service (HTML becomes heading-led markdown, JSON becomes a fenced block, output capped at 80 KB) with a `Link: <sibling>; rel="canonical"` header. `GET`/`HEAD` on `.md` twins bypasses the API bot gate, so plain `curl` works without a browser User-Agent.
+Every page on the site has an agent-readable markdown twin: append `.md` to the path (`/pricing.md`, `/countries/tw.md`, `/home.md` for the front page). Curated twins are static and cached `public, max-age=3600` with `Access-Control-Allow-Origin: *`; everything else is rendered on demand by the twin service, which asks the sibling page for `text/markdown` and serves what it gets back (HTML becomes heading-led markdown, JSON becomes a fenced block, output capped at 512 KB). The twin follows same-origin redirects and inherits the target's status, so a `.md` path with no page behind it answers `404`, not a stub. A twin carrying a document sends `Link: <sibling>; rel="canonical"` naming the HTML page; anything else sends `X-Robots-Tag: noindex` and no canonical. `GET`/`HEAD` on `.md` twins bypasses the API bot gate, so plain `curl` works without a browser User-Agent.
 
 ## Agent walkthroughs
 

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -3729,6 +3729,30 @@ describe('agent readiness: generic markdown URL-fallback rewrite', () => {
     assert.equal(sourceToRegExp(SPA_HTML_CACHE_SOURCE).test('/dashboard.md'), false);
     assert.equal(sourceToRegExp(SPA_HTML_CACHE_SOURCE).test('/dashboard'), true);
   });
+
+  it('never declares a static canonical over the unbounded generated .md space', () => {
+    // The curated twins (pricing.md, developers.md, …) are standalone documents
+    // with no HTML sibling, so their literal self-canonical header rules are
+    // correct. The generated space is unbounded — /countries/iran.md and an
+    // invented /countries/does-not-exist-xyz.md both land on /api/md-twin — so a
+    // canonical rule that reached them would mint a self-canonical soft-404 that
+    // no handler change can retract (#7860). Only the handler may set a
+    // canonical there, and it points at the sibling HTML page.
+    const generatedTwins = ['/countries/iran.md', '/countries/does-not-exist-xyz.md', '/stocks/AAPL.md'];
+    for (const rule of vercelConfig.headers ?? []) {
+      const declaresCanonical = (rule.headers ?? []).some(
+        (h) => h.key?.toLowerCase() === 'link' && /rel="?canonical"?/.test(h.value ?? ''),
+      );
+      if (!declaresCanonical) continue;
+      for (const path of generatedTwins) {
+        assert.equal(
+          sourceToRegExp(rule.source).test(path),
+          false,
+          `header rule "${rule.source}" declares a canonical over generated twin ${path}`,
+        );
+      }
+    }
+  });
 });
 
 describe('agent readiness: remaining markdown twins', () => {

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -268,6 +268,54 @@ describe('api/md-twin.ts', () => {
     });
   });
 
+  it('keeps the canonical query-less, the way the sibling page canonicalises itself', async () => {
+    const originalFetch = globalThis.fetch;
+    const { fetchImpl } = siblingChain(
+      new Response('# AAPL\n', { status: 200, headers: { 'content-type': 'text/markdown' } }),
+    );
+    globalThis.fetch = fetchImpl;
+    let response;
+    try {
+      response = await handler(
+        new Request('https://www.worldmonitor.app/api/md-twin?path=stocks%2FAAPL&range=1y'),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    // /stocks/AAPL?range=1y emits <link rel="canonical" href=".../dashboard">,
+    // so a query-bearing twin canonical would chain, and every param value
+    // would mint another indexable twin URL.
+    assert.match(
+      response.headers.get('link') ?? '',
+      /<https:\/\/www\.worldmonitor\.app\/stocks\/AAPL>; rel="canonical"/,
+    );
+    assert.doesNotMatch(response.headers.get('link') ?? '', /range=1y/);
+    assert.doesNotMatch(await response.text(), /range=1y/);
+  });
+
+  it('keeps front-matter intact when the sibling document has no H1', async () => {
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/example.md'),
+      '/example.md',
+      async () =>
+        new Response('---\ntitle: Upstream title\n---\n\nBody with no heading.\n', {
+          status: 200,
+          headers: { 'content-type': 'text/markdown; charset=utf-8' },
+        }),
+    );
+
+    const document = await response.text();
+    assert.ok(document.startsWith('---\n'), `front-matter must stay first, got: ${document.slice(0, 40)}`);
+    const block = document.match(/^---\n([\s\S]*?)\n---\n/);
+    assert.deepEqual(load(block[1]), {
+      title: 'Upstream title',
+      canonical: 'https://www.worldmonitor.app/example',
+    });
+    assert.match(document, /^# example$/m, 'the twin stays heading-led below the front-matter');
+    assert.match(document, /Body with no heading\./);
+  });
+
   it('returns the deprecation policy Link on OPTIONS preflights', async () => {
     const res = await buildMarkdownTwinResponse(
       new Request('https://www.worldmonitor.app/dashboard.md', { method: 'OPTIONS' }),

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -4,6 +4,7 @@ import { load } from 'js-yaml';
 
 import handler from '../api/md-twin.ts';
 import {
+  MAX_TWIN_BYTES,
   MD_TWIN_LOOP_HEADER,
   buildMarkdownTwinResponse,
   htmlToMarkdown,
@@ -11,6 +12,22 @@ import {
   resolveMarkdownTwinPath,
   siblingPathFromMarkdown,
 } from '../api/_md-url-twin.ts';
+
+/**
+ * Sequences sibling responses across a redirect chain. Each entry answers one
+ * hop, so a test can assert what the twin does with the LAST hop rather than
+ * with the 308 that every trailing-slash URL on this site emits first.
+ */
+function siblingChain(...responses) {
+  const seen = [];
+  const fetchImpl = async (input, init) => {
+    seen.push({ url: new URL(String(input)), init });
+    const next = responses[seen.length - 1];
+    if (!next) throw new Error(`unexpected sibling fetch #${seen.length}: ${String(input)}`);
+    return next;
+  };
+  return { fetchImpl, seen };
+}
 
 describe('markdown URL-fallback helpers', () => {
   it('accepts /{page}.md paths and maps them to the sibling', () => {
@@ -63,21 +80,154 @@ describe('api/md-twin.ts vary coverage (#7616 U4)', () => {
 });
 
 describe('api/md-twin.ts', () => {
-  it('includes metadata when a sibling redirects to its canonical page', async () => {
+  // #7860: every content URL on this site 308s from `/x` to `/x/`, so with
+  // `redirect: 'manual'` the twin answered EVERY path with a ~250-byte "this
+  // resource redirects to" stub — a self-canonical, CDN-cached, indexable 200
+  // over an unbounded `.md` space. The twin must follow the hop and serve the
+  // document, and must inherit the target's status when there is no document.
+  it('follows a same-origin redirect and serves the target document', async () => {
+    const { fetchImpl, seen } = siblingChain(
+      new Response(null, { status: 308, headers: { location: '/countries/' } }),
+      new Response('---\ntitle: Countries\n---\n\n# Countries\n\nEvery country page.\n', {
+        status: 200,
+        headers: { 'content-type': 'text/markdown; charset=utf-8' },
+      }),
+    );
+
     const response = await buildMarkdownTwinResponse(
       new Request('https://www.worldmonitor.app/countries.md'),
       '/countries.md',
-      async () => new Response(null, { status: 308, headers: { Location: '/countries/' } }),
+      fetchImpl,
     );
+
     assert.equal(response.status, 200);
+    assert.deepEqual(seen.map((hop) => hop.url.pathname), ['/countries', '/countries/']);
+    for (const hop of seen) {
+      assert.equal(
+        new Headers(hop.init?.headers).get(MD_TWIN_LOOP_HEADER),
+        '1',
+        'the loop guard must survive every hop, or a .md redirect target recurses',
+      );
+    }
+    assert.equal(
+      response.headers.get('x-robots-tag'),
+      null,
+      'a twin that serves the real document stays indexable and defers to its canonical',
+    );
     const document = await response.text();
+    assert.doesNotMatch(document, /redirects to/i, 'the redirect stub must be gone');
+    assert.match(document, /Every country page\./);
     const block = document.match(/^---\n([\s\S]*?)\n---\n/);
-    assert.ok(block, 'redirect documents must carry metadata');
+    assert.ok(block, 'the twin must carry front-matter');
     assert.deepEqual(load(block[1]), {
-      title: 'countries',
-      canonical: 'https://www.worldmonitor.app/countries.md',
+      title: 'Countries',
+      canonical: 'https://www.worldmonitor.app/countries/',
     });
-    assert.match(document, /\[\/countries\/\]\(\/countries\/\)/);
+    assert.match(
+      response.headers.get('link') ?? '',
+      /<https:\/\/www\.worldmonitor\.app\/countries\/>; rel="canonical"/,
+      'the canonical must name the HTML page, never the .md twin itself',
+    );
+  });
+
+  it('inherits a 404 from the redirect target instead of inventing a 200', async () => {
+    const { fetchImpl } = siblingChain(
+      new Response(null, { status: 308, headers: { location: '/countries/does-not-exist-xyz/' } }),
+      new Response('<html><head><meta name="robots" content="noindex"><title>Page not found</title></head></html>', {
+        status: 404,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      }),
+    );
+
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries/does-not-exist-xyz.md'),
+      '/countries/does-not-exist-xyz.md',
+      fetchImpl,
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get('cache-control'), 'no-store');
+    assert.equal(response.headers.get('x-robots-tag'), 'noindex');
+    assert.doesNotMatch(
+      response.headers.get('link') ?? '',
+      /rel="canonical"/,
+      'a soft-404 must never declare itself canonical',
+    );
+  });
+
+  it('asks the sibling for markdown before HTML', async () => {
+    const { fetchImpl, seen } = siblingChain(
+      new Response('# Iran\n\nThe real document.\n', {
+        status: 200,
+        headers: { 'content-type': 'text/markdown; charset=utf-8' },
+      }),
+    );
+
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries/iran.md'),
+      '/countries/iran.md',
+      fetchImpl,
+    );
+
+    const accept = new Headers(seen[0].init?.headers).get('accept') ?? '';
+    assert.match(accept, /^text\/markdown\b/, `the sibling Accept must lead with markdown, got: ${accept}`);
+    assert.match(await response.text(), /The real document\./);
+  });
+
+  it('does not leak the rewrite params into the sibling request', async () => {
+    const originalFetch = globalThis.fetch;
+    const { fetchImpl, seen } = siblingChain(
+      new Response('# AAPL\n', { status: 200, headers: { 'content-type': 'text/markdown' } }),
+    );
+    globalThis.fetch = fetchImpl;
+    try {
+      await handler(
+        new Request('https://www.worldmonitor.app/api/md-twin?path=stocks%2FAAPL&mdPath=stocks%2FAAPL&range=1y'),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.equal(seen[0].url.pathname, '/stocks/AAPL');
+    assert.equal(seen[0].url.searchParams.get('path'), null);
+    assert.equal(seen[0].url.searchParams.get('mdPath'), null);
+    assert.equal(seen[0].url.searchParams.get('range'), '1y', 'caller query params still reach the sibling');
+  });
+
+  it('stops following after the redirect hop limit', async () => {
+    const { fetchImpl } = siblingChain(
+      ...Array.from({ length: 8 }, (_, hop) =>
+        new Response(null, { status: 308, headers: { location: `/loop-${hop + 1}/` } }),
+      ),
+    );
+
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/loop-0.md'),
+      '/loop-0.md',
+      fetchImpl,
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get('cache-control'), 'no-store');
+    assert.equal(response.headers.get('x-robots-tag'), 'noindex');
+  });
+
+  it('serves a document larger than the retired 80 KB cap', async () => {
+    const huge = `# Sources\n\n${'source entry. '.repeat(10_000)}`;
+    assert.ok(huge.length > 80_000, 'fixture must exceed the cap that used to 502 /sources.md');
+    const { fetchImpl } = siblingChain(
+      new Response(null, { status: 308, headers: { location: '/sources/' } }),
+      new Response(huge, { status: 200, headers: { 'content-type': 'text/markdown; charset=utf-8' } }),
+    );
+
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/sources.md'),
+      '/sources.md',
+      fetchImpl,
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok((await response.text()).length > 80_000);
   });
 
   it('adds escaped title and canonical metadata to generated documents', async () => {
@@ -93,9 +243,29 @@ describe('api/md-twin.ts', () => {
     assert.ok(block);
     assert.deepEqual(load(block[1]), {
       title: 'Title: "quoted"',
-      canonical: 'https://www.worldmonitor.app/example.md',
+      canonical: 'https://www.worldmonitor.app/example',
     });
     assert.match(document, /Content\./);
+  });
+
+  it('merges the canonical into front-matter the sibling already emitted', async () => {
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/example.md'),
+      '/example.md',
+      async () =>
+        new Response('---\ntitle: Upstream title\ndescription: Upstream description\n---\n\n# Heading\n', {
+          status: 200,
+          headers: { 'content-type': 'text/markdown; charset=utf-8' },
+        }),
+    );
+
+    const block = (await response.text()).match(/^---\n([\s\S]*?)\n---\n/);
+    assert.ok(block);
+    assert.deepEqual(load(block[1]), {
+      title: 'Upstream title',
+      description: 'Upstream description',
+      canonical: 'https://www.worldmonitor.app/example',
+    });
   });
 
   it('returns the deprecation policy Link on OPTIONS preflights', async () => {
@@ -137,7 +307,7 @@ describe('api/md-twin.ts', () => {
     }
   });
 
-  it('documents a 302 sibling as heading-led markdown', async () => {
+  it('documents an off-origin redirect without making it indexable', async () => {
     const res = await buildMarkdownTwinResponse(
       new Request('https://www.worldmonitor.app/api/download.md'),
       '/api/download.md',
@@ -150,9 +320,14 @@ describe('api/md-twin.ts', () => {
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('location'), null);
     assert.equal(res.headers.get('cache-control'), 'public, max-age=3600');
+    // The off-origin hop is not ours to follow, so the document stays a stub —
+    // but a stub never advertises itself as canonical or indexable (#7860).
+    assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+    assert.doesNotMatch(res.headers.get('link') ?? '', /rel="canonical"/);
     const body = await res.text();
     assert.match(body, /^# /m);
     assert.match(body, /github\.com\/koala73\/worldmonitor\/releases\/latest/);
+    assert.doesNotMatch(body, /^canonical:/m);
   });
 
   it('preserves a bodyless 304 sibling', async () => {
@@ -220,6 +395,8 @@ describe('api/md-twin.ts', () => {
 
       assert.equal(res.status, status);
       assert.equal(res.headers.get('cache-control'), 'no-store');
+      assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+      assert.doesNotMatch(res.headers.get('link') ?? '', /rel="canonical"/);
       if (expectedHeader) assert.equal(res.headers.get(expectedHeader), expectedValue);
       assert.match(await res.text(), /^# health/m);
     });
@@ -229,7 +406,7 @@ describe('api/md-twin.ts', () => {
     const res = await buildMarkdownTwinResponse(
       new Request('https://www.worldmonitor.app/dashboard.md'),
       '/dashboard.md',
-      async () => new Response('small', { headers: { 'content-length': '80001' } }),
+      async () => new Response('small', { headers: { 'content-length': String(MAX_TWIN_BYTES + 1) } }),
     );
 
     assert.equal(res.status, 502);
@@ -241,7 +418,7 @@ describe('api/md-twin.ts', () => {
     let canceled = false;
     const body = new ReadableStream({
       start(controller) {
-        controller.enqueue(new Uint8Array(80_001));
+        controller.enqueue(new Uint8Array(MAX_TWIN_BYTES + 1));
       },
       cancel() {
         canceled = true;
@@ -314,6 +491,18 @@ describe('api/md-twin.ts', () => {
       },
     );
     assert.equal(res.status, 404);
+    assert.equal(res.headers.get('x-robots-tag'), 'noindex');
+    assert.doesNotMatch(res.headers.get('link') ?? '', /rel="canonical"/);
     assert.match(await res.text(), /^# /m);
+  });
+
+  it('carries a byte cap that covers the heaviest corpus document', () => {
+    // /sources/ answered 132,497 bytes of Accept-negotiated markdown on
+    // 2026-09-08. The retired 80 KB cap would have 502'd /sources.md, which is
+    // one of the URLs #7860 reported broken.
+    assert.ok(
+      MAX_TWIN_BYTES > 132_497,
+      `MAX_TWIN_BYTES (${MAX_TWIN_BYTES}) must exceed the heaviest measured corpus document`,
+    );
   });
 });

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -195,7 +195,7 @@ describe('api/md-twin.ts', () => {
   });
 
   it('stops following after the redirect hop limit', async () => {
-    const { fetchImpl } = siblingChain(
+    const { fetchImpl, seen } = siblingChain(
       ...Array.from({ length: 8 }, (_, hop) =>
         new Response(null, { status: 308, headers: { location: `/loop-${hop + 1}/` } }),
       ),
@@ -207,9 +207,39 @@ describe('api/md-twin.ts', () => {
       fetchImpl,
     );
 
+    // Pin the count, not just the eventual 404: asserting the status alone
+    // passes for any budget, so a change to MAX_SIBLING_REDIRECTS would slip
+    // through and multiply the worst-case latency unnoticed.
+    assert.deepEqual(
+      seen.map((hop) => hop.url.pathname),
+      ['/loop-0', '/loop-1/', '/loop-2/', '/loop-3/'],
+    );
     assert.equal(response.status, 404);
     assert.equal(response.headers.get('cache-control'), 'no-store');
     assert.equal(response.headers.get('x-robots-tag'), 'noindex');
+  });
+
+  it('spends one deadline across the whole redirect chain', async () => {
+    const signals = [];
+    const { fetchImpl } = siblingChain(
+      new Response(null, { status: 308, headers: { location: '/countries/' } }),
+      new Response('# Countries\n', { status: 200, headers: { 'content-type': 'text/markdown' } }),
+    );
+
+    await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries.md'),
+      '/countries.md',
+      async (input, init) => {
+        signals.push(init?.signal);
+        return fetchImpl(input, init);
+      },
+    );
+
+    // A fresh AbortSignal.timeout per hop multiplies the budget by the hop
+    // count, and four hops at 8s each overruns the edge execution ceiling.
+    assert.equal(signals.length, 2);
+    assert.ok(signals[0], 'every hop must carry a deadline');
+    assert.equal(signals[0], signals[1], 'all hops must share one deadline');
   });
 
   it('serves a document larger than the retired 80 KB cap', async () => {
@@ -314,6 +344,139 @@ describe('api/md-twin.ts', () => {
     });
     assert.match(document, /^# example$/m, 'the twin stays heading-led below the front-matter');
     assert.match(document, /Body with no heading\./);
+  });
+
+  it('re-quotes pass-through front-matter so the canonical stays parseable', async () => {
+    // Live 2026-09-08, /dashboard and /chokepoints/strait-of-hormuz/ both emit
+    // `description: <text>: <more text>` unquoted. A plain YAML scalar cannot
+    // contain ": ", so copying the block byte-for-byte and appending our
+    // canonical produces a block no consumer can parse -- which defeats the
+    // point of appending the canonical at all.
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/dashboard.md'),
+      '/dashboard.md',
+      async () =>
+        new Response(
+          '---\ntitle: World Monitor - Real-Time Global Intelligence Dashboard\ndescription: Real-time global intelligence: conflicts, markets, military.\nimage: https://www.worldmonitor.app/favico/og-image.png\n---\n\n# Dashboard\n',
+          { status: 200, headers: { 'content-type': 'text/markdown; charset=utf-8' } },
+        ),
+    );
+
+    const block = (await response.text()).match(/^---\n([\s\S]*?)\n---\n/);
+    assert.ok(block);
+    const parsed = load(block[1]);
+    assert.equal(parsed.canonical, 'https://www.worldmonitor.app/dashboard');
+    assert.equal(parsed.description, 'Real-time global intelligence: conflicts, markets, military.');
+    assert.equal(parsed.image, 'https://www.worldmonitor.app/favico/og-image.png');
+  });
+
+  it('replaces a canonical the sibling front-matter already declared', async () => {
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/example.md'),
+      '/example.md',
+      async () =>
+        new Response('---\ntitle: Upstream\ncanonical: https://elsewhere.example/wrong\n---\n\n# Heading\n', {
+          status: 200,
+          headers: { 'content-type': 'text/markdown; charset=utf-8' },
+        }),
+    );
+
+    const block = (await response.text()).match(/^---\n([\s\S]*?)\n---\n/);
+    assert.deepEqual(load(block[1]), {
+      title: 'Upstream',
+      canonical: 'https://www.worldmonitor.app/example',
+    });
+  });
+
+  it('does not mistake a leading thematic break for front-matter', async () => {
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/example.md'),
+      '/example.md',
+      async () =>
+        new Response('---\n\nAn essay that opens with a horizontal rule.\n\n---\n\nAnd continues.\n', {
+          status: 200,
+          headers: { 'content-type': 'text/markdown; charset=utf-8' },
+        }),
+    );
+
+    const document = await response.text();
+    const block = document.match(/^---\n([\s\S]*?)\n---\n/);
+    assert.ok(block);
+    assert.deepEqual(load(block[1]), {
+      title: 'example',
+      canonical: 'https://www.worldmonitor.app/example',
+    });
+    assert.match(document, /An essay that opens with a horizontal rule\./);
+    assert.match(document, /And continues\./);
+  });
+
+  it('omits the canonical for an API sibling, which is not a canonical web page', async () => {
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/symbol-search.md?q=AAPL'),
+      '/api/symbol-search.md',
+      async () => new Response('{"results":[]}', { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+
+    assert.equal(response.status, 200);
+    // A query-less canonical would name a different, degenerate resource: the
+    // bare endpoint returns nothing without its required q. Claim no canonical
+    // rather than the wrong one.
+    assert.doesNotMatch(response.headers.get('link') ?? '', /rel="canonical"/);
+    assert.doesNotMatch(await response.text(), /^canonical:/m);
+  });
+
+  it('refuses a redirect that targets another .md twin', async () => {
+    const { fetchImpl, seen } = siblingChain(
+      new Response(null, { status: 308, headers: { location: '/countries/iran.md' } }),
+    );
+
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries.md'),
+      '/countries.md',
+      fetchImpl,
+    );
+
+    assert.equal(seen.length, 1, 'the .md target must not be fetched');
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get('x-robots-tag'), 'noindex');
+  });
+
+  for (const location of ['//evil.example/x', 'https://user:pw@evil.example/x', 'http://www.worldmonitor.app/x']) {
+    it(`treats ${location} as off-origin and never fetches it`, async () => {
+      const { fetchImpl, seen } = siblingChain(new Response(null, { status: 302, headers: { location } }));
+
+      const response = await buildMarkdownTwinResponse(
+        new Request('https://www.worldmonitor.app/example.md'),
+        '/example.md',
+        fetchImpl,
+      );
+
+      assert.equal(seen.length, 1, 'an off-origin target must not be fetched');
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('x-robots-tag'), 'noindex');
+      assert.doesNotMatch(response.headers.get('link') ?? '', /rel="canonical"/);
+    });
+  }
+
+  it('carries the status and canonical across a redirect on HEAD', async () => {
+    const { fetchImpl, seen } = siblingChain(
+      new Response(null, { status: 308, headers: { location: '/countries/' } }),
+      new Response(null, { status: 200, headers: { 'content-type': 'text/markdown' } }),
+    );
+
+    const response = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/countries.md', { method: 'HEAD' }),
+      '/countries.md',
+      fetchImpl,
+    );
+
+    assert.deepEqual(seen.map((hop) => hop.init?.method), ['HEAD', 'HEAD']);
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '');
+    assert.match(
+      response.headers.get('link') ?? '',
+      /<https:\/\/www\.worldmonitor\.app\/countries\/>; rel="canonical"/,
+    );
   });
 
   it('returns the deprecation policy Link on OPTIONS preflights', async () => {


### PR DESCRIPTION
Fixes #7860. Supersedes #7888, which fixes the same issue but ships a metadata block that cannot be parsed on `/dashboard` and `/chokepoints/*` (detail below).

## What was broken

Every content URL on this site 308s from `/x` to `/x/`, and the twin fetched its sibling with `redirect: 'manual'`. So the redirect branch fired for essentially every path and answered a ~250-byte "This resource redirects to …" stub at HTTP 200 — self-canonical, CDN-cached, indexable — over an unbounded space. An invented `/countries/does-not-exist-xyz.md` returned 200 for the same reason: `/countries/does-not-exist-xyz` 308s exactly like a real page, and the twin never followed the hop to find the 404 waiting behind it.

`/dashboard.md` is the control that proves the mechanism: `/dashboard` does not redirect, so it returned 3,615 bytes of scraped content rather than a stub — but still not the 10,034 bytes of real markdown, because the outbound `Accept` never mentioned markdown.

## The fix

Follow same-origin redirects (3 hops, one shared deadline, loop guard on every hop, never onto a `.md` path) and inherit the final target's status. Ask the sibling for `text/markdown` — Vercel already renders `/countries/iran/` as 18 KB of real markdown under that `Accept`, which the twin previously never requested. Point the canonical at the sibling HTML page, query-less, matching what that page's own `<link rel="canonical">` emits. Mark every response that is not a document `X-Robots-Tag: noindex` with no canonical at all.

Two supporting changes the redirect fix made necessary. The byte cap rises to 512 KB because `/sources/` is 132,497 bytes of markdown and would have 502'd under the retired 80 KB cap — and `/sources.md` was one of the URLs the issue reported. Front-matter-led bodies are now the common case rather than a rarity, so the heading goes below the front-matter instead of above it, where it would have swallowed the block into the document text.

## Verified against live production

The fixed handler, driven against the live site, on every URL the issue listed:

| path | before | after |
|---|---|---|
| `/countries/iran.md` | 248 B stub | **18,209 B**, canonical `/countries/iran/` |
| `/countries/does-not-exist-xyz.md` | **200** stub | **404** + noindex, no canonical |
| `/crises.md` | 188 B stub | 6,061 B |
| `/sources.md` | 197 B stub | 132,472 B (would have 502'd under the old cap) |
| `/compare/liveuamap-alternatives.md` | 396 B stub | 26,771 B |
| `/chokepoints/strait-of-hormuz.md` | 370 B stub | 13,129 B |
| `/dashboard.md` | 3,615 B scrape | 10,067 B real markdown |

Invented paths now 404 across every content family (`/countries/atlantis-xyz.md`, `/chokepoints/strait-of-nowhere-xyz.md`, `/compare/not-a-real-competitor-xyz.md`, `/crises/invented-crisis-xyz.md`, `/totally-made-up-page-xyz.md`), and `/countries/iran.md?utm_source=chatgpt` collapses onto the one canonical instead of minting another indexable twin.

Tests: 39/39 in `tests/md-url-twin.test.mjs`, 285 pass / 0 fail in `tests/deploy-config.test.mjs`, `npm run typecheck:api` and `npm run docs:check` clean. The test commit landed first and was observed red (15 failures) before the handler changed.

## Why this supersedes #7888

#7888 gets the redirect-following, the shared `AbortSignal` deadline, and the exact hop-budget assertion right. Its defect is the front-matter pass-through: it copies the sibling's fields verbatim, and Vercel writes them **unquoted**, with descriptions that routinely contain `": "` — which a plain YAML scalar cannot hold. Driving both branches against live production and parsing the emitted block:

```
PR#7888  200  UNPARSEABLE bad indentation of a mapping entry (2:43)  /dashboard.md
PR#7888  200  UNPARSEABLE bad indentation of a mapping entry (1:48)  /chokepoints/strait-of-hormuz.md
PR#7888  200  PARSES                                                 /countries/iran.md
mine     200  PARSES                                                 /dashboard.md
mine     200  PARSES                                                 /chokepoints/strait-of-hormuz.md
mine     200  PARSES                                                 /countries/iran.md
```

So the canonical the fix exists to publish is unreadable on the two busiest pages. Its tests are green only because every fixture value is colon-free. Reported on that PR with the regression test; this branch re-quotes values on the way out.

This branch additionally omits the canonical for `/api/` siblings (`/api/symbol-search.md?q=AAPL` otherwise names the bare endpoint, which returns nothing without its required `q`), bounds `jsonToMarkdown`'s indent expansion against the raised cap, and covers protocol-relative / userinfo / scheme-downgrade off-origin targets, HEAD across a redirect, and a sibling that already declares its own canonical.

## Review notes

Two P1s from the adversarial pass were **refuted against production** and not acted on. `vercel.json`'s corpus header rules do not erase the handler's canonical — `/countries/iran.md` returns both `Link` headers, because Vercel appends rather than replaces — and they do not override its `Cache-Control`: a loop-guard 404 on that same path returns `no-store`, not the rule's `max-age=3600`.

Known residual, not fixable here: an invented `.md` path now costs two origin fetches and Cloudflare forces `no-store` on any 4xx regardless of what this handler sends, so those 404s are not edge-cached. That is inherent to returning the correct status and can only be addressed in the Cloudflare cache rule. Filing separately, along with `/stocks/*`, which is its own unbounded indexable 200 space at the HTML level — any symbol returns the 47 KB dashboard shell, so the twin faithfully mirrors a 200 there.

https://claude.ai/code/session_01H2sFHt1NxS2rRpsZytBAbZ