### PR TITLE
fix(gateway): enforce daily AI quota for compatible POST requests

### DIFF
--- a/server/__tests__/gateway-direct-llm-quota.test.ts
+++ b/server/__tests__/gateway-direct-llm-quota.test.ts
@@ -55,6 +55,20 @@ vi.mock("../_shared/usage", async (importOriginal) => {
 
 import { createDomainGateway } from "../gateway";
 import { getRequiredTier } from "../_shared/entitlement-check";
+import { createIntelligenceServiceRoutes } from "../../src/generated/server/worldmonitor/intelligence/v1/service_server";
+import { intelligenceHandler } from "../worldmonitor/intelligence/v1/handler";
+
+const callLlm = vi.fn();
+vi.mock("../_shared/llm", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../_shared/llm")>(),
+  callLlm: (...args: unknown[]) => callLlm(...args),
+}));
+
+const cachedFetchJson = vi.fn();
+vi.mock("../_shared/redis", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../_shared/redis")>(),
+  cachedFetchJson: (...args: unknown[]) => cachedFetchJson(...args),
+}));
 
 const CLASSIFY_PATH = "/api/intelligence/v1/classify-event";
 const DEDUCT_PATH = "/api/intelligence/v1/deduct-situation";
@@ -191,9 +205,135 @@ beforeEach(() => {
     rollback: async () => {},
   });
   deliverUsageEvents.mockReset().mockResolvedValue(undefined);
+  cachedFetchJson.mockReset().mockImplementation(async (_key, _ttl, fetcher) => fetcher());
+  callLlm.mockReset().mockImplementation(async (options) => {
+    options.validate(JSON.stringify({ level: "high", category: "conflict" }));
+    return { content: JSON.stringify({ level: "high", category: "conflict" }) };
+  });
 });
 
 describe("gateway direct LLM quota", () => {
+  describe.each([CLASSIFY_PATH, COUNTRY_BRIEF_PATH, ANALYZE_PATH])("GET compatibility quota: %s", (path) => {
+    beforeEach(() => {
+      const entitlements = {
+        planKey: "pro",
+        features: { tier: 1, planLimits: { dashboardAiCallsPerDay: 50 } },
+        validUntil: Date.now() + 60_000,
+      };
+      resolveClerkSession.mockResolvedValue({ userId: "user_pro", orgId: null, role: "pro" });
+      checkEntitlementDetailed.mockResolvedValue({ response: null, entitlements });
+      getEntitlements.mockResolvedValue(entitlements);
+    });
+
+    function request(method: string, body = JSON.stringify({ title: "Novel headline" })) {
+      return req(method === "POST" ? path : `${path}?title=Novel%20headline`, {
+        method,
+        headers: {
+          Authorization: "Bearer pro", "Content-Type": "application/json",
+          ...(method === "POST" ? { "Content-Length": String(new TextEncoder().encode(body).length) } : {}),
+        },
+        ...(method === "POST" ? { body } : {}),
+      });
+    }
+
+    test.each(["GET", "POST", "HEAD"])("exhausted %s allowance blocks dispatch", async (method) => {
+      const handler = vi.fn().mockResolvedValue(json({ ok: true }));
+      reserveDirectLlmQuota.mockResolvedValue({ ok: false, reason: "cap-exceeded", floor: 50, retryAfterSec: 123 });
+      const res = await createDomainGateway([{ method: "GET", path, handler }])(request(method), { waitUntil: () => {} });
+      expect(res.status).toBe(429);
+      expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+      expect(reserveDirectLlmQuota).toHaveBeenCalledWith(expect.objectContaining({ userId: "user_pro", limit: 50 }));
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    test.each(["GET", "POST", "HEAD"])("allowed %s reserves once before dispatch", async (method) => {
+      const handler = vi.fn(async (routed: Request) => {
+        expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+        expect(routed.method).toBe(method === "POST" ? "GET" : method);
+        expect(new URL(routed.url).searchParams.get("title")).toBe("Novel headline");
+        return json({ ok: true });
+      });
+      const res = await createDomainGateway([{ method: "GET", path, handler }])(request(method), { waitUntil: () => {} });
+      expect(res.status).toBe(200);
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+      expect(reserveDirectLlmQuota).toHaveBeenCalledWith(expect.objectContaining({ userId: "user_pro", limit: 50 }));
+    });
+
+    if (path === CLASSIFY_PATH) {
+      test.each(["GET", "POST"])("real classification %s respects exhaustion before LLM transport", async (method) => {
+        const gateway = createDomainGateway(createIntelligenceServiceRoutes(intelligenceHandler));
+        reserveDirectLlmQuota.mockResolvedValue({ ok: false, reason: "cap-exceeded", floor: 50, retryAfterSec: 123 });
+        const blocked = await gateway(request(method), { waitUntil: () => {} });
+        expect(blocked.status).toBe(429);
+        expect(callLlm).not.toHaveBeenCalled();
+        expect(cachedFetchJson).not.toHaveBeenCalled();
+
+        reserveDirectLlmQuota.mockReset().mockResolvedValue({ ok: true, newCount: 1, rollback: async () => {} });
+        const allowed = await gateway(request(method), { waitUntil: () => {} });
+        expect(allowed.status).toBe(200);
+        expect(await allowed.json()).toMatchObject({ classification: { category: "conflict", subcategory: "high" } });
+        expect(callLlm).toHaveBeenCalledTimes(1);
+        expect(callLlm).toHaveBeenCalledWith(expect.objectContaining({
+          messages: expect.arrayContaining([{ role: "user", content: "Novel headline" }]),
+        }));
+        expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+      });
+
+      test.each(["GET", "POST"])("real classification %s cache hit reserves once without LLM work", async (method) => {
+        cachedFetchJson.mockResolvedValue({ level: "high", category: "conflict", timestamp: Date.now() });
+        const gateway = createDomainGateway(createIntelligenceServiceRoutes(intelligenceHandler));
+        const res = await gateway(request(method), { waitUntil: () => {} });
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({ classification: { category: "conflict" } });
+        expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+        expect(callLlm).not.toHaveBeenCalled();
+      });
+    }
+
+    test.each(["GET", "POST"])("unlimited enterprise %s skips daily reservation", async (method) => {
+      const entitlements = {
+        planKey: "enterprise", features: { tier: 2, planLimits: { dashboardAiCallsPerDay: null } },
+        validUntil: Date.now() + 60_000,
+      };
+      checkEntitlementDetailed.mockResolvedValue({ response: null, entitlements });
+      getEntitlements.mockResolvedValue(entitlements);
+      const handler = vi.fn().mockResolvedValue(json({ ok: true }));
+      const res = await createDomainGateway([{ method: "GET", path, handler }])(request(method), { waitUntil: () => {} });
+      expect(res.status).toBe(200);
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(reserveDirectLlmQuota).not.toHaveBeenCalled();
+    });
+
+    test.each([null, "1048576"])("ineligible POST content length %s never dispatches or charges", async (length) => {
+      const post = request("POST");
+      if (length === null) post.headers.delete("Content-Length");
+      else post.headers.set("Content-Length", length);
+      const handler = vi.fn();
+      const res = await createDomainGateway([{ method: "GET", path, handler }])(post, { waitUntil: () => {} });
+      expect(res.status).toBe(405);
+      expect(handler).not.toHaveBeenCalled();
+      expect(reserveDirectLlmQuota).not.toHaveBeenCalled();
+    });
+
+    test.each(["{bad json", JSON.stringify({ title: { nested: true } })])("invalid POST body %s never dispatches or charges", async (body) => {
+      const handler = vi.fn();
+      const res = await createDomainGateway([{ method: "GET", path, handler }])(request("POST", body), { waitUntil: () => {} });
+      expect(res.status).toBe(400);
+      expect(checkEndpointRateLimit).toHaveBeenCalledTimes(1);
+      expect(handler).not.toHaveBeenCalled();
+      expect(reserveDirectLlmQuota).not.toHaveBeenCalled();
+    });
+
+    test("unsupported method never dispatches or charges", async () => {
+      const handler = vi.fn();
+      const res = await createDomainGateway([{ method: "GET", path, handler }])(request("PUT"), { waitUntil: () => {} });
+      expect(res.status).toBe(405);
+      expect(handler).not.toHaveBeenCalled();
+      expect(reserveDirectLlmQuota).not.toHaveBeenCalled();
+    });
+  });
+
   test("country brief is declared as a tier-1 Pro endpoint", () => {
     expect(getRequiredTier(COUNTRY_BRIEF_PATH)).toBe(1);
   });

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1343,7 +1343,20 @@ export function createDomainGateway(
       || isPublicSharedRpcRequest(request.url, request.method);
     const seedRefreshVerified = await isResilienceRankingSeedRefreshRequest(request, pathname);
     const relayWarmPingVerified = await isRelayWarmPingRequest(request, pathname);
-    const requiresDirectLlmQuota = !internalMcpVerified && await shouldReserveGatewayDirectLlmQuota(request, pathname);
+    // Resolve the quota policy against the route POST compatibility will use.
+    // Keep body validation after auth and abuse limiting; invalid bodies still
+    // return before reservation or dispatch.
+    let directLlmPolicyRequest = request;
+    if (
+      request.method === 'POST'
+      && GATEWAY_DIRECT_LLM_QUOTA_METHODS[pathname] === 'GET'
+      && isPostToGetCompatibleBodySize(request.headers)
+      && !router.match(request)
+    ) {
+      const getProbe = new Request(request.url, { method: 'GET', headers: request.headers });
+      if (router.match(getProbe)) directLlmPolicyRequest = getProbe;
+    }
+    const requiresDirectLlmQuota = !internalMcpVerified && await shouldReserveGatewayDirectLlmQuota(directLlmPolicyRequest, pathname);
     const isTierGated = !internalMcpVerified && !isPublicNoAuthRpc && !seedRefreshVerified && !relayWarmPingVerified && getRequiredTier(pathname) !== null;
     // Docker self-hosting has no Clerk/Convex entitlement backend. Its browser
     // still obtains and presents a server-signed anonymous session, so that


### PR DESCRIPTION
## Summary

A Pro caller could bypass the daily AI allowance by sending a compatible JSON POST to a GET-backed AI endpoint. GET and its accepted POST equivalent now use the same quota policy: an exhausted allowance returns 429 before handler/provider work, and an allowed call reserves once.

The gateway resolves the effective GET route for quota policy before authentication decisions. Body validation stays behind authentication and abuse limiting, and malformed compatibility requests still return before reservation. Enterprise/internal exemptions and existing cache, HEAD, idempotency and refund behavior are preserved.

Related: #7893. Deployment and production acceptance remain pending.

## Validation

- Reproduced seven failing cases before the repair, including real classification returning 200 for an over-limit POST. All pass after the repair.
- All three affected routes (`classify-event`, `get-country-intel-brief`, `analyze-stock`) pass GET/POST/HEAD dispatch and allowance checks, malformed/mismatched request checks, and unlimited Enterprise checks.
- The classification test uses the generated RPC adapter and real handler with mocked quota storage, cache and LLM transport. The sibling checks prove gateway dispatch behavior; they do not validate complete provider paths.
- `npm run test:convex -- server/__tests__/gateway server/__tests__/direct-llm-quota.test.ts server/__tests__/premium-check-direct-llm-limit.test.ts`: **183 passed**.
- `node --import tsx --test --test-timeout=60000 tests/gateway-internal-mcp.test.mjs tests/gateway-docker-country-brief.test.mts tests/gateway-pro-fresh-cache.test.mts tests/classify-entitlement-gate.test.mts`: **79 passed**.
- `npm run typecheck:api` and `git diff --check`: passed. Inline code and simplification review found no blocking issues.
- No paid live request or customer-data mutation was performed. PR #7872 also touches the gateway, but only adds a separate cache-tier map entry.

## Post-Deploy Monitoring & Validation

Owner: deploying maintainer, during the first 24 hours after an authorized deployment. Compare GET and compatibility POST traffic on the three routes for `rate_limit_429_direct_llm`, `rate_limit_degraded`, and unexpected 401/403/5xx responses. Healthy behavior is equal allowance enforcement with no handler/provider work after a quota denial. Use a synthetic exhausted allowance for runtime acceptance. Any over-limit provider work or new authorized-call failures blocks acceptance; disable the affected compatibility path or ship a focused correction rather than restoring the bypass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
