### PR TITLE
fix(schema): keep shared dataset and organization bodies consistent

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -5047,38 +5047,14 @@ export async function buildCorpus({
   }
 
   // Flagship downloadable datasets for the /sources/ DataCatalog node: every
-  // entry resolves to a generated download the corpus writes, so the catalog
-  // never advertises a dataset without a distribution.
-  const convergenceMetricName = data.livePulse.signalConvergence.metricName || 'Geographic Convergence Score';
+  // entry references the detail-page Dataset with its generated download.
+  // Keep the body on that page so shared identities cannot diverge.
   const sourcesCatalogDatasets = [
-    ...data.crises.map((crisis) => {
-      const pagePath = `/crises/${crisis.slug}/`;
-      return {
-        '@type': 'Dataset',
-        '@id': `${absoluteUrl(baseUrl, pagePath)}#crisis-dataset`,
-        name: crisis.title,
-        description: crisis.description,
-        url: absoluteUrl(baseUrl, pagePath),
-        keywords: ['crisis tracker', 'armed conflict', 'humanitarian response'],
-        creator: { ...WORLD_MONITOR_ORG },
-        license: DATASET_LICENSE,
-        distribution: [
-          dataDownload(absoluteUrl(baseUrl, datasetDownloadHref(pagePath, CRISIS_DATASET_DOWNLOAD))),
-        ],
-      };
-    }),
+    ...data.crises.map((crisis) => ({
+      '@id': `${absoluteUrl(baseUrl, `/crises/${crisis.slug}/`)}#crisis-dataset`,
+    })),
     {
-      '@type': 'Dataset',
-      name: `${convergenceMetricName} reference`,
       '@id': `${absoluteUrl(baseUrl, '/tools/signal-convergence/')}#signal-convergence-dataset`,
-      description: `World Monitor's ${convergenceMetricName} (0-100) names when protests, military flights, naval vessels, and earthquakes co-occur in the same 1° cell.`,
-      url: absoluteUrl(baseUrl, '/tools/signal-convergence/'),
-      keywords: ['signal convergence', 'geographic correlation', 'early warning'],
-      creator: { ...WORLD_MONITOR_ORG },
-      license: DATASET_LICENSE,
-      distribution: [
-        dataDownload(absoluteUrl(baseUrl, datasetDownloadHref('/tools/signal-convergence/', CONVERGENCE_DATASET_DOWNLOAD))),
-      ],
     },
   ];
 

--- a/src/config/docs-locale-seo.ts
+++ b/src/config/docs-locale-seo.ts
@@ -176,7 +176,7 @@ const DOCS_WEBSITE_IDS = new Set([
   `${DOCS_PUBLIC_ORIGIN}/docs/#website`,
 ]);
 const JSON_LD_SCRIPT_RE =
-  /<script\b(?=[^>]*\btype=["']application\/ld\+json["'])[^>]*>([\s\S]*?)<\/script>/gi;
+  /<script\b(?=[^>]*\btype\s*=\s*["']application\/ld\+json["'])[^>]*>([\s\S]*?)<\/script>/gi;
 
 /** `@type` may be a string or an array of strings in valid JSON-LD. */
 function hasJsonLdType(node: Record<string, unknown>, type: string): boolean {
@@ -249,19 +249,23 @@ function collapseCanonicalWebSite(node: Record<string, unknown>): Record<string,
 }
 
 /**
- * Walk every node at every depth — a WebSite can sit at the top level, inside a
+ * Collapse canonical Organization bodies to references and prune WebSites at
+ * every depth. These nodes can sit at the top level, inside a
  * top-level array, under `@graph`, or nested beneath any property such as
  * `mainEntity`. Returns null when the value itself must be removed.
  */
-function pruneWebSites(value: unknown): unknown | null {
+function pruneDocsEntities(value: unknown): unknown | null {
   if (Array.isArray(value)) {
-    // pruneWebSites returns null for a droppable entry, so mapping then
+    // pruneDocsEntities returns null for a droppable entry, so mapping then
     // discarding nulls removes and recurses in one pass.
     return value
-      .map((entry) => pruneWebSites(entry))
+      .map((entry) => pruneDocsEntities(entry))
       .filter((entry) => entry !== null);
   }
   if (!value || typeof value !== 'object') return value;
+  if ((value as Record<string, unknown>)['@id'] === ORGANIZATION_ID) {
+    return { '@id': ORGANIZATION_ID };
+  }
   if (shouldDropWebSite(value)) return null;
 
   const node = collapseCanonicalWebSite(value as Record<string, unknown>);
@@ -271,7 +275,7 @@ function pruneWebSites(value: unknown): unknown | null {
 
   const next: Record<string, unknown> = {};
   for (const [key, nested] of Object.entries(node)) {
-    const pruned = pruneWebSites(nested);
+    const pruned = pruneDocsEntities(nested);
     if (pruned === null) continue;
     next[key] = pruned;
   }
@@ -283,7 +287,7 @@ function rewriteDocsJsonLdValue(
   pathname?: string,
   allowArticleInjection = true,
 ): unknown | null {
-  const pruned = pruneWebSites(rewriteDocsWebsiteIds(value));
+  const pruned = pruneDocsEntities(rewriteDocsWebsiteIds(value));
   if (pruned === null) return null;
   const attributed = withDocsArticleAuthor(withDocsSpeakable(pruned));
   const withArticle = allowArticleInjection

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -3709,7 +3709,8 @@ describe('crawlable corpus generator', () => {
       assert.equal(catalog.dataset.length, corpusData.crises.length + 1);
       for (const dataset of catalog.dataset) {
         assert.ok(dataset['@id'], `${dataset.name} must reuse its detail-page identity`);
-        const detailPath = new URL(dataset.url).pathname.slice(1) + 'index.html';
+        assert.deepEqual(dataset, { '@id': dataset['@id'] }, 'catalog must reference the canonical Dataset');
+        const detailPath = new URL(dataset['@id']).pathname.slice(1) + 'index.html';
         const details = jsonLdObjects(read(outDir, detailPath)).flatMap((node) => collectDatasets(node));
         assert.ok(details.some((node) => node['@type'] === 'Dataset' && node['@id'] === dataset['@id']),
           `${dataset['@id']} must identify a Dataset on the generated detail page`);

--- a/tests/middleware-docs-locale-seo.test.mts
+++ b/tests/middleware-docs-locale-seo.test.mts
@@ -17,6 +17,38 @@ function docsHtmlRequest(): Request {
 }
 
 describe('middleware docs locale SEO proxy', () => {
+  it('replaces canonical Organization bodies with references throughout upstream JSON-LD (#7861)', async () => {
+    const id = 'https://www.worldmonitor.app/#organization';
+    const organization = {
+      '@id': id,
+      '@type': ['Organization'],
+      name: 'World Monitor',
+      logo: { '@type': 'ImageObject', url: 'https://www.worldmonitor.app/logo.png' },
+      sameAs: ['https://github.com/koala73/worldmonitor'],
+    };
+    const otherOrganization = { '@type': 'Organization', '@id': 'https://example.org/#organization', name: 'Source' };
+    const upstream = `<html><head><script TYPE = 'application/ld+json'>${JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [organization, { '@type': 'Article', publisher: organization, author: { '@id': id }, provider: otherOrganization }],
+    })}</script></head><body>Docs</body></html>`;
+    const originalFetch = globalThis.fetch;
+    mock.method(globalThis, 'fetch', async () => new Response(upstream, { headers: { 'content-type': 'text/html' } }));
+    try {
+      for (const path of ['/docs/about', '/docs/zh/about']) {
+        const response = await middleware(new Request(`https://www.worldmonitor.app${path}`, { headers: { accept: 'text/html' } }));
+        assert.ok(response instanceof Response);
+        const html = await response.text();
+        const graph = JSON.parse(html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)![1])['@graph'];
+        assert.deepEqual(graph[0], { '@id': id });
+        assert.deepEqual(graph[1].publisher, { '@id': id });
+        assert.deepEqual(graph[1].author, { '@id': id });
+        assert.deepEqual(graph[1].provider, otherOrganization);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('keeps the official canonical and excludes copied deployments from indexing', async () => {
     const originalFetch = globalThis.fetch;
     mock.method(globalThis, 'fetch', async () => new Response(

--- a/tests/schema-graph-contract.test.mts
+++ b/tests/schema-graph-contract.test.mts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
-import { readdirSync, readFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
 
 import middleware from '../middleware';
-import { WORLD_MONITOR_ORG } from '../scripts/build-crawlable-corpus.mjs';
+import { rewriteDocsLocaleHtml } from '../src/config/docs-locale-seo';
+import { buildCorpus, WORLD_MONITOR_ORG } from '../scripts/build-crawlable-corpus.mjs';
 import {
   SOFTWARE_SHARED_PROPERTIES,
   WEBSITE_SHARED_PROPERTIES,
@@ -276,8 +279,28 @@ describe('canonical schema graph', () => {
   // entity. Enumerating the properties that were wrong in Sept 2026 would only
   // freeze those; the invariant is "one `@id`, one body", so this asserts the
   // pinned values AND that no unpinned property diverges either.
-  it('serves one set of #software and #website property values across every surface (#7611)', () => {
-    const documents = jsonLdDocumentPaths();
+  it('serves consistent product, Organization and Dataset bodies across every surface (#7611, #7861)', async () => {
+    const documents = new Map(jsonLdDocumentPaths().map((path) => [path, read(path)]));
+    // CI does not prebuild the corpus. Exercise its real generator in isolation.
+    const corpusDir = mkdtempSync(join(tmpdir(), 'wm-schema-corpus-'));
+    try {
+      await buildCorpus({ outDir: corpusDir });
+      for (const path of readdirSync(corpusDir, { recursive: true }) as string[]) {
+        if (path.endsWith('.html')) documents.set(`public/${path}`, readFileSync(join(corpusDir, path), 'utf8'));
+      }
+    } finally {
+      rmSync(corpusDir, { recursive: true, force: true });
+    }
+    const docsOrganization = JSON.parse(read('docs/docs.json')).seo.organization;
+    const { id, logo, ...properties } = docsOrganization;
+    const docsHtml = `<html><head><script type="application/ld+json">${JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [{ '@type': 'Organization', '@id': id, ...properties, logo: { '@type': 'ImageObject', url: logo } }],
+    })}</script></head><body></body></html>`;
+    documents.set('docs/about (middleware output)', rewriteDocsLocaleHtml(docsHtml, '/docs/about'));
+    const datasetIds = new Set([...documents.values()].flatMap((html) =>
+      collectNodesOfType(html, 'Dataset').map((node) => node['@id']).filter((id): id is string => typeof id === 'string')));
+    assert.ok(datasetIds.size > 0, 'build the corpus before checking Dataset identities');
     const pinned: Array<[string, Record<string, unknown>, string[]]> = [
       [SOFTWARE_ID, SOFTWARE_SHARED_PROPERTIES, withoutUnbuiltProPaths([
         'index.html',
@@ -291,6 +314,8 @@ describe('canonical schema graph', () => {
         'pro-test/welcome.html',
         'public/pro/welcome.html',
       ])],
+      [ORGANIZATION_ID, {}, ['pro-test/welcome.html']],
+      ...[...datasetIds].map((id): [string, Record<string, unknown>, string[]] => [id, {}, []]),
     ];
 
     for (const [id, expected, required] of pinned) {
@@ -298,13 +323,14 @@ describe('canonical schema graph', () => {
       // identity is caught here rather than quietly exempted. The hand-listed
       // paths are the FLOOR -- they also catch a surface dropping the node.
       const emitters = new Map<string, Record<string, any>>();
-      for (const path of documents) {
-        const html = read(path);
+      for (const [path, html] of documents) {
         if (!html.includes(id)) continue;
         const declarations = declarationsOf(html, id);
         if (declarations.length === 0) continue;
-        assert.equal(declarations.length, 1, `${path} must declare ${id} exactly once`);
-        emitters.set(path, declarations[0]);
+        if (id === SOFTWARE_ID || id === WEBSITE_ID) {
+          assert.equal(declarations.length, 1, `${path} must declare ${id} exactly once`);
+        }
+        declarations.forEach((node, index) => emitters.set(index === 0 ? path : `${path} (node ${index + 1})`, node));
       }
       for (const path of required) {
         assert.ok(emitters.has(path), `${path} must still declare ${id}`);
@@ -324,7 +350,8 @@ describe('canonical schema graph', () => {
       const carriers = new Map<string, Array<[string, unknown]>>();
       for (const [path, node] of emitters) {
         for (const [property, value] of Object.entries(node)) {
-          if (MAY_DIVERGE_ACROSS_SURFACES.has(property)) continue;
+          if (property === '@context') continue;
+          if ((id === SOFTWARE_ID || id === WEBSITE_ID) && MAY_DIVERGE_ACROSS_SURFACES.has(property)) continue;
           const seen = carriers.get(property) ?? [];
           seen.push([path, value]);
           carriers.set(property, seen);


### PR DESCRIPTION
## Summary

Crawlers received conflicting names, descriptions, and keywords for shared Dataset IDs, plus a different Organization logo and sameAs list on docs pages. The source catalog now references the detail-page Datasets, and the docs response transform reduces the canonical Organization to an ID reference.

The graph guard covers Organization and all discovered Dataset identities, including docs transform output, and builds the corpus in isolation so it runs in CI without prebuilt pages. It also exposed the same conflict in signal convergence, fixed by the same catalog change. Existing software/website divergence exceptions remain limited to those identities.

Fixes #7861

## Validation

- Observed the Organization logo conflict and crisis Dataset name conflict before fixing each.
- Corpus/docs/schema suite: 187 passed, one initially skipped for missing /pro output. After building /pro, the schema and docs suites passed all 52 tests with no skips.
- Crawlable corpus and /pro builds, typecheck, boundary lint, and diff whitespace check passed.
- Local sequential code review completed; no remaining actionable findings. Live deployment output remains unverified.

## Post-Deploy Monitoring & Validation

Owner: PR author. After an approved deployment, fetch `/sources/`, all linked Dataset detail pages, `/docs/about`, and `/docs/zh/about` during the first hour. Expect catalog ID references, unchanged detail-page distributions, and no docs Organization body. Compare JSON-LD assertions by ID and check logs for `[docs-locale-seo] JSON-LD rewrite failed`. Any conflicting body or new parse failure is a rollback or repair trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
