### PR TITLE
fix(dom): sanitize promoted safeHtml descendants

### DIFF
--- a/src/utils/dom-utils.ts
+++ b/src/utils/dom-utils.ts
@@ -105,14 +105,18 @@ export function safeHtml(html: string): DocumentFragment {
   const tpl = document.createElement('template');
   tpl.innerHTML = html;
   const walk = (parent: Element | DocumentFragment) => {
-    const children = Array.from(parent.childNodes);
-    for (const node of children) {
+    let index = 0;
+    while (index < parent.childNodes.length) {
+      const node = parent.childNodes[index];
+      if (!node) break;
       if (node.nodeType === Node.ELEMENT_NODE) {
         const el = node as Element;
         if (!SAFE_TAGS.has(el.tagName.toLowerCase())) {
           // Unwrap: keep children, remove the element itself
           while (el.firstChild) parent.insertBefore(el.firstChild, el);
           parent.removeChild(el);
+          // Promoted children now occupy this index. Visit them before moving
+          // on so nested rejected wrappers cannot hide unsafe descendants.
           continue;
         }
         // Strip unsafe attributes
@@ -143,6 +147,7 @@ export function safeHtml(html: string): DocumentFragment {
         }
         walk(el);
       }
+      index += 1;
     }
   };
   walk(tpl.content);

--- a/tests/dom/safe-html.test.mts
+++ b/tests/dom/safe-html.test.mts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { safeHtml } from '../../src/utils/dom-utils';
+
+describe('safeHtml', () => {
+  it('sanitizes descendants promoted out of nested rejected wrappers', () => {
+    const fragment = safeHtml(`
+      <marquee>
+        <svg>
+          <a href="javascript:alert(1)" onclick="alert(1)" style="color: red; background: url(https://evil.example)">
+            <strong>Safe text</strong>
+          </a>
+          <a href="https://example.com" target="_blank" style="color: blue">Valid link</a>
+        </svg>
+      </marquee>
+    `);
+    const host = document.createElement('div');
+    host.append(fragment);
+
+    expect(host.querySelector('marquee')).toBeNull();
+    expect(host.querySelector('svg')).toBeNull();
+
+    const links = Array.from(host.querySelectorAll('a'));
+    expect(links).toHaveLength(2);
+    expect(links[0]?.hasAttribute('href')).toBe(false);
+    expect(links[0]?.hasAttribute('onclick')).toBe(false);
+    expect(links[0]?.hasAttribute('style')).toBe(false);
+    expect(links[0]?.querySelector('strong')?.textContent).toBe('Safe text');
+
+    expect(links[1]?.getAttribute('href')).toBe('https://example.com');
+    expect(links[1]?.getAttribute('style')).toBe('color: blue');
+    expect(links[1]?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+});


### PR DESCRIPTION
## Summary

- Continue sanitizing `safeHtml()` after rejected elements are unwrapped, including descendants promoted through nested rejected wrappers.
- Preserve allowed formatting and safe links while removing unsafe attributes, URLs, and styles from the promoted descendants.
- Add an actual happy-dom parser regression test covering nested wrappers, unsafe attributes, unsafe style, valid formatting, and noopener behavior.

Fixes #7898

## Validation

- Pre-fix regression test failed because the nested `<svg>` wrapper and unsafe descendants remained after one-level unwrapping.
- `npm run test:dom -- tests/dom/safe-html.test.mts` — passed.
- `node --import tsx --test tests/dom-utils.test.mts` — 11 passed.
- `npm run test:dom` — 118 files, 947 tests passed.
- `npm run typecheck` and `npm run typecheck:dom-tests` — passed.
- `npm run lint`, `npm run lint:boundaries`, and `npm run lint:safe-html` — passed. Repository lint reports existing non-blocking diagnostics outside this diff.
- Pre-push gates — passed.
- No attacker-controlled input was found in the reviewed call paths; this change hardens the shared sanitizer against future or indirect HTML input.

## Post-Deploy Monitoring & Validation

- Search Sentry and browser error reports for new sanitizer or DOM traversal errors after deployment.
- Exercise the existing safe HTML consumers with representative allowed formatting and rejected nested wrappers during the first release validation window.
- Healthy signals: formatted text and safe links remain intact; rejected wrappers and unsafe attributes/URLs/styles are absent; no new DOM exceptions occur.
- Failure signals: dropped allowed formatting, malformed output, or sanitizer-related exceptions. Revert the traversal change if these occur.
- Owner: WorldMonitor maintainers; validation window: first 24 hours after deployment.

## Known Residuals

None identified.

<!-- Compound Engineering: Luna xhigh / Codex desktop -->
