### PR TITLE
fix(china): recover SZSE disclosure coverage

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -3486,7 +3486,7 @@ function healthResponseBody(snapshot, compact) {
 
   const entries = snapshot.checks
     ? Object.entries(snapshot.checks).filter(
-      ([name, check]) => name !== 'chinaDecisionSignals' && (
+      ([name, check]) => (
         isProblemStatus(check.status)
         || (
           name === 'chinaCoverage'
@@ -3500,19 +3500,28 @@ function healthResponseBody(snapshot, compact) {
   const problems = Object.fromEntries(entries.filter(([, check]) => !isPendingHealthEntry(check, evaluatedAt)));
   const pending = Object.fromEntries(entries.filter(([, check]) => isPendingHealthEntry(check, evaluatedAt)));
   // Older compact snapshots may predate the operator-only China health
-  // projection. Strip it again at the response boundary so a cached value
-  // cannot leak source freshness details to anonymous status readers.
+  // projection. Reduce it to the public verdict again at the response boundary
+  // so a cached value cannot leak source freshness details to anonymous status
+  // readers while its warning still reconciles with summary.warn.
   // Same rule, applied per field rather than per check (#6060): a check's
   // STATUS is public, but its named entities are operator-only. `staleCountries`
   // and the decision-group breakdown identify WHICH source is degraded, which
-  // is exactly what the chinaDecisionSignals carve-out above exists to
+  // is exactly what the per-entry chinaDecisionSignals projection below exists to
   // withhold. `chinaRow` (#6395) names a country and says which part of a JODI
   // source is unusable, so it falls under the same rule. Runs on both shapes so
   // a cached compact snapshot written before this rule is scrubbed on the way
   // out too.
   for (const collection of [problems, pending]) {
-    delete collection.chinaDecisionSignals;
     for (const [name, check] of Object.entries(collection)) {
+      if (name === 'chinaDecisionSignals') {
+        collection[name] = { status: check?.status };
+        for (const { field } of ENTRY_SOFTENING_DEADLINES) {
+          if (Object.prototype.hasOwnProperty.call(check ?? {}, field)) {
+            collection[name][field] = check[field];
+          }
+        }
+        continue;
+      }
       if (check?.contentFreshness === undefined
         && check?.decisionGroups === undefined
         && check?.chinaRow === undefined) continue;

--- a/docs/china-corporate-disclosures.mdx
+++ b/docs/china-corporate-disclosures.mdx
@@ -13,7 +13,7 @@ service.
 | Exchange | Launch status | Admission decision | Collection contract |
 | --- | --- | --- | --- |
 | `SSE` | `launched` | `admitted_metadata_only` | Public announcement metadata, bounded first page, document links retained but bodies not fetched |
-| `SZSE` | `launched` | `admitted_metadata_only` | Public announcement metadata, bounded first page, document links retained but bodies not fetched |
+| `SZSE` | `launched` | `admitted_metadata_only` | Public announcement metadata, bounded two-page metadata collection, document links retained but bodies not fetched |
 | `HKEX` | `blocked` | `rejected` | No automated collection; `TERMS_PROHIBIT_AUTOMATED_ACCESS` |
 
 The reviewed terms records are:
@@ -66,9 +66,10 @@ in a bounded diagnostic collection rather than promoted to decision signals.
 ## Bounded collection
 
 SSE requests at most 100 rows from one reviewed 90-day page. SZSE requests at
-most 50 rows from one reviewed page. Neither adapter silently follows
-additional pages. A saturated page reports `PAGE_LIMIT_REACHED`; three
-consecutive empty results report `COVERAGE_GAP`.
+most two 50-row pages from the same reviewed window. The three-request total
+and two-proxy-request ceilings do not change. Results beyond those hard bounds
+report `PAGE_LIMIT_REACHED`; three consecutive empty results report
+`COVERAGE_GAP`.
 
 The combined snapshot retains at most 100 classified events, at most 20
 revisions per event, and at most 100 unclassified revisions. The Railway
@@ -95,8 +96,9 @@ Retries keep the selected host, credentials, and TLS mode. The China rotating
 port `30000` and unrecognized endpoint ranges stay unchanged.
 
 SSE uses up to four direct and four proxy requests with bounded concurrency.
-SZSE uses one direct attempt and up to two proxy attempts on distinct eligible
-gateway ports.
+SZSE uses at most 2 direct attempts and at most 2 proxy attempts on distinct
+eligible gateway ports. Both routes share a total ceiling of 3 requests per
+run.
 
 The fallback order applies only to transport failures. HTTP or schema results
 that prove an application-level response are recorded and do not trigger

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -850,7 +850,7 @@ This generated inventory covers **761 active source hosts** representing **748 a
 | www.sunnyskyz.com (www.sunnyskyz.com) | feed — src/config/feeds.ts |
 | www.svd.se (www.svd.se) | feed — src/config/feeds.ts |
 | www.svt.se (www.svt.se) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
-| www.szse.cn (www.szse.cn) | structured — scripts/china-stock-connect/adapters.mjs |
+| www.szse.cn (www.szse.cn) | structured — scripts/china-corporate-disclosures/adapters.mjs, scripts/china-stock-connect/adapters.mjs |
 | www.tagesschau.de (www.tagesschau.de) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | www.tanea.gr (www.tanea.gr) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | www.techinasia.com (www.techinasia.com) | feed+structured — server/worldmonitor/news/v1/_feeds.ts, src/config/variants/tech.ts |

--- a/docs/zh/china-corporate-disclosures.mdx
+++ b/docs/zh/china-corporate-disclosures.mdx
@@ -11,7 +11,7 @@ description: "SSE、SZSE、HKEX 来源准入、审核发行人、仅元数据采
 | 交易所 | 上线状态 | 准入决定 | 采集契约 |
 | --- | --- | --- | --- |
 | `SSE` | `launched` | `admitted_metadata_only` | 公共公告元数据、有界第一页；保留文件链接但不抓取正文 |
-| `SZSE` | `launched` | `admitted_metadata_only` | 公共公告元数据、有界第一页；保留文件链接但不抓取正文 |
+| `SZSE` | `launched` | `admitted_metadata_only` | 公共公告元数据、有界两页元数据采集；保留文件链接但不抓取正文 |
 | `HKEX` | `blocked` | `rejected` | 不自动采集；`TERMS_PROHIBIT_AUTOMATED_ACCESS` |
 
 审核条款记录为：
@@ -59,9 +59,9 @@ HKEX 发行人保留在审核注册表中，以便来源决定可见；它们不
 
 ## 有界采集
 
-SSE 在一个审核 90 天页面最多请求 100 行；SZSE 在一个审核页面最多请求 50 行。
-适配器不会静默追踪更多页面。页面饱和报告 `PAGE_LIMIT_REACHED`；连续三次空结果
-报告 `COVERAGE_GAP`。
+SSE 在一个审核 90 天页面最多请求 100 行；SZSE 在同一审核窗口最多请求两个
+50 行页面。总请求上限仍为三次，代理请求上限仍为两次。超过这些硬限制时报告
+`PAGE_LIMIT_REACHED`；连续三次空结果报告 `COVERAGE_GAP`。
 
 组合快照最多保留 100 个分类事件、每个事件 20 个修订，以及 100 个未分类修订。
 Railway market-backup 成员每 30 分钟运行并发布
@@ -81,8 +81,8 @@ SZSE: SZSE_PROXY_URL → PROXY_URL
 切换到下一个环境变量。SZSE 的不同代理尝试只会在已选代理配置内轮换符合条件的
 Decodo sticky gateway 端口。
 
-SSE 最多使用四个直接请求和四个代理请求，并限制并发。SZSE 使用一次直接尝试、
-最多两次符合条件的不同 gateway 端口代理尝试。
+SSE 最多使用四个直接请求和四个代理请求，并限制并发。SZSE 最多使用 2 次直接尝试、
+最多 2 次符合条件的不同 gateway 端口代理尝试。两种路线每次运行共享总上限 3 次请求。
 
 回退顺序只用于传输失败。能证明应用层响应的 HTTP 或 schema 结果会被记录，不会
 触发无界路线猜测。SZSE 需要连续两次成功运行才能清除持久传输失败状态。

--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -91,7 +91,7 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     metadataHost: 'www.szse.cn',
     documentHosts: CHINA_DISCLOSURE_DOCUMENT_HOSTS.SZSE,
     maxRequestsPerRun: 3,
-    maxDirectRequestsPerRun: 1,
+    maxDirectRequestsPerRun: 2,
     maxProxyRequestsPerRun: 2,
     transportRecoverySuccessRuns: SZSE_TRANSPORT_RECOVERY_SUCCESS_RUNS,
     fallbackPolicy: 'direct_then_proxy_on_transport_failure',
@@ -101,9 +101,9 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     maxResponseBytes: 131_072,
     redirectPolicy: 'error',
     documentRetrieval: 'lazy-link-only',
-    // Same bounded-first-page policy as SSE; saturation is an explicit health
-    // state, not permission to expand the source request budget automatically.
-    paginationPolicy: 'bounded_first_page',
+    // One extra page fits the existing one-direct-plus-two-proxy request
+    // ceiling. Counts beyond that hard bound stay visibly degraded.
+    paginationPolicy: 'bounded_two_pages',
     saturationBehavior: 'degraded_on_page_limit',
     emptyResultPolicy: Object.freeze({
       degradeAfterConsecutive: EMPTY_RESULT_DEGRADE_AFTER,
@@ -176,6 +176,7 @@ const SSE_PAGE_SIZE = 100;
 const SSE_DIRECT_TIMEOUT_MS = 20_000;
 const SSE_PROXY_TIMEOUT_MS = 12_000;
 const SZSE_PAGE_SIZE = 50;
+const SZSE_MAX_PAGES = 2;
 // Worst case (direct, two proxy attempts all time out) this
 // source can take about 55s before the bundle moves on. Keep this comfortably
 // inside the per-section timeoutMs configured in seed-bundle-market-backup.mjs.
@@ -191,10 +192,19 @@ export const CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS = (
     OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.sse.maxProxyRequestsPerRun
     / OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.sse.maxConcurrentRequests
   ) * SSE_PROXY_TIMEOUT_MS
-  + SZSE_DIRECT_TIMEOUT_MS
-  + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun * SZSE_PROXY_TIMEOUT_MS
-  + (OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun - 1)
-    * SZSE_PROXY_RETRY_DELAY_MS
+  + Math.max(
+    OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun
+      * SZSE_DIRECT_TIMEOUT_MS
+      + (
+        OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun
+        - OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun
+      ) * SZSE_PROXY_TIMEOUT_MS,
+    SZSE_DIRECT_TIMEOUT_MS
+      + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun
+        * SZSE_PROXY_TIMEOUT_MS
+      + (OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun - 1)
+        * SZSE_PROXY_RETRY_DELAY_MS,
+  )
 );
 const LAUNCHED_SOURCE_FETCHERS = Object.freeze([
   Object.freeze(['sse', fetchSseAnnouncements]),
@@ -400,6 +410,31 @@ export function normalizeSzseAnnouncements(payload, { retrievedAt = new Date().t
   return normalized;
 }
 
+function assertCompleteSzsePages(pages, total) {
+  if (!Number.isInteger(total) || total < 0) throw sourceError('MALFORMED_RESPONSE');
+
+  const announcementIds = new Set();
+  for (const [index, page] of pages.entries()) {
+    const pageTotal = Number(page.payload.announceCount);
+    const expectedRows = Math.max(
+      0,
+      Math.min(SZSE_PAGE_SIZE, total - index * SZSE_PAGE_SIZE),
+    );
+    if (
+      !Number.isFinite(pageTotal)
+      || pageTotal !== total
+      || page.payload.data.length !== expectedRows
+    ) {
+      throw sourceError('MALFORMED_RESPONSE');
+    }
+    for (const row of page.payload.data) {
+      const announcementId = String(row.annId);
+      if (announcementIds.has(announcementId)) throw sourceError('MALFORMED_RESPONSE');
+      announcementIds.add(announcementId);
+    }
+  }
+}
+
 function dateWindow(now, days = 90) {
   const end = new Date(now);
   const begin = new Date(now - days * 86_400_000);
@@ -529,14 +564,7 @@ async function fetchSzseAnnouncements(fetchFn, now, {
   const issuers = REVIEWED_DISCLOSURE_ISSUERS.filter((issuer) => issuer.exchange === 'SZSE');
   const url = new URL(contract.metadataEndpoint);
   url.searchParams.set('random', '0.5');
-  const body = JSON.stringify({
-    seDate: [begin, end],
-    channelCode: ['listedNotice_disc'],
-    stock: issuers.map((issuer) => issuer.securityCode),
-    pageSize: SZSE_PAGE_SIZE,
-    pageNum: 1,
-  });
-  const requestInit = (timeoutMs) => ({
+  const requestInit = (pageNum, timeoutMs) => ({
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -544,12 +572,18 @@ async function fetchSzseAnnouncements(fetchFn, now, {
       'Content-Type': 'application/json',
       'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
     },
-    body,
+    body: JSON.stringify({
+      seDate: [begin, end],
+      channelCode: ['listedNotice_disc'],
+      stock: issuers.map((issuer) => issuer.securityCode),
+      pageSize: SZSE_PAGE_SIZE,
+      pageNum,
+    }),
     redirect: contract.redirectPolicy,
     signal: AbortSignal.timeout(timeoutMs),
   });
-  const request = async (requestFn, timeoutMs) => {
-    const response = await requestFn(url, requestInit(timeoutMs));
+  const request = async (pageNum, requestFn, timeoutMs) => {
+    const response = await requestFn(url, requestInit(pageNum, timeoutMs));
     assertMetadataResponse(response, contract);
     const payload = await readBoundedJsonResponse(response, contract.maxResponseBytes);
     return {
@@ -558,8 +592,9 @@ async function fetchSzseAnnouncements(fetchFn, now, {
     };
   };
 
-  let fetched;
-  let requestCount = 1;
+  let requestCount = 0;
+  let directRequestCount = 0;
+  let proxyRequestCount = 0;
   let transportPath = 'direct';
   let fallbackReason = null;
   let proxyFailureReason = null;
@@ -567,63 +602,100 @@ async function fetchSzseAnnouncements(fetchFn, now, {
   // credential -- it is what makes "the fix never engaged" distinguishable from
   // "two distinct exits are both blocked" in the decision log.
   const proxyExitPorts = [];
-  try {
-    fetched = await request(fetchFn, SZSE_DIRECT_TIMEOUT_MS);
-  } catch (directError) {
-    fallbackReason = transportFailureReason(directError);
-    if (!shouldProxyExchangeFailure(directError)) throw directError;
+  const fail = (error) => {
+    const failure = sourceError(errorCodeFor(error), error);
+    failure.requestCount = requestCount;
+    failure.transportPath = transportPath;
+    if (fallbackReason) failure.fallbackReason = fallbackReason;
+    if (proxyFailureReason) failure.proxyFailureReason = proxyFailureReason;
+    if (proxyExitPorts.length) failure.proxyExitPorts = [...proxyExitPorts];
+    throw failure;
+  };
+  const requestViaProxy = async (pageNum) => {
     let proxyError = null;
-    if (proxyFetchFn) {
-      transportPath = 'proxy';
-      for (let attempt = 0; attempt < contract.maxProxyRequestsPerRun; attempt += 1) {
-        requestCount += 1;
-        try {
-          fetched = await request(
-            (input, init) => proxyFetchFn(
-              input,
-              init,
-              attempt,
-              (port) => { proxyExitPorts.push(port); },
-            ),
-            SZSE_PROXY_TIMEOUT_MS,
-          );
-          proxyError = null;
-          break;
-        } catch (error) {
-          proxyError = error;
-          if (
-            attempt + 1 < contract.maxProxyRequestsPerRun
-            && shouldRetryExchangeProxyFailure(error)
-          ) {
-            await new Promise((resolve) => setTimeout(resolve, SZSE_PROXY_RETRY_DELAY_MS));
-            continue;
-          }
-          break;
+    while (
+      proxyFetchFn
+      && proxyRequestCount < contract.maxProxyRequestsPerRun
+      && requestCount < contract.maxRequestsPerRun
+    ) {
+      const attempt = proxyRequestCount;
+      proxyRequestCount += 1;
+      requestCount += 1;
+      try {
+        const result = await request(
+          pageNum,
+          (input, init) => proxyFetchFn(
+            input,
+            init,
+            attempt,
+            (port) => { proxyExitPorts.push(port); },
+          ),
+          SZSE_PROXY_TIMEOUT_MS,
+        );
+        proxyFailureReason = null;
+        return result;
+      } catch (error) {
+        proxyError = error;
+        proxyFailureReason = transportFailureReason(error);
+        if (
+          proxyRequestCount < contract.maxProxyRequestsPerRun
+          && requestCount < contract.maxRequestsPerRun
+          && shouldRetryExchangeProxyFailure(error)
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, SZSE_PROXY_RETRY_DELAY_MS));
+          continue;
         }
+        break;
       }
-      proxyFailureReason = proxyError ? transportFailureReason(proxyError) : null;
     }
+    if (proxyError) fail(proxyError);
+    fail(sourceError('REQUEST_BUDGET_EXCEEDED'));
+  };
+  const requestDirect = async (pageNum) => {
+    if (
+      directRequestCount >= contract.maxDirectRequestsPerRun
+      || requestCount >= contract.maxRequestsPerRun
+    ) {
+      fail(sourceError('REQUEST_BUDGET_EXCEEDED'));
+    }
+    directRequestCount += 1;
+    requestCount += 1;
+    return request(pageNum, fetchFn, SZSE_DIRECT_TIMEOUT_MS);
+  };
+  const fetchPage = async (pageNum) => {
+    if (transportPath === 'proxy') return requestViaProxy(pageNum);
+    try {
+      return await requestDirect(pageNum);
+    } catch (directError) {
+      fallbackReason ??= transportFailureReason(directError);
+      if (!proxyFetchFn || !shouldProxyExchangeFailure(directError)) fail(directError);
+      transportPath = 'proxy';
+      return requestViaProxy(pageNum);
+    }
+  };
 
-    if (!fetched && proxyError) {
-      const failure = sourceError(errorCodeFor(proxyError), proxyError);
-      failure.requestCount = requestCount;
-      failure.transportPath = transportPath;
-      failure.fallbackReason = fallbackReason;
-      failure.proxyFailureReason = proxyFailureReason;
-      if (proxyExitPorts.length) failure.proxyExitPorts = [...proxyExitPorts];
-      throw failure;
-    }
-    if (!fetched) throw directError;
+  const fetched = await fetchPage(1);
+  const total = Number(fetched.payload.announceCount);
+  const totalPages = Math.max(1, Math.ceil(total / SZSE_PAGE_SIZE));
+  const pages = [fetched];
+  for (let pageNum = 2; pageNum <= Math.min(totalPages, SZSE_MAX_PAGES); pageNum += 1) {
+    pages.push(await fetchPage(pageNum));
   }
 
-  const contentTruncated = Number(fetched.payload.announceCount) > SZSE_PAGE_SIZE;
+  try {
+    assertCompleteSzsePages(pages, total);
+  } catch (error) {
+    fail(error);
+  }
+
+  const contentTruncated = totalPages > SZSE_MAX_PAGES;
   return {
     sourceId: 'szse',
     ok: !contentTruncated,
     partial: contentTruncated,
     transportOk: true,
     requestCount,
-    announcements: fetched.announcements,
+    announcements: pages.flatMap((page) => page.announcements),
     errorCode: contentTruncated ? 'PAGE_LIMIT_REACHED' : null,
     transportPath,
     ...(fallbackReason ? { fallbackReason } : {}),

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -13571,6 +13571,9 @@
       "status": "terms-review",
       "references": [
         {
+          "path": "scripts/china-corporate-disclosures/adapters.mjs"
+        },
+        {
           "path": "scripts/china-stock-connect/adapters.mjs"
         }
       ]

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -32,6 +32,28 @@ import {
 const fixtureRoot = resolve(import.meta.dirname, 'fixtures/china-corporate-disclosures');
 const fixture = (name: string) => JSON.parse(readFileSync(resolve(fixtureRoot, name), 'utf8'));
 const retrievedAt = '2026-07-25T10:00:00.000Z';
+const szsePage = (
+  total: number,
+  pageNum: number,
+  options: { announceCount?: number; data?: Array<Record<string, unknown>> } = {},
+) => {
+  const start = (pageNum - 1) * 50;
+  const rowCount = Math.max(0, Math.min(50, total - start));
+  const template = fixture('szse.json').data[0];
+  return {
+    announceCount: options.announceCount ?? total,
+    data: options.data ?? Array.from({ length: rowCount }, (_, offset) => {
+      const sequence = start + offset + 1;
+      return {
+        ...template,
+        id: `8b${String(sequence).padStart(6, '0')}-0000-0000-0000-000000000000`,
+        annId: 1_225_400_000 + sequence,
+        title: `宁德时代：第 ${sequence} 份股票停牌公告`,
+        attachPath: `/disc/disk03/finalpage/2026-07-24/szse-${sequence}.PDF`,
+      };
+    }),
+  };
+};
 
 describe('official China corporate disclosures (#5577)', () => {
   it('maps only the reviewed A/H basket and keeps HKEX blocked', () => {
@@ -67,7 +89,10 @@ describe('official China corporate disclosures (#5577)', () => {
       assert.ok(contract.maxResponseBytes >= 32_000 && contract.maxResponseBytes <= 262_144);
       assert.equal(contract.redirectPolicy, 'error');
       assert.equal(contract.documentRetrieval, 'lazy-link-only');
-      assert.equal(contract.paginationPolicy, 'bounded_first_page');
+      assert.equal(
+        contract.paginationPolicy,
+        id === 'szse' ? 'bounded_two_pages' : 'bounded_first_page',
+      );
       assert.equal(contract.saturationBehavior, 'degraded_on_page_limit');
       assert.deepEqual(contract.emptyResultPolicy, {
         degradeAfterConsecutive: EMPTY_RESULT_DEGRADE_AFTER,
@@ -105,7 +130,7 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.ok(timeoutMatch, 'China disclosure bundle section must declare timeoutMs');
     const sectionTimeoutMs = Number(timeoutMatch[1].replaceAll('_', ''));
 
-    assert.equal(CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS, 103_250);
+    assert.equal(CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS, 106_000);
     assert.ok(
       sectionTimeoutMs - CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS >= 20_000,
       'network attempts must leave at least 20s for startup, parsing, publication, and shutdown',
@@ -183,15 +208,27 @@ describe('official China corporate disclosures (#5577)', () => {
     });
 
     assert.equal(snapshot.status, 'healthy');
-    assert.equal(
+    assert.deepEqual(
       snapshot.sourceDecisions
         .filter((decision) => decision.launchStatus === 'launched')
-        .every(
-          (decision) => decision.paginationPolicy === 'bounded_first_page'
-            && decision.saturationBehavior === 'degraded_on_page_limit',
-        ),
-      true,
-      'the persisted source decision documents the intentional saturation behavior',
+        .map((decision) => ({
+          id: decision.id,
+          paginationPolicy: decision.paginationPolicy,
+          saturationBehavior: decision.saturationBehavior,
+        })),
+      [
+        {
+          id: 'sse',
+          paginationPolicy: 'bounded_first_page',
+          saturationBehavior: 'degraded_on_page_limit',
+        },
+        {
+          id: 'szse',
+          paginationPolicy: 'bounded_two_pages',
+          saturationBehavior: 'degraded_on_page_limit',
+        },
+      ],
+      'the persisted source decision documents each bounded saturation policy',
     );
     assert.deepEqual(
       [...new Set(snapshot.events.map((event) => event.disclosureType))].sort(),
@@ -992,15 +1029,15 @@ describe('official China corporate disclosures (#5577)', () => {
     );
     assert.equal(partial.events.some((event) => event.exchange === 'SSE'), true);
 
-    const saturatedCalls: Array<string> = [];
+    const saturatedCalls: Array<{ url: string; init?: RequestInit }> = [];
     const saturatedDecisions: Array<{ sourceId: string; reason?: string }> = [];
     const saturated = await fetchChinaCorporateDisclosureSnapshot({
       now: Date.parse('2026-07-25T12:00:00.000Z'),
       previousSnapshot: snapshot,
       onDecision: (decision) => saturatedDecisions.push(decision),
-      fetchFn: async (input) => {
+      fetchFn: async (input, init) => {
         const url = String(input);
-        saturatedCalls.push(url);
+        saturatedCalls.push({ url, init });
         if (url.includes('query.sse.com.cn')) {
           const productId = new URL(url).searchParams.get('productId');
           const payload = productId === '600519'
@@ -1008,12 +1045,14 @@ describe('official China corporate disclosures (#5577)', () => {
             : { pageHelp: { pageNo: 1, pageSize: 100, total: 0 }, result: [] };
           return new Response(JSON.stringify(payload), { status: 200 });
         }
-        return new Response(JSON.stringify({ ...fixture('szse.json'), announceCount: 51 }), {
+        const pageNum = JSON.parse(String(init?.body)).pageNum;
+        const payload = szsePage(51, pageNum);
+        return new Response(JSON.stringify(payload), {
           status: 200,
         });
       },
     });
-    assert.equal(saturatedCalls.length, 5);
+    assert.equal(saturatedCalls.length, 6);
     assert.equal(saturated.status, 'degraded');
     assert.equal(saturated.sources.find((source) => source.id === 'sse')?.transportStatus, 'fresh');
     assert.equal(saturated.sources.find((source) => source.id === 'sse')?.contentStatus, 'partial');
@@ -1022,11 +1061,166 @@ describe('official China corporate disclosures (#5577)', () => {
       '2026-07-25T12:00:00.000Z',
       'a complete transport that reaches the bounded page limit is still a successful collection',
     );
-    assert.equal(saturated.sources.find((source) => source.id === 'szse')?.contentStatus, 'partial');
+    assert.equal(saturated.sources.find((source) => source.id === 'szse')?.contentStatus, 'current');
+    assert.deepEqual(
+      saturatedCalls
+        .filter((call) => call.url.includes('www.szse.cn'))
+        .map((call) => JSON.parse(String(call.init?.body)).pageNum),
+      [1, 2],
+    );
     assert.equal(
       saturatedDecisions.filter((decision) => decision.reason === 'PAGE_LIMIT_REACHED').length,
-      2,
+      1,
     );
+  });
+
+  it('fails closed when the bounded second SZSE page cannot be fetched', async () => {
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse('2026-07-25T12:00:00.000Z'),
+      previousSnapshot: null,
+      onDecision: () => {},
+      fetchFn: async (input, init) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({ pageHelp: { total: 0 }, result: [] }), {
+            status: 200,
+          });
+        }
+        const pageNum = JSON.parse(String(init?.body)).pageNum;
+        if (pageNum === 2) throw Object.assign(new Error('page 2 timed out'), { name: 'TimeoutError' });
+        return new Response(JSON.stringify(szsePage(51, 1)), {
+          status: 200,
+        });
+      },
+    });
+
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.equal(snapshot.status, 'degraded');
+    assert.equal(szse?.transportStatus, 'error');
+    assert.equal(szse?.contentStatus, 'unavailable');
+    assert.equal(szse?.errorCode, 'TIMEOUT');
+  });
+
+  it('keeps SZSE partial when more than two pages are available', async () => {
+    const requestedPages: number[] = [];
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse('2026-07-25T12:00:00.000Z'),
+      previousSnapshot: null,
+      onDecision: () => {},
+      fetchFn: async (input, init) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({ pageHelp: { total: 0 }, result: [] }), {
+            status: 200,
+          });
+        }
+        const pageNum = JSON.parse(String(init?.body)).pageNum;
+        requestedPages.push(pageNum);
+        return new Response(JSON.stringify(szsePage(101, pageNum)), { status: 200 });
+      },
+    });
+
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.deepEqual(requestedPages, [1, 2]);
+    assert.equal(snapshot.status, 'degraded');
+    assert.equal(szse?.transportStatus, 'fresh');
+    assert.equal(szse?.contentStatus, 'partial');
+    assert.equal(szse?.requestCount, 2);
+    assert.equal(szse?.errorCode, 'PAGE_LIMIT_REACHED');
+  });
+
+  it('rejects incomplete or inconsistent bounded SZSE pages', async () => {
+    const pageOne = szsePage(51, 1);
+    const cases = [
+      {
+        name: 'empty first page',
+        response: (pageNum: number) => pageNum === 1
+          ? szsePage(51, 1, { data: [] })
+          : szsePage(51, 2),
+      },
+      {
+        name: 'duplicate announcement across pages',
+        response: (pageNum: number) => pageNum === 1
+          ? pageOne
+          : szsePage(51, 2, { data: [pageOne.data[0]] }),
+      },
+      {
+        name: 'changed total on second page',
+        response: (pageNum: number) => pageNum === 1
+          ? pageOne
+          : szsePage(51, 2, { announceCount: 52 }),
+      },
+    ];
+
+    for (const testCase of cases) {
+      const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+        now: Date.parse('2026-07-25T12:00:00.000Z'),
+        previousSnapshot: null,
+        onDecision: () => {},
+        fetchFn: async (input, init) => {
+          const url = String(input);
+          if (url.includes('query.sse.com.cn')) {
+            return new Response(JSON.stringify({ pageHelp: { total: 0 }, result: [] }), {
+              status: 200,
+            });
+          }
+          const pageNum = JSON.parse(String(init?.body)).pageNum;
+          return new Response(JSON.stringify(testCase.response(pageNum)), { status: 200 });
+        },
+      });
+
+      const szse = snapshot.sources.find((source) => source.id === 'szse');
+      assert.equal(snapshot.status, 'degraded', testCase.name);
+      assert.equal(szse?.transportStatus, 'error', testCase.name);
+      assert.equal(szse?.contentStatus, 'unavailable', testCase.name);
+      assert.equal(szse?.requestCount, 2, testCase.name);
+      assert.equal(szse?.errorCode, 'MALFORMED_RESPONSE', testCase.name);
+    }
+  });
+
+  it('recovers a failed direct second SZSE page through the proxy', async () => {
+    const directPages: number[] = [];
+    const proxyPages: number[] = [];
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      onDecision: () => {},
+      fetchFn: async (input, init) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({ pageHelp: { total: 0 }, result: [] }), {
+            status: 200,
+          });
+        }
+        const pageNum = JSON.parse(String(init?.body)).pageNum;
+        directPages.push(pageNum);
+        if (pageNum === 2) {
+          throw Object.assign(new TypeError('fetch failed'), {
+            cause: Object.assign(new Error('connection reset'), { code: 'ECONNRESET' }),
+          });
+        }
+        return new Response(JSON.stringify(szsePage(51, pageNum)), { status: 200 });
+      },
+      proxyRequestFn: async (_input, _proxyConfig, options) => {
+        const pageNum = JSON.parse(String(options.body)).pageNum;
+        proxyPages.push(pageNum);
+        return {
+          buffer: Buffer.from(JSON.stringify(szsePage(51, pageNum))),
+          status: 200,
+          contentType: 'application/json',
+        };
+      },
+    });
+
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.deepEqual(directPages, [1, 2]);
+    assert.deepEqual(proxyPages, [2]);
+    assert.equal(snapshot.status, 'healthy');
+    assert.equal(szse?.transportStatus, 'fresh');
+    assert.equal(szse?.contentStatus, 'current');
+    assert.equal(szse?.requestCount, 3);
+    assert.equal(szse?.transportPath, 'proxy');
   });
 
   it('falls back to a bounded proxy request when the direct SZSE transport fails', async () => {
@@ -1070,8 +1264,10 @@ describe('official China corporate disclosures (#5577)', () => {
           proxyConfig,
           options,
         });
+        const pageNum = JSON.parse(String(options.body)).pageNum;
+        const payload = szsePage(51, pageNum);
         return {
-          buffer: Buffer.from(JSON.stringify(fixture('szse.json'))),
+          buffer: Buffer.from(JSON.stringify(payload)),
           status: 200,
           contentType: 'application/json',
         };
@@ -1080,43 +1276,60 @@ describe('official China corporate disclosures (#5577)', () => {
 
     assert.equal(snapshot.status, 'healthy');
     assert.equal(directCalls.filter((call) => call.url.includes('www.szse.cn')).length, 1);
-    assert.equal(proxyCalls.length, 1);
+    assert.equal(proxyCalls.length, 2);
     assert.match(proxyCalls[0].url, /^https:\/\/www\.szse\.cn\/api\/disc\/announcement\/annList/);
-    assert.deepEqual(proxyCalls[0].proxyConfig, {
-      host: 'proxy.test',
-      port: 443,
-      auth: 'proxy-user:proxy-secret',
-      tls: true,
-    });
-    assert.equal(proxyCalls[0].options.method, 'POST');
     assert.equal(
-      proxyCalls[0].options.maxResponseBytes,
-      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxResponseBytes,
+      proxyCalls.every((call) => call.url === proxyCalls[0].url),
+      true,
     );
-    assert.deepEqual(
-      JSON.parse(String(proxyCalls[0].options.body)),
+    assert.equal(proxyCalls.every((call) => call.options.method === 'POST'), true);
+    assert.equal(
+      proxyCalls.every(
+        (call) => call.options.maxResponseBytes
+          === OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxResponseBytes,
+      ),
+      true,
+    );
+    assert.deepEqual(proxyCalls.map((call) => call.proxyConfig), [
       {
+        host: 'proxy.test',
+        port: 443,
+        auth: 'proxy-user:proxy-secret',
+        tls: true,
+      },
+      {
+        host: 'proxy.test',
+        port: 443,
+        auth: 'proxy-user:proxy-secret',
+        tls: true,
+      },
+    ]);
+    assert.deepEqual(
+      proxyCalls.map((call) => JSON.parse(String(call.options.body))),
+      [1, 2].map((pageNum) => ({
         seDate: ['2026-04-26', '2026-07-25'],
         channelCode: ['listedNotice_disc'],
         stock: ['300750'],
         pageSize: 50,
-        pageNum: 1,
-      },
+        pageNum,
+      })),
     );
 
     const szse = snapshot.sources.find((source) => source.id === 'szse');
     assert.equal(szse?.transportStatus, 'fresh');
     assert.equal(szse?.contentStatus, 'current');
-    assert.equal(szse?.requestCount, 2);
+    assert.equal(szse?.requestCount, 3);
     assert.equal(szse?.transportPath, 'proxy');
     assert.equal(szse?.fallbackReason, 'UND_ERR_CONNECT_TIMEOUT');
     assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun, 3);
-    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun, 1);
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun, 2);
     assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun, 2);
-    assert.equal(
-      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun,
+    assert.ok(
+      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun
+        <
       OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun
         + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun,
+      'the shared total ceiling prevents both route-specific maxima in one run',
     );
     assert.equal(
       OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.fallbackPolicy,
@@ -1127,11 +1340,11 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.deepEqual(szseDecision, {
       sourceId: 'szse',
       status: 'accepted',
-      requestCount: 2,
+      requestCount: 3,
       emptyResultCount: 0,
       transportPath: 'proxy',
       fallbackReason: 'UND_ERR_CONNECT_TIMEOUT',
-      proxyExitPorts: [443],
+      proxyExitPorts: [443, 443],
       proxyExitRotated: false,
       reliabilityStatus: 'stable',
       requiredRecoverySuccesses: 2,

--- a/tests/china-decision-access-contract.test.mts
+++ b/tests/china-decision-access-contract.test.mts
@@ -206,7 +206,7 @@ describe('China decision-signal access tiers (#5580)', () => {
     assert.deepEqual(await response.json(), { error: 'Operator API key required' });
   });
 
-  it('keeps China source freshness out of the anonymous compact health projection', () => {
+  it('keeps the China verdict but removes source freshness from anonymous compact health', () => {
     const compact = healthTesting.healthResponseBody({
       status: 'WARNING',
       summary: { ok: 1, warning: 2 },
@@ -224,7 +224,7 @@ describe('China decision-signal access tiers (#5580)', () => {
       },
     }, true);
 
-    assert.equal(compact.problems?.chinaDecisionSignals, undefined);
+    assert.deepEqual(compact.problems?.chinaDecisionSignals, { status: 'STALE_SEED' });
     assert.equal(compact.problems?.publicExample?.status, 'STALE_SEED');
   });
 

--- a/tests/china-documentation-contract.test.mts
+++ b/tests/china-documentation-contract.test.mts
@@ -195,6 +195,27 @@ describe('China documentation contract', () => {
       english.includes('not sequential URL failover'),
       'English disclosure transport documentation must distinguish precedence from failover',
     );
+    const szseContract = OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse;
+    assertIncludesEvery(
+      english,
+      [
+        'bounded two-page metadata collection',
+        `at most ${szseContract.maxDirectRequestsPerRun} direct attempts`,
+        `at most ${szseContract.maxProxyRequestsPerRun} proxy attempts`,
+        `total ceiling of ${szseContract.maxRequestsPerRun} requests`,
+      ],
+      'English SZSE collection documentation',
+    );
+    assertIncludesEvery(
+      chinese,
+      [
+        '有界两页元数据采集',
+        `最多使用 ${szseContract.maxDirectRequestsPerRun} 次直接尝试`,
+        `最多 ${szseContract.maxProxyRequestsPerRun} 次符合条件的不同 gateway 端口代理尝试`,
+        `共享总上限 ${szseContract.maxRequestsPerRun} 次请求`,
+      ],
+      'Chinese SZSE collection documentation',
+    );
   });
 
   it('documents every configured logistics corridor, signal family, and source family', () => {

--- a/tests/health-content-freshness.test.mjs
+++ b/tests/health-content-freshness.test.mjs
@@ -623,9 +623,10 @@ describe('portwatchPortActivity classification', () => {
   });
 
   // The anonymous `?compact=1` projection echoes whole check entries for every
-  // problem status. `chinaDecisionSignals` is already stripped there because
-  // China source freshness is operator-only; a named stale-country list is the
-  // same class of detail and must not ride out on the public status endpoint.
+  // problem status. `chinaDecisionSignals` is reduced to its public verdict
+  // because China source freshness is operator-only; a named stale-country
+  // list is the same class of detail and must not ride out on the public status
+  // endpoint.
   it('keeps named stale countries out of the anonymous compact projection', () => {
     const entry = classifyPortwatch(completeRun(contentFreshnessOf({
       freshCount: 173,
@@ -659,7 +660,10 @@ describe('portwatchPortActivity classification', () => {
         assert.equal(publicEntry?.contentFreshness, undefined, 'the per-country detail does not');
         assert.equal(publicEntry?.decisionGroups, undefined);
         assert.equal(publicEntry?.chinaRow, undefined);
-        assert.equal(compact[collection]?.chinaDecisionSignals, undefined);
+        assert.deepEqual(compact[collection]?.chinaDecisionSignals, {
+          status: 'STALE_CONTENT',
+          ...(inGrace ? { staleContentGraceUntil: diagnostic.staleContentGraceUntil } : {}),
+        });
         assert.doesNotMatch(JSON.stringify(compact), /"CN"/);
         assert.deepEqual(healthResponseBody(compact, true), compact);
       }


### PR DESCRIPTION
## Summary

SZSE corporate disclosures no longer degrade China decision coverage when the reviewed 90-day window contains 51-100 announcements. The seeder now reads a bounded second 50-row page while keeping the existing ceilings of three total requests and two proxy requests per run.

The collection still fails closed: counts above 100 remain `PAGE_LIMIT_REACHED`, and short, duplicated, or count-changing pages cannot refresh last-good data. Anonymous compact health now names `chinaDecisionSignals` with a privacy-safe status projection, so `summary.warn` cannot appear without its corresponding problem.

## Validation

- 92 focused China disclosure, health, access-contract, registration, and documentation tests passed.
- The pre-push gate passed TypeScript checks, API type checks, changed tests, 907 edge/docs tests, architectural boundaries, policy checks, and version checks.
- Code review findings for inconsistent pages, the 100-row ceiling, page-two proxy recovery, and stale docs were fixed before push.

## Post-deploy monitoring

- Watch `seed-bundle-market-backup` for `China-Corporate-Disclosures` decisions across two natural 30-minute runs.
- Accept when SZSE reports `accepted`, the bounded 51-100 path completes within three requests, China decision signals return to 6/6 operational coverage, and compact health has no unnamed warning.
- Treat a page-integrity error, a request-budget breach, continued `PAGE_LIMIT_REACHED` at 100 or fewer rows, or a persistent China warning as a rollback/investigation trigger.
- Counts above 100 intentionally remain degraded until a separate capacity decision changes the hard ceiling.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
