### PR TITLE
fix(health): reconcile duplicate China warning debounce

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -176,6 +176,11 @@ const CHINA_COVERAGE_SUMMARY_KEY = 'health:china-coverage:v1';
 // reported. See projectChinaCoverageStatus for why the debounce lives here and
 // not in the summary's own `status` field.
 const CHINA_DEGRADED_MIN_CONSECUTIVE = 2;
+// The aggregate China evaluator runs hourly. Give that second observation one
+// full cycle plus one 15-minute derived-signal publication interval to arrive.
+// A repeated incident stops being pending as soon as the evaluator publishes
+// streak 2; this deadline is only the fail-closed backstop when it does not.
+const CHINA_DECISION_SIGNALS_PENDING_MS = 75 * 60 * 1_000;
 const HEALTH_VERDICT_SNAPSHOT_TTL_MS = HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS * 1_000;
 const HEALTH_VERDICT_REFRESH_LOCK_KEY = `${HEALTH_VERDICT_SNAPSHOT_KEY}:refresh-lock`;
 // The sweep can consume its full 8s timeout, followed by a 4s failure-log read
@@ -3095,6 +3100,9 @@ const STATUS_COUNTS = {
 };
 
 function healthStatusBucket(entry, now) {
+  if (entry?.status === 'COVERAGE_PARTIAL'
+    && typeof entry.chinaCoveragePendingUntil === 'string'
+    && !isExpiredDeadline(entry.chinaCoveragePendingUntil, now)) return 'ok';
   if (entry?.status === 'SEED_ERROR'
     && typeof entry.sourceFailurePendingUntil === 'string'
     && !isExpiredDeadline(entry.sourceFailurePendingUntil, now)) return 'ok';
@@ -3261,6 +3269,50 @@ function composeChinaCoverageStatus(entry, raw, readError = false) {
   return { ...entry, ...projected, seedStatus };
 }
 
+function composeChinaDecisionSignalsStatus(entry, chinaCoverageEntry, now) {
+  if (
+    entry?.status !== 'COVERAGE_PARTIAL'
+    || chinaCoverageEntry?.status !== 'OK'
+    || chinaCoverageEntry?.chinaStatus !== 'degraded'
+    || chinaCoverageEntry?.degradedStreak !== CHINA_DEGRADED_MIN_CONSECUTIVE - 1
+  ) return entry;
+
+  const chinaProblems = Array.isArray(chinaCoverageEntry.problems)
+    ? chinaCoverageEntry.problems
+    : [];
+  const decisionProblems = Array.isArray(entry.decisionGroups?.unavailableGroups)
+    ? entry.decisionGroups.unavailableGroups
+    : [];
+  const requiredDecisionGroups = SEED_META.chinaDecisionSignals.minRecordCount;
+  const [chinaProblem] = chinaProblems;
+  const [decisionProblem] = decisionProblems;
+  const sameHeldCorporateIncident = chinaProblems.length === 1
+    && chinaProblem?.id === 'market.china-corporate-disclosures'
+    && chinaProblem?.status === 'degraded'
+    && Array.isArray(chinaProblem?.reasonCodes)
+    && chinaProblem.reasonCodes.length === 1
+    && chinaProblem.reasonCodes[0] === 'CHINA_COVERAGE_PARTIAL'
+    && decisionProblems.length === 1
+    && decisionProblem?.id === 'corporate-disclosures'
+    && decisionProblem?.unavailableCause === 'upstream_unavailable'
+    && entry.minRecordCount === requiredDecisionGroups
+    && entry.records === requiredDecisionGroups - 1
+    && entry.decisionGroups?.operationallyCovered === entry.records;
+  if (!sameHeldCorporateIncident) return entry;
+
+  const evaluatedAt = Date.parse(chinaCoverageEntry.evaluatedAt);
+  const pendingUntil = evaluatedAt + CHINA_DECISION_SIGNALS_PENDING_MS;
+  if (!Number.isFinite(evaluatedAt) || evaluatedAt > now || now >= pendingUntil) return entry;
+
+  // chinaDecisionSignals is derived from the same corporate snapshot the
+  // aggregate evaluator just held for its first degraded observation. Keep the
+  // derived coverage diagnosis visible, but bucket both projections together;
+  // otherwise one source incident bypasses the debounce through a second key
+  // and flips the fleet verdict despite retained last-good data. The deadline
+  // prevents a stalled evaluator from holding this projection indefinitely.
+  return { ...entry, chinaCoveragePendingUntil: new Date(pendingUntil).toISOString() };
+}
+
 function composeScorecardReadModelStatus(entry, raw, readError = false) {
   if (!entry) return entry;
   if (readError) return { ...entry, status: 'REDIS_PARTIAL', readModelReady: false };
@@ -3331,8 +3383,8 @@ function isExpiredDeadline(raw, now) {
 
 // Every per-entry softening deadline a snapshot can carry, in one place. Both
 // readers below walk this table instead of repeating a `hasOwnProperty` +
-// `isExpiredDeadline` block per field, so adding a FOURTH softening is one
-// entry here rather than two more near-identical branches that can drift apart.
+// `isExpiredDeadline` block per field, so adding another softening is one
+// entry here rather than more near-identical branches that can drift apart.
 //
 // `kind` decides which `hasExpiredActivationGrace` toggle governs the field.
 // `status` pins a field to one status where the field alone is not proof:
@@ -3343,6 +3395,7 @@ const ENTRY_SOFTENING_DEADLINES = [
   { field: 'contentFreshnessPendingUntil', kind: 'content', status: null },
   { field: 'staleContentGraceUntil', kind: 'content', status: null },
   { field: 'sourceFailurePendingUntil', kind: 'source', status: 'SEED_ERROR' },
+  { field: 'chinaCoveragePendingUntil', kind: 'source', status: 'COVERAGE_PARTIAL' },
 ];
 
 function entryDeadlineRaw(entry, { field, status }) {
@@ -3909,6 +3962,12 @@ export async function handleHealth(req, ctx, options = {}) {
     }
   }
 
+  checks.chinaDecisionSignals = composeChinaDecisionSignalsStatus(
+    checks.chinaDecisionSignals,
+    checks.chinaCoverage,
+    evaluationNow,
+  );
+
   // Now that every key has a status, claim (or read back) the one durable
   // deadline per STALE_CONTENT source and publish it. Only the claim half is
   // awaited — the recovery cleanup is bookkeeping no reader of this response
@@ -4118,8 +4177,10 @@ export const __testing__ = {
   HEALTH_VERDICT_REFRESH_LOCK_KEY,
   HEALTH_VERDICT_REFRESH_WAIT_MS,
   CHINA_COVERAGE_SUMMARY_KEY,
+  CHINA_DECISION_SIGNALS_PENDING_MS,
   projectChinaCoverageStatus,
   composeChinaCoverageStatus,
+  composeChinaDecisionSignalsStatus,
   composeScorecardReadModelStatus,
   healthVerdictRedisKey,
   parseHealthVerdictSnapshot,

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -88,6 +88,14 @@ export const MAX_ROLLOUT_WINDOW_MS = 24 * 60 * 60 * 1000;
 // window far longer than the publisher can legally mint.
 export const STALE_CONTENT_GRACE_SKEW_SLACK_MS = 5 * 60 * 1000;
 export const MAX_STALE_CONTENT_GRACE_MS = 3 * 60 * 60 * 1000 + STALE_CONTENT_GRACE_SKEW_SLACK_MS;
+// Mirrors CHINA_DECISION_SIGNALS_PENDING_MS in api/health.js, with the same
+// cross-machine clock-skew allowance used for stale-content grace. The API
+// keeps a first corporate-disclosures miss diagnostic-only while the hourly
+// China evaluator confirms it; this monitor must consume that bounded verdict
+// instead of turning the pending entry back into an operational failure.
+export const CHINA_COVERAGE_PENDING_SKEW_SLACK_MS = 5 * 60 * 1000;
+export const MAX_CHINA_COVERAGE_PENDING_MS = 75 * 60 * 1000
+  + CHINA_COVERAGE_PENDING_SKEW_SLACK_MS;
 
 function hasActiveBoundedDeadline(raw, now, maxWindowMs) {
   const until = Date.parse(typeof raw === 'string' ? raw : '');
@@ -110,6 +118,15 @@ export function isStaleContentGraceProblem(problem, now = Date.now()) {
   );
 }
 
+export function isChinaCoveragePendingProblem(problem, now = Date.now()) {
+  if (problem?.status !== 'COVERAGE_PARTIAL') return false;
+  return hasActiveBoundedDeadline(
+    problem.chinaCoveragePendingUntil,
+    now,
+    MAX_CHINA_COVERAGE_PENDING_MS,
+  );
+}
+
 export function isSourceFailurePendingProblem(problem, now = Date.now()) {
   const earthquake = problem?.errorCode === 'EARTHQUAKE_UPSTREAM_INCOMPLETE';
   const nhc = /^NHC_(POINT_REQUEST_FAILED|POINT_RESPONSE_INVALID)$/.test(problem?.errorCode || '');
@@ -126,11 +143,18 @@ export function isSourceFailurePendingProblem(problem, now = Date.now()) {
 
 export function findPendingDiagnostics(payload, now = Date.now()) {
   return compactHealthEntries(payload)
-    .filter(([, problem]) => isStaleContentGraceProblem(problem, now) || isSourceFailurePendingProblem(problem, now))
+    .filter(([, problem]) => (
+      isStaleContentGraceProblem(problem, now)
+      || isSourceFailurePendingProblem(problem, now)
+      || isChinaCoveragePendingProblem(problem, now)
+    ))
     .map(([name, problem]) => ({
       name,
       status: problem?.status ?? 'UNKNOWN',
-      graceUntil: problem?.staleContentGraceUntil ?? problem?.sourceFailurePendingUntil ?? null,
+      graceUntil: problem?.staleContentGraceUntil
+        ?? problem?.sourceFailurePendingUntil
+        ?? problem?.chinaCoveragePendingUntil
+        ?? null,
     }));
 }
 
@@ -146,6 +170,7 @@ export function findOperationalProblems(payload, now = Date.now()) {
       && !isRolloutPendingProblem(problem, now)
       && !isStaleContentGraceProblem(problem, now)
       && !isSourceFailurePendingProblem(problem, now)
+      && !isChinaCoveragePendingProblem(problem, now)
     ))
     .map(([name, problem]) => ({
       name,

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -31,6 +31,7 @@ const {
   ZERO_RECORD_DATA_OK_KEYS,
   EMPTY_DATA_OK_KEYS,
   projectChinaCoverageStatus,
+  composeChinaDecisionSignalsStatus,
 } = __testing__;
 
 const NOW = 1_700_000_000_000;
@@ -2367,6 +2368,155 @@ test('china coverage: a held verdict survives the compact health projection', ()
     (problem) => problem.id === 'market.china-stock-connect',
   ));
   assert.deepEqual(healthResponseBody(compact, true), compact, 'cached compact snapshots remain stable');
+});
+
+test('china coverage: the derived decision check shares the first corporate failure hold', () => {
+  const chinaCoverage = projectChinaCoverageStatus(chinaSummary({
+    degradedStreak: 1,
+    entries: [{
+      id: 'market.china-corporate-disclosures',
+      launchStatus: 'launched',
+      status: 'degraded',
+      reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
+    }],
+    degradedProblemKey: JSON.stringify([{
+      id: 'market.china-corporate-disclosures',
+      status: 'degraded',
+      reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
+    }]),
+  }));
+  const evaluatedAt = Date.parse(chinaCoverage.evaluatedAt);
+  const now = evaluatedAt + 60_000;
+  const pendingUntil = evaluatedAt + __testing__.CHINA_DECISION_SIGNALS_PENDING_MS;
+  const decisionSignals = composeChinaDecisionSignalsStatus({
+    status: 'COVERAGE_PARTIAL',
+    records: 5,
+    minRecordCount: 6,
+    decisionGroups: {
+      operationallyCovered: 5,
+      unavailableGroups: [{
+        id: 'corporate-disclosures',
+        unavailableCause: 'upstream_unavailable',
+      }],
+    },
+  }, chinaCoverage, now);
+
+  assert.equal(decisionSignals.status, 'COVERAGE_PARTIAL', 'the diagnosis stays truthful');
+  assert.equal(decisionSignals.chinaCoveragePendingUntil, new Date(pendingUntil).toISOString());
+  assert.equal(__testing__.healthStatusBucket(decisionSignals, pendingUntil - 1), 'ok');
+  assert.equal(__testing__.healthStatusBucket(decisionSignals, pendingUntil), 'warn');
+
+  const compact = healthResponseBody({
+    status: 'HEALTHY',
+    summary: { total: 2, ok: 2, warn: 0, pending: 1, crit: 0 },
+    checkedAt: new Date(now).toISOString(),
+    checks: { chinaCoverage, chinaDecisionSignals: decisionSignals },
+  }, true);
+  assert.deepEqual(compact.pending?.chinaDecisionSignals, {
+    status: 'COVERAGE_PARTIAL',
+    chinaCoveragePendingUntil: new Date(pendingUntil).toISOString(),
+  });
+  assert.equal(compact.problems?.chinaDecisionSignals, undefined);
+  assert.equal(compact.problems?.chinaCoverage?.degradedStreak, 1);
+  assert.equal(__testing__.hasExpiredActivationGrace(compact, pendingUntil - 1), false);
+  assert.equal(__testing__.hasExpiredActivationGrace(compact, pendingUntil), true);
+});
+
+test('china coverage: unrelated or repeated decision failures are never held', () => {
+  const firstCorporateFailure = projectChinaCoverageStatus(chinaSummary({
+    degradedStreak: 1,
+    entries: [{
+      id: 'market.china-corporate-disclosures',
+      launchStatus: 'launched',
+      status: 'degraded',
+      reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
+    }],
+  }));
+  const corporateDecisionFailure = {
+    status: 'COVERAGE_PARTIAL',
+    records: 5,
+    minRecordCount: 6,
+    decisionGroups: {
+      operationallyCovered: 5,
+      unavailableGroups: [{
+        id: 'corporate-disclosures',
+        unavailableCause: 'upstream_unavailable',
+      }],
+    },
+  };
+  const activityFailure = {
+    ...corporateDecisionFailure,
+    decisionGroups: {
+      unavailableGroups: [{
+        id: 'activity-nowcast',
+        unavailableCause: 'insufficient_data',
+      }],
+    },
+  };
+  const secondCorporateFailure = {
+    ...firstCorporateFailure,
+    status: 'CHINA_DEGRADED',
+    degradedStreak: 2,
+  };
+
+  assert.equal(
+    composeChinaDecisionSignalsStatus(activityFailure, firstCorporateFailure, Date.parse(firstCorporateFailure.evaluatedAt)).chinaCoveragePendingUntil,
+    undefined,
+    'another decision group remains an immediate warning',
+  );
+  assert.equal(
+    composeChinaDecisionSignalsStatus(corporateDecisionFailure, secondCorporateFailure, Date.parse(firstCorporateFailure.evaluatedAt)).chinaCoveragePendingUntil,
+    undefined,
+    'the second same corporate failure remains a warning',
+  );
+  assert.equal(
+    composeChinaDecisionSignalsStatus(
+      corporateDecisionFailure,
+      {
+        ...firstCorporateFailure,
+        problems: [{
+          id: 'market.china-corporate-disclosures',
+          status: 'degraded',
+          reasonCodes: ['CHINA_COVERAGE_PARTIAL', 'CHINA_SOURCE_UNAVAILABLE'],
+        }],
+      },
+      Date.parse(firstCorporateFailure.evaluatedAt),
+    ).chinaCoveragePendingUntil,
+    undefined,
+    'a mixed corporate failure remains an immediate warning',
+  );
+  assert.equal(__testing__.healthStatusBucket(corporateDecisionFailure, NOW), 'warn');
+  assert.deepEqual(
+    composeChinaDecisionSignalsStatus(
+      { status: 'COVERAGE_PARTIAL', records: 5 },
+      { ...firstCorporateFailure, problems: undefined },
+      Date.parse(firstCorporateFailure.evaluatedAt),
+    ),
+    { status: 'COVERAGE_PARTIAL', records: 5 },
+    'missing diagnostics fail closed without throwing',
+  );
+
+  for (const malformedCoverage of [
+    { records: 1, minRecordCount: 6, operationallyCovered: 1 },
+    { records: 5, minRecordCount: 7, operationallyCovered: 5 },
+    { records: 5, minRecordCount: 6, operationallyCovered: 4 },
+  ]) {
+    const candidate = {
+      ...corporateDecisionFailure,
+      records: malformedCoverage.records,
+      minRecordCount: malformedCoverage.minRecordCount,
+      decisionGroups: {
+        ...corporateDecisionFailure.decisionGroups,
+        operationallyCovered: malformedCoverage.operationallyCovered,
+      },
+    };
+    assert.equal(
+      composeChinaDecisionSignalsStatus(candidate, firstCorporateFailure, Date.parse(firstCorporateFailure.evaluatedAt))
+        .chinaCoveragePendingUntil,
+      undefined,
+      JSON.stringify(malformedCoverage),
+    );
+  }
 });
 
 test('china coverage: a summary with no streak field alarms as before', () => {

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -16,6 +16,8 @@ const {
   HEALTH_VERDICT_REFRESH_WAIT_MS,
   hasExpiredActivationGrace,
   snapshotTtlSeconds,
+  CHINA_COVERAGE_SUMMARY_KEY,
+  CHINA_DECISION_SIGNALS_PENDING_MS,
 } = __testing__;
 const realFetch = globalThis.fetch;
 const realSetTimeout = globalThis.setTimeout;
@@ -550,6 +552,7 @@ test('snapshot TTL is clamped down to the nearest activation deadline', () => {
   assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'OK', contentFreshnessPendingUntil: at(30_000) } } }, now), 30);
   assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'STALE_CONTENT', staleContentGraceUntil: at(20_000) } } }, now), 20);
   assert.equal(snapshotTtlSeconds({ problems: {}, pending: { a: { status: 'STALE_CONTENT', staleContentGraceUntil: at(20_000) } } }, now), 20);
+  assert.equal(snapshotTtlSeconds({ pending: { a: { status: 'COVERAGE_PARTIAL', chinaCoveragePendingUntil: at(12_000) } } }, now), 12);
   // Rollout deadline, which only counts on a ROLLOUT_PENDING entry.
   assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'ROLLOUT_PENDING', rolloutPendingUntil: at(10_000) } } }, now), 10);
   // Compact shape: deadlines live under `summary`, because a graced check is OK
@@ -576,6 +579,23 @@ test('stale-content grace invalidates full and compact snapshots at the exact de
   const compact = {
     problems: {},
     pending: { temporalAnomalies: { status: 'STALE_CONTENT', staleContentGraceUntil: deadline } },
+  };
+
+  assert.equal(hasExpiredActivationGrace(full, now - 1), false);
+  assert.equal(hasExpiredActivationGrace(compact, now - 1), false);
+  assert.equal(hasExpiredActivationGrace(full, now), true);
+  assert.equal(hasExpiredActivationGrace(compact, now), true);
+});
+
+test('China decision pending invalidates full and compact snapshots at the exact deadline', () => {
+  const now = Date.parse('2026-09-08T17:15:00.000Z');
+  const deadline = new Date(now).toISOString();
+  const full = {
+    checks: { chinaDecisionSignals: { status: 'COVERAGE_PARTIAL', chinaCoveragePendingUntil: deadline } },
+  };
+  const compact = {
+    problems: {},
+    pending: { chinaDecisionSignals: { status: 'COVERAGE_PARTIAL', chinaCoveragePendingUntil: deadline } },
   };
 
   assert.equal(hasExpiredActivationGrace(full, now - 1), false);
@@ -632,7 +652,13 @@ const TEMPORAL_META_KEY = 'seed-meta:temporal:anomalies';
 
 // A registry sweep where exactly one source has fresh seeder metadata but no
 // usable item timestamp — the undatable STALE_CONTENT shape.
-function sweepFetch({ graceStore = new Map(), onCommands = () => {}, failGraceClaim = false } = {}) {
+function sweepFetch({
+  graceStore = new Map(),
+  onCommands = () => {},
+  failGraceClaim = false,
+  chinaCoverageSummary,
+  chinaDecisionMeta,
+} = {}) {
   return async (_url, init) => {
     const commands = JSON.parse(init.body);
     onCommands(commands);
@@ -664,6 +690,14 @@ function sweepFetch({ graceStore = new Map(), onCommands = () => {}, failGraceCl
           }),
         };
       }
+      if (op === 'GET' && key === CHINA_COVERAGE_SUMMARY_KEY && chinaCoverageSummary) {
+        return { result: JSON.stringify(chinaCoverageSummary) };
+      }
+      if (op === 'GET'
+        && key === 'seed-meta:intelligence:china-decision-signals'
+        && chinaDecisionMeta) {
+        return { result: JSON.stringify(chinaDecisionMeta) };
+      }
       if (op === 'GET') {
         return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
       }
@@ -678,6 +712,94 @@ async function sweepCompactBody(fetchImpl) {
   const response = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
   return response.json();
 }
+
+function chinaCorporateCoverageSummary(now, degradedStreak) {
+  const problems = [{
+    id: 'market.china-corporate-disclosures',
+    status: 'degraded',
+    reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
+  }];
+  return {
+    schemaVersion: 1,
+    countryCode: 'CN',
+    status: 'degraded',
+    evaluatedAt: new Date(now - 60_000).toISOString(),
+    counts: {
+      total: 1,
+      launched: 1,
+      planned: 0,
+      blocked: 0,
+      healthy: 0,
+      degraded: 1,
+      unavailable: 0,
+    },
+    entries: problems.map((problem) => ({ ...problem, launchStatus: 'launched' })),
+    degradedStreak,
+    degradedProblemKey: JSON.stringify(problems),
+  };
+}
+
+function chinaCorporateDecisionMeta(now) {
+  return {
+    fetchedAt: now - 60_000,
+    recordCount: 5,
+    groupStates: {
+      macro: 'available',
+      'policy-enforcement': 'available',
+      'cross-strait-activity': 'available',
+      'corporate-disclosures': 'unavailable',
+      'corridor-conditions': 'available',
+      'activity-nowcast': 'available',
+    },
+    groupCounts: {
+      populated: 5,
+      partial: 0,
+      stale: 0,
+      unavailable: 1,
+      healthyQuiet: 0,
+      operationallyCovered: 5,
+    },
+    unavailableCauses: { 'corporate-disclosures': 'upstream_unavailable' },
+  };
+}
+
+test('handleHealth reconciles the duplicate China warning only for the first observation', async () => {
+  const now = Date.parse('2026-09-08T16:01:57.702Z');
+  Date.now = () => now;
+  const decisionMeta = chinaCorporateDecisionMeta(now);
+
+  const run = async (degradedStreak) => {
+    const pipelines = [];
+    const body = await sweepCompactBody(sweepFetch({
+      chinaCoverageSummary: chinaCorporateCoverageSummary(now, degradedStreak),
+      chinaDecisionMeta: decisionMeta,
+      onCommands: (commands) => pipelines.push(commands),
+    }));
+    const write = pipelines.flat().find(
+      ([op, key]) => op === 'SET' && key === HEALTH_SNAPSHOT_KEY,
+    );
+    return { body, stored: JSON.parse(write[2]) };
+  };
+
+  const first = await run(1);
+  const deadline = new Date(
+    now - 60_000 + CHINA_DECISION_SIGNALS_PENDING_MS,
+  ).toISOString();
+  assert.deepEqual(first.body.pending?.chinaDecisionSignals, {
+    status: 'COVERAGE_PARTIAL',
+    chinaCoveragePendingUntil: deadline,
+  });
+  assert.equal(first.body.problems?.chinaDecisionSignals, undefined);
+  assert.equal(first.body.problems?.chinaCoverage?.status, 'OK');
+  assert.equal(first.stored.checks.chinaDecisionSignals.chinaCoveragePendingUntil, deadline);
+
+  const repeated = await run(2);
+  assert.equal(repeated.body.pending?.chinaDecisionSignals, undefined);
+  assert.equal(repeated.body.problems?.chinaDecisionSignals?.status, 'COVERAGE_PARTIAL');
+  assert.equal(repeated.body.problems?.chinaCoverage?.status, 'CHINA_DEGRADED');
+  assert.equal(repeated.stored.checks.chinaDecisionSignals.chinaCoveragePendingUntil, undefined);
+  assert.equal(repeated.body.summary.warn, first.body.summary.warn + 2);
+});
 
 test('handleHealth claims, publishes, and reuses one stale-content deadline', async () => {
   const graceStore = new Map();

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -15,10 +15,13 @@ import {
   findOperationalProblems,
   formatAcceptanceReport,
   formatAcceptanceMarkdown,
+  isChinaCoveragePendingProblem,
   isOnDemandProblem,
   findPendingDiagnostics,
   isSourceFailurePendingProblem,
   isStaleContentGraceProblem,
+  CHINA_COVERAGE_PENDING_SKEW_SLACK_MS,
+  MAX_CHINA_COVERAGE_PENDING_MS,
   MAX_STALE_CONTENT_GRACE_MS,
   STALE_CONTENT_GRACE_SKEW_SLACK_MS,
   validateAcceptanceBaseline,
@@ -351,6 +354,55 @@ describe('scheduled seed freshness monitor', () => {
           [collection]: { temporalAnomalies: candidate },
         }, now).length, 1, `${collection}: ${label}`);
       }
+    }
+  });
+
+  it('consumes only active bounded China coverage pending entries', () => {
+    const now = Date.parse('2026-09-08T16:01:00.000Z');
+    assert.equal(
+      MAX_CHINA_COVERAGE_PENDING_MS,
+      healthTesting.CHINA_DECISION_SIGNALS_PENDING_MS
+        + CHINA_COVERAGE_PENDING_SKEW_SLACK_MS,
+    );
+    const pendingUntil = new Date(
+      now + healthTesting.CHINA_DECISION_SIGNALS_PENDING_MS,
+    ).toISOString();
+    const problem = {
+      status: 'COVERAGE_PARTIAL',
+      chinaCoveragePendingUntil: pendingUntil,
+    };
+    const compact = healthTesting.healthResponseBody({
+      status: 'HEALTHY',
+      summary: { total: 1, ok: 1, warn: 0, pending: 1, crit: 0 },
+      checkedAt: new Date(now).toISOString(),
+      checks: { chinaDecisionSignals: problem },
+    }, true);
+
+    assert.equal(isChinaCoveragePendingProblem(problem, now), true);
+    assert.deepEqual(compact.pending, { chinaDecisionSignals: problem });
+    assert.deepEqual(findOperationalProblems(compact, now), []);
+    assert.deepEqual(findPendingDiagnostics(compact, now), [{
+      name: 'chinaDecisionSignals',
+      status: 'COVERAGE_PARTIAL',
+      graceUntil: pendingUntil,
+    }]);
+
+    for (const [label, candidate] of [
+      ['exact deadline', { ...problem, chinaCoveragePendingUntil: new Date(now).toISOString() }],
+      ['missing deadline', { status: 'COVERAGE_PARTIAL' }],
+      ['malformed deadline', { ...problem, chinaCoveragePendingUntil: 'not-a-date' }],
+      ['non-string deadline', { ...problem, chinaCoveragePendingUntil: [pendingUntil] }],
+      ['excessive deadline', {
+        ...problem,
+        chinaCoveragePendingUntil: new Date(now + MAX_CHINA_COVERAGE_PENDING_MS + 1).toISOString(),
+      }],
+      ['wrong status', { ...problem, status: 'SEED_ERROR' }],
+    ]) {
+      assert.equal(isChinaCoveragePendingProblem(candidate, now), false, label);
+      assert.equal(findOperationalProblems({
+        status: 'HEALTHY',
+        pending: { chinaDecisionSignals: candidate },
+      }, now).length, 1, label);
     }
   });
 


### PR DESCRIPTION
## Summary

- reconcile the derived China decision-signal health key with the parent China coverage debounce
- keep first-observation diagnostics visible without emitting a duplicate fleet warning
- fail closed on any different incident, a repeated parent failure, or after a bounded 75-minute propagation window
- expire cached full and compact health snapshots at the pending deadline

## Root cause

A single transient corporate-disclosures incident was projected twice. `chinaCoverage` correctly kept its first degraded observation diagnostic-only, but `chinaDecisionSignals` independently emitted `COVERAGE_PARTIAL`, so the fleet still changed to WARNING.

## Verification

- `node --test tests/health-classify.test.mjs tests/health-verdict-snapshot.test.mjs tests/china-decision-coverage-classes.test.mjs` — 163 passed
- `npm run test:sidecar` — 474 passed
- pre-push gates — passed, including type checks and architecture boundaries
- structured code review — no unresolved actionable findings

## Production acceptance

Pending merge, deployment, and natural China evaluator runs. The acceptance condition is that a first retained corporate-disclosures miss stays diagnostic-only, while a repeated or different failure warns without delay.
