### PR TITLE
fix(infrastructure): preserve last-good on companion read failures

### DIFF
--- a/docs/solutions/infrastructure-companion-empty-cache.md
+++ b/docs/solutions/infrastructure-companion-empty-cache.md
@@ -1,0 +1,66 @@
+# Confirmed empty infrastructure results and stale client caches
+
+Issue: #7870. Audit date: 2026-09-08.
+
+## Contract
+
+The DDoS and traffic-anomaly RPCs return HTTP 200 only after reading a valid
+companion payload. Empty arrays are valid, including a country filter with no
+matches. Missing keys, missing Redis configuration, read errors, invalid JSON,
+and invalid payload shapes return HTTP 503 through the existing error mapper.
+No protobuf change is needed. The generated client rejects the failed response,
+so the real circuit breaker retains its last successful result.
+
+The infrastructure client caches valid empty responses, including country-filtered
+traffic results. DDoS hydration already has a presence/shape guard on main; the
+existing hydration tests verify that an empty payload replaces a non-empty cache
+without an RPC request.
+
+After the 30-minute client TTL expires, the first read can serve the old value
+while the background refresh runs. Subsequent reads use the confirmed empty
+result. Failed refreshes retain last-good, including a previously confirmed empty
+result. This change does not alter the shared breaker's retention policy.
+
+## Audit of the other named breakers
+
+All four have the same mechanical exposure: their `shouldCache` predicate accepts
+the old non-empty entry and rejects a new empty result, without refresh eviction.
+Their domain contracts differ:
+
+| Client | Affected behavior | Current producer/reader contract |
+| --- | --- | --- |
+| `src/services/cross-source-signals.ts` | Confirmed-empty bug is present. Old signals can remain after all signals clear. | `scripts/seed-cross-source-signals.mjs` explicitly publishes empty signals as a valid no-escalation result. The RPC also collapses missing/unreadable data to empty. It needs a success/failure distinction before changing the predicate. |
+| `src/services/cable-health.ts` | Confirmed-empty bug is present. Old cable evidence can remain after signals expire. | `get-cable-health.ts` can successfully compute an empty map; it also returns an empty map when no usable fallback remains after failure. Its one-minute local cache adds another delay. It needs an availability contract before changing the predicate. |
+| `src/services/cached-theater-posture.ts` | Stale retention on empty is present; a healthy-empty publication path is not established. | `get-theater-posture.ts` rejects empty live/stale/backup snapshots and returns a no-store empty fallback. Client retention preserves last-good, but can hide unavailable data. A blanket eviction change would change failure behavior. |
+| `src/services/cached-risk-scores.ts` | The predicate has the same exposure, but a normal global confirmed-empty result is not established. | The client requests the global dataset. `get-risk-scores.ts` computes country scores even on its final degraded fallback. Region-filtered empty responses are not used by this client. Cached empty/corrupt payloads can still exercise the mechanism. |
+
+The latter four services are audited here only. Their domain-specific repairs are
+outside the two companion RPCs covered by this issue.
+
+## Verification
+
+`tests/infrastructure-companion-cache.test.mts` drives the real infrastructure
+service, circuit breaker, generated HTTP client and router, error mapper, and
+Redis reader. Only Redis HTTP and time are controlled. It covers non-empty to
+empty replacement, read failures before and after empty publication, missing
+keys/configuration, malformed data, recovery, seed envelopes, and country filters.
+The initial regression failed because all three read paths returned 200 on Redis
+failure instead of 503.
+
+`tests/bootstrap-hydration-reuse.test.mts` verifies confirmed-empty hydration and
+country cache reuse. `tests/cloudflare-radar-companion-publication.test.mjs`
+retains the existing real seeder-to-RPC proof. Run them with:
+
+```sh
+node --import tsx --test tests/infrastructure-companion-cache.test.mts tests/bootstrap-hydration-reuse.test.mts tests/cloudflare-radar-companion-publication.test.mjs
+npm run typecheck
+npm run typecheck:api
+npm run lint:boundaries
+```
+
+These checks do not prove deployed Edge behavior, live Cloudflare freshness, or
+rendered dashboard behavior. After authorized deployment, observe both companion
+RPCs through an empty publication and a read-failure/recovery window. Confirm
+200/empty replaces an old summary and 503 preserves last-good. Search server logs
+for `DDoS summary cache unavailable` and `Traffic anomalies cache unavailable`;
+sustained 503s while valid seed keys exist require investigation.

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -122,7 +122,7 @@ export async function readCachedEnvelopeJson(key: string, raw = false): Promise<
   return readCachedJsonInternal(key, raw, false);
 }
 
-function logCacheReadError(key: string, err: unknown): void {
+export function logCacheReadError(key: string, err: unknown): void {
   // Structured timeout log goes to Sentry via Vercel integration. Large-
   // payload timeouts used to silently return null and let downstream callers
   // cache zero-state — see docs/plans/chokepoint-rpc-payload-split.md for

--- a/server/worldmonitor/infrastructure/v1/list-ddos-attacks.ts
+++ b/server/worldmonitor/infrastructure/v1/list-ddos-attacks.ts
@@ -10,7 +10,7 @@ import {
   type ListInternetDdosAttacksResponse,
 } from '../../../../src/generated/server/worldmonitor/infrastructure/v1/service_server';
 
-import { readCachedJson } from '../../../_shared/redis';
+import { logCacheReadError, readCachedJson } from '../../../_shared/redis';
 
 const SEED_CACHE_KEY = 'cf:radar:ddos:v1';
 
@@ -19,6 +19,7 @@ export async function listInternetDdosAttacks(
   _req: ListInternetDdosAttacksRequest,
 ): Promise<ListInternetDdosAttacksResponse> {
   const cached = await readCachedJson(SEED_CACHE_KEY, true);
+  if (cached.status === 'error') logCacheReadError(SEED_CACHE_KEY, cached.error);
   const data = cached.status === 'hit' ? cached.value as Partial<ListInternetDdosAttacksResponse> | null : null;
   if (!data || !Array.isArray(data.protocol) || !Array.isArray(data.vector)
     || typeof data.dateRangeStart !== 'string' || typeof data.dateRangeEnd !== 'string'

--- a/server/worldmonitor/infrastructure/v1/list-ddos-attacks.ts
+++ b/server/worldmonitor/infrastructure/v1/list-ddos-attacks.ts
@@ -3,13 +3,14 @@
  * All external Cloudflare Radar API calls happen in seed-internet-outages.mjs on Railway.
  */
 
-import type {
-  ServerContext,
-  ListInternetDdosAttacksRequest,
-  ListInternetDdosAttacksResponse,
+import {
+  ApiError,
+  type ServerContext,
+  type ListInternetDdosAttacksRequest,
+  type ListInternetDdosAttacksResponse,
 } from '../../../../src/generated/server/worldmonitor/infrastructure/v1/service_server';
 
-import { getCachedJson } from '../../../_shared/redis';
+import { readCachedJson } from '../../../_shared/redis';
 
 const SEED_CACHE_KEY = 'cf:radar:ddos:v1';
 
@@ -17,16 +18,18 @@ export async function listInternetDdosAttacks(
   _ctx: ServerContext,
   _req: ListInternetDdosAttacksRequest,
 ): Promise<ListInternetDdosAttacksResponse> {
-  try {
-    const data = await getCachedJson(SEED_CACHE_KEY, true) as ListInternetDdosAttacksResponse | null;
-    return {
-      protocol: data?.protocol || [],
-      vector: data?.vector || [],
-      dateRangeStart: data?.dateRangeStart || '',
-      dateRangeEnd: data?.dateRangeEnd || '',
-      topTargetLocations: data?.topTargetLocations || [],
-    };
-  } catch {
-    return { protocol: [], vector: [], dateRangeStart: '', dateRangeEnd: '', topTargetLocations: [] };
+  const cached = await readCachedJson(SEED_CACHE_KEY, true);
+  const data = cached.status === 'hit' ? cached.value as Partial<ListInternetDdosAttacksResponse> | null : null;
+  if (!data || !Array.isArray(data.protocol) || !Array.isArray(data.vector)
+    || typeof data.dateRangeStart !== 'string' || typeof data.dateRangeEnd !== 'string'
+    || !Array.isArray(data.topTargetLocations)) {
+    throw new ApiError(503, 'DDoS summary cache unavailable', '');
   }
+  return {
+    protocol: data.protocol,
+    vector: data.vector,
+    dateRangeStart: data.dateRangeStart,
+    dateRangeEnd: data.dateRangeEnd,
+    topTargetLocations: data.topTargetLocations,
+  };
 }

--- a/server/worldmonitor/infrastructure/v1/list-traffic-anomalies.ts
+++ b/server/worldmonitor/infrastructure/v1/list-traffic-anomalies.ts
@@ -3,14 +3,14 @@
  * All external Cloudflare Radar API calls happen in seed-internet-outages.mjs on Railway.
  */
 
-import type {
-  ServerContext,
-  ListInternetTrafficAnomaliesRequest,
-  ListInternetTrafficAnomaliesResponse,
-  TrafficAnomaly,
+import {
+  ApiError,
+  type ServerContext,
+  type ListInternetTrafficAnomaliesRequest,
+  type ListInternetTrafficAnomaliesResponse,
 } from '../../../../src/generated/server/worldmonitor/infrastructure/v1/service_server';
 
-import { getCachedJson } from '../../../_shared/redis';
+import { readCachedJson } from '../../../_shared/redis';
 
 const SEED_CACHE_KEY = 'cf:radar:traffic-anomalies:v1';
 
@@ -18,17 +18,13 @@ export async function listInternetTrafficAnomalies(
   _ctx: ServerContext,
   req: ListInternetTrafficAnomaliesRequest,
 ): Promise<ListInternetTrafficAnomaliesResponse> {
-  try {
-    const data = await getCachedJson(SEED_CACHE_KEY, true) as ListInternetTrafficAnomaliesResponse | null;
-    let anomalies: TrafficAnomaly[] = data?.anomalies || [];
-
-    if (req.country) {
-      const target = req.country.toUpperCase();
-      anomalies = anomalies.filter((a) => a.locationCode === target);
-    }
-
-    return { anomalies, totalCount: anomalies.length };
-  } catch {
-    return { anomalies: [], totalCount: 0 };
+  const cached = await readCachedJson(SEED_CACHE_KEY, true);
+  const data = cached.status === 'hit' ? cached.value as Partial<ListInternetTrafficAnomaliesResponse> | null : null;
+  if (!data || !Array.isArray(data.anomalies)
+    || !data.anomalies.every((a) => a && typeof a.locationCode === 'string')) {
+    throw new ApiError(503, 'Traffic anomalies cache unavailable', '');
   }
+  const target = req.country?.toUpperCase();
+  const anomalies = target ? data.anomalies.filter((a) => a.locationCode === target) : data.anomalies;
+  return { anomalies, totalCount: anomalies.length };
 }

--- a/server/worldmonitor/infrastructure/v1/list-traffic-anomalies.ts
+++ b/server/worldmonitor/infrastructure/v1/list-traffic-anomalies.ts
@@ -10,7 +10,7 @@ import {
   type ListInternetTrafficAnomaliesResponse,
 } from '../../../../src/generated/server/worldmonitor/infrastructure/v1/service_server';
 
-import { readCachedJson } from '../../../_shared/redis';
+import { logCacheReadError, readCachedJson } from '../../../_shared/redis';
 
 const SEED_CACHE_KEY = 'cf:radar:traffic-anomalies:v1';
 
@@ -19,6 +19,7 @@ export async function listInternetTrafficAnomalies(
   req: ListInternetTrafficAnomaliesRequest,
 ): Promise<ListInternetTrafficAnomaliesResponse> {
   const cached = await readCachedJson(SEED_CACHE_KEY, true);
+  if (cached.status === 'error') logCacheReadError(SEED_CACHE_KEY, cached.error);
   const data = cached.status === 'hit' ? cached.value as Partial<ListInternetTrafficAnomaliesResponse> | null : null;
   if (!data || !Array.isArray(data.anomalies)
     || !data.anomalies.every((a) => a && typeof a.locationCode === 'string')) {

--- a/src/services/infrastructure/index.ts
+++ b/src/services/infrastructure/index.ts
@@ -162,10 +162,7 @@ export async function fetchTrafficAnomalies(country?: string): Promise<ListInter
     return response;
   }, emptyAnomaliesFallback, {
     cacheKey: country,
-    // Global empty data is authoritative, but preserve the existing
-    // country-specific retry behavior for an empty filtered result.
-    shouldCache: (response) => isTrafficAnomaliesResponse(response)
-      && (!country || response.anomalies.length > 0),
+    shouldCache: isTrafficAnomaliesResponse,
   });
 }
 

--- a/tests/bootstrap-hydration-reuse.test.mts
+++ b/tests/bootstrap-hydration-reuse.test.mts
@@ -491,7 +491,7 @@ describe('bootstrap hydration reuse (#7048)', () => {
     assert.equal(rpcUrlCount(requests), 1, 'the filtered read must use its own RPC/cache key');
   });
 
-  it('traffic anomalies: authoritative empty global hydration replaces cache but empty country results remain retryable', async () => {
+  it('traffic anomalies: authoritative empty hydration and country results stay cached', async () => {
     const requests = bootstrapStub({
       trafficAnomalies: { anomalies: [], totalCount: 0 },
     });
@@ -503,9 +503,9 @@ describe('bootstrap hydration reuse (#7048)', () => {
     assert.deepEqual(globalSecond, globalFirst, 'the empty global snapshot replaces the previous cached response');
     assert.equal(rpcUrlCount(requests), 0, 'valid empty global traffic hydration must stay in the breaker cache');
 
-    await harness.fetchTrafficAnomalies('US');
-    await harness.fetchTrafficAnomalies('US');
-    assert.equal(rpcUrlCount(requests), 2, 'empty country-filtered results retain their existing retry behavior');
+    await harness.fetchTrafficAnomalies('CA');
+    await harness.fetchTrafficAnomalies('CA');
+    assert.equal(rpcUrlCount(requests), 1, 'the confirmed empty country result stays cached after its first RPC');
   });
 
   it('socialVelocity (no breaker): the hydration handoff answers recurring reads', async () => {

--- a/tests/infrastructure-companion-cache.test.mts
+++ b/tests/infrastructure-companion-cache.test.mts
@@ -42,13 +42,15 @@ for (const kind of ['ddos', 'traffic', 'country'] as const) {
     const good = kind === 'ddos' ? ddos : traffic;
     const empty = kind === 'ddos' ? emptyDdos : emptyTraffic;
     let payload: unknown = good;
-    let failure: 'http' | 'network' | 'command' | 'json' | undefined;
+    let failure: 'http' | 'network' | 'command' | 'json' | 'timeout' | undefined;
     let now = Date.now();
     const statuses: number[] = [];
     t.mock.method(Date, 'now', () => now);
     // Expected failure logs would otherwise contain the entire data-URL bundle.
-    t.mock.method(console, 'warn', () => {});
-    t.mock.method(console, 'error', () => {});
+    const logs: string[] = [];
+    const recordLog = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+    t.mock.method(console, 'warn', recordLog);
+    t.mock.method(console, 'error', recordLog);
     const env = { ...process.env };
     t.after(() => { process.env = env; });
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.fixture';
@@ -58,6 +60,8 @@ for (const kind of ['ddos', 'traffic', 'country'] as const) {
       const rawUrl = input instanceof Request ? input.url : String(input);
       const url = new URL(rawUrl, 'https://app.fixture');
       if (url.origin === 'https://redis.fixture') {
+        assert.equal(decodeURIComponent(url.pathname), `/get/cf:radar:${kind === 'ddos' ? 'ddos' : 'traffic-anomalies'}:v1`);
+        if (failure === 'timeout') throw new DOMException('fixture timeout', 'TimeoutError');
         if (failure === 'network') throw new TypeError('fetch failed');
         if (failure === 'http') return new Response('', { status: 503 });
         if (failure === 'command') return Response.json({ error: 'fixture read failure' });
@@ -83,9 +87,15 @@ for (const kind of ['ddos', 'traffic', 'country'] as const) {
     }
 
     assert.deepEqual(await read(), good);
-    for (const error of ['http', 'network', 'command', 'json'] as const) {
+    for (const error of ['http', 'network', 'command', 'json', 'timeout'] as const) {
       failure = error;
+      logs.length = 0;
       await refresh(good, 503);
+      if (error === 'timeout') {
+        assert.ok(logs.some((line) => line.includes(`[REDIS-TIMEOUT] getCachedJson key=cf:radar:${kind === 'ddos' ? 'ddos' : 'traffic-anomalies'}:v1`)));
+      } else {
+        assert.ok(logs.some((line) => line.startsWith('[redis] getCachedJson failed:')));
+      }
       failure = undefined;
       await refresh(good, 200);
     }

--- a/tests/infrastructure-companion-cache.test.mts
+++ b/tests/infrastructure-companion-cache.test.mts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { before, test } from 'node:test';
+import { build } from 'esbuild';
+
+// Keep the real service, breaker, generated HTTP client/router, error mapper,
+// and Redis reader together. Only the Redis HTTP transport and clock are controlled.
+let bundledSource: string;
+before(async () => {
+  const result = await build({
+    stdin: {
+      contents: `
+        export { fetchDdosAttacks, fetchTrafficAnomalies } from './src/services/infrastructure/index.ts';
+        import { createInfrastructureServiceRoutes } from './src/generated/server/worldmonitor/infrastructure/v1/service_server.ts';
+        import { listInternetDdosAttacks } from './server/worldmonitor/infrastructure/v1/list-ddos-attacks.ts';
+        import { listInternetTrafficAnomalies } from './server/worldmonitor/infrastructure/v1/list-traffic-anomalies.ts';
+        import { mapErrorToResponse } from './server/error-mapper.ts';
+        export const routes = createInfrastructureServiceRoutes(
+          { listInternetDdosAttacks, listInternetTrafficAnomalies }, { onError: mapErrorToResponse });
+      `,
+      resolveDir: process.cwd(), loader: 'ts',
+    },
+    bundle: true, write: false, format: 'esm', platform: 'node',
+    define: { 'import.meta.env': '{"DEV":false}' }, logLevel: 'silent',
+  });
+  bundledSource = result.outputFiles[0]!.text;
+});
+
+const ddos = {
+  protocol: [{ label: 'TCP', percentage: 80 }], vector: [],
+  dateRangeStart: '2026-09-01', dateRangeEnd: '2026-09-08', topTargetLocations: [],
+};
+const emptyDdos = { ...ddos, protocol: [] };
+const traffic = { anomalies: [{ id: 'traffic-us', locationCode: 'US' }], totalCount: 1 };
+const emptyTraffic = { anomalies: [], totalCount: 0 };
+const ttl = 30 * 60 * 1000;
+
+for (const kind of ['ddos', 'traffic', 'country'] as const) {
+  test(`${kind}: confirmed empty replaces stale data; failed Redis reads preserve last-good`, async (t) => {
+    const harness = await import(`data:text/javascript;base64,${Buffer.from(bundledSource).toString('base64')}#${kind}`);
+    const read = kind === 'ddos' ? harness.fetchDdosAttacks
+      : () => harness.fetchTrafficAnomalies(kind === 'country' ? 'US' : undefined);
+    const good = kind === 'ddos' ? ddos : traffic;
+    const empty = kind === 'ddos' ? emptyDdos : emptyTraffic;
+    let payload: unknown = good;
+    let failure: 'http' | 'network' | 'command' | 'json' | undefined;
+    let now = Date.now();
+    const statuses: number[] = [];
+    t.mock.method(Date, 'now', () => now);
+    // Expected failure logs would otherwise contain the entire data-URL bundle.
+    t.mock.method(console, 'warn', () => {});
+    t.mock.method(console, 'error', () => {});
+    const env = { ...process.env };
+    t.after(() => { process.env = env; });
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.fixture';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fixture';
+    delete process.env.LOCAL_API_MODE;
+    t.mock.method(globalThis, 'fetch', async (input: RequestInfo | URL) => {
+      const rawUrl = input instanceof Request ? input.url : String(input);
+      const url = new URL(rawUrl, 'https://app.fixture');
+      if (url.origin === 'https://redis.fixture') {
+        if (failure === 'network') throw new TypeError('fetch failed');
+        if (failure === 'http') return new Response('', { status: 503 });
+        if (failure === 'command') return Response.json({ error: 'fixture read failure' });
+        if (failure === 'json') return Response.json({ result: '{broken' });
+        return Response.json({ result: payload === null ? null : JSON.stringify(payload) });
+      }
+      const route = harness.routes.find((r: { path: string }) => r.path === url.pathname);
+      assert.ok(route, `unexpected request: ${url}`);
+      const response = await route.handler(new Request(url));
+      statuses.push(response.status);
+      return response;
+    });
+
+    async function refresh(expected: unknown, status: number) {
+      now += ttl + 1;
+      const count = statuses.length;
+      await read(); // SWR may serve the old value while refreshing.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(statuses.length, count + 1);
+      assert.equal(statuses.at(-1), status);
+      assert.deepEqual(await read(), expected);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    assert.deepEqual(await read(), good);
+    for (const error of ['http', 'network', 'command', 'json'] as const) {
+      failure = error;
+      await refresh(good, 503);
+      failure = undefined;
+      await refresh(good, 200);
+    }
+    for (const invalid of [null, {}, { anomalies: null, protocol: null }]) {
+      payload = invalid;
+      await refresh(good, 503);
+      payload = good;
+      await refresh(good, 200);
+    }
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    await refresh(good, 503);
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fixture';
+    await refresh(good, 200);
+    payload = empty;
+    await refresh(empty, 200);
+    failure = 'http';
+    await refresh(empty, 503);
+    failure = undefined;
+    payload = { _seed: { fetchedAt: now, state: 'OK' }, data: good };
+    await refresh(good, 200);
+    if (kind === 'country') {
+      payload = { anomalies: [{ id: 'traffic-fr', locationCode: 'FR' }], totalCount: 1 };
+      await refresh(emptyTraffic, 200);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

DDoS and traffic summaries now clear after a confirmed empty result while a failed cache read preserves the last successful summary. The RPCs return 503 for missing, unreadable, or malformed cache data and 200 for valid empty payloads; this lets the existing client breaker distinguish the two without a protobuf change. Country-filtered empty traffic results also replace old entries.

DDoS empty hydration was already fixed on main and remains covered. The audit in `docs/solutions/infrastructure-companion-empty-cache.md` identifies the same confirmed-empty bug in cross-source signals and cable health; theater posture and global risk scores have the same predicate exposure but different unavailable-data contracts. Those four clients are unchanged.

Fixes #7870.
Related: #7845, #7862.

## Validation

- 48 focused tests passed. The new test exercises the real service, breaker, generated HTTP client/router, error mapper, and Redis reader with controlled Redis HTTP and time. It first failed on the old 200-on-read-failure behavior, then passed for failure retention, empty replacement, recovery, invalid/missing data, missing configuration, and country filtering.
- Existing seeder-to-RPC and hydration tests passed; browser and API type checks, boundary lint, and pre-push gates passed.
- Rendered dashboard behavior, deployed Edge behavior, and live provider freshness were not tested. The first stale read can still serve old data while its background refresh runs.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the deployment owner should observe both companion RPCs through the first confirmed-empty publication and the next 30-minute client refresh, plus one failure/recovery window. Healthy: 200/empty replaces the old summary and 503 retains last-good. Check companion seed freshness and search server logs for `DDoS summary cache unavailable` or `Traffic anomalies cache unavailable`. Sustained 503s with valid seed keys, or a cleared last-good summary during a failed read, are investigation and rollback triggers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
