### PR TITLE
test(billing): characterize shared customer portal ownership

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -12,17 +12,18 @@ import {
 } from "../payments/billing";
 import { upsertEntitlements } from "../payments/subscriptionHelpers";
 import { getFeaturesForPlan } from "../lib/entitlements";
-import { signAnonClaimToken } from "../lib/identitySigning";
+import { signAnonClaimToken, signUserId } from "../lib/identitySigning";
 
-// Mock the Dodo REST SDK so the reconciliation action's `payments.retrieve`
-// is controllable per-test (no real network). billing.ts only news up
-// DodoPayments inside getDodoClient(), so a class stub is sufficient. No
-// other test in this file exercises the real SDK.
-const { dodoRetrieveMock } = vi.hoisted(() => ({ dodoRetrieveMock: vi.fn() }));
+// Control provider retrieval and portal responses without network access.
+// The billing actions, queries and storage still run through production code.
+const { dodoRetrieveMock, dodoPortalMock } = vi.hoisted(() => ({
+  dodoRetrieveMock: vi.fn(),
+  dodoPortalMock: vi.fn(),
+}));
 vi.mock("dodopayments", () => ({
   DodoPayments: class {
     payments = { retrieve: dodoRetrieveMock };
-    customers = { customerPortal: { create: vi.fn() } };
+    customers = { customerPortal: { create: dodoPortalMock } };
   },
 }));
 
@@ -40,6 +41,7 @@ type PlanKey = keyof typeof PRODUCT_CATALOG;
 afterEach(() => {
   vi.restoreAllMocks();
   dodoRetrieveMock.mockReset();
+  dodoPortalMock.mockReset();
   vi.useRealTimers();
   delete process.env.DODO_IDENTITY_SIGNING_SECRET;
   delete process.env.DODO_ANON_CLAIM_TOKEN_TTL_MS;
@@ -2702,58 +2704,73 @@ describe("payments billing getDodoCustomerIdForUserPortal", () => {
     expect(result).toBeNull();
   });
 
-  test("returns the right dodoCustomerId for each Clerk user when SAME Dodo customer is shared across multiple Clerk accounts (the WORLDMONITOR-R5 scenario)", async () => {
-    // user_A and user_B both checked out with the same email; Dodo deduped
-    // to one customer (cus_shared). Each has their OWN subscription row,
-    // and the customers table's userId field may point at either one due
-    // to webhook race. This query must work for BOTH users regardless of
-    // who currently owns the customers row.
+  test.each([
+    ["shared provider customer", "cus_shared", "cus_shared"],
+    ["distinct provider customers", "cus_A", "cus_B"],
+  ])("characterizes signed owners and portal requests with %s (#7897)", async (_label, customerA, customerB) => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    process.env.DODO_API_KEY = "synthetic-portal-api-key";
+    dodoPortalMock.mockImplementation(async (customerId: string) => ({
+      link: `https://portal.example.test/${customerId}`,
+    }));
     const t = convexTest(schema, modules);
+    const owners = [
+      { subject: "user_A", tokenIdentifier: "clerk|user_A", email: "login-a@example.test" },
+      { subject: "user_B", tokenIdentifier: "clerk|user_B", email: "login-b@example.test" },
+    ];
+    const customerIds = [customerA, customerB];
 
-    // customers row currently owned by user_A (could just as easily be user_B).
-    await t.run(async (ctx) => {
-      await ctx.db.insert("customers", {
-        userId: "user_A",
-        dodoCustomerId: "cus_shared",
-        email: "shared@example.com",
-        normalizedEmail: "shared@example.com",
-        createdAt: NOW - DAY_MS,
-        updatedAt: NOW - DAY_MS,
+    for (const [index, owner] of owners.entries()) {
+      // The provider customer assignment is a fixture input, not proof that
+      // hosted checkout permits reuse without control of this billing email.
+      await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+        webhookId: `msg_portal_${index}`,
+        eventType: "subscription.active",
+        timestamp: NOW + index,
+        rawPayload: {
+          type: "subscription.active",
+          data: {
+            subscription_id: `sub_portal_${index}`,
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "active",
+            customer: { customer_id: customerIds[index], email: "billing-alias@example.test" },
+            metadata: { wm_user_id: owner.subject, wm_user_id_sig: await signUserId(owner.subject) },
+            previous_billing_date: new Date(NOW - DAY_MS).toISOString(),
+            next_billing_date: new Date(NOW + 30 * DAY_MS).toISOString(),
+          },
+        },
       });
-    });
+    }
 
-    await seedSubscription(t, {
-      planKey: "pro_monthly",
-      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
-      status: "active",
-      currentPeriodEnd: NOW + 30 * DAY_MS,
-      suffix: "portal_userA",
-      userId: "user_A",
-      rawPayload: { customer: { customer_id: "cus_shared", email: "shared@example.com" } },
-    });
-    await seedSubscription(t, {
-      planKey: "pro_monthly",
-      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
-      status: "active",
-      currentPeriodEnd: NOW + 30 * DAY_MS,
-      suffix: "portal_userB",
-      userId: "user_B",
-      rawPayload: { customer: { customer_id: "cus_shared", email: "shared@example.com" } },
-    });
+    const beforePortal = await t.run(async (ctx) => ({
+      subscriptions: await ctx.db.query("subscriptions").collect(),
+      customers: await ctx.db.query("customers").collect(),
+    }));
+    expect(beforePortal.subscriptions).toHaveLength(2);
+    for (const [index, owner] of owners.entries()) {
+      expect(beforePortal.subscriptions.find((sub) => sub.dodoSubscriptionId === `sub_portal_${index}`))
+        .toMatchObject({ userId: owner.subject, dodoCustomerId: customerIds[index] });
+    }
+    expect(beforePortal.customers).toHaveLength(customerA === customerB ? 1 : 2);
+    expect(beforePortal.customers.find((customer) => customer.dodoCustomerId === customerB)?.userId)
+      .toBe("user_B");
 
-    const resultA = await t.query(
-      internal.payments.billing.getDodoCustomerIdForUserPortal,
-      { userId: "user_A" },
-    );
-    const resultB = await t.query(
-      internal.payments.billing.getDodoCustomerIdForUserPortal,
-      { userId: "user_B" },
-    );
-    // Both Clerk accounts resolve to the SAME shared Dodo customer,
-    // without needing to consult the customers table. Each Clerk
-    // account's "Manage Billing" click opens the right portal.
-    expect(resultA).toBe("cus_shared");
-    expect(resultB).toBe("cus_shared");
+    for (const [index, owner] of owners.entries()) {
+      const result = await t.withIdentity(owner).action(api.payments.billing.getCustomerPortalUrl, {});
+      expect(result).toEqual({ portal_url: `https://portal.example.test/${customerIds[index]}` });
+      expect(dodoPortalMock).toHaveBeenNthCalledWith(index + 1, customerIds[index], { send_email: false });
+    }
+    expect(dodoPortalMock).toHaveBeenCalledTimes(2);
+
+    // Knowing the same email alone provides no local customer mapping.
+    await expect(t.withIdentity({ subject: "user_unmapped", email: "billing-alias@example.test" })
+      .action(api.payments.billing.getCustomerPortalUrl, {})).rejects.toThrow("NO_CUSTOMER");
+    await expect(t.action(api.payments.billing.getCustomerPortalUrl, {})).rejects.toThrow("AUTH_REQUIRED");
+    expect(dodoPortalMock).toHaveBeenCalledTimes(2);
+    expect(await t.run(async (ctx) => ({
+      subscriptions: await ctx.db.query("subscriptions").collect(),
+      customers: await ctx.db.query("customers").collect(),
+    }))).toEqual(beforePortal);
   });
 
   test("resolves via the stable dodoCustomerId column even when a later lifecycle payload wiped the rawPayload customer field (P1 regression)", async () => {

--- a/convex/__tests__/checkoutLoginEmailMetadata.test.ts
+++ b/convex/__tests__/checkoutLoginEmailMetadata.test.ts
@@ -67,6 +67,8 @@ describe("checkout stamps a signed login email (#6335)", () => {
       .action(api.payments.checkout.createCheckout, { productId: PRODUCT_ID });
 
     const metadata = capturedMetadata();
+    // Billing email remains a provider input; signed login identity is separate.
+    expect(vi.mocked(createDodoCheckoutSession).mock.calls[0][0]).not.toHaveProperty("customer");
     // Case is preserved: the signature covers the exact bytes, and the local
     // part of an address is case-sensitive per RFC 5321.
     expect(metadata.wm_login_email).toBe("Fresh.Login@Example.com");

--- a/docs/investigations/shared-dodo-customer-portal.md
+++ b/docs/investigations/shared-dodo-customer-portal.md
@@ -1,0 +1,142 @@
+# Shared Dodo customer portal investigation (#7897)
+
+Date: 2026-09-08. Source revision: `b2a45cbbb9f3bbdac6ca308de4b9f3e45a5dbded`.
+Related: [issue #7897](https://github.com/koala73/worldmonitor/issues/7897).
+
+## Conclusion: blocked on provider checkout evidence
+
+Local characterization confirms that two separately signed Clerk subscription
+owners can receive portal links for the same provider customer, **if the provider
+assigns that customer ID to both subscriptions**. Documentation supports direct
+magic-link access and customer-wide billing permissions. It does not establish
+whether the hosted checkout requires mailbox proof before reusing a customer.
+This is not a confirmed exploit, nor evidence that the path is safe.
+
+No production code, customer records, provider settings, or migration changed.
+No real checkout, portal session, email, cancellation, or purchase was performed.
+Only synthetic fixtures, fake secrets, mocked provider calls, and public docs
+were used. No authorized provider sandbox dataset was supplied or used.
+
+## Identity boundaries
+
+| Concept | Authority and observed behavior |
+| --- | --- |
+| Clerk subject | Authenticated identity supplied to the public checkout/portal action. |
+| Login email | Checkout can stamp this separately with a signature; it does not lock the billing email. |
+| Billing email | Entered at Dodo checkout; may legitimately differ from login email. |
+| Subscription owner | New activation uses verified `wm_user_id` metadata; later activation retains the existing subscription owner. |
+| Provider customer ID | Supplied by Dodo in webhook data and retained on the subscription. It is not a Clerk ownership proof. |
+| Local customer owner | One `customers.userId` can move between Clerk subjects when a shared customer is activated. |
+| Portal permission | Session creation takes the provider customer ID, not a subscription ID or Clerk subject. |
+
+## Source trace
+
+- `convex/payments/checkout.ts`, `_createCheckoutSession`: signs the authenticated
+  user ID, optionally stamps signed login email, and omits the checkout `customer`
+  block so billing fields remain editable.
+- `convex/payments/subscriptionHelpers.ts`, `tryResolveUserId` and
+  `handleSubscriptionActive`: verify the identity signature, keep existing
+  subscription ownership, and preserve the provider customer ID. The
+  `preferExistingCustomerOwner` exception covers anonymous-to-real ownership;
+  it does not collapse two signed Clerk users into one owner.
+- `convex/payments/billing.ts`, `getDodoCustomerIdForUserPortal`: reads the user's
+  subscriptions, preferring their stable customer ID or raw payload, then a
+  same-user customer row. It does not compare every other subscription owner for
+  that provider customer.
+- The public `getCustomerPortalUrl` action requires authentication. Its helper
+  calls `customers.customerPortal.create(customerId, { send_email: false })`
+  and returns the provider link. `internalGetCustomerPortalUrl` uses that same
+  helper after the gateway supplies the verified subject.
+
+## Reproducible local fixture
+
+The existing shared-customer query fixture in `convex/__tests__/billing.test.ts`
+now drives the production webhook mutation and authenticated public portal
+action. It uses real identity signatures, Convex storage and lookup code; only
+the Dodo SDK response is mocked. The two cases use the same billing alias and
+different Clerk subjects/login emails:
+
+| Provider assignment supplied by fixture | Observed local result |
+| --- | --- |
+| Both activations carry `cus_shared` | Two subscriptions retain A/B ownership; the single customer row points to B; both portal requests target `cus_shared`. |
+| Activations carry `cus_A` and `cus_B` | Two customer rows; each portal request targets its owner's provider customer. |
+
+Both cases assert exact SDK arguments and returned URLs. An unmapped third user
+with the same email receives `NO_CUSTOMER`; an unauthenticated caller receives
+`AUTH_REQUIRED`; neither causes another SDK call. Portal requests leave the
+subscription and customer records unchanged.
+
+`convex/__tests__/checkoutLoginEmailMetadata.test.ts` additionally asserts that
+the authenticated checkout's provider payload omits `customer`, alongside its
+existing real-signature assertions.
+
+These tests do not prove hosted checkout customer reuse, mailbox verification,
+Clerk token validation, webhook HTTP signature validation, SDK HTTP encoding,
+portal rendering, or provider-side subscription access. Injecting a shared ID
+is an explicit premise, not an observed provider result.
+
+## Provider contract evidence
+
+Public documentation was read on 2026-09-08. These are documented contracts,
+not an observation of this merchant's sandbox or production configuration.
+
+1. **Customer reuse: documented, verification prerequisite unknown.** The
+   [v0.15.1 changelog](https://docs.dodopayments.com/changelog/v0.15.1) describes
+   consistent customer IDs across payments and subscriptions for the same email.
+   The current [Checkout Sessions guide](https://docs.dodopayments.com/developer-resources/checkout-session)
+   documents existing/new customers but does not specify mailbox proof before
+   reuse. The older changelog alone cannot establish current hosted-flow controls.
+2. **Portal entry: direct magic link documented.** The
+   [Customer Portal guide](https://docs.dodopayments.com/features/customer-portal)
+   distinguishes email-delivered static login from direct dynamic links, valid
+   for 24 hours. The [session API](https://docs.dodopayments.com/api-reference/customers/create-customer-portal-session)
+   accepts merchant bearer authentication, customer ID, optional `send_email`
+   and `return_url`, and returns `link`. No subscription filter is documented.
+3. **Scope: customer-wide permissions documented.** The portal guide lists all
+   active subscriptions, billing history and invoices, payment methods, and
+   cancellation controls. Some plan-change actions depend on merchant settings.
+   Inference: if A/B subscriptions share the provider customer, this documented
+   portal boundary does not separate them by Clerk subject. Actual visibility
+   and enabled actions for the two-user case remain unobserved.
+
+## Missing evidence and safe next step
+
+A confirmed/rejected conclusion needs an authorized test-mode merchant/product,
+two synthetic Clerk accounts, and controlled test mailboxes. Do not substitute
+real customer records or live credentials. In a fresh browser context, record:
+
+1. Whether a second hosted checkout using the first account's billing email
+   requires mailbox proof **before** assigning/reusing the provider customer.
+   Capture the point of verification and both resulting customer/subscription
+   IDs. Stop if the flow requires real charges or real customer data.
+2. Whether the resulting API-issued dynamic portal link requires another
+   identity proof, and which synthetic subscriptions/invoices/actions it exposes.
+   Record visible controls without executing cancellation or payment changes.
+
+Alternatively, obtain provider confirmation of these exact controls after
+separate authority to contact them. Absence of a documented control is not proof
+that the control is absent. Keep the issue open while this evidence is missing.
+
+## Repair constraints if the prerequisite is confirmed
+
+Do not bind billing email to login email or reassign signed subscription owners.
+Any repair must preserve legitimate aliases and multiple subscriptions. A
+verified-customer binding needs a mailbox-proof record with provenance and
+revocation rules. A subscription-scoped portal needs a provider-supported
+permission boundary; hiding links in the browser is insufficient. Existing shared
+customers require inventory and a migration decision that preserves subscription,
+invoice, payment-method and refund associations. No provider-side customer split,
+backfill or binding policy is proposed as a confirmed repair here.
+
+## Verification
+
+- Node `v24.20.0`; review and repair preflight ready on the recorded revision.
+- Baseline: `npm run test:convex -- convex/__tests__/billing.test.ts convex/__tests__/checkout.test.ts`
+  passed, 192 tests.
+- Focused characterization: `npm run test:convex -- convex/__tests__/billing.test.ts -t 'characterizes signed owners'`
+  passed, 2 cases. These are current-behavior characterization tests; no failing
+  exploit regression or production repair is claimed.
+- Final: `npm run test:convex -- convex/__tests__/billing.test.ts convex/__tests__/checkout.test.ts convex/__tests__/checkoutLoginEmailMetadata.test.ts`
+  passed, 207 tests across 3 files. `git diff --check` passed.
+- CI readiness, deployment and production acceptance are separate; none proves
+  the missing provider behavior.


### PR DESCRIPTION
## Summary

The shared-customer portal lead now has a reproducible local characterization: separately signed Clerk owners retain their subscriptions but request the same customer-scoped portal when Dodo supplies a shared customer ID. Distinct provider IDs remain separate, and unmapped or unauthenticated callers are refused.

The [evidence packet](docs/investigations/shared-dodo-customer-portal.md) separates local behavior from provider contracts. Dodo documents direct magic-link access and customer-wide billing permissions, but mailbox proof before checkout customer reuse remains unknown. The investigation is **blocked on that provider evidence**, not confirmed or rejected. Only tests and documentation change; billing aliases, ownership, customer data and provider settings are unchanged.

Related: #7897

## Validation

- Node 24; repository repair preflight ready on refreshed main.
- `npm run test:convex -- convex/__tests__/billing.test.ts convex/__tests__/checkout.test.ts convex/__tests__/checkoutLoginEmailMetadata.test.ts`: **207 passed**.
- Production webhook mutation, real identity signatures, stored ownership lookup and public portal action exercised with synthetic records and mocked Dodo SDK responses.
- Markdown lint, public-doc check and `git diff --check` passed.
- Sequential local review completed. No provider sandbox or production exploit reproduction; no confirmed repair or migration is claimed.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes only tests and an evidence note. Keep the investigation open until authorized provider evidence establishes checkout mailbox-proof requirements and the resulting portal's actual access scope.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
