### PR TITLE
fix(security): harden Docker RSS sidecar boundaries

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -119,6 +119,25 @@ http {
       try_files /embed.js =404;
     }
 
+    # RSS responses are untrusted publisher content. Keep the browser from
+    # treating a proxied HTML/SVG body as a same-origin document, even if the
+    # sidecar is reached through a Docker ingress error or fallback path.
+    location = /api/rss-proxy {
+      add_header Origin-Agent-Cluster "?1" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header Content-Security-Policy "sandbox; default-src 'none'; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'" always;
+      proxy_pass http://127.0.0.1:${LOCAL_API_PORT};
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Origin http://localhost;
+      proxy_set_header X-WorldMonitor-Local-Token "${LOCAL_API_TOKEN}";
+      proxy_read_timeout 120s;
+      proxy_send_timeout 120s;
+    }
+
     # Native management is never exposed through the public Docker ingress.
     location ^~ /api/local- {
       add_header Origin-Agent-Cluster "?1" always;

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -310,6 +310,12 @@ const ALLOWED_ENV_KEYS = new Set([
 ]);
 
 const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+const RSS_PROXY_SECURITY_HEADERS = Object.freeze({
+  // RSS publishers are untrusted. The response must not become a same-origin
+  // document if a caller navigates to or frames the proxy URL.
+  'content-security-policy': "sandbox; default-src 'none'; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'",
+  'x-content-type-options': 'nosniff',
+});
 
 // ── SSRF protection ──────────────────────────────────────────────────────
 // Block requests to private/reserved IP ranges to prevent the RSS proxy
@@ -345,10 +351,30 @@ const BLOCKED_IPV4_RANGES = [
   return [baseInt, mask];
 });
 
+function ipv4FromMappedIPv6(ip) {
+  const normalized = String(ip).replace(/^\[|\]$/g, '');
+  if (isIP(normalized) !== 6) return null;
+
+  let canonical = normalized;
+  try {
+    canonical = new URL(`http://[${normalized}]/`).hostname.slice(1, -1);
+  } catch {
+    return null;
+  }
+
+  const match = canonical.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (!match) return null;
+
+  const high = Number.parseInt(match[1], 16);
+  const low = Number.parseInt(match[2], 16);
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff].join('.');
+}
+
 function isPrivateIP(ip) {
-  // IPv4-mapped IPv6 — extract the v4 portion
-  const v4Mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
-  const addr = v4Mapped ? v4Mapped[1] : ip;
+  // IPv4-mapped IPv6 — WHATWG URL parsing canonicalizes mapped literals to
+  // hexadecimal (for example, ::ffff:127.0.0.1 -> ::ffff:7f00:1), so
+  // normalize every valid IPv6 spelling before extracting the v4 portion.
+  const addr = ipv4FromMappedIPv6(ip) || ip;
 
   // IPv6 loopback
   if (addr === '::1' || addr === '::') return true;
@@ -435,6 +461,20 @@ function json(data, status = 200, extraHeaders = {}) {
   return new Response(JSON.stringify(data), {
     status,
     headers: { 'content-type': 'application/json', ...extraHeaders },
+  });
+}
+
+function rssProxyJson(data, status = 200) {
+  return json(data, status, RSS_PROXY_SECURITY_HEADERS);
+}
+
+function rssProxyResponse(body, status = 200) {
+  return new Response(body, {
+    status,
+    headers: {
+      ...RSS_PROXY_SECURITY_HEADERS,
+      'content-type': 'application/xml; charset=utf-8',
+    },
   });
 }
 
@@ -1628,13 +1668,13 @@ async function dispatch(requestUrl, req, routes, context) {
   // RSS proxy — fetch public feeds with SSRF protection
   if (requestUrl.pathname === '/api/rss-proxy') {
     const feedUrl = requestUrl.searchParams.get('url');
-    if (!feedUrl) return json({ error: 'Missing url parameter' }, 400);
+    if (!feedUrl) return rssProxyJson({ error: 'Missing url parameter' }, 400);
 
     // SSRF protection: block private IPs, reserved ranges, and DNS rebinding
     const safety = await isSafeUrl(feedUrl);
     if (!safety.safe) {
       context.logger.warn(`[local-api] rss-proxy SSRF blocked: ${safety.reason} (url=${feedUrl})`);
-      return json({ error: safety.reason }, 403);
+      return rssProxyJson({ error: safety.reason }, 403);
     }
 
     try {
@@ -1645,7 +1685,7 @@ async function dispatch(requestUrl, req, routes, context) {
       const pinned = pickPinnedAddress(safety.resolvedAddresses);
       if (!pinned) {
         context.logger.warn(`[local-api] rss-proxy SSRF blocked: no validated address (url=${feedUrl})`);
-        return json({ error: 'Could not resolve hostname' }, 403);
+        return rssProxyJson({ error: 'Could not resolve hostname' }, 403);
       }
       const response = await fetchWithTimeout(feedUrl, {
         headers: {
@@ -1656,15 +1696,11 @@ async function dispatch(requestUrl, req, routes, context) {
         resolvedAddress: pinned.address,
         resolvedFamily: pinned.family,
       }, parsed.hostname.includes('news.google.com') ? 20000 : 12000);
-      const contentType = response.headers?.get?.('content-type') || 'application/xml';
       const rssBody = await response.text();
-      return new Response(rssBody || '', {
-        status: response.status,
-        headers: { 'content-type': contentType },
-      });
+      return rssProxyResponse(rssBody || '', response.status);
     } catch (e) {
       const isTimeout = e.name === 'AbortError' || e.message?.includes('timeout');
-      return json({ error: isTimeout ? 'Feed timeout' : 'Failed to fetch feed', url: feedUrl }, isTimeout ? 504 : 502);
+      return rssProxyJson({ error: isTimeout ? 'Feed timeout' : 'Failed to fetch feed', url: feedUrl }, isTimeout ? 504 : 502);
     }
   }
 

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -2619,6 +2619,144 @@ test('rss-proxy pins an IPv6-only hostname to the validated address', async () =
   }
 });
 
+test('rss-proxy blocks IPv4-mapped IPv6 literals and DNS answers before transport', async () => {
+  const localApi = await setupApiDir({});
+  const originalResolve4 = dns.resolve4;
+  const originalResolve6 = dns.resolve6;
+  const originalHttpsRequest = https.request;
+  let outboundCalls = 0;
+
+  dns.resolve4 = async () => ['93.184.216.34'];
+  dns.resolve6 = async () => ['::ffff:7f00:1'];
+  https.request = () => {
+    outboundCalls += 1;
+    throw new Error('blocked mapped address must not reach the network');
+  };
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() {}, warn() {}, error() {} },
+  });
+  const { port } = await app.start();
+
+  try {
+    const mappedUrls = [
+      'https://[::ffff:127.0.0.1]/feed.xml',
+      'https://[0:0:0:0:0:ffff:127.0.0.1]/feed.xml',
+      'https://[::ffff:7f00:1]/feed.xml',
+      'https://[::ffff:c0a8:101]/feed.xml',
+      'https://[::ffff:a9fe:101]/feed.xml',
+      'https://[::ffff:c633:6401]/feed.xml',
+    ];
+    for (const feedUrl of mappedUrls) {
+      const response = await authFetch(
+        `http://127.0.0.1:${port}/api/rss-proxy?url=${encodeURIComponent(feedUrl)}`,
+      );
+      assert.equal(response.status, 403, feedUrl);
+      const body = await response.json();
+      assert.match(body.error, /private\/reserved/, feedUrl);
+    }
+
+    const dnsResponse = await authFetch(
+      `http://127.0.0.1:${port}/api/rss-proxy?url=${encodeURIComponent('https://mapped-dns.example/feed.xml')}`,
+    );
+    assert.equal(dnsResponse.status, 403);
+    assert.match((await dnsResponse.json()).error, /private\/reserved/);
+    assert.equal(outboundCalls, 0);
+  } finally {
+    dns.resolve4 = originalResolve4;
+    dns.resolve6 = originalResolve6;
+    https.request = originalHttpsRequest;
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
+test('rss-proxy forces active and error responses through an inert response policy', async () => {
+  const localApi = await setupApiDir({});
+  const originalResolve4 = dns.resolve4;
+  const originalResolve6 = dns.resolve6;
+  const originalHttpsRequest = https.request;
+  const upstreamResponses = [
+    {
+      statusCode: 200,
+      statusMessage: 'OK',
+      contentType: 'text/html; charset=utf-8',
+      body: '<html><script>globalThis.rssProxyExecuted = true;</script></html>',
+    },
+    {
+      statusCode: 502,
+      statusMessage: 'Bad Gateway',
+      contentType: 'image/svg+xml',
+      body: '<svg><script>globalThis.rssProxyExecuted = true;</script></svg>',
+    },
+  ];
+  let upstreamIndex = 0;
+
+  dns.resolve4 = async () => ['93.184.216.34'];
+  dns.resolve6 = async () => {
+    const error = new Error('No AAAA records');
+    error.code = 'ENODATA';
+    throw error;
+  };
+  https.request = (_options, onResponse) => {
+    const upstream = upstreamResponses[upstreamIndex++];
+    const req = new EventEmitter();
+    req.setTimeout = () => {};
+    req.write = () => {};
+    req.destroy = (error) => {
+      if (error) req.emit('error', error);
+    };
+    req.end = () => {
+      queueMicrotask(() => {
+        const res = new EventEmitter();
+        res.statusCode = upstream.statusCode;
+        res.statusMessage = upstream.statusMessage;
+        res.headers = { 'content-type': upstream.contentType };
+        onResponse(res);
+        res.emit('data', Buffer.from(upstream.body));
+        res.emit('end');
+      });
+    };
+    return req;
+  };
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() {}, warn() {}, error() {} },
+  });
+  const { port } = await app.start();
+
+  try {
+    for (const upstream of upstreamResponses) {
+      const response = await authFetch(
+        `http://127.0.0.1:${port}/api/rss-proxy?url=${encodeURIComponent('https://publisher.example/feed.xml')}`,
+      );
+      assert.equal(response.status, upstream.statusCode);
+      assert.equal(await response.text(), upstream.body);
+      assert.equal(response.headers.get('content-type'), 'application/xml; charset=utf-8');
+      assert.equal(response.headers.get('x-content-type-options'), 'nosniff');
+      assert.match(response.headers.get('content-security-policy') || '', /(?:^|;\s*)sandbox(?:;|$)/);
+      assert.match(response.headers.get('content-security-policy') || '', /script-src 'none'/);
+    }
+
+    for (const query of ['', '?url=http%3A%2F%2F127.0.0.1%2F']) {
+      const response = await authFetch(`http://127.0.0.1:${port}/api/rss-proxy${query}`);
+      assert.ok(response.status === 400 || response.status === 403);
+      assert.equal(response.headers.get('x-content-type-options'), 'nosniff');
+      assert.match(response.headers.get('content-security-policy') || '', /(?:^|;\s*)sandbox(?:;|$)/);
+    }
+  } finally {
+    dns.resolve4 = originalResolve4;
+    dns.resolve6 = originalResolve6;
+    https.request = originalHttpsRequest;
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
 test('rss-proxy rejects a hostname with mixed public and private DNS answers', async () => {
   const localApi = await setupApiDir({});
   const originalResolve4 = dns.resolve4;

--- a/tests/docker-sidecar-auth-config.test.mjs
+++ b/tests/docker-sidecar-auth-config.test.mjs
@@ -72,6 +72,19 @@ test('Docker nginx injects LOCAL_API_TOKEN through a private transport header', 
   assert.doesNotMatch(nginx, /proxy_set_header Authorization/);
 });
 
+test('Docker nginx applies an inert response policy to the RSS proxy route', () => {
+  const nginx = readProjectFile('docker/nginx.conf');
+  const rssBlock = nginx.match(/location = \/api\/rss-proxy \{[\s\S]*?\n    \}/)?.[0] ?? '';
+
+  assert.ok(rssBlock, 'RSS proxy must have a dedicated Docker location');
+  assert.match(rssBlock, /add_header X-Content-Type-Options "nosniff" always;/);
+  assert.match(rssBlock, /add_header Content-Security-Policy "sandbox; default-src 'none'; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'" always;/);
+  assert.match(rssBlock, /proxy_pass http:\/\/127\.0\.0\.1:\$\{LOCAL_API_PORT\};/);
+  assert.match(rssBlock, /proxy_set_header X-WorldMonitor-Local-Token "\$\{LOCAL_API_TOKEN\}";/);
+  assert.match(rssBlock, /proxy_read_timeout 120s;/);
+  assert.match(rssBlock, /proxy_send_timeout 120s;/);
+});
+
 test('Docker nginx denies the native administration namespace before the data proxy', () => {
   const nginx = readProjectFile('docker/nginx.conf');
   assert.match(nginx, /location \^~ \/api\/local- \{\s*add_header Origin-Agent-Cluster "\?1" always;\s*return 403;/);


### PR DESCRIPTION
## Summary

RSS proxy responses could inherit active publisher MIME types, so HTML or SVG bytes could execute when a caller navigated to or framed the proxy URL. The sidecar now emits a fixed inert XML response policy for feed success and error paths, and Docker gives `/api/rss-proxy` a dedicated protected ingress route. SSRF validation also normalizes WHATWG's hexadecimal IPv4-mapped IPv6 form before checking the existing private/reserved ranges, so mapped loopback, private, link-local, and documentation addresses are rejected before transport.

Valid feed bodies and upstream status codes remain unchanged for the client-side XML parser. The change does not alter the general `/api/` route because the YouTube embed endpoint intentionally serves executable HTML.

## Type of change

- [x] Bug fix
- [x] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [x] Config / Settings

## Affected areas

- [x] News panels / RSS feeds
- [x] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [x] Config / Settings

## Validation

- `npm run test:sidecar`: 469 passed, 0 failed.
- Focused sidecar and Docker contract tests: 94 passed, 1 optional live-Nginx test skipped.
- `npm run typecheck`, `npm run lint:boundaries`, `npm run lint`, and `git diff --check` passed.
- Headless browser probe against a harmless mocked HTML publisher: final response was `200`, `application/xml; charset=utf-8`, `X-Content-Type-Options: nosniff`, and the sandbox CSP; direct navigation did not execute the script, and the framed payload did not set the parent marker.
- Live Nginx was not available on the host. The dedicated Docker route is covered by `tests/docker-sidecar-auth-config.test.mjs` and still needs the normal image rebuild/redeploy for production activation.

## Post-Deploy Monitoring & Validation

- Rebuild and deploy the Docker image from this head.
- Request `/api/rss-proxy?url=<approved-feed>` through the Docker ingress and record `Content-Type`, `Content-Security-Policy`, and `X-Content-Type-Options`.
- Confirm a valid RSS/Atom feed still reaches the dashboard news parser and a non-2xx upstream status/body is preserved.
- Confirm logs contain no unexpected `rss-proxy SSRF blocked` events for approved public feeds; mapped private/reserved test addresses must remain blocked before outbound transport.

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] New RSS feed domains added to `api/rss-proxy.js` allowlist (not applicable)

Fixes #7891
Fixes #7892

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-Codex-000000)
