### PR TITLE
fix(sidecar): validate URL objects before outbound fetch

### DIFF
--- a/docs/operations/security-7902-release-acceptance.md
+++ b/docs/operations/security-7902-release-acceptance.md
@@ -1,0 +1,64 @@
+# Security repair release acceptance (#7902)
+
+This packet covers #7907–#7911, #7913 and #7914. It is a release-owner
+checklist, not deployment or message authorization. Keep acceptance separate
+from merge and CI. Use synthetic accounts and owned destinations; keep account
+identifiers, addresses, chat IDs and credentials out of public evidence.
+
+## Decisions before live acceptance
+
+1. Approve email re-verification and Telegram re-pairing for existing connections.
+   Old unproven rows stop delivering. Do not backfill ownership markers from old
+   flags, billing data or account email. Use the existing settings flow and the
+   [email procedure](notification-email-ownership.md) and
+   [Telegram procedure](telegram-recipient-proof.md).
+2. Designate one test account, an owned verified mailbox and a private test chat.
+   Explicitly approve a welcome, one realtime alert, one due digest and the
+   deactivation check for these destinations. Reused/expired pairing links and
+   an unrelated synthetic email destination must cause no delivery.
+3. Verify that Convex can use the matching Clerk instance's backend credential.
+   Record only instance alignment and success/failure, never credential values.
+   Missing credentials must fail closed. Deployment metadata alone cannot prove
+   Clerk configuration, recipient proof or delivery.
+
+## Refresh before taking action
+
+Record exact revisions and status for the Vercel production deployment, the
+`convex-deployed` tag and its successful deploy job, and each Railway worker's
+latest successful deployment. A skipped worker build is not a new deployment.
+Compare the revisions with the relevant fixes using commit ancestry. Do not
+redeploy already-current services merely because old PR prose says deployment
+is pending. Historical activation order cannot be inferred from creation times.
+
+For any separately approved rollout, deploy Convex before relay and digest.
+Retain delivery guards if recovery is needed. Never restore unproven delivery.
+For Docker, record the immutable image digest, source revision and operator
+rollout separately. A successful image publication does not prove an operator
+has replaced a running container.
+
+## Required runtime evidence
+
+| Surface | Acceptance evidence | Limits of local proof |
+| --- | --- | --- |
+| Docker administration | Public nginx rejects `/api/local-*`; health and ordinary data routes work. Native credentials cannot override Docker mode. | A rebuilt runtime fixture does not prove the full published image or production exposure. |
+| Docker RSS and sidecar fetch | RSS HTML/SVG remains inert through nginx; mapped private addresses and string/URL/Request private fetch targets are blocked before transport. Allowed requests still work. | Synthetic transport and loopback fixtures establish guard behavior, not an attacker-controlled production caller. |
+| Gateway | Authorized test identity reaches the daily limit through both GET and normalized POST; no provider call follows denial. | Local quota-store fixtures do not prove deployed Redis state. Live quota tests require separate approval and must avoid paid provider calls. |
+| Email and Telegram | Fresh proof permits only the owned destination; old/unproven, reused/expired and deactivated connections cannot deliver welcome, queued, realtime or digest messages. | Mock transport cannot establish provider delivery. |
+| Waitlist | Approved synthetic signup crosses the edge-to-Convex bridge; direct public backing mutation is unavailable; retries expose no membership/referral data. | Local tests cannot prove deployed bridge-secret alignment; a live signup is a production write and needs separate approval. |
+| DOM | Promoted descendants are sanitized and allowed formatting survives in the released browser bundle. | Local DOM proof does not establish attacker-input reachability or deployed bundle behavior. |
+
+The retained #7892 URL-object lead was reproduced through a real local sidecar
+handler: `fetch(new URL(loopbackFixture))` returned 200 before repair, while
+string and Request inputs returned 502. Normalize URL inputs through the same
+address validation and pinned transport. This confirms a wrapper defect; it does
+not establish a public attacker-controlled route to a private target.
+
+## Stop conditions and owner
+
+The release owner records the approved account/destination references privately,
+exact revisions, UTC timestamps and each result. Observe email for 24 hours and
+at least one due digest. Watch `EMAIL_OWNERSHIP_REQUIRED`,
+`EMAIL_VERIFICATION_UNAVAILABLE`, provider failures and `No deliverable channels`
+without publishing recipient data. Unexpected delivery or failure of verified
+recipient delivery blocks acceptance. Retain guards and repair configuration or
+roll forward. Keep #7902 and operationally incomplete child acceptance open.

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -211,7 +211,7 @@ async function assertSafeSidecarFetchUrl(url) {
 globalThis.fetch = async function ipv4Fetch(input, init) {
   const isRequest = input && typeof input === 'object' && 'url' in input;
   let url;
-  try { url = new URL(typeof input === 'string' ? input : input.url); } catch { return _originalFetch(input, init); }
+  try { url = new URL(isRequest ? input.url : input); } catch { return _originalFetch(input, init); }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') return _originalFetch(input, init);
   const allowPrivateNetwork = init?.[ALLOW_PRIVATE_NETWORK_FETCH] === true;
   const safety = allowPrivateNetwork

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -892,7 +892,7 @@ test('does not forward the sidecar transport token through Docker cloud proxy ro
   }
 });
 
-test('preserves Request body when handler uses fetch(Request)', async () => {
+for (const inputKind of ['Request', 'URL']) test(`preserves body when handler uses fetch(${inputKind})`, async () => {
   // Use a DISTINCT upstream server (not the sidecar itself) so this test
   // exercises real "handler proxies to external host" semantics. The upstream
   // is on 127.0.0.1, so it must be opted into the SSRF allowlist via
@@ -919,7 +919,7 @@ test('preserves Request body when handler uses fetch(Request)', async () => {
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ secret: 'keep-body' }),
         });
-        const upstream = await fetch(request);
+        const upstream = await fetch(${inputKind === 'Request' ? 'request' : 'new URL(request.url), { method: request.method, headers: request.headers, body: await request.text() }'});
         const payload = await upstream.text();
         return new Response(payload, {
           status: upstream.status,
@@ -1008,7 +1008,7 @@ test('returns local handler error when fetch(Request) uses a consumed body', asy
   }
 });
 
-test('blocks handler global fetches to private network targets (#3549)', async () => {
+for (const inputKind of ['string', 'URL', 'Request']) test(`blocks handler ${inputKind} fetches to private network targets (#3549, #7892)`, async () => {
   let upstreamHits = 0;
 
   const upstream = createServer((_req, res) => {
@@ -1022,7 +1022,7 @@ test('blocks handler global fetches to private network targets (#3549)', async (
   const localApi = await setupApiDir({
     'private-proxy.js': `
       export default async function handler() {
-        const upstream = await fetch(process.env.WM_TEST_UPSTREAM);
+        const upstream = await fetch(${inputKind === 'string' ? 'process.env.WM_TEST_UPSTREAM' : `new ${inputKind}(process.env.WM_TEST_UPSTREAM)`});
         const payload = await upstream.text();
         return new Response(payload, {
           status: upstream.status,


### PR DESCRIPTION
## Summary

Sidecar handlers could reach a private destination when they passed a URL object to fetch, while the same string or Request input was blocked. URL objects now use the existing address validation and pinned transport. The real-handler loopback fixture returned 200 before this repair and returns 502 with zero upstream hits afterwards; allowed URL/Request POST bodies still work. This proves the wrapper defect, not a public attacker-controlled production route.

The release-owner checklist records the remaining notification, gateway, waitlist, DOM and Docker acceptance decisions. Live delivery and deployment are not claimed complete. The new repair in this PR is not included in the earlier successful production deployment metadata.

Related: #7892, #7902

## Validation

- `npm run test:sidecar`: 474 passed.
- Existing Convex notification, Telegram, waitlist and gateway quota suites: 140 passed; DOM sanitizer: 1 passed.
- Existing delivery/bridge/config contracts: 36 passed, 1 skipped on the host because `WM_TEST_NGINX` was unset. Re-ran the existing Docker config/ingress suite inside a local nginx image with that variable set: 14 passed, no skips. Full production-image rollout remains unverified.
- Rebuilt local nginx/current-sidecar fixture: management routes 403, health/data 200; synthetic RSS is XML with sandbox CSP. Chromium did not execute its script. This fixture is not the full published image.
- Pre-push checks, including Markdown lint, passed. Inline diff review completed; dedicated review dispatch was unavailable under the task's no-subagent constraint.

## Post-Deploy Monitoring & Validation

Release owner: after separate merge/release approval, record the Docker/desktop artifact revision and run the harmless input-form and ingress checks on the release candidate. Watch `SSRF blocked` and `Local handler error` during the first startup and representative allowed requests. Unexpected private-target success or failure of allowed requests blocks acceptance; retain the guard and roll forward. Notification re-verification, owned mailbox/chat messages and 24-hour/one-digest observation require the separate approvals in `docs/operations/security-7902-release-acceptance.md`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
