### PR TITLE
fix(corpus): explain missing briefs and count eligible countries

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -3147,7 +3147,8 @@ export function renderCountryDevelopments({ countryCode = '', countryName, devel
   if (brief) assertDevelopmentsBrief(brief);
   for (const event of timeline) assertDevelopmentsTimelineEvent(event);
 
-  const movementSentence = describeDevelopmentsMovement({ countryName: name, ciiEntry, pulse });
+  const movementSentence = developmentsHasDatedItem(rows)
+    ? describeDevelopmentsMovement({ countryName: name, ciiEntry, pulse }) : '';
   const briefExtraSources = brief
     ? (Array.isArray(brief.sources) ? brief.sources : [])
       .filter((source) => source && typeof source.url === 'string'

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -3154,15 +3154,6 @@ export function renderCountryDevelopments({ countryCode = '', countryName, devel
         && !headlines.some((headline) => headline.url === source.url))
     : [];
   for (const source of briefExtraSources) assertDevelopmentsHeadline(source);
-  const itemCount = headlines.length + briefExtraSources.length + timeline.length + (brief ? 1 : 0);
-
-  // Zero items render nothing at all — not an absence note. A "no items"
-  // paragraph would stamp ~140 pages with the same boilerplate sentence and
-  // push the template share the enrichment is meant to reduce (#7615). The
-  // gap stays visible where it belongs: developments:null in resilience.json,
-  // the post-enrichment input to residual hub consolidation.
-  if (itemCount === 0) return '';
-
   const parts = [];
   if (movementSentence) parts.push(`        <p>${movementSentence}</p>`);
   if (headlines.length > 0 || briefExtraSources.length > 0) {
@@ -3178,6 +3169,19 @@ export function renderCountryDevelopments({ countryCode = '', countryName, devel
     const briefHtml = formatCrawlableIntelBrief(brief.text, name);
     const generatedLine = `Brief generated <time datetime="${escapeHtml(brief.generatedAt)}">${escapeHtml(formatStaticDateTime(brief.generatedAt))}</time>`;
     parts.push(`        <div data-intel-brief>\n          <h3>Country brief</h3>\n${briefHtml}\n          <p class="source">${generatedLine}${brief.model ? ` by ${escapeHtml(brief.model)}` : ''} from ${brief.sources.length} grounding sources.</p>\n        </div>`);
+  } else {
+    const reasons = {
+      'no-grounding': 'No country-specific grounding sources were captured.',
+      'thin-grounding': 'The grounding sources did not include at least two distinct publishers.',
+      'uncurated-grounding': 'The grounding sources did not include a curated news source.',
+      'unsupported-citation': 'The brief was withheld because its citations did not pass the source-grounding checks.',
+      'no-service-key': 'Brief generation was unavailable when this snapshot was captured.',
+      failed: 'The brief request failed when this snapshot was captured.',
+      empty: 'The brief service returned no usable brief for this snapshot.',
+    };
+    const reason = Object.hasOwn(reasons, rows?.briefSkipped)
+      ? reasons[rows.briefSkipped] : 'No brief was captured for this snapshot.';
+    parts.push(`        <p data-brief-unavailable>No country brief is available for ${escapeHtml(name)} in this snapshot. ${reason}</p>`);
   }
   if (timeline.length > 0) {
     const events = timeline

--- a/scripts/freeze-crawlable-live-pulse.mjs
+++ b/scripts/freeze-crawlable-live-pulse.mjs
@@ -1106,6 +1106,8 @@ export async function freezeCrawlableLivePulse({
         .filter((row) => (row.developments?.headlines?.length || 0) > 0).length,
       briefCountryCount: Object.values(countries)
         .filter((row) => row.developments?.brief != null).length,
+      // Grounding eligibility is independent of credentials or request outcome.
+      briefEligibleCount: [...headlinesByCode.values()].filter(hasBriefGrounding).length,
       briefUnsupportedCitationCount: Object.values(countries)
         .filter((row) => row.developments?.briefSkipped === 'unsupported-citation').length,
       // Countries a brief was requested for: keyed, and grounded on at least
@@ -1231,6 +1233,7 @@ if (isMain) {
         + `quotes=${snapshot.coverage.quoteCount} `
         + `headlineCountries=${snapshot.coverage.headlineCountryCount} `
         + `briefCountries=${snapshot.coverage.briefCountryCount} `
+        + `briefEligible=${snapshot.coverage.briefEligibleCount} `
         + `briefUnsupportedCitations=${snapshot.coverage.briefUnsupportedCitationCount} `
         + `briefThinGrounding=${snapshot.coverage.briefThinGroundingCount} `
         + `timelineCountries=${snapshot.coverage.timelineCountryCount} `

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -5815,6 +5815,18 @@ describe('country recent developments', () => {
     assert.match(html, /No country-specific grounding sources were captured/);
     assert.match(renderCountryDevelopments({ countryName: 'Palau', developments: null }), /No brief was captured/);
     assert.equal(developmentsHasDatedItem({ headlines: [], brief: null, timeline: [] }), false);
+    for (const signals of [
+      { ciiEntry: CII_ENTRY },
+      { pulse: { score: CII_ENTRY.score, band: CII_ENTRY.band, trend: 'stable', asOf: CII_ENTRY.asOf } },
+    ]) {
+      const emptyHtml = renderCountryDevelopments({
+        countryName: 'Palau',
+        developments: { headlines: [], brief: null, timeline: [], briefSkipped: 'no-grounding' },
+        ...signals,
+      });
+      assert.match(emptyHtml, /data-brief-unavailable/);
+      assert.doesNotMatch(emptyHtml, /Reporting captured in the same window/);
+    }
   });
 
   it('explains each withheld state and never exposes internal or unknown reason text', () => {

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -2647,6 +2647,10 @@ describe('crawlable corpus generator', () => {
         const route = `/countries/${country.slug}/`;
         const countryHtml = read(outDir, `${route.slice(1)}index.html`);
         const countryDocument = htmlDocument(countryHtml, `https://www.worldmonitor.app${route}`);
+        assert.ok(
+          countryDocument.querySelector('[data-intel-brief], [data-brief-unavailable]'),
+          `${route} must publish a grounded brief or explain its absence`,
+        );
         if (country.rank == null) {
           assert.match(countryHtml, /Nearest ranked comparators:/);
           assert.doesNotMatch(
@@ -5801,15 +5805,39 @@ describe('country recent developments', () => {
     assertCountryBriefPresentation({ pagePath: '/countries/sudan/', html, sources });
   });
 
-  it('renders nothing when zero items were captured', () => {
-    // No absence boilerplate: the same note on ~140 pages would be the exact
-    // template share the enrichment exists to reduce. The gap is recorded in
-    // resilience.json for the residual hub-consolidation decision.
-    assert.equal(renderCountryDevelopments({
+  it('explains an empty snapshot without presenting the note as a development', () => {
+    const html = renderCountryDevelopments({
       countryName: 'Palau',
       developments: { headlines: [], brief: null, timeline: [], briefSkipped: 'no-grounding', capturedAt: '2026-09-03T00:00:00.000Z' },
-    }), '');
-    assert.equal(renderCountryDevelopments({ countryName: 'Palau', developments: null }), '');
+    });
+    assert.match(html, /data-brief-unavailable/);
+    assert.match(html, /No country brief is available for Palau in this snapshot/);
+    assert.match(html, /No country-specific grounding sources were captured/);
+    assert.match(renderCountryDevelopments({ countryName: 'Palau', developments: null }), /No brief was captured/);
+    assert.equal(developmentsHasDatedItem({ headlines: [], brief: null, timeline: [] }), false);
+  });
+
+  it('explains each withheld state and never exposes internal or unknown reason text', () => {
+    const reasons = {
+      'thin-grounding': /at least two distinct publishers/,
+      'uncurated-grounding': /curated news source/,
+      'unsupported-citation': /citations did not pass/,
+      'no-service-key': /generation was unavailable/,
+      failed: /request failed/,
+      empty: /no usable brief/,
+      '<script>': /No brief was captured/,
+      constructor: /No brief was captured/,
+    };
+    for (const [briefSkipped, expected] of Object.entries(reasons)) {
+      const html = renderCountryDevelopments({
+        countryName: 'Sudan', developments: { ...DEVELOPMENTS, brief: null, briefSkipped },
+      });
+      assert.match(html, expected);
+      assert.match(html, /data-brief-unavailable/);
+      assert.ok(!html.includes('data-intel-brief'));
+      assert.ok(html.includes(HEADLINE.url), 'keep the lighter sourced developments');
+    }
+    assert.ok(!renderCountryDevelopments({ countryName: 'Sudan', developments: DEVELOPMENTS }).includes('data-brief-unavailable'));
   });
 
   it('throws on unattributable rows instead of publishing them', () => {
@@ -6295,8 +6323,8 @@ describe('country recent developments', () => {
     withoutDevelopments.countries.NO = { ...(withoutDevelopments.countries.NO || {}) };
     delete withoutDevelopments.countries.NO.developments;
     const plain = renderCountryPage({ ...pageArgs, livePulse: withoutDevelopments });
-    assert.ok(!plain.includes('data-country-developments'),
-      'a country with no frozen developments renders no section');
+    assert.ok(plain.includes('data-brief-unavailable'),
+      'a country with no frozen developments explains why no brief is available');
     const plainWebPage = jsonLdObjects(plain).find((entry) => entry['@type'] === 'WebPage');
     assert.ok(!('dateModified' in plainWebPage), 'no items means no dateModified claim');
   });

--- a/tests/freeze-crawlable-live-pulse.test.mjs
+++ b/tests/freeze-crawlable-live-pulse.test.mjs
@@ -819,6 +819,9 @@ describe('freeze per-country developments capture', () => {
     assert.ok(!requested.some((href) => href.includes('/api/wm-session') === false && href.includes('get-country-intel-brief')));
     assert.ok(!requested.some((href) => href.includes('get-intel-timeline')));
     assert.equal(snapshot.coverage.serviceKeyPresent, false);
+    assert.equal(snapshot.coverage.briefEligibleCount, 2);
+    assert.equal(snapshot.coverage.briefMatchedCount, 0);
+    assert.equal(snapshot.coverage.briefCountryCount, 0);
     const sudan = snapshot.countries.SD.developments;
     assert.equal(sudan.headlines.length, 2);
     assert.equal(sudan.headlines[0].source, 'UN News');
@@ -909,6 +912,7 @@ describe('freeze per-country developments capture', () => {
       'no LLM call is spent on a brief that would be withheld');
     assert.equal(snapshot.coverage.briefThinGroundingCount, 1);
     assert.equal(snapshot.coverage.briefMatchedCount, 2, 'only the two-headline countries are owed a brief');
+    assert.equal(snapshot.coverage.briefEligibleCount, 2);
     // The stub timeline serves every country, so a keyed run has no tail.
     assert.equal(snapshot.coverage.developmentsMissingCount, 0);
     assert.equal(
@@ -1260,6 +1264,7 @@ describe('freeze per-country developments capture', () => {
     assert.equal(snapshot.coverage.briefMatchedCount, 2);
     assert.equal(snapshot.coverage.briefCountryCount, 0);
     assert.equal(snapshot.coverage.briefUnsupportedCitationCount, 2);
+    assert.equal(snapshot.coverage.briefEligibleCount, 2, 'withholding does not erase grounding eligibility');
     for (const code of ['SD', 'NO']) {
       const row = snapshot.countries[code].developments;
       assert.equal(row.brief, null);


### PR DESCRIPTION
## Summary

Country pages could silently omit a brief, leaving readers unable to tell whether sources were insufficient or capture failed. Every page now shows either a grounded brief or a clear reason for its absence, while retaining available dated developments. Weekly captures separately report grounding-eligible countries and published briefs, including when credentials are unavailable or citation checks withhold a returned brief.

Related: #7748. This follows the issue's revised requirements and preserves the publisher, curated-source, citation, and capture-failure safeguards. The existing pipeline already attempts every eligible country; no live enrichment run or deployment was performed.

## Verification

- Both initial regression checks failed before implementation.
- 200 corpus and freeze tests passed, including a guard over all generated country pages; five focused checks passed after incorporating current main.
- Built 196 country pages. Checked Palau's absence note at desktop and 390px mobile widths.
- Typecheck and import-boundary checks passed. Biome had no errors; existing warnings/info remain. A review regression check covers empty sections with valid CII or pulse data: they do not claim reporting is listed below.

## Post-Deploy Monitoring & Validation

On the next natural weekly capture, the PR author should compare `briefEligible`, `briefCountries`, and `briefUnsupportedCitations` in the freeze log and inspect `coverage.briefEligibleCount` in its snapshot. Check a published brief, a thin-grounding page, and an empty page: each must retain sourced items or state why a brief is unavailable. An absence note must not count as a dated development. Missing reasons, misleading counts, or changes to withholding behavior require a fix or revert. Production acceptance remains pending that observation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
