### PR TITLE
fix(seo): mark stock workspace routes noindex

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -727,6 +727,19 @@ describe('crawlable content corpus deployment contracts', () => {
     }
   });
 
+  it('marks stock workspaces and their markdown twins noindex without breaking deep links (#7905)', () => {
+    for (const path of ['/stocks', '/stocks/', '/stocks.md', '/stocks/AAPL', '/stocks/ZZZZFAKE',
+      '/stocks/aapl/', '/stocks/BRK.B', '/stocks/7203.T', '/stocks/AAPL.md', '/stocks/ZZZZFAKE.md']) {
+      assert.equal(effectiveHeader(path, 'X-Robots-Tag'), 'noindex, follow', path);
+    }
+    for (const path of ['/dashboard', '/stocksmith', '/countries/united-states']) {
+      assert.equal(effectiveHeader(path, 'X-Robots-Tag'), null, path);
+    }
+    for (const symbol of ['AAPL', 'ZZZZFAKE', 'BRK.B', '7203.T']) {
+      assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: `/stocks/${symbol}` })?.destination, DASHBOARD_HTML_DESTINATION);
+    }
+  });
+
   it('serves no SPA fallback for generated corpus paths while keeping real client deep links', () => {
     // #6575: unknown paths must fall through to the filesystem (404), so the
     // only dashboard-serving rewrites left are the explicit client History

--- a/vercel.json
+++ b/vercel.json
@@ -146,6 +146,18 @@
   ],
   "headers": [
     {
+      "source": "/stocks",
+      "headers": [{ "key": "X-Robots-Tag", "value": "noindex, follow" }]
+    },
+    {
+      "source": "/stocks/(.*)",
+      "headers": [{ "key": "X-Robots-Tag", "value": "noindex, follow" }]
+    },
+    {
+      "source": "/stocks.md",
+      "headers": [{ "key": "X-Robots-Tag", "value": "noindex, follow" }]
+    },
+    {
       "source": "/mcp",
       "headers": [
         { "key": "Access-Control-Allow-Origin", "value": "*" },


### PR DESCRIPTION
## Summary

Stock workspace URLs such as `/stocks/ZZZZFAKE` currently return an indexable dashboard shell. Mark the stock route family and `/stocks.md` with `X-Robots-Tag: noindex, follow`, including symbol Markdown twins and trailing-slash URLs. Existing deep links keep working.

This takes the noindex floor proposed in the issue. The S&P 500 scanner is an index-specific upstream query, not an authoritative list of all supported stocks. Using it as an allowlist would reject valid symbols outside that index. All stock workspace shells receive the same indexing policy because none supplies a distinct server-rendered stock page. This prevents indexing; it does not eliminate crawl requests or change unknown symbols to 404.

Fixes #7905.

## Validation

- Production baseline: HEAD `/stocks/ZZZZFAKE` returned 200 with no X-Robots-Tag.
- Regression failed before the fix. The deployment test uses the existing strict route matcher and effective-header ordering, covering invented/real/dotted symbols, trailing slashes, Markdown twins, unrelated routes, and preserved dashboard rewrites.
- `node --import tsx --test tests/spa-fallback-scope.test.mjs tests/deploy-config.test.mjs tests/md-url-twin.test.mjs`: 330 passed, 6 skipped, 0 failed.
- `git diff --check` passed. Manual diff review completed; no review agents or external review automation invoked.
- Live Vercel header application remains unverified until preview/deployment. No UI rendering changes.

## Post-Deploy Monitoring & Validation

Owner: PR author. Within the first hour after an authorized deployment, check GET and HEAD for `/stocks`, `/stocks/ZZZZFAKE`, `/stocks/AAPL`, `/stocks/BRK.B`, and `/stocks/ZZZZFAKE.md` on www and finance hosts. Expect `X-Robots-Tag: noindex, follow` and working existing deep links; `/dashboard` must remain unaffected. Search request logs for `/stocks/` and check for new errors. Revert the header rules if deep links fail or unrelated pages receive noindex. Monitor Search Console indexing after recrawl; immediate crawl-volume reduction is not an acceptance criterion.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
