### PR TITLE
fix(ci): dispatch desktop releases with the current workflow

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,4 +1,5 @@
 name: 'Build Desktop App'
+run-name: Build Desktop App (${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }})
 
 # One published desktop binary (#5908). World Monitor ships as a single build
 # and every variant — tech, finance, commodity, energy, happy — is selected
@@ -40,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
 
       - name: Require matching release target
         env:
@@ -121,6 +124,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
 
       - name: Start job timer
         shell: bash
@@ -490,6 +495,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
           fetch-depth: 0
 
       - name: Generate and update release notes

--- a/.github/workflows/desktop-release-train.yml
+++ b/.github/workflows/desktop-release-train.yml
@@ -110,9 +110,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          RUNNING=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/build-desktop.yml/runs?branch=$TAG&per_page=100" --paginate --slurp |
-            jq -er 'if type == "array" and length > 0 and all(.[]; (.workflow_runs | type) == "array")
-              then any(.[].workflow_runs[]; .status != "completed") | tostring
+          RUNNING=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/build-desktop.yml/runs?per_page=100" --paginate --slurp |
+            jq -er --arg tag "$TAG" 'if type == "array" and length > 0 and all(.[]; (.workflow_runs | type) == "array")
+              then any(.[].workflow_runs[]; .status != "completed" and
+                (.head_branch == $tag or .display_title == ("Build Desktop App (" + $tag + ")"))) | tostring
               else error("Incomplete desktop workflow-run response") end')
           echo "running=$RUNNING" >> "$GITHUB_OUTPUT"
           if [ "$RUNNING" = "true" ]; then
@@ -152,16 +153,19 @@ jobs:
           echo "Created release tag $TAG at $RELEASE_SHA."
 
       - name: Dispatch desktop build
+        # Existing tags can contain an older dispatch schema. The current
+        # workflow checks out TAG explicitly for validation, builds and notes.
         if: steps.release.outputs.action == 'release' && steps.active.outputs.running == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         shell: bash
         run: |
           set -euo pipefail
           gh workflow run build-desktop.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref "$TAG" \
+            --ref "$WORKFLOW_REF" \
             -f draft=false \
             -f release_tag="$TAG"
           echo "::notice::Dispatched Build Desktop App for $TAG."

--- a/tests/desktop-release-train.test.mjs
+++ b/tests/desktop-release-train.test.mjs
@@ -26,7 +26,7 @@ const stepNamed = (name) => {
   return matches[0];
 };
 const activeLookup =
-  'api repos/fixture/repository/actions/workflows/build-desktop.yml/runs?branch=v2.10.0&per_page=100 --paginate --slurp';
+  'api repos/fixture/repository/actions/workflows/build-desktop.yml/runs?per_page=100 --paginate --slurp';
 const clientEnv = Object.fromEntries([
   'VITE_CLERK_PUBLISHABLE_KEY', 'VITE_WS_RELAY_URL', 'VITE_PMTILES_URL_PUBLIC', 'CONVEX_URL',
 ].map((key) => [key, 'fixture-configured']));
@@ -44,6 +44,10 @@ function runPreparation({ env = clientEnv, runs = [], apiExit = 0, response = [{
       '  printf \'%s\\n\' "$FAKE_RUNS"',
       'else',
       '  printf \'%s\\n\' "$*" >> "$FAKE_CALLS"',
+      '  if [ "$7" = "$TAG" ]; then',
+      '    echo \'HTTP 422: Unexpected inputs provided: ["release_tag"]\' >&2',
+      '    exit 1',
+      '  fi',
       'fi',
     ].join('\n'));
     chmodSync(join(bin, 'gh'), 0o755);
@@ -64,6 +68,7 @@ function runPreparation({ env = clientEnv, runs = [], apiExit = 0, response = [{
         GITHUB_REPOSITORY: 'fixture/repository',
         GITHUB_OUTPUT: join(temp, 'output'),
         TAG: 'v2.10.0',
+        WORKFLOW_REF: 'main',
         FAKE_CALLS: join(temp, 'calls'),
         FAKE_API_EXIT: String(apiExit),
         FAKE_RUNS: JSON.stringify(response),
@@ -93,7 +98,7 @@ test('preparation refuses every missing release secret before tag creation or di
 test('preparation skips active builds and permits a configured retry after a completed failure', () => {
   assert.equal(stepNamed('Check for an active desktop build').if, "steps.release.outputs.action == 'release'");
   for (const status of ['queued', 'in_progress', 'waiting', 'pending', 'requested']) {
-    const result = runPreparation({ runs: [{ status }] });
+    const result = runPreparation({ runs: [{ status, head_branch: 'v2.10.0' }] });
     assert.equal(result.status, 0, result.stderr);
     assert.deepEqual(result.calls, [activeLookup]);
   }
@@ -102,7 +107,7 @@ test('preparation skips active builds and permits a configured retry after a com
     assert.equal(result.status, 0, result.stderr);
     assert.deepEqual(result.calls, [
       activeLookup,
-      'workflow run build-desktop.yml --repo fixture/repository --ref v2.10.0 -f draft=false -f release_tag=v2.10.0',
+      'workflow run build-desktop.yml --repo fixture/repository --ref main -f draft=false -f release_tag=v2.10.0',
     ]);
   }
   const failedRead = runPreparation({ apiExit: 1 });
@@ -111,6 +116,34 @@ test('preparation skips active builds and permits a configured retry after a com
   const incompleteRead = runPreparation({ response: [{ message: 'unavailable' }] });
   assert.notEqual(incompleteRead.status, 0);
   assert.deepEqual(incompleteRead.calls, [activeLookup]);
+});
+
+test('preparation recognizes current-workflow builds by release target', () => {
+  const active = runPreparation({ runs: [{ status: 'in_progress', head_branch: 'main', display_title: 'Build Desktop App (v2.10.0)' }] });
+  assert.equal(active.status, 0, active.stderr);
+  assert.deepEqual(active.calls, [activeLookup]);
+  const other = runPreparation({ runs: [{ status: 'in_progress', head_branch: 'main', display_title: 'Build Desktop App (v2.9.0)' }] });
+  assert.equal(other.status, 0, other.stderr);
+  assert.equal(other.calls.length, 2);
+});
+
+test('dispatch avoids the legacy tag workflow that rejects release_tag', () => {
+  const legacy = runPreparation({ env: { ...clientEnv, WORKFLOW_REF: 'v2.10.0' } });
+  assert.notEqual(legacy.status, 0);
+  assert.match(legacy.stderr, /HTTP 422: Unexpected inputs/);
+  const current = runPreparation();
+  assert.equal(current.status, 0, current.stderr);
+  assert.match(current.calls.at(-1), /--ref main .*release_tag=v2\.10\.0$/);
+});
+
+test('current workflow builds and publishes only the selected tag source', () => {
+  const desktop = loadYaml(readFileSync(resolve(root, '.github/workflows/build-desktop.yml'), 'utf8'));
+  assert.equal(desktop['run-name'], "Build Desktop App (${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }})");
+  for (const job of Object.values(desktop.jobs)) {
+    for (const checkout of job.steps.filter((step) => step.uses?.startsWith('actions/checkout@'))) {
+      assert.equal(checkout.with.ref, "${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}");
+    }
+  }
 });
 
 test('direct builds validate client configuration once before matrix expansion and preserve draft policy', () => {
@@ -259,7 +292,8 @@ test('the workflow creates only a compatible main-history tag and dispatches the
   const dispatch = stepNamed('Dispatch desktop build');
   assert.equal(dispatch.if, "steps.release.outputs.action == 'release' && steps.active.outputs.running == 'false'");
   assert.match(dispatch.run, /gh workflow run build-desktop\.yml/);
-  assert.match(dispatch.run, /--ref "\$TAG"/);
+  assert.match(dispatch.run, /--ref "\$WORKFLOW_REF"/);
+  assert.equal(dispatch.env.WORKFLOW_REF, "${{ github.event.repository.default_branch }}");
   assert.match(dispatch.run, /-f draft=false/);
   assert.match(dispatch.run, /-f release_tag="\$TAG"/);
   assert.doesNotMatch(workflowSource, /gh release create/);


### PR DESCRIPTION
## Summary

Desktop release preparation failed with HTTP 422 because the existing `v2.10.0` tag contains an older build workflow without the `release_tag` input. Preparation now dispatches the current default-branch workflow, while every build, validation and release-notes checkout explicitly selects the requested tag. Existing tags are preserved, and active builds are recognized by release target even when dispatched from main.

Related: #7920. Failure evidence: [post-merge preparation job](https://github.com/koala73/worldmonitor/actions/runs/34254111313/job/102155454712).

## Validation

69 focused desktop and workflow tests passed, including a simulated legacy-tag HTTP 422, current-workflow dispatch, active-build detection, release-source checkout contracts, and existing configuration/draft guards. Desktop environment parity, version consistency, shell parsing and diff checks passed. Simplification and code review were performed inline. No release was dispatched, no tag was changed, and full platform packaging remains unverified.

## Post-Deploy Monitoring & Validation

After merge, the existing release preparation trigger can start a public desktop release. The release owner should verify that preparation dispatches successfully, the run title names the requested tag, and all platform builds use that tag before publication. Any source/version mismatch or missing platform asset must keep publication blocked. This PR does not itself authorize merge or release execution.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
