### PR TITLE
fix(notifications): require verified email ownership

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -510,6 +510,12 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       const resp = relay.response;
       if (!resp.ok) {
         console.error(`[notification-channels] POST ${relayAction} relay error:`, resp.status);
+        if (welcomeChannelType === 'email' && resp.status === 400) {
+          const failure = await resp.json().catch(() => null);
+          if (failure?.error === 'EMAIL_OWNERSHIP_REQUIRED') {
+            return finish(json({ error: 'EMAIL_OWNERSHIP_REQUIRED' }, 400, corsHeaders));
+          }
+        }
         if (resp.status === 503) {
           return finish(json({ error: 'Service unavailable' }, 503, corsHeaders));
         }

--- a/convex/__tests__/notificationChannels.test.ts
+++ b/convex/__tests__/notificationChannels.test.ts
@@ -10,10 +10,13 @@ const originalFetch = globalThis.fetch;
 const originalUpstashUrl = process.env.UPSTASH_REDIS_REST_URL;
 const originalUpstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 const originalRelaySecret = process.env.RELAY_SHARED_SECRET;
+const originalClerkSecret = process.env.CLERK_SECRET_KEY;
 
 const USER = {
   subject: "user-tests-notification-channels",
   tokenIdentifier: "clerk|user-tests-notification-channels",
+  email: "pro-user@example.com",
+  emailVerified: true,
 };
 
 afterEach(() => {
@@ -24,6 +27,8 @@ afterEach(() => {
   else process.env.UPSTASH_REDIS_REST_TOKEN = originalUpstashToken;
   if (originalRelaySecret === undefined) delete process.env.RELAY_SHARED_SECRET;
   else process.env.RELAY_SHARED_SECRET = originalRelaySecret;
+  if (originalClerkSecret === undefined) delete process.env.CLERK_SECRET_KEY;
+  else process.env.CLERK_SECRET_KEY = originalClerkSecret;
   vi.restoreAllMocks();
   vi.useRealTimers();
 });
@@ -197,11 +202,13 @@ describe("notificationChannels — durable first-connect welcome", () => {
     vi.useFakeTimers();
     const fetchMock = installQueueMock();
     const t = convexTest(schema, modules);
+    await seedEntitlement(t);
 
     await expect(t.mutation(notificationChannelFns.setChannelForUser, {
       userId: USER.subject,
       channelType: "email",
       email: "first-connect@example.com",
+      verifiedAccountEmail: "first-connect@example.com",
       scheduleWelcome: true,
     })).resolves.toEqual({ isNew: true });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
@@ -238,6 +245,7 @@ describe("notificationChannels — durable first-connect welcome", () => {
       userId: USER.subject,
       channelType: "email",
       email: "first-connect@example.com",
+      verifiedAccountEmail: "first-connect@example.com",
       scheduleWelcome: true,
     })).resolves.toEqual({ isNew: false });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
@@ -274,8 +282,8 @@ describe("notificationChannels — durable first-connect welcome", () => {
       body: JSON.stringify({
         action: "set-channel",
         userId: USER.subject,
-        channelType: "email",
-        email: "relay-first-connect@example.com",
+        channelType: "slack",
+        webhookEnvelope: "encrypted-slack-credential",
         scheduleWelcome: true,
       }),
     });
@@ -291,7 +299,7 @@ describe("notificationChannels — durable first-connect welcome", () => {
     expect(queuedEvent(fetchMock).message).toEqual({
       eventType: "channel_welcome",
       userId: USER.subject,
-      channelType: "email",
+      channelType: "slack",
       welcomeId: expect.any(String),
     });
   });
@@ -333,6 +341,7 @@ describe("notificationChannels — durable first-connect welcome", () => {
     const fetchMock = installQueueMock();
     process.env.RELAY_SHARED_SECRET = "relay-secret";
     const t = convexTest(schema, modules);
+    await seedEntitlement(t);
 
     const response = await t.fetch("/relay/notification-channels", {
       method: "POST",
@@ -343,8 +352,8 @@ describe("notificationChannels — durable first-connect welcome", () => {
       body: JSON.stringify({
         action: "set-channel",
         userId: USER.subject,
-        channelType: "email",
-        email: "legacy-relay@example.com",
+        channelType: "slack",
+        webhookEnvelope: "encrypted-slack-credential",
       }),
     });
     expect(response.status).toBe(200);
@@ -364,11 +373,13 @@ describe("notificationChannels — durable first-connect welcome", () => {
     fetchMock.mockRejectedValueOnce(new Error("temporary Upstash timeout"));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const t = convexTest(schema, modules);
+    await seedEntitlement(t);
 
     await expect(t.mutation(notificationChannelFns.setChannelForUser, {
       userId: USER.subject,
       channelType: "email",
       email: "retry-enqueue@example.com",
+      verifiedAccountEmail: "retry-enqueue@example.com",
       scheduleWelcome: true,
     })).resolves.toEqual({ isNew: true });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
@@ -390,11 +401,13 @@ describe("notificationChannels — durable first-connect welcome", () => {
       .mockResolvedValueOnce(Response.json({ result: 0 }));
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const t = convexTest(schema, modules);
+    await seedEntitlement(t);
 
     await expect(t.mutation(notificationChannelFns.setChannelForUser, {
       userId: USER.subject,
       channelType: "email",
       email: "ambiguous-enqueue@example.com",
+      verifiedAccountEmail: "ambiguous-enqueue@example.com",
       scheduleWelcome: true,
     })).resolves.toEqual({ isNew: true });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
@@ -437,11 +450,13 @@ describe("notificationChannels — durable first-connect welcome", () => {
     );
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const t = convexTest(schema, modules);
+    await seedEntitlement(t);
 
     await expect(t.mutation(notificationChannelFns.setChannelForUser, {
       userId: USER.subject,
       channelType: "email",
       email: "script-error@example.com",
+      verifiedAccountEmail: "script-error@example.com",
       scheduleWelcome: true,
     })).resolves.toEqual({ isNew: true });
     await t.finishAllScheduledFunctions(vi.runAllTimers);
@@ -459,11 +474,13 @@ describe("notificationChannels — durable first-connect welcome", () => {
     vi.useFakeTimers();
     const fetchMock = installQueueMock();
     const t = convexTest(schema, modules);
+    await seedEntitlement(t);
 
     await expect(t.mutation(notificationChannelFns.setChannelForUser, {
       userId: USER.subject,
       channelType: "email",
       email: "old-connection@example.com",
+      verifiedAccountEmail: "old-connection@example.com",
       scheduleWelcome: true,
     })).resolves.toEqual({ isNew: true });
     await t.run(async (ctx) => {
@@ -492,6 +509,7 @@ describe("notificationChannels — durable first-connect welcome", () => {
     vi.useFakeTimers();
     const fetchMock = installQueueMock();
     const t = convexTest(schema, modules);
+    await seedEntitlement(t);
     const endpoint = "https://fcm.googleapis.com/push/shared-device";
     const otherUser = "user-tests-notification-channels-b";
 
@@ -540,11 +558,13 @@ describe("notificationChannels — durable first-connect welcome", () => {
     );
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const t = convexTest(schema, modules);
+    await seedEntitlement(t);
 
     await expect(t.mutation(notificationChannelFns.setChannelForUser, {
       userId: USER.subject,
       channelType: "email",
       email: "retry-exhausted@example.com",
+      verifiedAccountEmail: "retry-exhausted@example.com",
       scheduleWelcome: true,
     })).resolves.toEqual({ isNew: true });
     // The terminal attempt (attempt 5, no successor) rethrows inside the
@@ -563,5 +583,100 @@ describe("notificationChannels — durable first-connect welcome", () => {
     );
     // Attempts 1-5 warn-and-retry; the terminal attempt rethrows instead.
     expect(retryWarns).toHaveLength(5);
+  });
+});
+
+describe("notificationChannels — email ownership", () => {
+  test.each([
+    { email: "owner@example.com", emailVerified: true, destination: "unrelated@example.com" },
+    { email: "owner@example.com", emailVerified: false, destination: "owner@example.com" },
+    { email: "owner@example.com", emailVerified: undefined, destination: "owner@example.com" },
+  ])("public setter rejects missing or mismatched proof: %j", async ({ destination, ...claims }) => {
+    const t = convexTest(schema, modules);
+    await seedEntitlement(t);
+    await expect(t.withIdentity({ ...USER, ...claims }).mutation(api.notificationChannels.setChannel, {
+      channelType: "email", email: destination,
+    })).rejects.toThrow(/EMAIL_OWNERSHIP_REQUIRED/);
+    expect(await t.query(notificationChannelFns.getChannelsByUserId, { userId: USER.subject })).toEqual([]);
+  });
+
+  test("internal setter cannot promote an arbitrary email without proof", async () => {
+    const t = convexTest(schema, modules);
+    await seedEntitlement(t);
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject, channelType: "email", email: "unrelated@example.com",
+    })).rejects.toThrow(/EMAIL_OWNERSHIP_REQUIRED/);
+    expect(await t.query(notificationChannelFns.getChannelsByUserId, { userId: USER.subject })).toEqual([]);
+  });
+
+  test("verified identity email persists ownership proof", async () => {
+    const t = convexTest(schema, modules);
+    await seedEntitlement(t);
+    await t.withIdentity({ ...USER, email: "owner@example.com", emailVerified: true }).mutation(api.notificationChannels.setChannel, {
+      channelType: "email", email: "owner@example.com",
+    });
+    expect(await t.query(notificationChannelFns.getChannelsByUserId, { userId: USER.subject })).toMatchObject([
+      { email: "owner@example.com", verified: true, emailOwnership: "verified_account" },
+    ]);
+  });
+
+  test("legacy verified flags are not delivery proof and rows remain unchanged", async () => {
+    const t = convexTest(schema, modules);
+    const id = await t.run(ctx => ctx.db.insert("notificationChannels", {
+      userId: USER.subject, channelType: "email", email: "unrelated@example.com", verified: true, linkedAt: 1,
+    }));
+    expect(await t.query(notificationChannelFns.getChannelsByUserId, { userId: USER.subject })).toMatchObject([
+      { email: "unrelated@example.com", verified: false },
+    ]);
+    expect(await t.run(ctx => ctx.db.get(id))).toMatchObject({ verified: true, linkedAt: 1 });
+  });
+});
+
+describe("notificationChannels — relay email ownership", () => {
+  test.each([
+    { destination: "unrelated@example.com", status: "verified", expected: 400 },
+    { destination: "owner@example.com", status: "unverified", expected: 400 },
+    { destination: "owner@example.com", status: "verified", expected: 200 },
+  ])("server verifies Clerk primary email: %j", async ({ destination, status, expected }) => {
+    process.env.RELAY_SHARED_SECRET = "relay-secret";
+    process.env.CLERK_SECRET_KEY = "fake-clerk-secret";
+    const t = convexTest(schema, modules);
+    await seedEntitlement(t);
+    const clerk = vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+      expect(String(url)).toBe(`https://api.clerk.com/v1/users/${USER.subject}`);
+      expect(init?.headers).toMatchObject({ Authorization: "Bearer fake-clerk-secret" });
+      return Response.json({ id: USER.subject, primary_email_address_id: "primary", email_addresses: [
+        { id: "primary", email_address: "owner@example.com", verification: { status } },
+        { id: "other", email_address: "unrelated@example.com", verification: { status: "unverified" } },
+      ] });
+    });
+    const response = await t.fetch("/relay/notification-channels", {
+      method: "POST", headers: { Authorization: "Bearer relay-secret", "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "set-channel", userId: USER.subject, channelType: "email", email: destination,
+        verifiedAccountEmail: destination, emailVerified: true, emailOwnership: "verified_account" }),
+    });
+    expect(response.status).toBe(expected);
+    expect(clerk).toHaveBeenCalledTimes(1);
+    const channels = await t.query(notificationChannelFns.getChannelsByUserId, { userId: USER.subject });
+    expect(channels).toMatchObject(expected === 200 ? [{ email: "owner@example.com", verified: true, emailOwnership: "verified_account" }] : []);
+  });
+
+  test.each(["missing-secret", "provider-error", "wrong-user"])("fails closed when verification is unavailable: %s", async failure => {
+    process.env.RELAY_SHARED_SECRET = "relay-secret";
+    process.env.CLERK_SECRET_KEY = "fake-clerk-secret";
+    if (failure === "missing-secret") delete process.env.CLERK_SECRET_KEY;
+    const t = convexTest(schema, modules);
+    await seedEntitlement(t);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => failure === "provider-error"
+      ? new Response("unavailable", { status: 503 })
+      : Response.json({ id: "different-user", primary_email_address_id: "primary", email_addresses: [
+        { id: "primary", email_address: "owner@example.com", verification: { status: "verified" } },
+      ] }));
+    const response = await t.fetch("/relay/notification-channels", {
+      method: "POST", headers: { Authorization: "Bearer relay-secret", "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "set-channel", userId: USER.subject, channelType: "email", email: "owner@example.com" }),
+    });
+    expect(response.status).toBe(500);
+    expect(await t.query(notificationChannelFns.getChannelsByUserId, { userId: USER.subject })).toEqual([]);
   });
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,6 +1,7 @@
 import { anyApi, httpRouter } from "convex/server";
 import { httpAction, type ActionCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
+import { lookupVerifiedAccountEmail, requireVerifiedAccountEmail } from "./lib/notificationEmail";
 import { TOUCH_DEBOUNCE_MS } from "./apiKeys";
 import {
   CHECKOUT_RATE_LIMITED,
@@ -651,12 +652,16 @@ http.route({
         if (!body.channelType) {
           return new Response(JSON.stringify({ error: "channelType required" }), { status: 400, headers: { "Content-Type": "application/json" } });
         }
+        const verifiedAccountEmail = body.channelType === "email"
+          ? requireVerifiedAccountEmail(body.email, await lookupVerifiedAccountEmail(userId))
+          : undefined;
         const setResult = await ctx.runMutation((internal as any).notificationChannels.setChannelForUser, {
           userId,
           channelType: body.channelType as "telegram" | "slack" | "email" | "webhook",
           chatId: body.chatId,
           webhookEnvelope: body.webhookEnvelope,
           email: body.email,
+          verifiedAccountEmail,
           webhookLabel: body.webhookLabel,
           scheduleWelcome: body.scheduleWelcome === true,
         });
@@ -884,6 +889,10 @@ http.route({
 
       return new Response(JSON.stringify({ error: "Unknown action" }), { status: 400, headers: { "Content-Type": "application/json" } });
     } catch (err: unknown) {
+      const code = extractConvexErrorCode(err);
+      if (code === "EMAIL_OWNERSHIP_REQUIRED" || code === "PRO_REQUIRED") {
+        return new Response(JSON.stringify({ error: code }), { status: code === "PRO_REQUIRED" ? 402 : 400, headers: { "Content-Type": "application/json" } });
+      }
       const msg = err instanceof Error ? err.message : String(err);
       return new Response(JSON.stringify({ error: msg }), { status: 500, headers: { "Content-Type": "application/json" } });
     }

--- a/convex/lib/notificationEmail.ts
+++ b/convex/lib/notificationEmail.ts
@@ -1,0 +1,29 @@
+import { ConvexError } from "convex/values";
+
+/** Only the authenticated identity or the server's Clerk lookup supplies proof. */
+export function requireVerifiedAccountEmail(requested: string | undefined, verifiedEmail: string | undefined): string {
+  const email = verifiedEmail?.trim();
+  if (!email || typeof requested !== "string" || requested.trim().toLowerCase() !== email.toLowerCase()) {
+    throw new ConvexError({ code: "EMAIL_OWNERSHIP_REQUIRED", message: "Connect your verified account email to receive notifications." });
+  }
+  return email;
+}
+
+export async function lookupVerifiedAccountEmail(userId: string): Promise<string | undefined> {
+  const secret = process.env.CLERK_SECRET_KEY;
+  if (!secret) throw new Error("EMAIL_VERIFICATION_UNAVAILABLE");
+  const response = await fetch(`https://api.clerk.com/v1/users/${encodeURIComponent(userId)}`, {
+    headers: { Authorization: `Bearer ${secret}`, "User-Agent": "worldmonitor-convex/1.0" },
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error("EMAIL_VERIFICATION_UNAVAILABLE");
+  const user = await response.json() as {
+    id?: string;
+    primary_email_address_id?: string;
+    email_addresses?: Array<{ id: string; email_address: string; verification?: { status?: string } }>;
+  };
+  if (user.id !== userId) throw new Error("EMAIL_VERIFICATION_UNAVAILABLE");
+  return user.email_addresses?.find(address =>
+    address.id === user.primary_email_address_id && address.verification?.status === "verified",
+  )?.email_address;
+}

--- a/convex/notificationChannels.ts
+++ b/convex/notificationChannels.ts
@@ -9,6 +9,7 @@ import {
 } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { channelTypeValidator } from "./constants";
+import { requireVerifiedAccountEmail } from "./lib/notificationEmail";
 
 // Versioned queue: old Railway relays only poll wm:events:queue and ignore
 // welcomeId. Keeping connection-scoped events on a new queue means they wait
@@ -186,10 +187,12 @@ export const queueChannelWelcome = internalAction({
 export const getChannelsByUserId = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
-    return await ctx.db
+    const channels = await ctx.db
       .query("notificationChannels")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .collect();
+    return channels.map(channel => channel.channelType === "email" && channel.emailOwnership !== "verified_account"
+      ? { ...channel, verified: false } : channel);
   },
 });
 
@@ -202,6 +205,8 @@ export const setChannelForUser = internalMutation({
     email: v.optional(v.string()),
     webhookLabel: v.optional(v.string()),
     scheduleWelcome: v.optional(v.boolean()),
+    // Internal-only: derived by the relay HTTP handler from Clerk, never the body.
+    verifiedAccountEmail: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const { userId, channelType, chatId, webhookEnvelope, email, webhookLabel } = args;
@@ -223,8 +228,9 @@ export const setChannelForUser = internalMutation({
       const doc = { userId, channelType: "slack" as const, webhookEnvelope, verified: true, linkedAt: now };
       if (existing) { await ctx.db.replace(existing._id, doc); } else { channelId = String(await ctx.db.insert("notificationChannels", doc)); }
     } else if (channelType === "email") {
-      if (!email) throw new ConvexError("email required for email channel");
-      const doc = { userId, channelType: "email" as const, email, verified: true, linkedAt: now };
+      await assertProEntitlement(ctx, userId);
+      const recipient = requireVerifiedAccountEmail(email, args.verifiedAccountEmail);
+      const doc = { userId, channelType: "email" as const, email: recipient, emailOwnership: "verified_account" as const, verified: true, linkedAt: now };
       if (existing) { await ctx.db.replace(existing._id, doc); } else { channelId = String(await ctx.db.insert("notificationChannels", doc)); }
     } else if (channelType === "webhook") {
       if (!webhookEnvelope) throw new ConvexError("webhookEnvelope required for webhook channel");
@@ -459,10 +465,12 @@ export const getChannels = query({
   handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) return [];
-    return await ctx.db
+    const channels = await ctx.db
       .query("notificationChannels")
       .withIndex("by_user", (q) => q.eq("userId", identity.subject))
       .collect();
+    return channels.map(channel => channel.channelType === "email" && channel.emailOwnership !== "verified_account"
+      ? { ...channel, verified: false } : channel);
   },
 });
 
@@ -506,8 +514,8 @@ export const setChannel = mutation({
         await ctx.db.insert("notificationChannels", doc);
       }
     } else if (args.channelType === "email") {
-      if (!args.email) throw new ConvexError("email required for email channel");
-      const doc = { userId, channelType: "email" as const, email: args.email, verified: true, linkedAt: now };
+      const email = requireVerifiedAccountEmail(args.email, identity.emailVerified === true ? identity.email : undefined);
+      const doc = { userId, channelType: "email" as const, email, emailOwnership: "verified_account" as const, verified: true, linkedAt: now };
       if (existing) {
         await ctx.db.replace(existing._id, doc);
       } else {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -157,6 +157,7 @@ export default defineSchema({
         userId: v.string(),
         channelType: v.literal("email"),
         email: v.string(),
+        emailOwnership: v.optional(v.literal("verified_account")),
         verified: v.boolean(),
         linkedAt: v.number(),
       }),

--- a/docs/operations/notification-email-ownership.md
+++ b/docs/operations/notification-email-ownership.md
@@ -1,0 +1,50 @@
+# Notification email ownership rollout (#7894)
+
+Email notification destinations must match a verified account email. The public
+Convex mutation requires the authenticated identity's `emailVerified === true`
+and matching `email`. The existing HTTP route looks up the user's verified
+primary email through Clerk's Backend API. Only this server result becomes the
+internal mutation's `verifiedAccountEmail` argument; request-body proof is ignored.
+The mutation checks the recipient and Pro entitlement before saving.
+
+Newly proven rows carry `emailOwnership: "verified_account"`. An old
+`verified: true` flag alone is not proof. Channel queries report such email rows
+as `verified: false`; real-time, held-batch, welcome and digest workers also reject
+email rows without the marker. Query masking does not modify stored records.
+
+## Existing records and release decision
+
+Do not bulk backfill the marker from the old flag, `users.email`, or billing email.
+Those fields do not prove ownership of the stored destination. This PR contains
+no migration and the coding task does not change customer records.
+
+The release owner must approve the customer re-verification plan before deploying:
+existing email channels without proof stop delivering after this repair. Users
+can reconnect their verified primary account email through the existing settings
+flow. Reconnection replaces that user's email row with a proven destination.
+Other notification channel types remain unchanged. A future bulk re-verification
+would require a separately approved plan using authoritative ownership proof.
+
+## Deployment and acceptance (requires separate authorization)
+
+1. Ensure `CLERK_SECRET_KEY` for the same Clerk instance is available to Convex.
+   No key is copied or configured by this change. Missing credentials or failed
+   lookup prevents email connection; no caller email is accepted as a fallback.
+2. Deploy Convex schema/functions first, then the Railway relay and digest worker.
+   The read-side mask protects old workers. New workers reject unmarked rows even
+   with an old backend. The marker is optional in schema so old rows remain valid.
+3. With an approved test account and owned mailbox, reconnect email and confirm
+   the stored marker, one normal real-time alert and the next due digest. Test a
+   rejected unrelated synthetic destination without sending to it. Verify old
+   unproven rows remain unchanged and cannot send welcome or queued alerts.
+4. For 24 hours and at least one due digest, the release owner watches Convex
+   connection errors (`EMAIL_OWNERSHIP_REQUIRED`, `EMAIL_VERIFICATION_UNAVAILABLE`),
+   relay provider failures, digest `No deliverable channels` logs and approved
+   test-account delivery records. No inbox addresses or credentials go in logs.
+5. Missing verified-account delivery or repeated verification failures blocks
+   acceptance. Fix Clerk configuration or roll forward. Do not restore legacy
+   delivery trust or backfill proof as a rollback workaround. If mitigation is
+   needed, retain the read-side mask and pause email delivery until repaired.
+
+Local fixture checks do not establish deployed configuration, real Clerk claims,
+provider delivery or production acceptance. Keep #7894 open for that acceptance.

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -259,7 +259,7 @@ async function drainHeldForUser(userId, variant, allowedChannelTypes) {
   }
 
   const verifiedChannels = channels.filter(c =>
-    c.verified && (allowedChannelTypes == null || allowedChannelTypes.includes(c.channelType)),
+    c.verified && (c.channelType !== 'email' || c.emailOwnership === 'verified_account') && (allowedChannelTypes == null || allowedChannelTypes.includes(c.channelType)),
   );
   let anyDelivered = false;
   for (const ch of verifiedChannels) {
@@ -949,7 +949,7 @@ async function processWelcome(event) {
 
   const ch = channels.find(c =>
     c.channelType === channelType &&
-    c.verified &&
+    c.verified && (c.channelType !== 'email' || c.emailOwnership === 'verified_account') &&
     // Events created before connection-scoped welcome IDs remain compatible.
     // New events must still target the exact channel document that scheduled
     // them, so a delayed retry cannot welcome a replacement connection.
@@ -1251,7 +1251,7 @@ async function processEvent(event) {
       channels = [];
     }
 
-    const verifiedChannels = channels.filter(c => c.verified && rule.channels.includes(c.channelType));
+    const verifiedChannels = channels.filter(c => c.verified && (c.channelType !== 'email' || c.emailOwnership === 'verified_account') && rule.channels.includes(c.channelType));
     if (verifiedChannels.length === 0) continue;
 
     let deliveryText = text;
@@ -1366,6 +1366,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  processEvent,
   sendTelegram,
   checkDedup,
   upstashDedupSetNx,

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -2391,7 +2391,7 @@ async function main() {
     }
 
     const ruleChannelSet = new Set(rule.channels ?? []);
-    const deliverableChannels = channels.filter(ch => ruleChannelSet.has(ch.channelType) && ch.verified);
+    const deliverableChannels = channels.filter(ch => ruleChannelSet.has(ch.channelType) && ch.verified && (ch.channelType !== 'email' || ch.emailOwnership === 'verified_account'));
     if (deliverableChannels.length === 0) {
       console.log(`[digest] No deliverable channels for ${rule.userId} — skipping`);
       continue;

--- a/src/services/notification-channels.ts
+++ b/src/services/notification-channels.ts
@@ -260,7 +260,13 @@ export async function setEmailChannel(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'set-channel', channelType: 'email', email }),
   }, expectedUserId, signal);
-  if (!res.ok) throw new Error(`set email channel: ${res.status}`);
+  if (!res.ok) {
+    const failure = await res.json().catch(() => null);
+    if (failure?.error === 'EMAIL_OWNERSHIP_REQUIRED') {
+      throw new Error('Verify your account email, then try again.');
+    }
+    throw new Error('Could not connect email. Please try again.');
+  }
 }
 
 export async function setSlackChannel(

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -1118,7 +1118,11 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           }
           setEmailChannel(email, undefined, signal).then(() => {
             if (!signal.aborted) { saveRuleWithNewChannel('email'); reloadNotifSection(); }
-          }).catch(() => {});
+          }).catch((error: unknown) => {
+            if (signal.aborted) return;
+            const rowEl = target.closest('.us-notif-ch-row') as HTMLElement | null;
+            if (rowEl) appendNotificationError(rowEl, error instanceof Error ? error.message : 'Could not connect email. Please try again.');
+          });
           return;
         }
 

--- a/tests/dom/notifications-settings-web-push.test.mts
+++ b/tests/dom/notifications-settings-web-push.test.mts
@@ -14,6 +14,7 @@ const channelMocks = vi.hoisted(() => ({
   getChannelsData: vi.fn(),
   saveAlertRules: vi.fn(),
   deleteChannel: vi.fn(),
+  setEmailChannel: vi.fn(),
 }));
 
 vi.mock('@/services/push-notifications', () => ({
@@ -27,7 +28,7 @@ vi.mock('@/services/notification-channels', () => ({
   getChannelsData: channelMocks.getChannelsData,
   saveAlertRules: channelMocks.saveAlertRules,
   createPairingToken: vi.fn(),
-  setEmailChannel: vi.fn(),
+  setEmailChannel: channelMocks.setEmailChannel,
   setWebhookChannel: vi.fn(),
   startSlackOAuth: vi.fn(),
   startDiscordOAuth: vi.fn(),
@@ -116,6 +117,7 @@ beforeEach(() => {
     userAgent: 'test',
   });
   channelMocks.getChannelsData.mockReset();
+  channelMocks.setEmailChannel.mockReset().mockResolvedValue(undefined);
   channelMocks.saveAlertRules.mockReset();
   channelMocks.saveAlertRules.mockResolvedValue(undefined);
   channelMocks.deleteChannel.mockReset();
@@ -467,6 +469,24 @@ describe('notification Settings browser push', () => {
     const row = webPushRow(container);
     expect(row.dataset.webPushState).toBe('available');
     expect(row.querySelector('.us-notif-error')).toBeNull();
+    expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
+  });
+});
+
+
+describe('email connection recovery', () => {
+  it('saves the email rule after linking succeeds', async () => {
+    const container = await mount();
+    container.querySelector<HTMLButtonElement>('#usConnectEmail')!.click();
+    await vi.waitFor(() => expect(channelMocks.saveAlertRules).toHaveBeenCalled());
+    expect(channelMocks.setEmailChannel).toHaveBeenCalledWith('push@worldmonitor.test', undefined, expect.any(AbortSignal));
+  });
+
+  it('shows a failed link and does not save email rules', async () => {
+    channelMocks.setEmailChannel.mockRejectedValueOnce(new Error('Verify your account email, then try again.'));
+    const container = await mount();
+    container.querySelector<HTMLButtonElement>('#usConnectEmail')!.click();
+    await vi.waitFor(() => expect(container.textContent).toContain('Verify your account email, then try again.'));
     expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
   });
 });

--- a/tests/notification-channels-billing-retry.test.mts
+++ b/tests/notification-channels-billing-retry.test.mts
@@ -99,6 +99,20 @@ afterEach(() => {
   __setNotificationChannelsClientDepsForTests(null);
 });
 
+describe('email ownership errors', () => {
+  it('turns the ownership denial into recovery guidance without retrying', async () => {
+    const { calls, slept } = installTransport([Response.json({ error: 'EMAIL_OWNERSHIP_REQUIRED' }, { status: 400 })]);
+    await assert.rejects(setEmailChannel('buyer@example.com'), /Verify your account email, then try again\./);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(slept, []);
+  });
+
+  it('uses a safe retry message for an unexpected server error', async () => {
+    installTransport([Response.json({ error: 'private provider details' }, { status: 500 })]);
+    await assert.rejects(setEmailChannel('buyer@example.com'), /Could not connect email\. Please try again\./);
+  });
+});
+
 describe('billingVerificationRetryDelayMs', () => {
   it('honors Retry-After exactly for every retryable code', () => {
     for (const code of RETRYABLE_CODES) {

--- a/tests/notification-channels-relay-timeout.test.mts
+++ b/tests/notification-channels-relay-timeout.test.mts
@@ -397,3 +397,27 @@ describe('/api/notification-channels relay timeout recovery', () => {
     assert.equal(relayFetch.mock.calls.length, 3);
   });
 });
+
+describe('/api/notification-channels email ownership errors', () => {
+  it('preserves the ownership rejection for the browser', async () => {
+    installInMemoryUpstash();
+    const mod = await importFreshNotificationChannels();
+    mod.__setNotificationChannelsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: 'user-email-proof' }),
+      getEntitlements: async () => ({
+        planKey: 'pro_monthly',
+        features: { tier: 1, apiAccess: true, apiRateLimit: 1_000, maxDashboards: 10, prioritySupport: true, exportFormats: ['json'], mcpAccess: true },
+        validUntil: Date.now() + 60_000,
+      }),
+      fetch: async (_input, init) => {
+        const body = JSON.parse(String(init?.body));
+        if (body.action === 'welcome-scheduling-capability') return Response.json({ durableWelcomeScheduling: true });
+        return Response.json({ error: 'EMAIL_OWNERSHIP_REQUIRED' }, { status: 400 });
+      },
+    });
+    const response = await mod.default(makeSetChannelRequest(), { waitUntil() {} });
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: 'EMAIL_OWNERSHIP_REQUIRED' });
+    mod.__setNotificationChannelsDepsForTests(null);
+  });
+});

--- a/tests/notification-email-ownership.test.mts
+++ b/tests/notification-email-ownership.test.mts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import Module, { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import notify, { __setNotifyDepsForTests } from '../api/notify.ts';
+
+const require = createRequire(import.meta.url);
+const originalFetch = globalThis.fetch;
+const savedEnv = { ...process.env };
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  __setNotifyDepsForTests(null);
+  for (const key of Object.keys(process.env)) if (!(key in savedEnv)) delete process.env[key];
+  Object.assign(process.env, savedEnv);
+});
+
+for (const proof of ['legacy', 'unverified', 'verified'] as const) {
+  test(`/api/notify through relay and mocked Resend: ${proof}`, async () => {
+    Object.assign(process.env, {
+      UPSTASH_REDIS_REST_URL: 'https://upstash.test', UPSTASH_REDIS_REST_TOKEN: 'fake',
+      CONVEX_URL: 'https://convex.test', CONVEX_SITE_URL: 'https://convex.test',
+      RELAY_SHARED_SECRET: 'fake', RESEND_API_KEY: 'fake', AI_IMPACT_ENABLED: 'false',
+    });
+    const sends: Array<{ to: string; subject: string; text: string }> = [];
+    const loader = Module as unknown as { _load: (...args: any[]) => any };
+    const originalLoad = loader._load;
+    loader._load = function (name, ...args) {
+      if (name === 'resend') return { Resend: class { emails = { send: async (message: any) => { sends.push(message); return { data: { id: 'fake' } }; } }; } };
+      return originalLoad.call(this, name, ...args);
+    };
+    const relayPath = require.resolve('../scripts/notification-relay.cjs');
+    delete require.cache[relayPath];
+    let relay: any;
+    try { relay = require(relayPath); } finally { loader._load = originalLoad; }
+    const queued: any[] = [];
+    const channelReads: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url.includes('/lpush/')) {
+        queued.push(JSON.parse(decodeURIComponent(url.split('/').at(-1)!)));
+        return Response.json({ result: 1 });
+      }
+      if (url.includes('/relay/enabled-rules')) return Response.json(['owner', 'other'].map(userId => ({
+        userId, variant: 'full', enabled: true, sensitivity: 'critical', digestMode: 'realtime', eventTypes: ['market_alert'], channels: ['email'],
+      })));
+      if (url.includes('/relay/channels')) {
+        channelReads.push(JSON.parse(String(init?.body)).userId);
+        return Response.json([{
+          _id: 'channel', channelType: 'email', email: 'owner@example.com',
+          verified: proof !== 'unverified', ...(proof === 'legacy' ? {} : { emailOwnership: 'verified_account' }),
+        }]);
+      }
+      if (url.includes('/GET/relay%3Aentitlement')) return Response.json({ result: '1' });
+      if (url.includes('/SET/')) return Response.json({ result: 'OK' });
+      throw new Error(`Unexpected transport: ${url}`);
+    };
+    __setNotifyDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: 'owner' }),
+      checkTierProEntitlement: async () => ({ allowed: true }),
+      checkScopedRateLimit: async () => ({ allowed: true, limit: 30, remaining: 29, reset: 0, degraded: false }),
+    });
+    const response = await notify(new Request('https://worldmonitor.app/api/notify', {
+      method: 'POST', headers: { Authorization: 'Bearer fake', Origin: 'https://worldmonitor.app', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventType: 'market_alert', severity: 'critical', variant: 'full', payload: { title: 'Synthetic market alert', link: 'https://example.com/alert' } }),
+    }));
+    assert.equal(response.status, 200);
+    assert.equal(queued.length, 1);
+    await relay.processEvent(queued[0]);
+    assert.deepEqual(channelReads, ['owner'], 'caller event cannot fan out to another user');
+    assert.equal(sends.length, proof === 'verified' ? 1 : 0);
+    if (proof === 'verified') {
+      assert.equal(sends[0].to, 'owner@example.com');
+      assert.match(sends[0].subject, /Synthetic market alert/);
+      assert.match(sends[0].text, /https:\/\/example.com\/alert/);
+    }
+    await relay.processWelcome({ userId: 'owner', channelType: 'email', welcomeId: 'channel' });
+    assert.equal(sends.length, proof === 'verified' ? 2 : 0);
+  });
+}
+
+for (const proof of ['legacy', 'unverified', 'verified'] as const) {
+  test(`digest main enforces email ownership: ${proof}`, async () => {
+    // Execute the production orchestration function without starting the cron.
+    // Mock story/provider dependencies, not the channel selection or send loop.
+    const source = readFileSync(new URL('../scripts/seed-digest-notifications.mjs', import.meta.url), 'utf8');
+    const main = source.slice(source.indexOf('async function main() {'), source.lastIndexOf('\nmain().catch'));
+    const metadata: any[] = [];
+    let channelReads = 0;
+    let sends = 0;
+    const run = runInNewContext(`${main}\nmain`, {
+      Date, Map, Set, AbortSignal, process: { env: {} }, console: { log() {}, warn() {} },
+      CONVEX_SITE_URL: 'https://convex.test', RELAY_SECRET: 'fake', DIGEST_LOOKBACK_MS: 86400000,
+      scanAndEnqueueWatchlistStoryEvents: async () => {},
+      fetch: async (url: string) => {
+        if (url.endsWith('/relay/digest-rules')) return Response.json([{ userId: 'owner', variant: 'full', channels: ['email'] }]);
+        assert.ok(url.endsWith('/relay/channels'));
+        channelReads++;
+        return Response.json([{ channelType: 'email', email: 'owner@example.com', verified: proof !== 'unverified', ...(proof === 'legacy' ? {} : { emailOwnership: 'verified_account' }) }]);
+      },
+      parseDigestOnlyUser: () => ({ kind: 'unset' }),
+      composeBriefsForRun: async () => ({ briefByUser: new Map(), composeSuccess: 0, composeFailed: 0 }),
+      readCooldownConfig: () => ({ invalidRaw: null, mode: 'off' }),
+      getLastSentAt: async () => 0, isDue: () => true, isUserPro: async () => true,
+      digestWindowStartMs: () => 0, buildDigest: async () => [{ title: 'Synthetic alert' }],
+      shouldExitOnBriefFailures: () => false,
+      AI_DIGEST_ENABLED: false,
+      buildDigestDeliveryPlan: ({ rawStories }: any) => ({ formatterStories: rawStories, cooldownIterableStories: [], sourceCountByClusterId: new Map() }),
+      formatDigest: () => 'Synthetic digest', formatDigestHtml: () => '<p>Synthetic digest</p>',
+      buildChannelBodies: (text: string) => ({ text }),
+      injectEmailSummary: (html: string) => html, injectBriefCta: (html: string) => html,
+      subjectForBrief: () => 'Synthetic digest', issueSlotInTz: () => 'slot',
+      emitCooldownShadowLog: () => {}, upstashRest: async () => 'OK',
+      sendEmail: async (email: string) => { assert.equal(email, 'owner@example.com'); sends++; return true; },
+      writeDigestLastRunMeta: async (meta: unknown) => { metadata.push(meta); },
+    });
+    await run();
+    assert.equal(channelReads, 1);
+    assert.equal(sends, proof === 'verified' ? 1 : 0);
+    assert.equal(metadata[0].sentCount, proof === 'verified' ? 1 : 0);
+  });
+}

--- a/tests/notification-email-ownership.test.mts
+++ b/tests/notification-email-ownership.test.mts
@@ -35,6 +35,7 @@ for (const proof of ['legacy', 'unverified', 'verified'] as const) {
     try { relay = require(relayPath); } finally { loader._load = originalLoad; }
     const queued: any[] = [];
     const channelReads: string[] = [];
+    let heldDeleted = false;
     globalThis.fetch = async (input, init) => {
       const url = String(input);
       if (url.includes('/lpush/')) {
@@ -52,6 +53,9 @@ for (const proof of ['legacy', 'unverified', 'verified'] as const) {
         }]);
       }
       if (url.includes('/GET/relay%3Aentitlement')) return Response.json({ result: '1' });
+      if (url.includes('/LLEN/')) return Response.json({ result: 1 });
+      if (url.includes('/LRANGE/')) return Response.json({ result: [JSON.stringify(queued[0])] });
+      if (url.includes('/DEL/')) { heldDeleted = true; return Response.json({ result: 1 }); }
       if (url.includes('/SET/')) return Response.json({ result: 'OK' });
       throw new Error(`Unexpected transport: ${url}`);
     };
@@ -76,6 +80,9 @@ for (const proof of ['legacy', 'unverified', 'verified'] as const) {
     }
     await relay.processWelcome({ userId: 'owner', channelType: 'email', welcomeId: 'channel' });
     assert.equal(sends.length, proof === 'verified' ? 2 : 0);
+    await relay.processEvent({ eventType: 'flush_quiet_held', userId: 'owner', variant: 'full' });
+    assert.equal(sends.length, proof === 'verified' ? 3 : 0);
+    assert.equal(heldDeleted, proof === 'verified', 'held alerts remain queued until an owned channel receives them');
   });
 }
 

--- a/tests/notification-relay-welcome-identity.test.mjs
+++ b/tests/notification-relay-welcome-identity.test.mjs
@@ -72,6 +72,7 @@ describe('notification relay welcome identity', () => {
         channelType: 'email',
         email: 'replacement@example.com',
         verified: true,
+        emailOwnership: 'verified_account',
       }]);
     });
     globalThis.fetch = fetchMock;
@@ -144,6 +145,7 @@ describe('notification relay welcome identity', () => {
         channelType: 'email',
         email: 'current@example.com',
         verified: true,
+        emailOwnership: 'verified_account',
       }]);
     });
 


### PR DESCRIPTION
## Summary

A Pro caller could register an unrelated email as verified and send alert content through WorldMonitor's sender. Both channel setters now require a matching, server-proven account email. The HTTP path verifies the primary address through Clerk; body-supplied proof cannot override it.

Existing email rows lack ownership evidence. Queries and all email delivery paths reject unproven rows without rewriting customer data. Reconnecting a verified account email establishes proof. Release requires a re-verification decision and `CLERK_SECRET_KEY` in Convex; the [rollout and acceptance plan](docs/operations/notification-email-ownership.md) documents this. No production messages, customer mutations, merge or deployment were performed.

Related: #7894. Keep the issue open for deployment/production acceptance. #7896 follows this change for shared Telegram code.

## Verification

- Reproduced six failing Convex ownership assertions before the repair; all pass after it.
- 65 tests pass: `npm run test:convex -- convex/__tests__/notificationChannels.test.ts convex/__tests__/http.test.ts convex/__tests__/alertRules.test.ts`.
- 161 broader Node notification checks pass, including billing denial, reserved events, rate limits, relay filters and digest container imports. The expanded ownership/welcome suite then passes all 8 tests.
- `node --import tsx --test tests/notification-email-ownership.test.mts tests/notification-relay-welcome-identity.test.mjs` exercises actual `/api/notify` queue output through the real relay with mocked Resend, plus production digest orchestration with mocked story/provider dependencies. Proven email sends; legacy/unverified email does not. Removing ownership filters makes both real-time and digest assertions fail with an unauthorized send.
- `npm run typecheck:api`, `npx tsc --noEmit -p convex/tsconfig.json`, and `git diff --check` pass.
- Inline simplification and security/correctness/API/reliability review completed. Independent agent review was not run under this workspace's sequential-main-thread instruction.

## Post-Deploy Monitoring & Validation

The release owner must approve the re-verification plan, provision Clerk access in Convex, and deploy Convex before the relay/digest workers. Validate an approved owned mailbox for real-time and the next due digest; verify an unrelated synthetic destination is rejected without delivery. For 24 hours and at least one digest, watch `EMAIL_OWNERSHIP_REQUIRED`, `EMAIL_VERIFICATION_UNAVAILABLE`, relay provider failures and digest `No deliverable channels` logs. Missing verified-account delivery or repeated verification failures blocks acceptance; fix configuration or roll forward while retaining the legacy read mask. Do not backfill ownership from old flags or restore unsafe delivery as rollback.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
