### PR TITLE
fix(leads): protect waitlist backing mutation

### DIFF
--- a/convex/__tests__/registerInterest.test.ts
+++ b/convex/__tests__/registerInterest.test.ts
@@ -1,0 +1,143 @@
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+const SHARED_SECRET = "test-convex-secret-register-interest-7895";
+
+function postHeaders(secret = SHARED_SECRET): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "x-convex-shared-secret": secret,
+  };
+}
+
+async function post(
+  t: ReturnType<typeof convexTest>,
+  body: unknown,
+  secret = SHARED_SECRET,
+): Promise<Response> {
+  return t.fetch("/api/internal-register-interest", {
+    method: "POST",
+    headers: postHeaders(secret),
+    body: JSON.stringify(body),
+  });
+}
+
+describe("registerInterest backing mutation", () => {
+  let originalSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+    process.env.CONVEX_SERVER_SHARED_SECRET = SHARED_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.CONVEX_SERVER_SHARED_SECRET;
+    else process.env.CONVEX_SERVER_SHARED_SECRET = originalSecret;
+  });
+
+  test("requires the shared secret before parsing or writing", async () => {
+    const t = convexTest(schema, modules);
+
+    const missing = await t.fetch("/api/internal-register-interest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "missing-secret@example.com" }),
+    });
+    expect(missing.status).toBe(401);
+
+    const wrong = await post(t, { email: "wrong-secret@example.com" }, "wrong-secret");
+    expect(wrong.status).toBe(401);
+
+    await expect(t.run((ctx) => ctx.db.query("registrations").collect())).resolves.toHaveLength(0);
+  });
+
+  test("rejects malformed JSON and invalid email without a write", async () => {
+    const t = convexTest(schema, modules);
+    const malformed = await t.fetch("/api/internal-register-interest", {
+      method: "POST",
+      headers: postHeaders(),
+      body: "null",
+    });
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toEqual({ error: "INVALID_JSON" });
+
+    const invalid = await post(t, { email: "not-an-email" });
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toEqual({ error: "INVALID_EMAIL" });
+
+    await expect(t.run((ctx) => ctx.db.query("registrations").collect())).resolves.toHaveLength(0);
+  });
+
+  test("writes registrations, counters, referral credits, and suppression state", async () => {
+    const t = convexTest(schema, modules);
+
+    const firstResponse = await post(t, {
+      email: "first@example.com",
+      source: "pro-waitlist",
+      appVersion: "test",
+    });
+    expect(firstResponse.status).toBe(200);
+    const first = await firstResponse.json() as {
+      status: string;
+      referralCode: string;
+      position: number;
+      emailSuppressed: boolean;
+    };
+    expect(first).toMatchObject({
+      status: "registered",
+      position: 1,
+      emailSuppressed: false,
+    });
+
+    const secondResponse = await post(t, {
+      email: "second@example.com",
+      referredBy: first.referralCode,
+    });
+    expect(secondResponse.status).toBe(200);
+    expect(await secondResponse.json()).toMatchObject({
+      status: "registered",
+      position: 2,
+    });
+
+    await t.mutation(internal.emailSuppressions.suppress, {
+      email: "suppressed@example.com",
+      reason: "bounce",
+    });
+    const suppressedResponse = await post(t, { email: "suppressed@example.com" });
+    expect(suppressedResponse.status).toBe(200);
+    expect(await suppressedResponse.json()).toMatchObject({
+      status: "registered",
+      emailSuppressed: true,
+    });
+
+    const rows = await t.run((ctx) => ctx.db.query("registrations").collect());
+    expect(rows).toHaveLength(3);
+    expect(rows.find((row) => row.email === "first@example.com")?.referralCount).toBe(1);
+    expect(rows.find((row) => row.email === "second@example.com")?.referredBy).toBe(first.referralCode);
+    await expect(
+      t.run(async (ctx) => ctx.db.query("counters").withIndex("by_name", (q) => q.eq("name", "registrations_total")).first()),
+    ).resolves.toMatchObject({ value: 3 });
+  });
+
+  test("keeps the existing-registration response stable without creating a row", async () => {
+    const t = convexTest(schema, modules);
+    const initial = await post(t, { email: "repeat@example.com" });
+    const initialBody = await initial.json() as { referralCode: string };
+
+    const retry = await post(t, {
+      email: "REPEAT@example.com",
+      referredBy: "ignored-referrer",
+    });
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toEqual({
+      status: "already_registered",
+      referralCode: initialBody.referralCode,
+      referralCount: 0,
+    });
+
+    await expect(t.run((ctx) => ctx.db.query("registrations").collect())).resolves.toHaveLength(1);
+  });
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -144,6 +144,96 @@ function setRateLimitResponseHeaders(headers: Headers, limit: number, reset: num
   headers.set("Retry-After", String(retryAfter));
 }
 
+const REGISTER_INTEREST_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const REGISTER_INTEREST_MAX_EMAIL_LENGTH = 320;
+const REGISTER_INTEREST_MAX_META_LENGTH = 100;
+
+/**
+ * Server-to-server bridge for the anonymous waitlist flow. The public
+ * registerInterest mutation is internal so a Convex client cannot bypass the
+ * edge handler's Turnstile/desktop proof, email validation, and rate limits.
+ */
+export async function registerInterestHttpHandler(
+  ctx: ActionCtx,
+  request: Request,
+): Promise<Response> {
+  const providedSecret = request.headers.get("x-convex-shared-secret") ?? "";
+  const expectedSecret = process.env.CONVEX_SERVER_SHARED_SECRET ?? "";
+  if (!expectedSecret || !(await timingSafeEqualStrings(providedSecret, expectedSecret))) {
+    return new Response(JSON.stringify({ error: "UNAUTHORIZED" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const body = await parseJsonObjectBody<{
+    email?: unknown;
+    source?: unknown;
+    appVersion?: unknown;
+    referredBy?: unknown;
+  }>(request);
+  if (!body) {
+    return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const email = typeof body.email === "string" ? body.email : "";
+  if (
+    email.length === 0 ||
+    email.length > REGISTER_INTEREST_MAX_EMAIL_LENGTH ||
+    !REGISTER_INTEREST_EMAIL_RE.test(email)
+  ) {
+    return new Response(JSON.stringify({ error: "INVALID_EMAIL" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const metadata = [
+    ["source", body.source],
+    ["appVersion", body.appVersion],
+    ["referredBy", body.referredBy],
+  ] as const;
+  for (const [field, value] of metadata) {
+    if (
+      value !== undefined &&
+      (typeof value !== "string" || value.length > REGISTER_INTEREST_MAX_META_LENGTH)
+    ) {
+      return new Response(JSON.stringify({ error: `INVALID_${field.toUpperCase()}` }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+  if (typeof body.referredBy === "string" && body.referredBy.length > 20) {
+    return new Response(JSON.stringify({ error: "INVALID_REFERRED_BY" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const result = await ctx.runMutation(internal.registerInterest.register, {
+      email,
+      source: body.source as string | undefined,
+      appVersion: body.appVersion as string | undefined,
+      referredBy: body.referredBy as string | undefined,
+    });
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("[register-interest] internal mutation failed:", err);
+    return new Response(JSON.stringify({ error: "REGISTRATION_UNAVAILABLE" }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+
 export async function internalEntitlementsHttpHandler(
   ctx: ActionCtx,
   request: Request,
@@ -267,6 +357,12 @@ export async function internalEntitlementsHttpHandler(
 }
 
 const http = httpRouter();
+
+http.route({
+  path: "/api/internal-register-interest",
+  method: "POST",
+  handler: httpAction(registerInterestHttpHandler),
+});
 
 http.route({
   path: "/api/internal-entitlements",

--- a/convex/registerInterest.ts
+++ b/convex/registerInterest.ts
@@ -1,4 +1,4 @@
-import { internalMutation, mutation, query } from "./_generated/server";
+import { internalMutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { DatabaseReader, DatabaseWriter } from "./_generated/server";
 
@@ -49,7 +49,10 @@ async function incrementCounter(db: DatabaseWriter, name: string): Promise<numbe
   return newVal;
 }
 
-export const register = mutation({
+// This write is intentionally internal. The public edge handler performs the
+// Turnstile/desktop proof, email validation, rate limits, and honeypot check;
+// exposing the mutation itself would let a caller bypass that entire boundary.
+export const register = internalMutation({
   args: {
     email: v.string(),
     source: v.optional(v.string()),

--- a/server/worldmonitor/leads/v1/register-interest.ts
+++ b/server/worldmonitor/leads/v1/register-interest.ts
@@ -402,19 +402,6 @@ export async function registerInterest(
   }
   const result = resultBody;
 
-  // The caller has passed the bot/email gates, but that does not prove control
-  // of an address already in the waitlist. Do not turn a retry into an email
-  // membership oracle or disclose the existing row's referral metadata.
-  if (result.status === 'already_registered') {
-    return {
-      status: 'registered',
-      referralCode: '',
-      referralCount: 0,
-      position: 0,
-      emailSuppressed: false,
-    };
-  }
-
   if (result.status === 'registered' && result.referralCode) {
     if (!result.emailSuppressed) {
       await sendConfirmationEmail(email, result.referralCode);
@@ -423,11 +410,13 @@ export async function registerInterest(
     }
   }
 
+  // Bot verification does not prove address ownership. Keep both outcomes
+  // identical; referral details belong in the confirmation email above.
   return {
-    status: result.status,
-    referralCode: result.referralCode,
-    referralCount: result.referralCount,
-    position: result.position ?? 0,
-    emailSuppressed: result.emailSuppressed ?? false,
+    status: 'registered',
+    referralCode: '',
+    referralCount: 0,
+    position: 0,
+    emailSuppressed: false,
   };
 }

--- a/server/worldmonitor/leads/v1/register-interest.ts
+++ b/server/worldmonitor/leads/v1/register-interest.ts
@@ -4,8 +4,6 @@
  * Sources: Convex registerInterest:register mutation + Resend confirmation email
  */
 
-import { ConvexHttpClient } from 'convex/browser';
-import { api } from '../../../../convex/_generated/api';
 import type {
   ServerContext,
   RegisterInterestRequest,
@@ -34,6 +32,8 @@ const DESKTOP_AUTH_ALLOW_LEGACY_ENV = 'WM_DESKTOP_AUTH_ALLOW_LEGACY';
 const DESKTOP_RATE_SCOPE = '/api/leads/v1/register-interest#desktop';
 const DESKTOP_RATE_LIMIT = 2;
 const DESKTOP_RATE_WINDOW = '1 h' as const;
+const CONVEX_REGISTER_INTEREST_PATH = '/api/internal-register-interest';
+const CONVEX_REGISTER_INTEREST_TIMEOUT_MS = 5_000;
 
 interface ConvexRegisterResult {
   status: 'registered' | 'already_registered';
@@ -41,6 +41,26 @@ interface ConvexRegisterResult {
   referralCount: number;
   position?: number;
   emailSuppressed?: boolean;
+}
+
+function convexSiteUrl(): string {
+  return (
+    process.env.CONVEX_SITE_URL ??
+    (process.env.CONVEX_URL ?? '').replace('.convex.cloud', '.convex.site')
+  ).replace(/\/$/, '');
+}
+
+function isConvexRegisterResult(value: unknown): value is ConvexRegisterResult {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const result = value as Partial<ConvexRegisterResult>;
+  return (
+    (result.status === 'registered' || result.status === 'already_registered') &&
+    typeof result.referralCode === 'string' &&
+    typeof result.referralCount === 'number' &&
+    Number.isSafeInteger(result.referralCount) &&
+    (result.position === undefined || Number.isSafeInteger(result.position)) &&
+    (result.emailSuppressed === undefined || typeof result.emailSuppressed === 'boolean')
+  );
 }
 
 function canonicalizeDesktopAuthPayload(req: RegisterInterestRequest): string {
@@ -334,18 +354,66 @@ export async function registerInterest(
   const safeAppVersion = appVersion ? appVersion.slice(0, MAX_META_LENGTH) : 'unknown';
   const safeReferredBy = referredBy ? referredBy.slice(0, 20) : undefined;
 
-  const convexUrl = process.env.CONVEX_URL;
-  if (!convexUrl) {
+  const convexUrl = convexSiteUrl();
+  const convexSharedSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+  if (!convexUrl || !convexSharedSecret) {
     throw new ApiError(503, 'Registration service unavailable', '');
   }
 
-  const client = new ConvexHttpClient(convexUrl);
-  const result = (await client.mutation(api.registerInterest.register, {
-    email,
-    source: safeSource,
-    appVersion: safeAppVersion,
-    referredBy: safeReferredBy,
-  })) as ConvexRegisterResult;
+  let convexResponse: Response;
+  try {
+    convexResponse = await fetch(`${convexUrl}${CONVEX_REGISTER_INTEREST_PATH}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'worldmonitor-leads/1.0',
+        'x-convex-shared-secret': convexSharedSecret,
+      },
+      body: JSON.stringify({
+        email,
+        source: safeSource,
+        appVersion: safeAppVersion,
+        referredBy: safeReferredBy,
+      }),
+      signal: AbortSignal.timeout(CONVEX_REGISTER_INTEREST_TIMEOUT_MS),
+    });
+  } catch (err) {
+    console.warn(
+      '[register-interest] Convex request failed:',
+      err instanceof Error ? err.message : String(err),
+    );
+    throw new ApiError(503, 'Registration service unavailable', '');
+  }
+
+  if (!convexResponse.ok) {
+    console.warn(`[register-interest] Convex HTTP ${convexResponse.status}`);
+    throw new ApiError(503, 'Registration service unavailable', '');
+  }
+
+  let resultBody: unknown;
+  try {
+    resultBody = await convexResponse.json();
+  } catch {
+    throw new ApiError(503, 'Registration service unavailable', '');
+  }
+  if (!isConvexRegisterResult(resultBody)) {
+    console.error('[register-interest] Convex returned an invalid registration response');
+    throw new ApiError(503, 'Registration service unavailable', '');
+  }
+  const result = resultBody;
+
+  // The caller has passed the bot/email gates, but that does not prove control
+  // of an address already in the waitlist. Do not turn a retry into an email
+  // membership oracle or disclose the existing row's referral metadata.
+  if (result.status === 'already_registered') {
+    return {
+      status: 'registered',
+      referralCode: '',
+      referralCount: 0,
+      position: 0,
+      emailSuppressed: false,
+    };
+  }
 
   if (result.status === 'registered' && result.referralCode) {
     if (!result.emailSuppressed) {

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1629,10 +1629,10 @@ async function dispatch(requestUrl, req, routes, context) {
       } catch {
         return json({ error: 'Registration failed' }, 502);
       }
-      if (result.status === 'already_registered') {
-        return json({ status: 'registered', referralCode: '', referralCount: 0, position: 0, emailSuppressed: false });
+      if (!result || (result.status !== 'registered' && result.status !== 'already_registered')) {
+        return json({ error: 'Registration failed' }, 502);
       }
-      return json(result.value || result);
+      return json({ status: 'registered', referralCode: '', referralCount: 0, position: 0, emailSuppressed: false });
     } catch (e) {
       context.logger.error(`[register-interest] error: ${e.message}`);
       return json({ error: 'Registration service unreachable' }, 502);

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1562,8 +1562,9 @@ async function dispatch(requestUrl, req, routes, context) {
     }
     return json({ verboseMode });
   }
-  // Registration — call Convex directly when CONVEX_URL is available (self-hosted),
-  // otherwise proxy to cloud (desktop sidecar never has CONVEX_URL).
+  // Registration — use the authenticated Convex HTTP bridge when CONVEX_URL is
+  // available (self-hosted), otherwise proxy to cloud (desktop sidecar never
+  // has CONVEX_URL).
   // Keeps the legacy /api/register-interest local path so older desktop builds
   // continue to work; cloud fallback rewrites to the new sebuf RPC path.
   if (requestUrl.pathname === '/api/register-interest' && req.method === 'POST') {
@@ -1594,20 +1595,42 @@ async function dispatch(requestUrl, req, routes, context) {
       if (!email || typeof email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
         return json({ error: 'Invalid email address' }, 400);
       }
-      const response = await fetchWithTimeout(`${convexUrl}/api/mutation`, {
+      const sharedSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+      if (!sharedSecret) {
+        context.logger.warn('[local-api] self-hosted register-interest bridge is not configured');
+        return json({ error: 'Registration service unavailable' }, 503);
+      }
+      const convexSiteUrl = (
+        process.env.CONVEX_SITE_URL || convexUrl.replace(/\.convex\.cloud\/?$/, '.convex.site')
+      ).replace(/\/$/, '');
+      const args = {
+        email,
+        source: typeof parsed.source === 'string' ? parsed.source : 'desktop',
+        appVersion: typeof parsed.appVersion === 'string' ? parsed.appVersion : 'unknown',
+      };
+      if (typeof parsed.referredBy === 'string') args.referredBy = parsed.referredBy;
+      const response = await fetchWithTimeout(`${convexSiteUrl}/api/internal-register-interest`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          path: 'registerInterest:register',
-          args: { email, source: parsed.source || 'desktop', appVersion: parsed.appVersion || 'unknown' },
-          format: 'json',
-        }),
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'worldmonitor-sidecar/1.0',
+          'x-convex-shared-secret': sharedSecret,
+        },
+        body: JSON.stringify(args),
       }, 15000);
+      if (!response.ok) {
+        context.logger.warn(`[local-api] self-hosted register-interest bridge returned ${response.status}`);
+        return json({ error: 'Registration failed' }, 502);
+      }
       const responseBody = await response.text();
       let result;
-      try { result = JSON.parse(responseBody); } catch { result = { status: 'registered' }; }
-      if (result.status === 'error') {
-        return json({ error: result.errorMessage || 'Registration failed' }, 500);
+      try {
+        result = JSON.parse(responseBody);
+      } catch {
+        return json({ error: 'Registration failed' }, 502);
+      }
+      if (result.status === 'already_registered') {
+        return json({ status: 'registered', referralCode: '', referralCount: 0, position: 0, emailSuppressed: false });
       }
       return json(result.value || result);
     } catch (e) {

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -781,6 +781,71 @@ test('preserves caller Authorization while hiding the sidecar transport token', 
   }
 });
 
+test('uses the authenticated Convex bridge for self-hosted register-interest', async () => {
+  const originalConvex = process.env.CONVEX_URL;
+  const originalSite = process.env.CONVEX_SITE_URL;
+  const originalSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+  const originalFetch = globalThis.fetch;
+  process.env.CONVEX_URL = 'https://self-hosted.convex.cloud';
+  process.env.CONVEX_SITE_URL = 'http://self-hosted.convex.site';
+  process.env.CONVEX_SERVER_SHARED_SECRET = 'convex-test-secret';
+
+  let captured;
+  globalThis.fetch = async (url, init) => {
+    captured = { url, init };
+    return new Response(JSON.stringify({
+      status: 'already_registered',
+      referralCode: 'secret-referral-code',
+      referralCount: 9,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  const localApi = await setupApiDir({});
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    remoteBase: 'https://worldmonitor.app',
+    logger: { log() { }, warn() { }, error() { } },
+  });
+  const { port } = await app.start();
+
+  try {
+    const response = await postJsonViaHttp(`http://127.0.0.1:${port}/api/register-interest`, {
+      email: 'self-hosted@example.com',
+      source: 'desktop-settings',
+      appVersion: '2.8.0',
+      referredBy: 'REF123',
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.json, {
+      status: 'registered',
+      referralCode: '',
+      referralCount: 0,
+      position: 0,
+      emailSuppressed: false,
+    });
+    assert.equal(captured.url, 'http://self-hosted.convex.site/api/internal-register-interest');
+    assert.equal(captured.init.headers['x-convex-shared-secret'], 'convex-test-secret');
+    assert.equal(captured.init.headers['User-Agent'], 'worldmonitor-sidecar/1.0');
+    assert.deepEqual(JSON.parse(captured.init.body), {
+      email: 'self-hosted@example.com',
+      source: 'desktop-settings',
+      appVersion: '2.8.0',
+      referredBy: 'REF123',
+    });
+  } finally {
+    await app.close();
+    await localApi.cleanup();
+    globalThis.fetch = originalFetch;
+    if (originalConvex === undefined) delete process.env.CONVEX_URL;
+    else process.env.CONVEX_URL = originalConvex;
+    if (originalSite === undefined) delete process.env.CONVEX_SITE_URL;
+    else process.env.CONVEX_SITE_URL = originalSite;
+    if (originalSecret === undefined) delete process.env.CONVEX_SERVER_SHARED_SECRET;
+    else process.env.CONVEX_SERVER_SHARED_SECRET = originalSecret;
+  }
+});
+
 test('does not forward the sidecar transport token through Docker cloud proxy routes', async () => {
   const originalConvex = process.env.CONVEX_URL;
   delete process.env.CONVEX_URL;

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -781,70 +781,74 @@ test('preserves caller Authorization while hiding the sidecar transport token', 
   }
 });
 
-test('uses the authenticated Convex bridge for self-hosted register-interest', async () => {
-  const originalConvex = process.env.CONVEX_URL;
-  const originalSite = process.env.CONVEX_SITE_URL;
-  const originalSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
-  const originalFetch = globalThis.fetch;
-  process.env.CONVEX_URL = 'https://self-hosted.convex.cloud';
-  process.env.CONVEX_SITE_URL = 'http://self-hosted.convex.site';
-  process.env.CONVEX_SERVER_SHARED_SECRET = 'convex-test-secret';
+for (const registrationStatus of ['registered', 'already_registered']) {
+  test(`uses the authenticated Convex bridge for self-hosted register-interest (${registrationStatus})`, async () => {
+    const originalConvex = process.env.CONVEX_URL;
+    const originalSite = process.env.CONVEX_SITE_URL;
+    const originalSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+    const originalFetch = globalThis.fetch;
+    process.env.CONVEX_URL = 'https://self-hosted.convex.cloud';
+    process.env.CONVEX_SITE_URL = 'http://self-hosted.convex.site';
+    process.env.CONVEX_SERVER_SHARED_SECRET = 'convex-test-secret';
 
-  let captured;
-  globalThis.fetch = async (url, init) => {
-    captured = { url, init };
-    return new Response(JSON.stringify({
-      status: 'already_registered',
-      referralCode: 'secret-referral-code',
-      referralCount: 9,
-    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
-  };
+    let captured;
+    globalThis.fetch = async (url, init) => {
+      captured = { url, init };
+      return new Response(JSON.stringify({
+        status: registrationStatus,
+        position: 7,
+        emailSuppressed: true,
+        referralCode: 'secret-referral-code',
+        referralCount: 9,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
 
-  const localApi = await setupApiDir({});
-  const app = await createLocalApiServer({
-    port: 0,
-    apiDir: localApi.apiDir,
-    remoteBase: 'https://worldmonitor.app',
-    logger: { log() { }, warn() { }, error() { } },
+    const localApi = await setupApiDir({});
+    const app = await createLocalApiServer({
+      port: 0,
+      apiDir: localApi.apiDir,
+      remoteBase: 'https://worldmonitor.app',
+      logger: { log() { }, warn() { }, error() { } },
+    });
+    const { port } = await app.start();
+
+    try {
+      const response = await postJsonViaHttp(`http://127.0.0.1:${port}/api/register-interest`, {
+        email: 'self-hosted@example.com',
+        source: 'desktop-settings',
+        appVersion: '2.8.0',
+        referredBy: 'REF123',
+      });
+      assert.equal(response.status, 200);
+      assert.deepEqual(response.json, {
+        status: 'registered',
+        referralCode: '',
+        referralCount: 0,
+        position: 0,
+        emailSuppressed: false,
+      });
+      assert.equal(captured.url, 'http://self-hosted.convex.site/api/internal-register-interest');
+      assert.equal(captured.init.headers['x-convex-shared-secret'], 'convex-test-secret');
+      assert.equal(captured.init.headers['User-Agent'], 'worldmonitor-sidecar/1.0');
+      assert.deepEqual(JSON.parse(captured.init.body), {
+        email: 'self-hosted@example.com',
+        source: 'desktop-settings',
+        appVersion: '2.8.0',
+        referredBy: 'REF123',
+      });
+    } finally {
+      await app.close();
+      await localApi.cleanup();
+      globalThis.fetch = originalFetch;
+      if (originalConvex === undefined) delete process.env.CONVEX_URL;
+      else process.env.CONVEX_URL = originalConvex;
+      if (originalSite === undefined) delete process.env.CONVEX_SITE_URL;
+      else process.env.CONVEX_SITE_URL = originalSite;
+      if (originalSecret === undefined) delete process.env.CONVEX_SERVER_SHARED_SECRET;
+      else process.env.CONVEX_SERVER_SHARED_SECRET = originalSecret;
+    }
   });
-  const { port } = await app.start();
-
-  try {
-    const response = await postJsonViaHttp(`http://127.0.0.1:${port}/api/register-interest`, {
-      email: 'self-hosted@example.com',
-      source: 'desktop-settings',
-      appVersion: '2.8.0',
-      referredBy: 'REF123',
-    });
-    assert.equal(response.status, 200);
-    assert.deepEqual(response.json, {
-      status: 'registered',
-      referralCode: '',
-      referralCount: 0,
-      position: 0,
-      emailSuppressed: false,
-    });
-    assert.equal(captured.url, 'http://self-hosted.convex.site/api/internal-register-interest');
-    assert.equal(captured.init.headers['x-convex-shared-secret'], 'convex-test-secret');
-    assert.equal(captured.init.headers['User-Agent'], 'worldmonitor-sidecar/1.0');
-    assert.deepEqual(JSON.parse(captured.init.body), {
-      email: 'self-hosted@example.com',
-      source: 'desktop-settings',
-      appVersion: '2.8.0',
-      referredBy: 'REF123',
-    });
-  } finally {
-    await app.close();
-    await localApi.cleanup();
-    globalThis.fetch = originalFetch;
-    if (originalConvex === undefined) delete process.env.CONVEX_URL;
-    else process.env.CONVEX_URL = originalConvex;
-    if (originalSite === undefined) delete process.env.CONVEX_SITE_URL;
-    else process.env.CONVEX_SITE_URL = originalSite;
-    if (originalSecret === undefined) delete process.env.CONVEX_SERVER_SHARED_SECRET;
-    else process.env.CONVEX_SERVER_SHARED_SECRET = originalSecret;
-  }
-});
+}
 
 test('does not forward the sidecar transport token through Docker cloud proxy routes', async () => {
   const originalConvex = process.env.CONVEX_URL;

--- a/tests/convex-http-json-object-guard.test.mjs
+++ b/tests/convex-http-json-object-guard.test.mjs
@@ -9,6 +9,7 @@ const source = readFileSync(resolve(__dirname, '..', 'convex', 'http.ts'), 'utf8
 
 const guardedPaths = [
   '/api/internal-entitlements',
+  '/api/internal-register-interest',
   '/api/user-prefs',
   '/api/telegram-pair-callback',
   '/relay/deactivate',

--- a/tests/register-interest-desktop-auth.test.mjs
+++ b/tests/register-interest-desktop-auth.test.mjs
@@ -1,7 +1,9 @@
 import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
+import { installRedis } from './helpers/fake-upstash-redis.mts';
 
 const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
 
 function makeCtx(headers = {}) {
   return {
@@ -51,6 +53,7 @@ describe('LeadsService.registerInterest desktop auth', () => {
   });
 
   afterEach(() => {
+    globalThis.fetch = originalFetch;
     Object.keys(process.env).forEach((key) => {
       if (!(key in originalEnv)) delete process.env[key];
     });
@@ -154,5 +157,102 @@ describe('LeadsService.registerInterest desktop auth', () => {
       () => registerInterest(makeCtx({ [timestampHeader]: timestamp, [signatureHeader]: signature }), req),
       (err) => err instanceof ApiError && err.statusCode === 503,
     );
+  });
+
+  it('forwards validated signups through the secret-guarded Convex HTTP bridge', async () => {
+    const redis = installRedis({});
+    process.env.CONVEX_SITE_URL = 'https://fake-convex.site';
+    process.env.CONVEX_SERVER_SHARED_SECRET = 'convex-test-secret';
+
+    const req = desktopReq({ email: 'bridge@example.com' });
+    const timestamp = String(Date.now());
+    const signature = await createDesktopAuthSignature(
+      process.env.WM_DESKTOP_SHARED_SECRET,
+      timestamp,
+      req,
+    );
+    let captured;
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.startsWith('https://redis.example')) {
+        return redis.fetchImpl(input, init);
+      }
+      if (url.startsWith('https://cloudflare-dns.com')) {
+        return new Response(JSON.stringify({ Answer: [{ type: 15, data: '10 mx.example.com.' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/dns-json' },
+        });
+      }
+      captured = { url, init };
+      return new Response(JSON.stringify({
+        status: 'registered',
+        referralCode: 'ref123',
+        referralCount: 0,
+        position: 7,
+        emailSuppressed: false,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const result = await registerInterest(
+      makeCtx({ [timestampHeader]: timestamp, [signatureHeader]: signature }),
+      req,
+    );
+
+    assert.deepEqual(result, {
+      status: 'registered',
+      referralCode: 'ref123',
+      referralCount: 0,
+      position: 7,
+      emailSuppressed: false,
+    });
+    assert.equal(captured.url, 'https://fake-convex.site/api/internal-register-interest');
+    assert.equal(captured.init.headers['x-convex-shared-secret'], 'convex-test-secret');
+    assert.equal(captured.init.headers['User-Agent'], 'worldmonitor-leads/1.0');
+    assert.deepEqual(JSON.parse(captured.init.body), {
+      email: 'bridge@example.com',
+      source: 'desktop-settings',
+      appVersion: '2.8.0',
+    });
+  });
+
+  it('hides existing-address membership and referral metadata on retries', async () => {
+    const redis = installRedis({});
+    process.env.CONVEX_SITE_URL = 'https://fake-convex.site';
+    process.env.CONVEX_SERVER_SHARED_SECRET = 'convex-test-secret';
+
+    const req = desktopReq({ email: 'repeat@example.com' });
+    const timestamp = String(Date.now());
+    const signature = await createDesktopAuthSignature(
+      process.env.WM_DESKTOP_SHARED_SECRET,
+      timestamp,
+      req,
+    );
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.startsWith('https://redis.example')) return redis.fetchImpl(input, init);
+      if (url.startsWith('https://cloudflare-dns.com')) {
+        return new Response(JSON.stringify({ Answer: [{ type: 15, data: '10 mx.example.com.' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/dns-json' },
+        });
+      }
+      return new Response(JSON.stringify({
+        status: 'already_registered',
+        referralCode: 'secret-referral-code',
+        referralCount: 9,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const result = await registerInterest(
+      makeCtx({ [timestampHeader]: timestamp, [signatureHeader]: signature }),
+      req,
+    );
+    assert.deepEqual(result, {
+      status: 'registered',
+      referralCode: '',
+      referralCount: 0,
+      position: 0,
+      emailSuppressed: false,
+    });
   });
 });

--- a/tests/register-interest-desktop-auth.test.mjs
+++ b/tests/register-interest-desktop-auth.test.mjs
@@ -163,6 +163,7 @@ describe('LeadsService.registerInterest desktop auth', () => {
     const redis = installRedis({});
     process.env.CONVEX_SITE_URL = 'https://fake-convex.site';
     process.env.CONVEX_SERVER_SHARED_SECRET = 'convex-test-secret';
+    process.env.RESEND_API_KEY = 'fake-resend-key';
 
     const req = desktopReq({ email: 'bridge@example.com' });
     const timestamp = String(Date.now());
@@ -172,6 +173,7 @@ describe('LeadsService.registerInterest desktop auth', () => {
       req,
     );
     let captured;
+    let confirmation;
     globalThis.fetch = async (input, init) => {
       const url = typeof input === 'string' ? input : input.url;
       if (url.startsWith('https://redis.example')) {
@@ -182,6 +184,10 @@ describe('LeadsService.registerInterest desktop auth', () => {
           status: 200,
           headers: { 'Content-Type': 'application/dns-json' },
         });
+      }
+      if (url === 'https://api.resend.com/emails') {
+        confirmation = JSON.parse(init.body);
+        return new Response('{}', { status: 200 });
       }
       captured = { url, init };
       return new Response(JSON.stringify({
@@ -200,9 +206,9 @@ describe('LeadsService.registerInterest desktop auth', () => {
 
     assert.deepEqual(result, {
       status: 'registered',
-      referralCode: 'ref123',
+      referralCode: '',
       referralCount: 0,
-      position: 7,
+      position: 0,
       emailSuppressed: false,
     });
     assert.equal(captured.url, 'https://fake-convex.site/api/internal-register-interest');
@@ -213,6 +219,7 @@ describe('LeadsService.registerInterest desktop auth', () => {
       source: 'desktop-settings',
       appVersion: '2.8.0',
     });
+    assert.ok(confirmation.html.includes('https://worldmonitor.app/pro?ref=ref123'));
   });
 
   it('hides existing-address membership and referral metadata on retries', async () => {


### PR DESCRIPTION
## Summary

- Make the Convex waitlist write internal so a direct Convex client cannot bypass the edge Turnstile, desktop proof, validation, rate-limit, and honeypot boundary.
- Add a shared-secret protected Convex HTTP bridge for the validated edge path.
- Return a uniform successful response for existing-address retries so anonymous callers do not learn membership, referral code, referral count, or position.
- Keep referrals, counters, suppression state, and confirmation-email behavior on the trusted path.

Fixes #7895

## Validation

- `node --import tsx --test tests/register-interest-desktop-auth.test.mjs tests/convex-http-json-object-guard.test.mjs` — 11 passed.
- `npm run test:convex -- convex/__tests__/registerInterest.test.ts convex/__tests__/emailSuppressions.test.ts` — 15 passed.
- `npm run typecheck` — passed.
- `npm run typecheck:api` — passed.
- `npm run lint:boundaries` — passed.
- Focused Biome check — passed.
- Pre-push gates — passed after generating required ignored inventory artifacts; the initial hook failure was the unrelated missing generated inventory artifact.
- No real email was sent; tests mock the Convex, Redis, and DNS surfaces.

## Post-Deploy Monitoring & Validation

- Search logs for `[register-interest] internal mutation failed`, `[register-interest] Convex HTTP`, `Registration service unavailable`, and unexpected `401` responses on `/api/internal-register-interest`.
- Monitor register-interest 2xx/4xx/5xx rates, Convex bridge latency, and waitlist registration volume for 24 hours after deployment.
- Healthy signals: valid browser and desktop submissions remain successful; retries return the generic success shape; referral and suppression behavior remains unchanged.
- Failure signals: elevated 503s, missing referral/suppression fields on new registrations, or direct Convex client requests succeeding without the shared secret. Investigate and roll back the edge/bridge change if these occur.
- Owner: WorldMonitor maintainers; validation window: first 24 hours after deployment.

## Known Residuals

None identified.

<!-- Compound Engineering: Luna xhigh / Codex desktop -->
