### PR TITLE
fix(health): retain China coverage for three hours

### DIFF
--- a/api/_china-decision-health.js
+++ b/api/_china-decision-health.js
@@ -72,65 +72,23 @@ export function projectChinaDecisionGroupDiagnostics(
   };
   if (Object.entries(expectedCounts).some(([key, value]) => counts[key] !== value)) return null;
 
-  const hasCoverageFailureFields = meta !== null
-    && typeof meta === 'object'
-    && [
-      'decisionCoverageFailureKey',
-      'consecutiveDecisionCoverageFailures',
-      'firstDecisionCoverageFailureAt',
-      'lastDecisionCoverageAttemptAt',
-      'lastDecisionCoverageSuccessAt',
-    ].some((key) => Object.hasOwn(meta, key));
-  const failureKey = typeof meta?.decisionCoverageFailureKey === 'string'
-    && meta.decisionCoverageFailureKey.length <= 1_000
-      ? meta.decisionCoverageFailureKey
-      : null;
-  const consecutiveFailures = Number.isInteger(meta?.consecutiveDecisionCoverageFailures)
-    && meta.consecutiveDecisionCoverageFailures >= 1
-    && meta.consecutiveDecisionCoverageFailures <= 100
-      ? meta.consecutiveDecisionCoverageFailures
-      : null;
-  const firstFailureAt = Number.isSafeInteger(meta?.firstDecisionCoverageFailureAt)
-    && meta.firstDecisionCoverageFailureAt > 0
-      ? meta.firstDecisionCoverageFailureAt
-      : null;
-  const lastAttemptAt = Number.isSafeInteger(meta?.lastDecisionCoverageAttemptAt)
-    && meta.lastDecisionCoverageAttemptAt > 0
-      ? meta.lastDecisionCoverageAttemptAt
-      : null;
+  const fetchedAt = Number.isSafeInteger(meta?.fetchedAt) && meta.fetchedAt > 0
+    ? meta.fetchedAt
+    : null;
   const lastSuccessAt = Number.isSafeInteger(meta?.lastDecisionCoverageSuccessAt)
     && meta.lastDecisionCoverageSuccessAt > 0
       ? meta.lastDecisionCoverageSuccessAt
       : null;
-  const coverageFailure = failureKey !== null
-    && consecutiveFailures !== null
-    && firstFailureAt !== null
-    && lastAttemptAt !== null
-    && lastSuccessAt !== null
-    && lastSuccessAt <= firstFailureAt
-    && firstFailureAt <= lastAttemptAt
-      ? { failureKey, consecutiveFailures, firstFailureAt, lastAttemptAt, lastSuccessAt }
+  const legacyLastSuccessAt = expectedCounts.operationallyCovered === groupIds.length
+    && fetchedAt !== null
+      ? fetchedAt
       : null;
-  const recoveryTuple = meta?.decisionCoverageFailureKey === null
-    && meta?.consecutiveDecisionCoverageFailures === 0
-    && meta?.firstDecisionCoverageFailureAt === null
-    && lastAttemptAt !== null
-    && lastSuccessAt === lastAttemptAt;
-  const recoveredCoverage = recoveryTuple
-    && expectedCounts.operationallyCovered === groupIds.length;
-  const coverageFailureInvalidReason = !hasCoverageFailureFields
-    || coverageFailure
-    || recoveredCoverage
-      ? null
-      : recoveryTuple
-        ? 'RECOVERY_COVERAGE_MISMATCH'
-        : failureKey === null
-          ? 'FAILURE_KEY_INVALID'
-        : consecutiveFailures === null
-          ? 'FAILURE_COUNT_INVALID'
-          : firstFailureAt === null || lastAttemptAt === null || lastSuccessAt === null
-            ? 'FAILURE_TIMESTAMP_MISSING'
-            : 'FAILURE_TIMESTAMP_ORDER_INVALID';
+  const coverageLastSuccessAt = lastSuccessAt ?? legacyLastSuccessAt;
+  const coverageFailureInvalidReason = coverageLastSuccessAt === null
+    ? 'LAST_SUCCESS_MISSING'
+    : fetchedAt === null || coverageLastSuccessAt > fetchedAt
+      ? 'LAST_SUCCESS_INVALID'
+      : null;
 
   return {
     groupStates,
@@ -146,7 +104,7 @@ export function projectChinaDecisionGroupDiagnostics(
     partialGroups,
     staleGroups,
     unavailableGroups,
-    ...(coverageFailure ? { coverageFailure } : {}),
+    ...(coverageLastSuccessAt !== null ? { coverageLastSuccessAt } : {}),
     ...(coverageFailureInvalidReason ? { coverageFailureInvalidReason } : {}),
   };
 }

--- a/api/_china-decision-health.js
+++ b/api/_china-decision-health.js
@@ -62,6 +62,76 @@ export function projectChinaDecisionGroupDiagnostics(
     }
   }
 
+  const expectedCounts = {
+    populated: groupIds.filter((groupId) => groupStates[groupId] !== 'unavailable').length,
+    partial: partialGroups.length,
+    stale: staleGroups.length,
+    unavailable: quietGroups.length + unavailableGroups.length,
+    healthyQuiet: quietGroups.length,
+    operationallyCovered: groupIds.length - staleGroups.length - unavailableGroups.length,
+  };
+  if (Object.entries(expectedCounts).some(([key, value]) => counts[key] !== value)) return null;
+
+  const hasCoverageFailureFields = meta !== null
+    && typeof meta === 'object'
+    && [
+      'decisionCoverageFailureKey',
+      'consecutiveDecisionCoverageFailures',
+      'firstDecisionCoverageFailureAt',
+      'lastDecisionCoverageAttemptAt',
+      'lastDecisionCoverageSuccessAt',
+    ].some((key) => Object.hasOwn(meta, key));
+  const failureKey = typeof meta?.decisionCoverageFailureKey === 'string'
+    && meta.decisionCoverageFailureKey.length <= 1_000
+      ? meta.decisionCoverageFailureKey
+      : null;
+  const consecutiveFailures = Number.isInteger(meta?.consecutiveDecisionCoverageFailures)
+    && meta.consecutiveDecisionCoverageFailures >= 1
+    && meta.consecutiveDecisionCoverageFailures <= 100
+      ? meta.consecutiveDecisionCoverageFailures
+      : null;
+  const firstFailureAt = Number.isSafeInteger(meta?.firstDecisionCoverageFailureAt)
+    && meta.firstDecisionCoverageFailureAt > 0
+      ? meta.firstDecisionCoverageFailureAt
+      : null;
+  const lastAttemptAt = Number.isSafeInteger(meta?.lastDecisionCoverageAttemptAt)
+    && meta.lastDecisionCoverageAttemptAt > 0
+      ? meta.lastDecisionCoverageAttemptAt
+      : null;
+  const lastSuccessAt = Number.isSafeInteger(meta?.lastDecisionCoverageSuccessAt)
+    && meta.lastDecisionCoverageSuccessAt > 0
+      ? meta.lastDecisionCoverageSuccessAt
+      : null;
+  const coverageFailure = failureKey !== null
+    && consecutiveFailures !== null
+    && firstFailureAt !== null
+    && lastAttemptAt !== null
+    && lastSuccessAt !== null
+    && lastSuccessAt <= firstFailureAt
+    && firstFailureAt <= lastAttemptAt
+      ? { failureKey, consecutiveFailures, firstFailureAt, lastAttemptAt, lastSuccessAt }
+      : null;
+  const recoveryTuple = meta?.decisionCoverageFailureKey === null
+    && meta?.consecutiveDecisionCoverageFailures === 0
+    && meta?.firstDecisionCoverageFailureAt === null
+    && lastAttemptAt !== null
+    && lastSuccessAt === lastAttemptAt;
+  const recoveredCoverage = recoveryTuple
+    && expectedCounts.operationallyCovered === groupIds.length;
+  const coverageFailureInvalidReason = !hasCoverageFailureFields
+    || coverageFailure
+    || recoveredCoverage
+      ? null
+      : recoveryTuple
+        ? 'RECOVERY_COVERAGE_MISMATCH'
+        : failureKey === null
+          ? 'FAILURE_KEY_INVALID'
+        : consecutiveFailures === null
+          ? 'FAILURE_COUNT_INVALID'
+          : firstFailureAt === null || lastAttemptAt === null || lastSuccessAt === null
+            ? 'FAILURE_TIMESTAMP_MISSING'
+            : 'FAILURE_TIMESTAMP_ORDER_INVALID';
+
   return {
     groupStates,
     groupCounts: {
@@ -76,5 +146,7 @@ export function projectChinaDecisionGroupDiagnostics(
     partialGroups,
     staleGroups,
     unavailableGroups,
+    ...(coverageFailure ? { coverageFailure } : {}),
+    ...(coverageFailureInvalidReason ? { coverageFailureInvalidReason } : {}),
   };
 }

--- a/api/health.js
+++ b/api/health.js
@@ -172,15 +172,11 @@ const HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS = 60;
 // Edge runtime mirror of scripts/china-coverage-manifest.mjs. Edge functions
 // cannot import scripts/; tests enforce key and status-projection parity.
 const CHINA_COVERAGE_SUMMARY_KEY = 'health:china-coverage:v1';
-// Consecutive non-healthy evaluations required before CHINA_DEGRADED is
-// reported. See projectChinaCoverageStatus for why the debounce lives here and
-// not in the summary's own `status` field.
-const CHINA_DEGRADED_MIN_CONSECUTIVE = 2;
-// The aggregate China evaluator runs hourly. Give that second observation one
-// full cycle plus one 15-minute derived-signal publication interval to arrive.
-// A repeated incident stops being pending as soon as the evaluator publishes
-// streak 2; this deadline is only the fail-closed backstop when it does not.
-const CHINA_DECISION_SIGNALS_PENDING_MS = 75 * 60 * 1_000;
+// China decision cards are useful for hours, not minutes. Keep health pending
+// for three hours after proven full operational coverage while the current partial
+// snapshot stays visible and the 15-minute producer records every attempt. The
+// same ceiling is enforced by the seed-age budget and freshness monitor.
+const CHINA_DECISION_SIGNALS_PENDING_MS = 3 * 60 * 60 * 1_000;
 const HEALTH_VERDICT_SNAPSHOT_TTL_MS = HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS * 1_000;
 const HEALTH_VERDICT_REFRESH_LOCK_KEY = `${HEALTH_VERDICT_SNAPSHOT_KEY}:refresh-lock`;
 // The sweep can consume its full 8s timeout, followed by a 4s failure-log read
@@ -795,7 +791,7 @@ const SEED_META = {
   // but no other unavailable cause.
   chinaDecisionSignals: {
     key: 'seed-meta:intelligence:china-decision-signals',
-    maxStaleMin: 60,
+    maxStaleMin: 180,
     minRecordCount: 6,
     decisionGroups: CHINA_DECISION_SIGNAL_GROUP_IDS,
   },
@@ -2466,8 +2462,16 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       partialGroups: decisionDiagnostics.partialGroups,
       staleGroups: decisionDiagnostics.staleGroups,
       unavailableGroups: decisionDiagnostics.unavailableGroups,
+      ...(decisionDiagnostics.coverageFailure
+        ? { coverageFailure: decisionDiagnostics.coverageFailure }
+        : {}),
+      ...(decisionDiagnostics.coverageFailureInvalidReason
+        ? { coverageFailureInvalidReason: decisionDiagnostics.coverageFailureInvalidReason }
+        : {}),
     }
-    : null;
+    : seedCfg.decisionGroups
+      ? { coverageFailureInvalidReason: 'GROUP_DIAGNOSTICS_INVALID' }
+      : null;
   // Per-market coverage: optional { status, completedPages, failedPages, completionRatio, rejectedCount, failureReasons, retailers }
   // written by consumer-prices publish.ts and other seeders that track partial completion.
   // null when the seeder didn't write coverage fields.
@@ -2846,6 +2850,10 @@ function classifyKey(name, redisKey, opts, ctx) {
     seedCfg?.requiredRedistributionPolicyVersion != null
     && redistributionPolicyVersion !== seedCfg.requiredRedistributionPolicyVersion
   ) status = 'POLICY_INCOMPATIBLE';
+  else if (
+    decisionGroups?.coverageFailureInvalidReason
+    || decisionGroups?.staleGroups?.length > 0
+  ) status = 'COVERAGE_PARTIAL';
   // Coverage threshold: producers that know their canonical shape size can
   // declare minRecordCount. When the writer reports a count below threshold
   // (e.g., 10/13 chokepoints because portwatch dropped some), this degrades
@@ -3100,7 +3108,7 @@ const STATUS_COUNTS = {
 };
 
 function healthStatusBucket(entry, now) {
-  if (entry?.status === 'COVERAGE_PARTIAL'
+  if (['COVERAGE_PARTIAL', 'CHINA_DEGRADED'].includes(entry?.status)
     && typeof entry.chinaCoveragePendingUntil === 'string'
     && !isExpiredDeadline(entry.chinaCoveragePendingUntil, now)) return 'ok';
   if (entry?.status === 'SEED_ERROR'
@@ -3193,7 +3201,7 @@ function isValidChinaCoverageSummary(candidate) {
   return candidate.status === expectedStatus;
 }
 
-function projectChinaCoverageStatus(raw, readError = false) {
+function projectChinaCoverageStatus(raw, readError = false, now = Date.now()) {
   if (readError) {
     return { status: 'REDIS_PARTIAL', chinaStatus: null, reason: 'SUMMARY_READ_FAILED' };
   }
@@ -3204,32 +3212,32 @@ function projectChinaCoverageStatus(raw, readError = false) {
     return { status: 'CHINA_UNAVAILABLE', chinaStatus: 'unavailable', reason: 'SUMMARY_INVALID' };
   }
 
-  let status = {
+  const status = {
     healthy: 'OK',
     degraded: 'CHINA_DEGRADED',
     unavailable: 'CHINA_UNAVAILABLE',
   }[candidate.status] ?? 'CHINA_UNAVAILABLE';
-  // Debounce DEGRADED only. The evaluator samples 16 sources once an hour, so a
-  // source that is degraded at the sampling instant and healthy moments later
-  // pins CHINA_DEGRADED for a full cycle — measured at ~50 minutes for a
-  // two-minute miss on 2026-08-25. Requiring a second consecutive observation
-  // costs one cycle of detection latency on a real outage, which is affordable
-  // here: this is a warn, and every source underneath carries its own probe with
-  // its own budget.
-  //
-  // UNAVAILABLE is never debounced — it is the more severe verdict, and holding
-  // it back would be the expensive direction to be wrong in.
-  //
-  // A summary with NO streak field (written before the producer shipped this)
-  // alarms exactly as it did before. Absent evidence must not read as evidence
-  // of health, or the rollout window would silence a genuine outage.
-  if (
-    status === 'CHINA_DEGRADED'
-    && candidate.degradedStreak === CHINA_DEGRADED_MIN_CONSECUTIVE - 1
-    && typeof candidate.degradedProblemKey === 'string'
-  ) {
-    status = 'OK';
-  }
+  // Hold DEGRADED only when the producer proves a recent healthy evaluation and
+  // the current unresolved episode. The deadline is wall-clock based, so retries
+  // and changing problem identities cannot exhaust or restart the three hours.
+  // UNAVAILABLE remains immediate. Missing or malformed timing evidence also
+  // fails closed as CHINA_DEGRADED.
+  const evaluatedAt = Date.parse(candidate.evaluatedAt ?? '');
+  const validEpisode = status === 'CHINA_DEGRADED'
+    && Number.isSafeInteger(candidate.firstDegradedAt)
+    && Number.isSafeInteger(candidate.lastDegradedAt)
+    && Number.isSafeInteger(candidate.lastHealthyAt)
+    && candidate.lastHealthyAt > 0
+    && candidate.lastHealthyAt <= candidate.firstDegradedAt
+    && candidate.firstDegradedAt <= candidate.lastDegradedAt
+    && candidate.lastDegradedAt === evaluatedAt
+    && candidate.lastDegradedAt <= now;
+  const pendingUntil = validEpisode
+    ? Math.min(
+      candidate.firstDegradedAt + CHINA_DECISION_SIGNALS_PENDING_MS,
+      candidate.lastHealthyAt + CHINA_DECISION_SIGNALS_PENDING_MS,
+    )
+    : null;
   const problems = Array.isArray(candidate.entries)
     ? candidate.entries
       .filter((entry) => entry?.launchStatus === 'launched' && entry?.status !== 'healthy')
@@ -3248,15 +3256,27 @@ function projectChinaCoverageStatus(raw, readError = false) {
     ...(typeof candidate.degradedProblemKey === 'string'
       ? { degradedProblemKey: candidate.degradedProblemKey }
       : {}),
+    ...(Number.isSafeInteger(candidate.firstDegradedAt)
+      ? { firstDegradedAt: candidate.firstDegradedAt }
+      : {}),
+    ...(Number.isSafeInteger(candidate.lastDegradedAt)
+      ? { lastDegradedAt: candidate.lastDegradedAt }
+      : {}),
+    ...(Number.isSafeInteger(candidate.lastHealthyAt)
+      ? { lastHealthyAt: candidate.lastHealthyAt }
+      : {}),
+    ...(pendingUntil !== null && now < pendingUntil
+      ? { chinaCoveragePendingUntil: new Date(pendingUntil).toISOString() }
+      : {}),
     ...(problems.length > 0 ? { problems } : {}),
   };
 }
 
-function composeChinaCoverageStatus(entry, raw, readError = false) {
+function composeChinaCoverageStatus(entry, raw, readError = false, now = Date.now()) {
   if (!entry || !['OK', 'STALE_SEED', 'SEED_ERROR'].includes(entry.status)) return entry;
 
   const seedStatus = entry.status;
-  const projected = projectChinaCoverageStatus(raw, readError);
+  const projected = projectChinaCoverageStatus(raw, readError, now);
   if (seedStatus === 'OK') return { ...entry, ...projected };
 
   // Preserve writer-health failures when the last summary was healthy, but do
@@ -3269,48 +3289,34 @@ function composeChinaCoverageStatus(entry, raw, readError = false) {
   return { ...entry, ...projected, seedStatus };
 }
 
-function composeChinaDecisionSignalsStatus(entry, chinaCoverageEntry, now) {
-  if (
-    entry?.status !== 'COVERAGE_PARTIAL'
-    || chinaCoverageEntry?.status !== 'OK'
-    || chinaCoverageEntry?.chinaStatus !== 'degraded'
-    || chinaCoverageEntry?.degradedStreak !== CHINA_DEGRADED_MIN_CONSECUTIVE - 1
-  ) return entry;
+function composeChinaDecisionSignalsStatus(entry, _chinaCoverageEntry, now) {
+  if (entry?.status !== 'COVERAGE_PARTIAL') return entry;
 
-  const chinaProblems = Array.isArray(chinaCoverageEntry.problems)
-    ? chinaCoverageEntry.problems
-    : [];
   const decisionProblems = Array.isArray(entry.decisionGroups?.unavailableGroups)
     ? entry.decisionGroups.unavailableGroups
     : [];
+  const failure = entry.decisionGroups?.coverageFailure;
+  const expectedFailureKey = decisionProblems.length > 0
+    ? JSON.stringify([...decisionProblems].sort((left, right) => left.id.localeCompare(right.id)))
+    : null;
   const requiredDecisionGroups = SEED_META.chinaDecisionSignals.minRecordCount;
-  const [chinaProblem] = chinaProblems;
-  const [decisionProblem] = decisionProblems;
-  const sameHeldCorporateIncident = chinaProblems.length === 1
-    && chinaProblem?.id === 'market.china-corporate-disclosures'
-    && chinaProblem?.status === 'degraded'
-    && Array.isArray(chinaProblem?.reasonCodes)
-    && chinaProblem.reasonCodes.length === 1
-    && chinaProblem.reasonCodes[0] === 'CHINA_COVERAGE_PARTIAL'
-    && decisionProblems.length === 1
-    && decisionProblem?.id === 'corporate-disclosures'
-    && decisionProblem?.unavailableCause === 'upstream_unavailable'
+  const validCoverageShortfall = expectedFailureKey !== null
+    && failure?.failureKey === expectedFailureKey
     && entry.minRecordCount === requiredDecisionGroups
-    && entry.records === requiredDecisionGroups - 1
-    && entry.decisionGroups?.operationallyCovered === entry.records;
-  if (!sameHeldCorporateIncident) return entry;
+    && entry.records === entry.decisionGroups?.operationallyCovered
+    && entry.records > 0
+    && entry.records < requiredDecisionGroups;
+  if (validCoverageShortfall) {
+    const pendingUntil = Math.min(
+      failure.firstFailureAt + CHINA_DECISION_SIGNALS_PENDING_MS,
+      failure.lastSuccessAt + SEED_META.chinaDecisionSignals.maxStaleMin * 60_000,
+    );
+    if (failure.lastAttemptAt <= now && now < pendingUntil) {
+      return { ...entry, chinaCoveragePendingUntil: new Date(pendingUntil).toISOString() };
+    }
+  }
 
-  const evaluatedAt = Date.parse(chinaCoverageEntry.evaluatedAt);
-  const pendingUntil = evaluatedAt + CHINA_DECISION_SIGNALS_PENDING_MS;
-  if (!Number.isFinite(evaluatedAt) || evaluatedAt > now || now >= pendingUntil) return entry;
-
-  // chinaDecisionSignals is derived from the same corporate snapshot the
-  // aggregate evaluator just held for its first degraded observation. Keep the
-  // derived coverage diagnosis visible, but bucket both projections together;
-  // otherwise one source incident bypasses the debounce through a second key
-  // and flips the fleet verdict despite retained last-good data. The deadline
-  // prevents a stalled evaluator from holding this projection indefinitely.
-  return { ...entry, chinaCoveragePendingUntil: new Date(pendingUntil).toISOString() };
+  return entry;
 }
 
 function composeScorecardReadModelStatus(entry, raw, readError = false) {
@@ -3395,7 +3401,7 @@ const ENTRY_SOFTENING_DEADLINES = [
   { field: 'contentFreshnessPendingUntil', kind: 'content', status: null },
   { field: 'staleContentGraceUntil', kind: 'content', status: null },
   { field: 'sourceFailurePendingUntil', kind: 'source', status: 'SEED_ERROR' },
-  { field: 'chinaCoveragePendingUntil', kind: 'source', status: 'COVERAGE_PARTIAL' },
+  { field: 'chinaCoveragePendingUntil', kind: 'source', status: null },
 ];
 
 function entryDeadlineRaw(entry, { field, status }) {
@@ -3946,7 +3952,12 @@ export async function handleHealth(req, ctx, options = {}) {
       totalChecks++;
       let entry = classifyKey(name, redisKey, opts, classifyCtx);
       if (name === 'chinaCoverage') {
-        entry = composeChinaCoverageStatus(entry, chinaCoverageRaw, Boolean(chinaCoverageResult?.error));
+        entry = composeChinaCoverageStatus(
+          entry,
+          chinaCoverageRaw,
+          Boolean(chinaCoverageResult?.error),
+          evaluationNow,
+        );
       }
       if (name === 'scorecardFiveFactor') {
         entry = composeScorecardReadModelStatus(

--- a/api/health.js
+++ b/api/health.js
@@ -177,6 +177,10 @@ const CHINA_COVERAGE_SUMMARY_KEY = 'health:china-coverage:v1';
 // snapshot stays visible and the 15-minute producer records every attempt. The
 // same ceiling is enforced by the seed-age budget and freshness monitor.
 const CHINA_DECISION_SIGNALS_PENDING_MS = 3 * 60 * 60 * 1_000;
+const CHINA_TRANSIENT_COVERAGE_REASONS = new Set([
+  'CHINA_COVERAGE_PARTIAL',
+  'TRANSPORT_ERROR',
+]);
 const HEALTH_VERDICT_SNAPSHOT_TTL_MS = HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS * 1_000;
 const HEALTH_VERDICT_REFRESH_LOCK_KEY = `${HEALTH_VERDICT_SNAPSHOT_KEY}:refresh-lock`;
 // The sweep can consume its full 8s timeout, followed by a 4s failure-log read
@@ -2462,8 +2466,8 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       partialGroups: decisionDiagnostics.partialGroups,
       staleGroups: decisionDiagnostics.staleGroups,
       unavailableGroups: decisionDiagnostics.unavailableGroups,
-      ...(decisionDiagnostics.coverageFailure
-        ? { coverageFailure: decisionDiagnostics.coverageFailure }
+      ...(decisionDiagnostics.coverageLastSuccessAt
+        ? { coverageLastSuccessAt: decisionDiagnostics.coverageLastSuccessAt }
         : {}),
       ...(decisionDiagnostics.coverageFailureInvalidReason
         ? { coverageFailureInvalidReason: decisionDiagnostics.coverageFailureInvalidReason }
@@ -3217,32 +3221,28 @@ function projectChinaCoverageStatus(raw, readError = false, now = Date.now()) {
     degraded: 'CHINA_DEGRADED',
     unavailable: 'CHINA_UNAVAILABLE',
   }[candidate.status] ?? 'CHINA_UNAVAILABLE';
-  // Hold DEGRADED only when the producer proves a recent healthy evaluation and
-  // the current unresolved episode. The deadline is wall-clock based, so retries
-  // and changing problem identities cannot exhaust or restart the three hours.
-  // UNAVAILABLE remains immediate. Missing or malformed timing evidence also
-  // fails closed as CHINA_DEGRADED.
+  // Hold DEGRADED only while the last proven healthy evaluation remains valid.
+  // Failed evaluations never advance that clock. UNAVAILABLE and missing or
+  // malformed timing evidence remain immediate.
   const evaluatedAt = Date.parse(candidate.evaluatedAt ?? '');
-  const validEpisode = status === 'CHINA_DEGRADED'
-    && Number.isSafeInteger(candidate.firstDegradedAt)
-    && Number.isSafeInteger(candidate.lastDegradedAt)
+  const validLastHealthy = status === 'CHINA_DEGRADED'
     && Number.isSafeInteger(candidate.lastHealthyAt)
     && candidate.lastHealthyAt > 0
-    && candidate.lastHealthyAt <= candidate.firstDegradedAt
-    && candidate.firstDegradedAt <= candidate.lastDegradedAt
-    && candidate.lastDegradedAt === evaluatedAt
-    && candidate.lastDegradedAt <= now;
-  const pendingUntil = validEpisode
-    ? Math.min(
-      candidate.firstDegradedAt + CHINA_DECISION_SIGNALS_PENDING_MS,
-      candidate.lastHealthyAt + CHINA_DECISION_SIGNALS_PENDING_MS,
-    )
+    && candidate.lastHealthyAt <= evaluatedAt
+    && evaluatedAt <= now;
+  const pendingUntil = validLastHealthy
+    ? candidate.lastHealthyAt + CHINA_DECISION_SIGNALS_PENDING_MS
     : null;
   const problems = Array.isArray(candidate.entries)
     ? candidate.entries
       .filter((entry) => entry?.launchStatus === 'launched' && entry?.status !== 'healthy')
       .map((entry) => ({ id: entry.id, status: entry.status, reasonCodes: entry.reasonCodes ?? [] }))
     : [];
+  const transientCoverageOnly = problems.length > 0 && problems.every((problem) => (
+    problem.status === 'degraded'
+    && problem.reasonCodes.length > 0
+    && problem.reasonCodes.every((reason) => CHINA_TRANSIENT_COVERAGE_REASONS.has(reason))
+  ));
   return {
     status,
     chinaStatus: candidate.status,
@@ -3256,16 +3256,10 @@ function projectChinaCoverageStatus(raw, readError = false, now = Date.now()) {
     ...(typeof candidate.degradedProblemKey === 'string'
       ? { degradedProblemKey: candidate.degradedProblemKey }
       : {}),
-    ...(Number.isSafeInteger(candidate.firstDegradedAt)
-      ? { firstDegradedAt: candidate.firstDegradedAt }
-      : {}),
-    ...(Number.isSafeInteger(candidate.lastDegradedAt)
-      ? { lastDegradedAt: candidate.lastDegradedAt }
-      : {}),
     ...(Number.isSafeInteger(candidate.lastHealthyAt)
       ? { lastHealthyAt: candidate.lastHealthyAt }
       : {}),
-    ...(pendingUntil !== null && now < pendingUntil
+    ...(transientCoverageOnly && pendingUntil !== null && now < pendingUntil
       ? { chinaCoveragePendingUntil: new Date(pendingUntil).toISOString() }
       : {}),
     ...(problems.length > 0 ? { problems } : {}),
@@ -3295,23 +3289,18 @@ function composeChinaDecisionSignalsStatus(entry, _chinaCoverageEntry, now) {
   const decisionProblems = Array.isArray(entry.decisionGroups?.unavailableGroups)
     ? entry.decisionGroups.unavailableGroups
     : [];
-  const failure = entry.decisionGroups?.coverageFailure;
-  const expectedFailureKey = decisionProblems.length > 0
-    ? JSON.stringify([...decisionProblems].sort((left, right) => left.id.localeCompare(right.id)))
-    : null;
+  const lastSuccessAt = entry.decisionGroups?.coverageLastSuccessAt;
   const requiredDecisionGroups = SEED_META.chinaDecisionSignals.minRecordCount;
-  const validCoverageShortfall = expectedFailureKey !== null
-    && failure?.failureKey === expectedFailureKey
+  const validCoverageShortfall = decisionProblems.length > 0
+    && !entry.decisionGroups?.coverageFailureInvalidReason
+    && !entry.decisionGroups?.staleGroups?.length
     && entry.minRecordCount === requiredDecisionGroups
     && entry.records === entry.decisionGroups?.operationallyCovered
     && entry.records > 0
     && entry.records < requiredDecisionGroups;
   if (validCoverageShortfall) {
-    const pendingUntil = Math.min(
-      failure.firstFailureAt + CHINA_DECISION_SIGNALS_PENDING_MS,
-      failure.lastSuccessAt + SEED_META.chinaDecisionSignals.maxStaleMin * 60_000,
-    );
-    if (failure.lastAttemptAt <= now && now < pendingUntil) {
+    const pendingUntil = lastSuccessAt + CHINA_DECISION_SIGNALS_PENDING_MS;
+    if (Number.isSafeInteger(lastSuccessAt) && now < pendingUntil) {
       return { ...entry, chinaCoveragePendingUntil: new Date(pendingUntil).toISOString() };
     }
   }

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -197,7 +197,9 @@ const SEED_DOMAINS = {
   'economic:china-macro':     { key: 'seed-meta:economic:china-macro-transport', intervalMin: 2160 },
   'economic:china-release-calendar': { key: 'seed-meta:economic:china-release-calendar', intervalMin: 2160 },
   'china:policy-events':      { key: 'seed-meta:china:policy-events',      intervalMin: 360 },
-  'intelligence:china-decision-signals': { key: 'seed-meta:intelligence:china-decision-signals', intervalMin: 30, minRecordCount: 6 },
+  // The producer still runs every 15min. seed-health stales at intervalMin*2,
+  // so 90 mirrors the three-hour operational-coverage budget in api/health.js.
+  'intelligence:china-decision-signals': { key: 'seed-meta:intelligence:china-decision-signals', intervalMin: 90, minRecordCount: 6 },
   'economic:bis-dsr':                  { key: 'seed-meta:economic:bis-dsr',                  intervalMin: 720 }, // 12h cron; only written when DSR slice fetched fresh entries
   'economic:bis-property-residential': { key: 'seed-meta:economic:bis-property-residential', intervalMin: 720 }, // 12h cron; only written when SPP slice fetched fresh entries
   'economic:bis-property-commercial':  { key: 'seed-meta:economic:bis-property-commercial',  intervalMin: 720 }, // 12h cron; only written when CPP slice fetched fresh entries
@@ -658,6 +660,15 @@ export async function handleSeedHealth(req, options = {}) {
     const ageMs = evaluationNow - (meta.fetchedAt || 0);
     const recordCount = parseFiniteRecordCount(meta.recordCount);
     const rankableRecordCount = parseRankableRecordCount(meta);
+    const chinaDecisionDiagnostics = domain === 'intelligence:china-decision-signals'
+      ? projectChinaDecisionGroupDiagnostics(meta, {
+          groupIds: CHINA_DECISION_SIGNAL_GROUP_IDS,
+          allowedStates: CHINA_DECISION_SIGNAL_STATES,
+          healthyQuietCause: CHINA_DECISION_HEALTHY_QUIET_CAUSE,
+        })
+      : null;
+    const chinaDecisionDiagnosticsInvalid = domain === 'intelligence:china-decision-signals'
+      && chinaDecisionDiagnostics === null;
     const redistributionPolicyVersion = Number.isInteger(meta.redistributionPolicyVersion)
       ? meta.redistributionPolicyVersion
       : null;
@@ -671,7 +682,9 @@ export async function handleSeedHealth(req, options = {}) {
       && redistributionPolicyVersion !== cfg.requiredRedistributionPolicyVersion;
     const coveragePartial = recordCoveragePartial
       || rankableCoveragePartial
-      || poolCoveragePartial;
+      || poolCoveragePartial
+      || chinaDecisionDiagnosticsInvalid
+      || (chinaDecisionDiagnostics?.staleGroups.length ?? 0) > 0;
     // Source-specific seed projections retain their last-good records while
     // reporting a current upstream failure through sourceState. Treat that as
     // an immediate operator error instead of waiting for the freshness window.
@@ -819,12 +832,8 @@ export async function handleSeedHealth(req, options = {}) {
       seeds[domain].lastErrorCode = meta.lastErrorCode;
     }
     if (domain === 'intelligence:china-decision-signals') {
-      const diagnostics = projectChinaDecisionGroupDiagnostics(meta, {
-        groupIds: CHINA_DECISION_SIGNAL_GROUP_IDS,
-        allowedStates: CHINA_DECISION_SIGNAL_STATES,
-        healthyQuietCause: CHINA_DECISION_HEALTHY_QUIET_CAUSE,
-      });
-      if (diagnostics) Object.assign(seeds[domain], diagnostics);
+      if (chinaDecisionDiagnostics) Object.assign(seeds[domain], chinaDecisionDiagnostics);
+      else seeds[domain].coverageFailureInvalidReason = 'GROUP_DIAGNOSTICS_INVALID';
     }
   }
 

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -669,6 +669,9 @@ export async function handleSeedHealth(req, options = {}) {
       : null;
     const chinaDecisionDiagnosticsInvalid = domain === 'intelligence:china-decision-signals'
       && chinaDecisionDiagnostics === null;
+    const chinaDecisionFailureEvidenceInvalid = Boolean(
+      chinaDecisionDiagnostics?.coverageFailureInvalidReason,
+    );
     const redistributionPolicyVersion = Number.isInteger(meta.redistributionPolicyVersion)
       ? meta.redistributionPolicyVersion
       : null;
@@ -684,6 +687,7 @@ export async function handleSeedHealth(req, options = {}) {
       || rankableCoveragePartial
       || poolCoveragePartial
       || chinaDecisionDiagnosticsInvalid
+      || chinaDecisionFailureEvidenceInvalid
       || (chinaDecisionDiagnostics?.staleGroups.length ?? 0) > 0;
     // Source-specific seed projections retain their last-good records while
     // reporting a current upstream failure through sourceState. Treat that as
@@ -758,7 +762,7 @@ export async function handleSeedHealth(req, options = {}) {
       || probe?.ok === false
       || contentFreshnessInvalid
       || contentFreshnessStale;
-    if (stale || poolCoveragePartial) staleCount++;
+    if (stale || coveragePartial) staleCount++;
     // A policy mismatch is an operator error only once the producer has
     // actually activated. Before the first publish the field is legitimately
     // absent, so escalating then would drive `overall: degraded` (HTTP 503) for

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -90,11 +90,11 @@ export const STALE_CONTENT_GRACE_SKEW_SLACK_MS = 5 * 60 * 1000;
 export const MAX_STALE_CONTENT_GRACE_MS = 3 * 60 * 60 * 1000 + STALE_CONTENT_GRACE_SKEW_SLACK_MS;
 // Mirrors CHINA_DECISION_SIGNALS_PENDING_MS in api/health.js, with the same
 // cross-machine clock-skew allowance used for stale-content grace. The API
-// keeps a first corporate-disclosures miss diagnostic-only while the hourly
-// China evaluator confirms it; this monitor must consume that bounded verdict
-// instead of turning the pending entry back into an operational failure.
+// keeps health pending for three hours after proven full operational coverage
+// while producer retries remain diagnostic-only. This monitor must consume the
+// bounded verdict instead of turning it back into an operational failure.
 export const CHINA_COVERAGE_PENDING_SKEW_SLACK_MS = 5 * 60 * 1000;
-export const MAX_CHINA_COVERAGE_PENDING_MS = 75 * 60 * 1000
+export const MAX_CHINA_COVERAGE_PENDING_MS = 3 * 60 * 60 * 1000
   + CHINA_COVERAGE_PENDING_SKEW_SLACK_MS;
 
 function hasActiveBoundedDeadline(raw, now, maxWindowMs) {
@@ -119,7 +119,7 @@ export function isStaleContentGraceProblem(problem, now = Date.now()) {
 }
 
 export function isChinaCoveragePendingProblem(problem, now = Date.now()) {
-  if (problem?.status !== 'COVERAGE_PARTIAL') return false;
+  if (!['COVERAGE_PARTIAL', 'CHINA_DEGRADED'].includes(problem?.status)) return false;
   return hasActiveBoundedDeadline(
     problem.chinaCoveragePendingUntil,
     now,

--- a/scripts/china-coverage-health.mjs
+++ b/scripts/china-coverage-health.mjs
@@ -308,10 +308,8 @@ export function evaluateChinaCoverage({
   if (launched.length > 0 && counts.unavailable === launched.length) status = 'unavailable';
   else if (counts.degraded > 0 || counts.unavailable > 0) status = 'degraded';
 
-  // Keep the instantaneous status truthful, but also publish a producer-owned
-  // episode clock. Health can then retain proven last-good coverage for a fixed
-  // wall-clock window; extra evaluations cannot spend that window faster, and a
-  // rotating problem identity cannot restart it.
+  // Keep the instantaneous status truthful while retaining the last proven
+  // healthy clock. Non-healthy evaluations never advance it.
   const degradedProblemKey = normalizeChinaProblemIdentity(evaluated);
   const previousStreak = Number.isInteger(previous?.degradedStreak)
     && previous.degradedStreak > 0
@@ -322,6 +320,7 @@ export function evaluateChinaCoverage({
   const previousEvaluatedAt = Date.parse(previous?.evaluatedAt ?? '');
   const explicitLastHealthyAt = Number.isSafeInteger(previous?.lastHealthyAt)
     && previous.lastHealthyAt > 0
+    && previous.lastHealthyAt <= previousEvaluatedAt
     && previous.lastHealthyAt <= now
       ? previous.lastHealthyAt
       : null;
@@ -329,31 +328,9 @@ export function evaluateChinaCoverage({
   const legacyLastHealthyAt = previousSummaryValid && previous.status === 'healthy'
       ? previousEvaluatedAt
       : null;
-  const priorFirstDegradedAt = Number.isSafeInteger(previous?.firstDegradedAt)
-    && previous.firstDegradedAt > 0
-      ? previous.firstDegradedAt
-      : null;
-  const priorLastDegradedAt = Number.isSafeInteger(previous?.lastDegradedAt)
-    && previous.lastDegradedAt > 0
-      ? previous.lastDegradedAt
-      : null;
-  const priorLastHealthyAt = explicitLastHealthyAt ?? legacyLastHealthyAt;
-  const validPriorEpisode = previousSummaryValid
-    && previous.status !== 'healthy'
-    && priorLastHealthyAt !== null
-    && priorFirstDegradedAt !== null
-    && priorLastDegradedAt !== null
-    && priorLastHealthyAt <= priorFirstDegradedAt
-    && priorFirstDegradedAt <= priorLastDegradedAt
-    && priorLastDegradedAt === previousEvaluatedAt
-    && priorLastDegradedAt <= now;
   const lastHealthyAt = status === 'healthy'
     ? now
-    : validPriorEpisode ? priorLastHealthyAt : legacyLastHealthyAt;
-  const firstDegradedAt = status === 'healthy'
-    ? null
-    : validPriorEpisode ? priorFirstDegradedAt : now;
-  const lastDegradedAt = status === 'healthy' ? null : now;
+    : previousSummaryValid ? explicitLastHealthyAt ?? legacyLastHealthyAt : null;
 
   return {
     schemaVersion: 1,
@@ -361,8 +338,6 @@ export function evaluateChinaCoverage({
     status,
     degradedStreak,
     degradedProblemKey,
-    firstDegradedAt,
-    lastDegradedAt,
     lastHealthyAt,
     evaluatedAt: new Date(now).toISOString(),
     counts,

--- a/scripts/china-coverage-health.mjs
+++ b/scripts/china-coverage-health.mjs
@@ -190,6 +190,73 @@ export function normalizeChinaProblemIdentity(entries) {
   return problems.length > 0 ? JSON.stringify(problems) : null;
 }
 
+function isConsistentCoverageSummary(summary, currentEntries, evaluatedAt, now) {
+  if (
+    !Array.isArray(summary?.entries)
+    || summary.entries.length === 0
+    || summary.entries.length > 100
+  ) return false;
+
+  const ids = new Set();
+  for (const entry of summary.entries) {
+    if (
+      !entry
+      || typeof entry !== 'object'
+      || typeof entry.id !== 'string'
+      || entry.id.length === 0
+      || entry.id.length > 100
+      || ids.has(entry.id)
+      || !['launched', 'planned', 'blocked'].includes(entry.launchStatus)
+      || !Array.isArray(entry.reasonCodes)
+      || entry.reasonCodes.length > 16
+      || entry.reasonCodes.some((reason) => typeof reason !== 'string' || reason.length > 64)
+      || (entry.launchStatus === 'launched'
+        ? !['healthy', 'degraded', 'unavailable'].includes(entry.status)
+        : entry.status !== entry.launchStatus)
+    ) {
+      return false;
+    }
+    ids.add(entry.id);
+  }
+
+  const launched = summary.entries.filter((entry) => entry.launchStatus === 'launched');
+  const currentLaunchedIds = currentEntries
+    .filter((entry) => entry.launchStatus === 'launched')
+    .map((entry) => entry.id)
+    .sort();
+  const previousLaunchedIds = launched.map((entry) => entry.id).sort();
+  if (
+    currentLaunchedIds.length !== previousLaunchedIds.length
+    || currentLaunchedIds.some((id, index) => id !== previousLaunchedIds[index])
+  ) {
+    return false;
+  }
+
+  const healthy = launched.filter((entry) => entry.status === 'healthy').length;
+  const degraded = launched.filter((entry) => entry.status === 'degraded').length;
+  const unavailable = launched.filter((entry) => entry.status === 'unavailable').length;
+  const expectedStatus = unavailable === launched.length
+    ? 'unavailable'
+    : degraded > 0 || unavailable > 0
+      ? 'degraded'
+      : 'healthy';
+  return summary?.schemaVersion === 1
+    && summary?.countryCode === 'CN'
+    && launched.length > 0
+    && healthy + degraded + unavailable === launched.length
+    && summary.status === expectedStatus
+    && summary?.counts?.total === summary.entries.length
+    && summary?.counts?.launched === launched.length
+    && summary.counts.planned === summary.entries.filter((entry) => entry.launchStatus === 'planned').length
+    && summary.counts.blocked === summary.entries.filter((entry) => entry.launchStatus === 'blocked').length
+    && summary.counts.healthy === healthy
+    && summary.counts.degraded === degraded
+    && summary.counts.unavailable === unavailable
+    && Number.isSafeInteger(evaluatedAt)
+    && evaluatedAt > 0
+    && evaluatedAt <= now;
+}
+
 export function evaluateChinaCoverage({
   entries = CHINA_COVERAGE_ENTRIES,
   data = {},
@@ -241,19 +308,10 @@ export function evaluateChinaCoverage({
   if (launched.length > 0 && counts.unavailable === launched.length) status = 'unavailable';
   else if (counts.degraded > 0 || counts.unavailable > 0) status = 'degraded';
 
-  // How many CONSECUTIVE evaluations have landed non-healthy. `status` stays
-  // instantaneous and truthful — isValidChinaCoverageSummary recomputes it from
-  // counts and rejects any summary whose status disagrees, so debouncing the
-  // field itself would make every held summary read CHINA_UNAVAILABLE. The
-  // streak is published alongside it and the CONSUMER decides how many
-  // observations it wants before alarming.
-  //
-  // This runs hourly against 16 sources, so a source that is degraded at the
-  // sampling instant and healthy moments later freezes the verdict for a full
-  // hour. Observed 2026-08-25: the evaluator sampled market.china-stock-connect
-  // at 17:03:23 and its snapshot published `status: healthy` at 17:05:26 — a
-  // two-minute miss that cost ~50 minutes of CHINA_DEGRADED, with 13 of the
-  // surrounding 16 monitor runs clean.
+  // Keep the instantaneous status truthful, but also publish a producer-owned
+  // episode clock. Health can then retain proven last-good coverage for a fixed
+  // wall-clock window; extra evaluations cannot spend that window faster, and a
+  // rotating problem identity cannot restart it.
   const degradedProblemKey = normalizeChinaProblemIdentity(evaluated);
   const previousStreak = Number.isInteger(previous?.degradedStreak)
     && previous.degradedStreak > 0
@@ -261,6 +319,41 @@ export function evaluateChinaCoverage({
     ? previous.degradedStreak
     : 0;
   const degradedStreak = status === 'healthy' ? 0 : previousStreak + 1;
+  const previousEvaluatedAt = Date.parse(previous?.evaluatedAt ?? '');
+  const explicitLastHealthyAt = Number.isSafeInteger(previous?.lastHealthyAt)
+    && previous.lastHealthyAt > 0
+    && previous.lastHealthyAt <= now
+      ? previous.lastHealthyAt
+      : null;
+  const previousSummaryValid = isConsistentCoverageSummary(previous, evaluated, previousEvaluatedAt, now);
+  const legacyLastHealthyAt = previousSummaryValid && previous.status === 'healthy'
+      ? previousEvaluatedAt
+      : null;
+  const priorFirstDegradedAt = Number.isSafeInteger(previous?.firstDegradedAt)
+    && previous.firstDegradedAt > 0
+      ? previous.firstDegradedAt
+      : null;
+  const priorLastDegradedAt = Number.isSafeInteger(previous?.lastDegradedAt)
+    && previous.lastDegradedAt > 0
+      ? previous.lastDegradedAt
+      : null;
+  const priorLastHealthyAt = explicitLastHealthyAt ?? legacyLastHealthyAt;
+  const validPriorEpisode = previousSummaryValid
+    && previous.status !== 'healthy'
+    && priorLastHealthyAt !== null
+    && priorFirstDegradedAt !== null
+    && priorLastDegradedAt !== null
+    && priorLastHealthyAt <= priorFirstDegradedAt
+    && priorFirstDegradedAt <= priorLastDegradedAt
+    && priorLastDegradedAt === previousEvaluatedAt
+    && priorLastDegradedAt <= now;
+  const lastHealthyAt = status === 'healthy'
+    ? now
+    : validPriorEpisode ? priorLastHealthyAt : legacyLastHealthyAt;
+  const firstDegradedAt = status === 'healthy'
+    ? null
+    : validPriorEpisode ? priorFirstDegradedAt : now;
+  const lastDegradedAt = status === 'healthy' ? null : now;
 
   return {
     schemaVersion: 1,
@@ -268,6 +361,9 @@ export function evaluateChinaCoverage({
     status,
     degradedStreak,
     degradedProblemKey,
+    firstDegradedAt,
+    lastDegradedAt,
+    lastHealthyAt,
     evaluatedAt: new Date(now).toISOString(),
     counts,
     entries: evaluated,

--- a/scripts/seed-china-decision-signals.mjs
+++ b/scripts/seed-china-decision-signals.mjs
@@ -180,70 +180,29 @@ function hasProvenFreshOperationalCoverage(meta) {
   });
 }
 
-function decisionCoverageFailureKey(snapshot) {
-  const groups = Array.isArray(snapshot?.groups) ? snapshot.groups : [];
-  const failures = groups
-    .filter((group) => (
-      group?.state === 'stale' || !isChinaDecisionGroupOperationallyCovered(group)
-    ))
-    .map((group) => ({
-      id: typeof group?.id === 'string' ? group.id : 'unknown',
-      unavailableCause: group?.state === 'stale' ? 'stale' : unavailableCauseOf(group),
-    }))
-    .sort((left, right) => left.id.localeCompare(right.id));
-  return failures.length > 0 ? JSON.stringify(failures) : null;
-}
-
 /**
- * Attempt-owned coverage state for the health reader. Health polls never
- * advance this streak: only a newly published, validated six-group snapshot
- * can do that. A changed failure identity resets the count but preserves the
- * original unresolved episode deadline, so rotating upstream failures cannot
- * extend validity forever.
+ * Preserve only the last proven full-coverage clock. Partial publications do
+ * not advance it, so retries and changing failure identities cannot extend the
+ * fixed health-validity window.
  */
 export function nextChinaDecisionCoverageFailure(snapshot, previousMeta, now = Date.now()) {
   const generatedAt = Date.parse(snapshot?.generatedAt ?? '');
   const attemptedAt = positiveTimestamp(generatedAt) && positiveTimestamp(now)
     ? Math.min(generatedAt, now)
     : NaN;
-  const failureKey = decisionCoverageFailureKey(snapshot);
-  const complete = failureKey === null
+  const complete = Array.isArray(snapshot?.groups)
+    && snapshot.groups.every((group) => group?.state !== 'stale')
     && declareChinaDecisionSignalRecords(snapshot) === CHINA_DECISION_SIGNAL_GROUP_IDS.length;
-  if (!positiveTimestamp(attemptedAt)) {
-    return {
-      decisionCoverageFailureKey: failureKey,
-      consecutiveDecisionCoverageFailures: failureKey ? 1 : 0,
-      firstDecisionCoverageFailureAt: null,
-      lastDecisionCoverageAttemptAt: null,
-      lastDecisionCoverageSuccessAt: null,
-    };
-  }
+  if (!positiveTimestamp(attemptedAt)) return { lastDecisionCoverageSuccessAt: null };
   if (complete) {
-    return {
-      decisionCoverageFailureKey: null,
-      consecutiveDecisionCoverageFailures: 0,
-      firstDecisionCoverageFailureAt: null,
-      lastDecisionCoverageAttemptAt: attemptedAt,
-      lastDecisionCoverageSuccessAt: attemptedAt,
-    };
+    return { lastDecisionCoverageSuccessAt: attemptedAt };
   }
 
-  const priorKey = typeof previousMeta?.decisionCoverageFailureKey === 'string'
-    ? previousMeta.decisionCoverageFailureKey
-    : null;
-  const priorCount = Number.isInteger(previousMeta?.consecutiveDecisionCoverageFailures)
-    && previousMeta.consecutiveDecisionCoverageFailures >= 1
-    && previousMeta.consecutiveDecisionCoverageFailures <= 100
-      ? previousMeta.consecutiveDecisionCoverageFailures
-      : null;
-  const priorFirst = positiveTimestamp(previousMeta?.firstDecisionCoverageFailureAt)
-    ? previousMeta.firstDecisionCoverageFailureAt
-    : null;
-  const priorAttempt = positiveTimestamp(previousMeta?.lastDecisionCoverageAttemptAt)
-    ? previousMeta.lastDecisionCoverageAttemptAt
-    : null;
   const explicitLastSuccess = positiveTimestamp(previousMeta?.lastDecisionCoverageSuccessAt)
-    ? previousMeta.lastDecisionCoverageSuccessAt
+    && positiveTimestamp(previousMeta?.fetchedAt)
+    && previousMeta.lastDecisionCoverageSuccessAt <= previousMeta.fetchedAt
+    && previousMeta.fetchedAt <= attemptedAt
+      ? previousMeta.lastDecisionCoverageSuccessAt
     : null;
   const legacyLastSuccess = hasProvenFreshOperationalCoverage(previousMeta)
     && Number(previousMeta?.recordCount) === CHINA_DECISION_SIGNAL_GROUP_IDS.length
@@ -251,35 +210,7 @@ export function nextChinaDecisionCoverageFailure(snapshot, previousMeta, now = D
     && previousMeta.fetchedAt <= attemptedAt
       ? previousMeta.fetchedAt
       : null;
-  const priorLastSuccess = explicitLastSuccess ?? legacyLastSuccess;
-  const validPriorEpisode = priorKey !== null
-    && priorCount !== null
-    && priorFirst !== null
-    && priorAttempt !== null
-    && priorLastSuccess !== null
-    && priorLastSuccess <= priorFirst
-    && priorFirst <= priorAttempt
-    && priorAttempt <= attemptedAt;
-  const lastSuccessAt = validPriorEpisode ? priorLastSuccess : legacyLastSuccess;
-
-  if (validPriorEpisode && priorAttempt === attemptedAt && priorKey === failureKey) {
-    return {
-      decisionCoverageFailureKey: failureKey,
-      consecutiveDecisionCoverageFailures: priorCount,
-      firstDecisionCoverageFailureAt: priorFirst,
-      lastDecisionCoverageAttemptAt: priorAttempt,
-      lastDecisionCoverageSuccessAt: lastSuccessAt,
-    };
-  }
-  return {
-    decisionCoverageFailureKey: failureKey,
-    consecutiveDecisionCoverageFailures: validPriorEpisode && priorKey === failureKey
-      ? Math.min(priorCount + 1, 100)
-      : 1,
-    firstDecisionCoverageFailureAt: validPriorEpisode ? priorFirst : attemptedAt,
-    lastDecisionCoverageAttemptAt: attemptedAt,
-    lastDecisionCoverageSuccessAt: lastSuccessAt,
-  };
+  return { lastDecisionCoverageSuccessAt: explicitLastSuccess ?? legacyLastSuccess };
 }
 
 export async function publishChinaDecisionSignalAlerts(
@@ -357,7 +288,7 @@ export function createChinaDecisionSignalSeedHooks({
   log = console.log,
 } = {}) {
   let preparedAlertEvents = [];
-  let coverageFailure = null;
+  let coverageClock = null;
   return {
     beforePublish: async (snapshot) => {
       const [alerts, previousMeta] = await Promise.all([
@@ -365,12 +296,12 @@ export function createChinaDecisionSignalSeedHooks({
         readSeedMeta().catch(() => null),
       ]);
       preparedAlertEvents = alerts;
-      coverageFailure = nextChinaDecisionCoverageFailure(snapshot, previousMeta);
+      coverageClock = nextChinaDecisionCoverageFailure(snapshot, previousMeta);
     },
     afterPublish: async (snapshot) => {
       const diagnostics = {
         ...diagnosticsFor(snapshot),
-        ...(coverageFailure ?? nextChinaDecisionCoverageFailure(snapshot, null)),
+        ...(coverageClock ?? nextChinaDecisionCoverageFailure(snapshot, null)),
       };
       log(`[china-decision-signals] group diagnostics ${JSON.stringify(diagnostics)}`);
       return { freshnessMetaPatch: diagnostics };

--- a/scripts/seed-china-decision-signals.mjs
+++ b/scripts/seed-china-decision-signals.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url';
 import {
   loadEnvFile,
   readCanonicalValue,
+  readExistingSeedMeta,
   readSeedSnapshot,
   runSeed,
   writeExtraKey,
@@ -108,7 +109,8 @@ function unavailableCauseOf(group) {
 
 export function isChinaDecisionGroupOperationallyCovered(group) {
   if (!group) return false;
-  if (group.state !== 'unavailable') return true;
+  if (group.state === 'available' || group.state === 'partial') return true;
+  if (group.state !== 'unavailable') return false;
   return unavailableCauseOf(group) === CHINA_DECISION_SIGNAL_COVERED_UNAVAILABLE_CAUSE;
 }
 
@@ -156,6 +158,127 @@ export function chinaDecisionSignalGroupDiagnostics(snapshot) {
         .map((groupId) => [groupId, unavailableCauseOf(byId(groupId))]),
     ),
     groupCounts: summarizeChinaDecisionGroups(groups),
+  };
+}
+
+function positiveTimestamp(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function hasProvenFreshOperationalCoverage(meta) {
+  const states = meta?.groupStates;
+  const causes = meta?.unavailableCauses;
+  if (!states || typeof states !== 'object' || Array.isArray(states)) return false;
+  return CHINA_DECISION_SIGNAL_GROUP_IDS.every((groupId) => {
+    const state = states[groupId];
+    if (state === 'available' || state === 'partial') return true;
+    return state === 'unavailable'
+      && causes
+      && typeof causes === 'object'
+      && !Array.isArray(causes)
+      && causes[groupId] === CHINA_DECISION_SIGNAL_COVERED_UNAVAILABLE_CAUSE;
+  });
+}
+
+function decisionCoverageFailureKey(snapshot) {
+  const groups = Array.isArray(snapshot?.groups) ? snapshot.groups : [];
+  const failures = groups
+    .filter((group) => (
+      group?.state === 'stale' || !isChinaDecisionGroupOperationallyCovered(group)
+    ))
+    .map((group) => ({
+      id: typeof group?.id === 'string' ? group.id : 'unknown',
+      unavailableCause: group?.state === 'stale' ? 'stale' : unavailableCauseOf(group),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  return failures.length > 0 ? JSON.stringify(failures) : null;
+}
+
+/**
+ * Attempt-owned coverage state for the health reader. Health polls never
+ * advance this streak: only a newly published, validated six-group snapshot
+ * can do that. A changed failure identity resets the count but preserves the
+ * original unresolved episode deadline, so rotating upstream failures cannot
+ * extend validity forever.
+ */
+export function nextChinaDecisionCoverageFailure(snapshot, previousMeta, now = Date.now()) {
+  const generatedAt = Date.parse(snapshot?.generatedAt ?? '');
+  const attemptedAt = positiveTimestamp(generatedAt) && positiveTimestamp(now)
+    ? Math.min(generatedAt, now)
+    : NaN;
+  const failureKey = decisionCoverageFailureKey(snapshot);
+  const complete = failureKey === null
+    && declareChinaDecisionSignalRecords(snapshot) === CHINA_DECISION_SIGNAL_GROUP_IDS.length;
+  if (!positiveTimestamp(attemptedAt)) {
+    return {
+      decisionCoverageFailureKey: failureKey,
+      consecutiveDecisionCoverageFailures: failureKey ? 1 : 0,
+      firstDecisionCoverageFailureAt: null,
+      lastDecisionCoverageAttemptAt: null,
+      lastDecisionCoverageSuccessAt: null,
+    };
+  }
+  if (complete) {
+    return {
+      decisionCoverageFailureKey: null,
+      consecutiveDecisionCoverageFailures: 0,
+      firstDecisionCoverageFailureAt: null,
+      lastDecisionCoverageAttemptAt: attemptedAt,
+      lastDecisionCoverageSuccessAt: attemptedAt,
+    };
+  }
+
+  const priorKey = typeof previousMeta?.decisionCoverageFailureKey === 'string'
+    ? previousMeta.decisionCoverageFailureKey
+    : null;
+  const priorCount = Number.isInteger(previousMeta?.consecutiveDecisionCoverageFailures)
+    && previousMeta.consecutiveDecisionCoverageFailures >= 1
+    && previousMeta.consecutiveDecisionCoverageFailures <= 100
+      ? previousMeta.consecutiveDecisionCoverageFailures
+      : null;
+  const priorFirst = positiveTimestamp(previousMeta?.firstDecisionCoverageFailureAt)
+    ? previousMeta.firstDecisionCoverageFailureAt
+    : null;
+  const priorAttempt = positiveTimestamp(previousMeta?.lastDecisionCoverageAttemptAt)
+    ? previousMeta.lastDecisionCoverageAttemptAt
+    : null;
+  const explicitLastSuccess = positiveTimestamp(previousMeta?.lastDecisionCoverageSuccessAt)
+    ? previousMeta.lastDecisionCoverageSuccessAt
+    : null;
+  const legacyLastSuccess = hasProvenFreshOperationalCoverage(previousMeta)
+    && Number(previousMeta?.recordCount) === CHINA_DECISION_SIGNAL_GROUP_IDS.length
+    && positiveTimestamp(previousMeta?.fetchedAt)
+    && previousMeta.fetchedAt <= attemptedAt
+      ? previousMeta.fetchedAt
+      : null;
+  const priorLastSuccess = explicitLastSuccess ?? legacyLastSuccess;
+  const validPriorEpisode = priorKey !== null
+    && priorCount !== null
+    && priorFirst !== null
+    && priorAttempt !== null
+    && priorLastSuccess !== null
+    && priorLastSuccess <= priorFirst
+    && priorFirst <= priorAttempt
+    && priorAttempt <= attemptedAt;
+  const lastSuccessAt = validPriorEpisode ? priorLastSuccess : legacyLastSuccess;
+
+  if (validPriorEpisode && priorAttempt === attemptedAt && priorKey === failureKey) {
+    return {
+      decisionCoverageFailureKey: failureKey,
+      consecutiveDecisionCoverageFailures: priorCount,
+      firstDecisionCoverageFailureAt: priorFirst,
+      lastDecisionCoverageAttemptAt: priorAttempt,
+      lastDecisionCoverageSuccessAt: lastSuccessAt,
+    };
+  }
+  return {
+    decisionCoverageFailureKey: failureKey,
+    consecutiveDecisionCoverageFailures: validPriorEpisode && priorKey === failureKey
+      ? Math.min(priorCount + 1, 100)
+      : 1,
+    firstDecisionCoverageFailureAt: validPriorEpisode ? priorFirst : attemptedAt,
+    lastDecisionCoverageAttemptAt: attemptedAt,
+    lastDecisionCoverageSuccessAt: lastSuccessAt,
   };
 }
 
@@ -230,15 +353,25 @@ export function createChinaDecisionSignalSeedHooks({
   prepareAlerts = prepareChinaDecisionSignalAlertEvents,
   deliverAlerts = deliverChinaDecisionSignalAlertOutbox,
   diagnosticsFor = chinaDecisionSignalGroupDiagnostics,
+  readSeedMeta = () => readExistingSeedMeta('intelligence', 'china-decision-signals'),
   log = console.log,
 } = {}) {
   let preparedAlertEvents = [];
+  let coverageFailure = null;
   return {
     beforePublish: async (snapshot) => {
-      preparedAlertEvents = await prepareAlerts(snapshot);
+      const [alerts, previousMeta] = await Promise.all([
+        prepareAlerts(snapshot),
+        readSeedMeta().catch(() => null),
+      ]);
+      preparedAlertEvents = alerts;
+      coverageFailure = nextChinaDecisionCoverageFailure(snapshot, previousMeta);
     },
     afterPublish: async (snapshot) => {
-      const diagnostics = diagnosticsFor(snapshot);
+      const diagnostics = {
+        ...diagnosticsFor(snapshot),
+        ...(coverageFailure ?? nextChinaDecisionCoverageFailure(snapshot, null)),
+      };
       log(`[china-decision-signals] group diagnostics ${JSON.stringify(diagnostics)}`);
       return { freshnessMetaPatch: diagnostics };
     },
@@ -262,7 +395,7 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
       schemaVersion: 1,
       declareRecords: declareChinaDecisionSignalRecords,
       zeroIsValid: true,
-      maxStaleMin: 60,
+      maxStaleMin: 180,
       // Prepare against the previous canonical value without sending anything.
       // runSeed publishes the validated snapshot between this callback and
       // afterPublish, preventing phantom alerts for a state that never landed.

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -558,7 +558,8 @@ describe('China coverage degraded streak', () => {
   // whole cycle: on 2026-08-25 it sampled market.china-stock-connect at
   // 17:03:23 and that snapshot published `status: healthy` at 17:05:26 — a
   // two-minute miss that cost ~50 minutes, with 13 of the surrounding 16
-  // monitor runs clean. The streak lets the consumer wait for a second look.
+  // monitor runs clean. The streak gives retained data a three-hour validity
+  // window before the consumer reports a warning.
   const degradedInputs = () => [
     singleEntry(),
     { 'data:test': { rows: [{ countryCode: 'US', observedAt: '2026-07-13T11:30:00Z' }] } },
@@ -570,6 +571,168 @@ describe('China coverage degraded streak', () => {
     const result = evaluateChinaCoverage({ entries: [entry], data, meta, now: NOW });
     assert.equal(result.status, 'degraded');
     assert.equal(result.degradedStreak, 1);
+    assert.equal(result.firstDegradedAt, NOW);
+    assert.equal(result.lastDegradedAt, NOW);
+    assert.equal(result.lastHealthyAt, null);
+  });
+
+  it('anchors a degraded episode to the last proven healthy evaluation', () => {
+    const entry = singleEntry();
+    const healthyAt = NOW - 15 * 60_000;
+    const healthy = evaluateChinaCoverage({
+      entries: [entry],
+      data: { 'data:test': { rows: [{ countryCode: 'CN', observedAt: new Date(healthyAt).toISOString(), value: 42 }] } },
+      meta: { 'seed-meta:test': { fetchedAt: healthyAt, status: 'ok' } },
+      now: healthyAt,
+    });
+    const [degraded, data, meta] = degradedInputs();
+    const first = evaluateChinaCoverage({ entries: [degraded], data, meta, now: NOW, previous: healthy });
+    const retry = evaluateChinaCoverage({ entries: [degraded], data, meta, now: NOW + 60_000, previous: first });
+
+    assert.equal(first.lastHealthyAt, healthyAt);
+    assert.equal(first.firstDegradedAt, NOW);
+    assert.equal(retry.lastHealthyAt, healthyAt);
+    assert.equal(retry.firstDegradedAt, NOW);
+    assert.equal(retry.lastDegradedAt, NOW + 60_000);
+  });
+
+  it('does not infer last-good coverage from a contradictory legacy summary', () => {
+    const [entry, data, meta] = degradedInputs();
+    const result = evaluateChinaCoverage({
+      entries: [entry],
+      data,
+      meta,
+      now: NOW,
+      previous: {
+        schemaVersion: 1,
+        countryCode: 'CN',
+        status: 'healthy',
+        evaluatedAt: new Date(NOW - 15 * 60_000).toISOString(),
+        counts: { launched: 1, healthy: 1, degraded: 0, unavailable: 0 },
+        entries: [{ launchStatus: 'launched', status: 'degraded' }],
+      },
+    });
+
+    assert.equal(result.lastHealthyAt, null);
+  });
+
+  it('does not protect a newly launched source with an older manifest success', () => {
+    const healthyAt = NOW - 15 * 60_000;
+    const oldEntry = degradedEntry('existing-source');
+    const oldHealthy = evaluateChinaCoverage({
+      entries: [oldEntry],
+      data: {
+        'data:existing-source': {
+          rows: [{ countryCode: 'CN', observedAt: new Date(healthyAt).toISOString(), value: 42 }],
+        },
+      },
+      meta: { 'seed-meta:existing-source': { fetchedAt: healthyAt, status: 'ok' } },
+      now: healthyAt,
+    });
+    const newlyLaunched = degradedEntry('new-source');
+    const result = evaluateChinaCoverage({
+      entries: [oldEntry, newlyLaunched],
+      data: {
+        'data:existing-source': {
+          rows: [{ countryCode: 'CN', observedAt: new Date(healthyAt).toISOString(), value: 42 }],
+        },
+      },
+      meta: { 'seed-meta:existing-source': { fetchedAt: healthyAt, status: 'ok' } },
+      now: NOW,
+      previous: oldHealthy,
+    });
+
+    assert.equal(result.status, 'degraded');
+    assert.equal(result.lastHealthyAt, null);
+    assert.equal(result.firstDegradedAt, NOW);
+  });
+
+  it('does not carry last-good coverage from counts rejected by the API contract', () => {
+    const entry = singleEntry();
+    const healthyAt = NOW - 15 * 60_000;
+    const healthy = evaluateChinaCoverage({
+      entries: [entry],
+      data: {
+        'data:test': {
+          rows: [{ countryCode: 'CN', observedAt: new Date(healthyAt).toISOString(), value: 42 }],
+        },
+      },
+      meta: { 'seed-meta:test': { fetchedAt: healthyAt, status: 'ok' } },
+      now: healthyAt,
+    });
+    healthy.counts.total = 2;
+    const [degraded, data, meta] = degradedInputs();
+    const result = evaluateChinaCoverage({ entries: [degraded], data, meta, now: NOW, previous: healthy });
+
+    assert.equal(result.lastHealthyAt, null);
+    assert.equal(result.firstDegradedAt, NOW);
+  });
+
+  it('does not carry last-good coverage from a summary above the API entry limit', () => {
+    const launched = singleEntry();
+    const planned = Array.from({ length: 100 }, (_, index) => singleEntry({
+      id: `planned-${index}`,
+      launchStatus: 'planned',
+    }));
+    const healthyAt = NOW - 15 * 60_000;
+    const healthy = evaluateChinaCoverage({
+      entries: [launched, ...planned],
+      data: {
+        'data:test': {
+          rows: [{ countryCode: 'CN', observedAt: new Date(healthyAt).toISOString(), value: 42 }],
+        },
+      },
+      meta: { 'seed-meta:test': { fetchedAt: healthyAt, status: 'ok' } },
+      now: healthyAt,
+    });
+    const [degraded, data, meta] = degradedInputs();
+    const result = evaluateChinaCoverage({
+      entries: [degraded, ...planned], data, meta, now: NOW, previous: healthy,
+    });
+
+    assert.equal(result.lastHealthyAt, null);
+    assert.equal(result.firstDegradedAt, NOW);
+  });
+
+  it('does not carry last-good coverage through a malformed episode clock', () => {
+    const [entry, data, meta] = degradedInputs();
+    const result = evaluateChinaCoverage({
+      entries: [entry],
+      data,
+      meta,
+      now: NOW,
+      previous: {
+        status: 'degraded',
+        evaluatedAt: new Date(NOW - 15 * 60_000).toISOString(),
+        firstDegradedAt: NOW - 30 * 60_000,
+        lastDegradedAt: NOW - 20 * 60_000,
+        lastHealthyAt: NOW - 45 * 60_000,
+      },
+    });
+
+    assert.equal(result.lastHealthyAt, null);
+    assert.equal(result.firstDegradedAt, NOW);
+  });
+
+  it('does not carry an ordered episode clock from a structurally invalid summary', () => {
+    const [entry, data, meta] = degradedInputs();
+    const priorEvaluatedAt = NOW - 15 * 60_000;
+    const result = evaluateChinaCoverage({
+      entries: [entry],
+      data,
+      meta,
+      now: NOW,
+      previous: {
+        status: 'garbage',
+        evaluatedAt: new Date(priorEvaluatedAt).toISOString(),
+        firstDegradedAt: NOW - 30 * 60_000,
+        lastDegradedAt: priorEvaluatedAt,
+        lastHealthyAt: NOW - 45 * 60_000,
+      },
+    });
+
+    assert.equal(result.lastHealthyAt, null);
+    assert.equal(result.firstDegradedAt, NOW);
   });
 
   it('increments while the degradation persists', () => {
@@ -598,6 +761,9 @@ describe('China coverage degraded streak', () => {
     });
     assert.equal(healthy.status, 'healthy');
     assert.equal(healthy.degradedStreak, 0, 'a recovery must not stay one observation away from alarming');
+    assert.equal(healthy.firstDegradedAt, null);
+    assert.equal(healthy.lastDegradedAt, null);
+    assert.equal(healthy.lastHealthyAt, NOW);
   });
 
   it('treats a missing or malformed previous streak as no history', () => {
@@ -651,6 +817,7 @@ describe('China coverage degraded streak', () => {
     assert.equal(healthy.status, 'healthy');
     assert.equal(healthy.degradedStreak, 0);
     assert.equal(healthy.degradedProblemKey, null);
+    assert.equal(healthy.lastHealthyAt, NOW);
   });
 });
 

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -552,7 +552,7 @@ describe('China coverage manifest', () => {
   });
 });
 
-describe('China coverage degraded streak', () => {
+describe('China coverage last-good validity', () => {
   // The evaluator samples 16 sources once an hour. A source degraded at the
   // sampling instant and healthy moments later pinned CHINA_DEGRADED for the
   // whole cycle: on 2026-08-25 it sampled market.china-stock-connect at
@@ -571,8 +571,6 @@ describe('China coverage degraded streak', () => {
     const result = evaluateChinaCoverage({ entries: [entry], data, meta, now: NOW });
     assert.equal(result.status, 'degraded');
     assert.equal(result.degradedStreak, 1);
-    assert.equal(result.firstDegradedAt, NOW);
-    assert.equal(result.lastDegradedAt, NOW);
     assert.equal(result.lastHealthyAt, null);
   });
 
@@ -590,10 +588,7 @@ describe('China coverage degraded streak', () => {
     const retry = evaluateChinaCoverage({ entries: [degraded], data, meta, now: NOW + 60_000, previous: first });
 
     assert.equal(first.lastHealthyAt, healthyAt);
-    assert.equal(first.firstDegradedAt, NOW);
     assert.equal(retry.lastHealthyAt, healthyAt);
-    assert.equal(retry.firstDegradedAt, NOW);
-    assert.equal(retry.lastDegradedAt, NOW + 60_000);
   });
 
   it('does not infer last-good coverage from a contradictory legacy summary', () => {
@@ -644,7 +639,6 @@ describe('China coverage degraded streak', () => {
 
     assert.equal(result.status, 'degraded');
     assert.equal(result.lastHealthyAt, null);
-    assert.equal(result.firstDegradedAt, NOW);
   });
 
   it('does not carry last-good coverage from counts rejected by the API contract', () => {
@@ -665,7 +659,6 @@ describe('China coverage degraded streak', () => {
     const result = evaluateChinaCoverage({ entries: [degraded], data, meta, now: NOW, previous: healthy });
 
     assert.equal(result.lastHealthyAt, null);
-    assert.equal(result.firstDegradedAt, NOW);
   });
 
   it('does not carry last-good coverage from a summary above the API entry limit', () => {
@@ -691,7 +684,6 @@ describe('China coverage degraded streak', () => {
     });
 
     assert.equal(result.lastHealthyAt, null);
-    assert.equal(result.firstDegradedAt, NOW);
   });
 
   it('does not carry last-good coverage through a malformed episode clock', () => {
@@ -704,14 +696,11 @@ describe('China coverage degraded streak', () => {
       previous: {
         status: 'degraded',
         evaluatedAt: new Date(NOW - 15 * 60_000).toISOString(),
-        firstDegradedAt: NOW - 30 * 60_000,
-        lastDegradedAt: NOW - 20 * 60_000,
         lastHealthyAt: NOW - 45 * 60_000,
       },
     });
 
     assert.equal(result.lastHealthyAt, null);
-    assert.equal(result.firstDegradedAt, NOW);
   });
 
   it('does not carry an ordered episode clock from a structurally invalid summary', () => {
@@ -725,14 +714,11 @@ describe('China coverage degraded streak', () => {
       previous: {
         status: 'garbage',
         evaluatedAt: new Date(priorEvaluatedAt).toISOString(),
-        firstDegradedAt: NOW - 30 * 60_000,
-        lastDegradedAt: priorEvaluatedAt,
         lastHealthyAt: NOW - 45 * 60_000,
       },
     });
 
     assert.equal(result.lastHealthyAt, null);
-    assert.equal(result.firstDegradedAt, NOW);
   });
 
   it('increments while the degradation persists', () => {
@@ -761,8 +747,6 @@ describe('China coverage degraded streak', () => {
     });
     assert.equal(healthy.status, 'healthy');
     assert.equal(healthy.degradedStreak, 0, 'a recovery must not stay one observation away from alarming');
-    assert.equal(healthy.firstDegradedAt, null);
-    assert.equal(healthy.lastDegradedAt, null);
     assert.equal(healthy.lastHealthyAt, NOW);
   });
 

--- a/tests/china-decision-access-contract.test.mts
+++ b/tests/china-decision-access-contract.test.mts
@@ -248,6 +248,25 @@ describe('China decision-signal access tiers (#5580)', () => {
       const chinaMeta = {
         fetchedAt: Date.now() - 60_000,
         recordCount: expectation.recordCount,
+        groupStates: {
+          macro: 'available',
+          'policy-enforcement': 'available',
+          'cross-strait-activity': 'available',
+          'corporate-disclosures': expectation.recordCount === 6 ? 'available' : 'unavailable',
+          'corridor-conditions': 'available',
+          'activity-nowcast': 'available',
+        },
+        groupCounts: {
+          populated: expectation.recordCount,
+          partial: 0,
+          stale: 0,
+          unavailable: 6 - expectation.recordCount,
+          healthyQuiet: 0,
+          operationallyCovered: expectation.recordCount,
+        },
+        unavailableCauses: expectation.recordCount === 6
+          ? {}
+          : { 'corporate-disclosures': 'upstream_unavailable' },
       };
       const mainEntry = classifyMainHealth(chinaMeta);
       const { response, body } = await readSeedHealth(chinaMeta);
@@ -280,11 +299,11 @@ describe('China decision-signal access tiers (#5580)', () => {
       stale: 1,
       unavailable: 2,
       healthyQuiet: 1,
-      operationallyCovered: 5,
+      operationallyCovered: 4,
     };
     const { body } = await readSeedHealth({
       fetchedAt: Date.now() - 60_000,
-      recordCount: 5,
+      recordCount: 4,
       groupStates,
       groupCounts,
       unavailableCauses: {

--- a/tests/china-decision-alerts.test.mjs
+++ b/tests/china-decision-alerts.test.mjs
@@ -307,7 +307,7 @@ describe('China decision-signal alert policy (#5580)', () => {
     assert.doesNotMatch(JSON.stringify(diagnostics), /macro-item|policy-item|cross-strait-item/);
   });
 
-  it('counts three same-incident coverage failures against a proven last success', () => {
+  it('keeps the last proven success across repeated coverage failures', () => {
     const successAt = Date.parse('2026-07-26T11:45:00.000Z');
     const firstAt = Date.parse('2026-07-26T12:00:00.000Z');
     const secondAt = Date.parse('2026-07-26T12:15:00.000Z');
@@ -325,18 +325,13 @@ describe('China decision-signal alert policy (#5580)', () => {
       { ...second, fetchedAt: secondAt, recordCount: GROUP_IDS.length - 1 },
     );
 
-    assert.equal(first.consecutiveDecisionCoverageFailures, 1);
-    assert.equal(second.consecutiveDecisionCoverageFailures, 2);
-    assert.equal(third.consecutiveDecisionCoverageFailures, 3);
-    assert.equal(first.firstDecisionCoverageFailureAt, firstAt);
-    assert.equal(second.firstDecisionCoverageFailureAt, firstAt);
-    assert.equal(third.firstDecisionCoverageFailureAt, firstAt);
+    assert.deepEqual(first, { lastDecisionCoverageSuccessAt: successAt });
+    assert.deepEqual(second, first);
+    assert.deepEqual(third, first);
     assert.equal(third.lastDecisionCoverageSuccessAt, successAt);
-    assert.equal(third.lastDecisionCoverageAttemptAt, thirdAt);
-    assert.equal(third.decisionCoverageFailureKey, first.decisionCoverageFailureKey);
   });
 
-  it('does not let a changed coverage failure extend the incident deadline', () => {
+  it('does not let a changed coverage failure extend validity', () => {
     const successAt = Date.parse('2026-07-26T11:45:00.000Z');
     const firstAt = Date.parse('2026-07-26T12:00:00.000Z');
     const changedAt = Date.parse('2026-07-26T12:15:00.000Z');
@@ -349,10 +344,7 @@ describe('China decision-signal alert policy (#5580)', () => {
       { ...first, fetchedAt: firstAt, recordCount: GROUP_IDS.length - 1 },
     );
 
-    assert.equal(changed.consecutiveDecisionCoverageFailures, 1);
-    assert.notEqual(changed.decisionCoverageFailureKey, first.decisionCoverageFailureKey);
-    assert.equal(changed.firstDecisionCoverageFailureAt, firstAt);
-    assert.equal(changed.lastDecisionCoverageSuccessAt, successAt);
+    assert.deepEqual(changed, first);
   });
 
   it('clamps future snapshot clocks to the local attempt time', () => {
@@ -364,12 +356,10 @@ describe('China decision-signal alert policy (#5580)', () => {
       now,
     );
 
-    assert.equal(state.firstDecisionCoverageFailureAt, now);
-    assert.equal(state.lastDecisionCoverageAttemptAt, now);
     assert.equal(state.lastDecisionCoverageSuccessAt, now - 15 * 60_000);
   });
 
-  it('does not increment the same producer attempt twice', () => {
+  it('is idempotent for the same producer attempt', () => {
     const successAt = Date.parse('2026-07-26T11:45:00.000Z');
     const attemptAt = Date.parse('2026-07-26T12:00:00.000Z');
     const first = nextChinaDecisionCoverageFailure(
@@ -397,13 +387,7 @@ describe('China decision-signal alert policy (#5580)', () => {
       { ...failed, fetchedAt: failureAt, recordCount: GROUP_IDS.length - 1 },
     );
 
-    assert.deepEqual(recovered, {
-      decisionCoverageFailureKey: null,
-      consecutiveDecisionCoverageFailures: 0,
-      firstDecisionCoverageFailureAt: null,
-      lastDecisionCoverageAttemptAt: recoveryAt,
-      lastDecisionCoverageSuccessAt: recoveryAt,
-    });
+    assert.deepEqual(recovered, { lastDecisionCoverageSuccessAt: recoveryAt });
   });
 
   it('does not invent a last success for legacy partial metadata', () => {
@@ -413,7 +397,6 @@ describe('China decision-signal alert policy (#5580)', () => {
       { fetchedAt: failureAt - 15 * 60_000, recordCount: GROUP_IDS.length - 1 },
     );
 
-    assert.equal(state.consecutiveDecisionCoverageFailures, 1);
     assert.equal(state.lastDecisionCoverageSuccessAt, null);
   });
 
@@ -426,22 +409,17 @@ describe('China decision-signal alert policy (#5580)', () => {
       previous,
     );
 
-    assert.equal(state.consecutiveDecisionCoverageFailures, 1);
     assert.equal(state.lastDecisionCoverageSuccessAt, null);
   });
 
-  it('does not carry an explicit success through malformed failure history', () => {
+  it('does not carry a future success timestamp', () => {
     const failureAt = Date.parse('2026-07-26T12:00:00.000Z');
     const state = nextChinaDecisionCoverageFailure(
       coverageFailureSnapshot(failureAt),
       {
         fetchedAt: failureAt - 15 * 60_000,
         recordCount: GROUP_IDS.length - 1,
-        decisionCoverageFailureKey: '{malformed-history}',
-        consecutiveDecisionCoverageFailures: 2,
-        firstDecisionCoverageFailureAt: null,
-        lastDecisionCoverageAttemptAt: failureAt - 15 * 60_000,
-        lastDecisionCoverageSuccessAt: failureAt - 30 * 60_000,
+        lastDecisionCoverageSuccessAt: failureAt + 30 * 60_000,
       },
     );
 

--- a/tests/china-decision-alerts.test.mjs
+++ b/tests/china-decision-alerts.test.mjs
@@ -13,6 +13,7 @@ import {
   deliverChinaDecisionSignalAlertOutbox,
   declareChinaDecisionSignalRecords,
   fetchChinaDecisionSignals,
+  nextChinaDecisionCoverageFailure,
   prepareChinaDecisionSignalAlertEvents,
   publishChinaDecisionSignalAlerts,
   validateChinaDecisionSignalSnapshot,
@@ -60,6 +61,37 @@ function snapshot(overrides = {}) {
       pro: 'same_provenance_via_mcp',
       operator: 'source_health_only',
     },
+  };
+}
+
+function coveredSnapshot(generatedAt) {
+  const value = snapshot(Object.fromEntries(GROUP_IDS.map((id) => [id, {
+    state: 'available',
+    items: [item(`${id}-item`)],
+  }])));
+  value.generatedAt = new Date(generatedAt).toISOString();
+  return value;
+}
+
+function coverageFailureSnapshot(generatedAt, groupId = 'corporate-disclosures') {
+  const value = coveredSnapshot(generatedAt);
+  value.groups = value.groups.map((group) => group.id === groupId
+    ? {
+      ...group,
+      state: 'unavailable',
+      items: [],
+      metadata: { unavailableCause: 'upstream_unavailable' },
+    }
+    : group);
+  return value;
+}
+
+function provenCoverageMeta(fetchedAt) {
+  return {
+    fetchedAt,
+    recordCount: GROUP_IDS.length,
+    groupStates: Object.fromEntries(GROUP_IDS.map((id) => [id, 'available'])),
+    unavailableCauses: {},
   };
 }
 
@@ -262,7 +294,7 @@ describe('China decision-signal alert policy (#5580)', () => {
       // None of the three unavailable groups declares a cause, so none is a
       // proven healthy quiet window (#6060).
       healthyQuiet: 0,
-      operationallyCovered: 3,
+      operationallyCovered: 2,
     });
     assert.deepEqual(diagnostics.groupStates, {
       macro: 'available',
@@ -275,11 +307,155 @@ describe('China decision-signal alert policy (#5580)', () => {
     assert.doesNotMatch(JSON.stringify(diagnostics), /macro-item|policy-item|cross-strait-item/);
   });
 
+  it('counts three same-incident coverage failures against a proven last success', () => {
+    const successAt = Date.parse('2026-07-26T11:45:00.000Z');
+    const firstAt = Date.parse('2026-07-26T12:00:00.000Z');
+    const secondAt = Date.parse('2026-07-26T12:15:00.000Z');
+    const thirdAt = Date.parse('2026-07-26T12:30:00.000Z');
+    const first = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(firstAt),
+      provenCoverageMeta(successAt),
+    );
+    const second = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(secondAt),
+      { ...first, fetchedAt: firstAt, recordCount: GROUP_IDS.length - 1 },
+    );
+    const third = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(thirdAt),
+      { ...second, fetchedAt: secondAt, recordCount: GROUP_IDS.length - 1 },
+    );
+
+    assert.equal(first.consecutiveDecisionCoverageFailures, 1);
+    assert.equal(second.consecutiveDecisionCoverageFailures, 2);
+    assert.equal(third.consecutiveDecisionCoverageFailures, 3);
+    assert.equal(first.firstDecisionCoverageFailureAt, firstAt);
+    assert.equal(second.firstDecisionCoverageFailureAt, firstAt);
+    assert.equal(third.firstDecisionCoverageFailureAt, firstAt);
+    assert.equal(third.lastDecisionCoverageSuccessAt, successAt);
+    assert.equal(third.lastDecisionCoverageAttemptAt, thirdAt);
+    assert.equal(third.decisionCoverageFailureKey, first.decisionCoverageFailureKey);
+  });
+
+  it('does not let a changed coverage failure extend the incident deadline', () => {
+    const successAt = Date.parse('2026-07-26T11:45:00.000Z');
+    const firstAt = Date.parse('2026-07-26T12:00:00.000Z');
+    const changedAt = Date.parse('2026-07-26T12:15:00.000Z');
+    const first = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(firstAt),
+      provenCoverageMeta(successAt),
+    );
+    const changed = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(changedAt, 'activity-nowcast'),
+      { ...first, fetchedAt: firstAt, recordCount: GROUP_IDS.length - 1 },
+    );
+
+    assert.equal(changed.consecutiveDecisionCoverageFailures, 1);
+    assert.notEqual(changed.decisionCoverageFailureKey, first.decisionCoverageFailureKey);
+    assert.equal(changed.firstDecisionCoverageFailureAt, firstAt);
+    assert.equal(changed.lastDecisionCoverageSuccessAt, successAt);
+  });
+
+  it('clamps future snapshot clocks to the local attempt time', () => {
+    const now = Date.parse('2026-07-26T12:00:00.000Z');
+    const futureAt = now + 60 * 60_000;
+    const state = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(futureAt),
+      provenCoverageMeta(now - 15 * 60_000),
+      now,
+    );
+
+    assert.equal(state.firstDecisionCoverageFailureAt, now);
+    assert.equal(state.lastDecisionCoverageAttemptAt, now);
+    assert.equal(state.lastDecisionCoverageSuccessAt, now - 15 * 60_000);
+  });
+
+  it('does not increment the same producer attempt twice', () => {
+    const successAt = Date.parse('2026-07-26T11:45:00.000Z');
+    const attemptAt = Date.parse('2026-07-26T12:00:00.000Z');
+    const first = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(attemptAt),
+      provenCoverageMeta(successAt),
+    );
+    const replay = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(attemptAt),
+      { ...first, fetchedAt: attemptAt, recordCount: GROUP_IDS.length - 1 },
+    );
+
+    assert.deepEqual(replay, first);
+  });
+
+  it('resets the coverage-failure episode only after full operational recovery', () => {
+    const successAt = Date.parse('2026-07-26T11:45:00.000Z');
+    const failureAt = Date.parse('2026-07-26T12:00:00.000Z');
+    const recoveryAt = Date.parse('2026-07-26T12:15:00.000Z');
+    const failed = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(failureAt),
+      provenCoverageMeta(successAt),
+    );
+    const recovered = nextChinaDecisionCoverageFailure(
+      coveredSnapshot(recoveryAt),
+      { ...failed, fetchedAt: failureAt, recordCount: GROUP_IDS.length - 1 },
+    );
+
+    assert.deepEqual(recovered, {
+      decisionCoverageFailureKey: null,
+      consecutiveDecisionCoverageFailures: 0,
+      firstDecisionCoverageFailureAt: null,
+      lastDecisionCoverageAttemptAt: recoveryAt,
+      lastDecisionCoverageSuccessAt: recoveryAt,
+    });
+  });
+
+  it('does not invent a last success for legacy partial metadata', () => {
+    const failureAt = Date.parse('2026-07-26T12:00:00.000Z');
+    const state = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(failureAt),
+      { fetchedAt: failureAt - 15 * 60_000, recordCount: GROUP_IDS.length - 1 },
+    );
+
+    assert.equal(state.consecutiveDecisionCoverageFailures, 1);
+    assert.equal(state.lastDecisionCoverageSuccessAt, null);
+  });
+
+  it('does not treat a six-record legacy snapshot with stale coverage as a success', () => {
+    const failureAt = Date.parse('2026-07-26T12:00:00.000Z');
+    const previous = provenCoverageMeta(failureAt - 15 * 60_000);
+    previous.groupStates.macro = 'stale';
+    const state = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(failureAt),
+      previous,
+    );
+
+    assert.equal(state.consecutiveDecisionCoverageFailures, 1);
+    assert.equal(state.lastDecisionCoverageSuccessAt, null);
+  });
+
+  it('does not carry an explicit success through malformed failure history', () => {
+    const failureAt = Date.parse('2026-07-26T12:00:00.000Z');
+    const state = nextChinaDecisionCoverageFailure(
+      coverageFailureSnapshot(failureAt),
+      {
+        fetchedAt: failureAt - 15 * 60_000,
+        recordCount: GROUP_IDS.length - 1,
+        decisionCoverageFailureKey: '{malformed-history}',
+        consecutiveDecisionCoverageFailures: 2,
+        firstDecisionCoverageFailureAt: null,
+        lastDecisionCoverageAttemptAt: failureAt - 15 * 60_000,
+        lastDecisionCoverageSuccessAt: failureAt - 30 * 60_000,
+      },
+    );
+
+    assert.equal(state.lastDecisionCoverageSuccessAt, null);
+  });
+
   it('returns the diagnostics patch before a rejected durable alert delivery', async () => {
     const writes = [];
     const hooks = createChinaDecisionSignalSeedHooks({
       prepareAlerts: async () => [{ eventType: 'china_policy_decision_signal' }],
       diagnosticsFor: chinaDecisionSignalGroupDiagnostics,
+      readSeedMeta: async () => ({
+        ...provenCoverageMeta(Date.parse('2026-07-26T11:45:00.000Z')),
+      }),
       log: () => {},
       deliverAlerts: async () => {
         throw new Error('outbox unavailable');
@@ -296,7 +472,12 @@ describe('China decision-signal alert policy (#5580)', () => {
     writes.push(afterPublishResult.freshnessMetaPatch);
     await assert.rejects(hooks.afterFreshness(value), /outbox unavailable/);
 
-    assert.deepEqual(writes, [chinaDecisionSignalGroupDiagnostics(value)]);
+    assert.deepEqual(writes, [{
+      ...chinaDecisionSignalGroupDiagnostics(value),
+      ...nextChinaDecisionCoverageFailure(value, {
+        ...provenCoverageMeta(Date.parse('2026-07-26T11:45:00.000Z')),
+      }),
+    }]);
   });
 
   it('continues publishing after one alert publisher rejects', async () => {

--- a/tests/china-decision-coverage-classes.test.mjs
+++ b/tests/china-decision-coverage-classes.test.mjs
@@ -20,6 +20,7 @@ import { jsonResponse } from '../api/_json-response.js';
 import {
   chinaDecisionSignalGroupDiagnostics,
   declareChinaDecisionSignalRecords,
+  nextChinaDecisionCoverageFailure,
   summarizeChinaDecisionGroups,
 } from '../scripts/seed-china-decision-signals.mjs';
 
@@ -75,6 +76,15 @@ const healthyQuiet = {
   reason: 'healthy_quiet_window: Healthy exchange queries contained no qualifying disclosure events.',
   metadata: { unavailableCause: 'healthy_quiet_window' },
 };
+
+function provenCoverageMeta(fetchedAt) {
+  return {
+    fetchedAt,
+    recordCount: GROUP_IDS.length,
+    groupStates: Object.fromEntries(GROUP_IDS.map((id) => [id, 'available'])),
+    unavailableCauses: {},
+  };
+}
 
 // The exact 2026-08-02 14:40 UTC production snapshot.
 function auditSnapshot() {
@@ -252,6 +262,129 @@ describe('health decision-group classes (#6060)', () => {
     assert.equal(entry.decisionGroups.healthyQuiet, 1);
   });
 
+  it('projects only a complete producer-owned coverage-failure episode', () => {
+    const snapshotValue = auditSnapshot();
+    const base = decisionMeta(snapshotValue);
+    const failureKey = JSON.stringify([{
+      id: 'activity-nowcast',
+      unavailableCause: 'insufficient_data',
+    }]);
+    const failure = {
+      decisionCoverageFailureKey: failureKey,
+      consecutiveDecisionCoverageFailures: 2,
+      firstDecisionCoverageFailureAt: NOW - 10 * 60_000,
+      lastDecisionCoverageAttemptAt: NOW - 5 * 60_000,
+      lastDecisionCoverageSuccessAt: NOW - 20 * 60_000,
+    };
+    const entry = classifyDecisionSignals({ ...base, ...failure });
+
+    assert.deepEqual(entry.decisionGroups.coverageFailure, {
+      failureKey,
+      consecutiveFailures: 2,
+      firstFailureAt: NOW - 10 * 60_000,
+      lastAttemptAt: NOW - 5 * 60_000,
+      lastSuccessAt: NOW - 20 * 60_000,
+    });
+
+    const malformed = classifyDecisionSignals({
+      ...base,
+      ...failure,
+      lastDecisionCoverageSuccessAt: NOW,
+    });
+    assert.equal(malformed.decisionGroups.coverageFailure, undefined);
+    assert.equal(
+      malformed.decisionGroups.coverageFailureInvalidReason,
+      'FAILURE_TIMESTAMP_ORDER_INVALID',
+    );
+  });
+
+  it('projects the exact failure metadata emitted by the producer', () => {
+    const snapshotValue = auditSnapshot();
+    const priorSuccessAt = NOW - 20 * 60_000;
+    const failure = nextChinaDecisionCoverageFailure(
+      snapshotValue,
+      provenCoverageMeta(priorSuccessAt),
+    );
+    const entry = classifyDecisionSignals({
+      ...decisionMeta(snapshotValue),
+      ...failure,
+    });
+
+    assert.deepEqual(entry.decisionGroups.coverageFailure, {
+      failureKey: JSON.stringify([{
+        id: 'activity-nowcast',
+        unavailableCause: 'insufficient_data',
+      }]),
+      consecutiveFailures: 1,
+      firstFailureAt: Date.parse(snapshotValue.generatedAt),
+      lastAttemptAt: Date.parse(snapshotValue.generatedAt),
+      lastSuccessAt: priorSuccessAt,
+    });
+  });
+
+  it('accepts the producer recovery tuple without an invalid-evidence diagnostic', () => {
+    const recoveredSnapshot = snapshot(Object.fromEntries(
+      GROUP_IDS.map((id) => [id, { state: 'available', items: [item(`${id}-1`)] }]),
+    ));
+    const recovered = classifyDecisionSignals({
+      ...decisionMeta(recoveredSnapshot),
+      decisionCoverageFailureKey: null,
+      consecutiveDecisionCoverageFailures: 0,
+      firstDecisionCoverageFailureAt: null,
+      lastDecisionCoverageAttemptAt: NOW,
+      lastDecisionCoverageSuccessAt: NOW,
+    });
+    assert.equal(recovered.decisionGroups.coverageFailure, undefined);
+    assert.equal(recovered.decisionGroups.coverageFailureInvalidReason, undefined);
+  });
+
+  it('warns immediately when a covered group is stale', () => {
+    const staleSnapshot = snapshot(Object.fromEntries(
+      GROUP_IDS.map((id) => [id, { state: 'available', items: [item(`${id}-1`)] }]),
+    ));
+    staleSnapshot.groups = staleSnapshot.groups.map((group) => group.id === 'macro'
+      ? { ...group, state: 'stale', items: group.items.map((value) => ({ ...value, stale: true })) }
+      : group);
+    const priorSuccessAt = NOW - 20 * 60_000;
+    const failure = nextChinaDecisionCoverageFailure(
+      staleSnapshot,
+      provenCoverageMeta(priorSuccessAt),
+    );
+    const entry = classifyDecisionSignals({
+      ...decisionMeta(staleSnapshot),
+      ...failure,
+    });
+
+    assert.equal(entry.records, GROUP_IDS.length - 1);
+    assert.equal(entry.status, 'COVERAGE_PARTIAL');
+    assert.deepEqual(entry.decisionGroups.staleGroups, ['macro']);
+    assert.equal(entry.decisionGroups.coverageFailure.failureKey, JSON.stringify([{
+      id: 'macro',
+      unavailableCause: 'stale',
+    }]));
+    assert.equal(
+      __testing__.composeChinaDecisionSignalsStatus(entry, null, NOW).chinaCoveragePendingUntil,
+      undefined,
+    );
+  });
+
+  it('rejects a recovery tuple attached to partial current coverage', () => {
+    const partial = classifyDecisionSignals({
+      ...decisionMeta(auditSnapshot()),
+      decisionCoverageFailureKey: null,
+      consecutiveDecisionCoverageFailures: 0,
+      firstDecisionCoverageFailureAt: null,
+      lastDecisionCoverageAttemptAt: NOW,
+      lastDecisionCoverageSuccessAt: NOW,
+    });
+
+    assert.equal(partial.decisionGroups.coverageFailure, undefined);
+    assert.equal(
+      partial.decisionGroups.coverageFailureInvalidReason,
+      'RECOVERY_COVERAGE_MISMATCH',
+    );
+  });
+
   it('reports OK when the only unavailable group is a healthy quiet window', () => {
     const entry = classifyDecisionSignals(decisionMeta(snapshot({
       macro: { state: 'available', items: [item('macro-1')] },
@@ -305,7 +438,9 @@ describe('health decision-group classes (#6060)', () => {
   it('does not invent a group breakdown when the producer wrote no diagnostics', () => {
     const entry = classifyDecisionSignals({ fetchedAt: NOW - 5 * 60_000, recordCount: 4 });
     assert.equal(entry.status, 'COVERAGE_PARTIAL', 'the coverage floor still fails closed');
-    assert.equal(entry.decisionGroups, undefined);
+    assert.deepEqual(entry.decisionGroups, {
+      coverageFailureInvalidReason: 'GROUP_DIAGNOSTICS_INVALID',
+    });
   });
 
   // api/_json-response.js drops any key literally named `cause` (an
@@ -328,19 +463,14 @@ describe('health decision-group classes (#6060)', () => {
     );
   });
 
-  // seed-health's sibling projection withholds the whole breakdown on a
-  // malformed counts object; health must not publish a block of nulls instead.
-  it('withholds the breakdown when groupCounts is malformed', () => {
+  it('fails closed when groupCounts is malformed', () => {
     for (const counts of [undefined, null, 'not-an-object', 42, []]) {
       const entry = classifyDecisionSignals({
         ...decisionMeta(auditSnapshot()),
         groupCounts: counts,
       });
-      assert.equal(
-        entry.decisionGroups,
-        undefined,
-        `groupCounts=${JSON.stringify(counts) ?? 'undefined'} must not publish a null-filled block`,
-      );
+      assert.equal(entry.status, 'COVERAGE_PARTIAL');
+      assert.equal(entry.decisionGroups.coverageFailureInvalidReason, 'GROUP_DIAGNOSTICS_INVALID');
     }
   });
 
@@ -351,9 +481,29 @@ describe('health decision-group classes (#6060)', () => {
       unavailableCauses: { 'not-a-group': 'healthy_quiet_window' },
     });
     assert.equal(
-      entry.decisionGroups,
-      undefined,
-      'a partial state map cannot be published as a complete diagnostic contract',
+      entry.decisionGroups.coverageFailureInvalidReason,
+      'GROUP_DIAGNOSTICS_INVALID',
     );
+    assert.equal(entry.status, 'COVERAGE_PARTIAL');
+  });
+
+  it('fails closed when claimed counts contradict the canonical group states', () => {
+    const covered = snapshot(Object.fromEntries(
+      GROUP_IDS.map((id) => [id, { state: 'available', items: [item(`${id}-1`)] }]),
+    ));
+    const meta = decisionMeta(covered);
+    meta.groupStates.macro = 'unavailable';
+    meta.unavailableCauses.macro = 'upstream_unavailable';
+    const entry = classifyDecisionSignals({
+      ...meta,
+      decisionCoverageFailureKey: null,
+      consecutiveDecisionCoverageFailures: 0,
+      firstDecisionCoverageFailureAt: null,
+      lastDecisionCoverageAttemptAt: NOW,
+      lastDecisionCoverageSuccessAt: NOW,
+    });
+
+    assert.equal(entry.status, 'COVERAGE_PARTIAL');
+    assert.equal(entry.decisionGroups.coverageFailureInvalidReason, 'GROUP_DIAGNOSTICS_INVALID');
   });
 });

--- a/tests/china-decision-coverage-classes.test.mjs
+++ b/tests/china-decision-coverage-classes.test.mjs
@@ -262,39 +262,23 @@ describe('health decision-group classes (#6060)', () => {
     assert.equal(entry.decisionGroups.healthyQuiet, 1);
   });
 
-  it('projects only a complete producer-owned coverage-failure episode', () => {
+  it('projects only a valid producer-owned last-success clock', () => {
     const snapshotValue = auditSnapshot();
     const base = decisionMeta(snapshotValue);
-    const failureKey = JSON.stringify([{
-      id: 'activity-nowcast',
-      unavailableCause: 'insufficient_data',
-    }]);
-    const failure = {
-      decisionCoverageFailureKey: failureKey,
-      consecutiveDecisionCoverageFailures: 2,
-      firstDecisionCoverageFailureAt: NOW - 10 * 60_000,
-      lastDecisionCoverageAttemptAt: NOW - 5 * 60_000,
+    const entry = classifyDecisionSignals({
+      ...base,
       lastDecisionCoverageSuccessAt: NOW - 20 * 60_000,
-    };
-    const entry = classifyDecisionSignals({ ...base, ...failure });
-
-    assert.deepEqual(entry.decisionGroups.coverageFailure, {
-      failureKey,
-      consecutiveFailures: 2,
-      firstFailureAt: NOW - 10 * 60_000,
-      lastAttemptAt: NOW - 5 * 60_000,
-      lastSuccessAt: NOW - 20 * 60_000,
     });
+    assert.equal(entry.decisionGroups.coverageLastSuccessAt, NOW - 20 * 60_000);
 
     const malformed = classifyDecisionSignals({
       ...base,
-      ...failure,
       lastDecisionCoverageSuccessAt: NOW,
     });
-    assert.equal(malformed.decisionGroups.coverageFailure, undefined);
+    assert.equal(malformed.decisionGroups.coverageLastSuccessAt, NOW);
     assert.equal(
       malformed.decisionGroups.coverageFailureInvalidReason,
-      'FAILURE_TIMESTAMP_ORDER_INVALID',
+      'LAST_SUCCESS_INVALID',
     );
   });
 
@@ -310,31 +294,19 @@ describe('health decision-group classes (#6060)', () => {
       ...failure,
     });
 
-    assert.deepEqual(entry.decisionGroups.coverageFailure, {
-      failureKey: JSON.stringify([{
-        id: 'activity-nowcast',
-        unavailableCause: 'insufficient_data',
-      }]),
-      consecutiveFailures: 1,
-      firstFailureAt: Date.parse(snapshotValue.generatedAt),
-      lastAttemptAt: Date.parse(snapshotValue.generatedAt),
-      lastSuccessAt: priorSuccessAt,
-    });
+    assert.equal(entry.decisionGroups.coverageLastSuccessAt, priorSuccessAt);
   });
 
-  it('accepts the producer recovery tuple without an invalid-evidence diagnostic', () => {
+  it('accepts the producer recovery clock without an invalid-evidence diagnostic', () => {
     const recoveredSnapshot = snapshot(Object.fromEntries(
       GROUP_IDS.map((id) => [id, { state: 'available', items: [item(`${id}-1`)] }]),
     ));
     const recovered = classifyDecisionSignals({
       ...decisionMeta(recoveredSnapshot),
-      decisionCoverageFailureKey: null,
-      consecutiveDecisionCoverageFailures: 0,
-      firstDecisionCoverageFailureAt: null,
-      lastDecisionCoverageAttemptAt: NOW,
+      fetchedAt: NOW,
       lastDecisionCoverageSuccessAt: NOW,
     });
-    assert.equal(recovered.decisionGroups.coverageFailure, undefined);
+    assert.equal(recovered.decisionGroups.coverageLastSuccessAt, NOW);
     assert.equal(recovered.decisionGroups.coverageFailureInvalidReason, undefined);
   });
 
@@ -358,30 +330,22 @@ describe('health decision-group classes (#6060)', () => {
     assert.equal(entry.records, GROUP_IDS.length - 1);
     assert.equal(entry.status, 'COVERAGE_PARTIAL');
     assert.deepEqual(entry.decisionGroups.staleGroups, ['macro']);
-    assert.equal(entry.decisionGroups.coverageFailure.failureKey, JSON.stringify([{
-      id: 'macro',
-      unavailableCause: 'stale',
-    }]));
+    assert.equal(entry.decisionGroups.coverageLastSuccessAt, priorSuccessAt);
     assert.equal(
       __testing__.composeChinaDecisionSignalsStatus(entry, null, NOW).chinaCoveragePendingUntil,
       undefined,
     );
   });
 
-  it('rejects a recovery tuple attached to partial current coverage', () => {
+  it('rejects a last-success clock newer than the partial publication', () => {
     const partial = classifyDecisionSignals({
       ...decisionMeta(auditSnapshot()),
-      decisionCoverageFailureKey: null,
-      consecutiveDecisionCoverageFailures: 0,
-      firstDecisionCoverageFailureAt: null,
-      lastDecisionCoverageAttemptAt: NOW,
       lastDecisionCoverageSuccessAt: NOW,
     });
 
-    assert.equal(partial.decisionGroups.coverageFailure, undefined);
     assert.equal(
       partial.decisionGroups.coverageFailureInvalidReason,
-      'RECOVERY_COVERAGE_MISMATCH',
+      'LAST_SUCCESS_INVALID',
     );
   });
 
@@ -496,10 +460,6 @@ describe('health decision-group classes (#6060)', () => {
     meta.unavailableCauses.macro = 'upstream_unavailable';
     const entry = classifyDecisionSignals({
       ...meta,
-      decisionCoverageFailureKey: null,
-      consecutiveDecisionCoverageFailures: 0,
-      firstDecisionCoverageFailureAt: null,
-      lastDecisionCoverageAttemptAt: NOW,
       lastDecisionCoverageSuccessAt: NOW,
     });
 

--- a/tests/china-decision-parity-audit.test.mjs
+++ b/tests/china-decision-parity-audit.test.mjs
@@ -5,6 +5,11 @@ import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { pathToFileURL } from 'node:url';
 
+import { __testing__ as healthTesting } from '../api/health.js';
+import {
+  CHINA_COVERAGE_PENDING_SKEW_SLACK_MS,
+  MAX_CHINA_COVERAGE_PENDING_MS,
+} from '../scripts/check-seed-freshness.mjs';
 import { readChinaDecisionSignalWireContract } from '../scripts/lib/openapi-codegen.mjs';
 import { validateChinaDecisionSignalSnapshot } from '../scripts/seed-china-decision-signals.mjs';
 import { CHINA_DECISION_SIGNAL_GROUP_MANIFEST } from '../shared/china-decision-signal-manifest.ts';
@@ -27,6 +32,25 @@ const REPO_ROOT = resolve(import.meta.dirname, '..');
 const ROUTE = '/api/intelligence/v1/get-china-decision-signals';
 
 describe('China decision-signal static and staging audit (#5580)', () => {
+  it('keeps every China decision health surface on the three-hour budget', () => {
+    const budgetMin = healthTesting.CHINA_DECISION_SIGNALS_PENDING_MS / 60_000;
+    assert.equal(budgetMin, 180);
+    assert.equal(healthTesting.SEED_META.chinaDecisionSignals.maxStaleMin, budgetMin);
+    assert.equal(
+      MAX_CHINA_COVERAGE_PENDING_MS - CHINA_COVERAGE_PENDING_SKEW_SLACK_MS,
+      healthTesting.CHINA_DECISION_SIGNALS_PENDING_MS,
+    );
+    assert.match(
+      readFileSync(join(REPO_ROOT, 'scripts/seed-china-decision-signals.mjs'), 'utf8'),
+      /maxStaleMin:\s*180/,
+    );
+    assert.match(
+      readFileSync(join(REPO_ROOT, 'api/seed-health.js'), 'utf8'),
+      /'intelligence:china-decision-signals':\s*\{[^}]*intervalMin:\s*90/,
+      'seed-health multiplies intervalMin by two, so 90 must match 180 minutes',
+    );
+  });
+
   it('pins all six domains across API, MCP, bootstrap, health, alerts, Railway, and docs', () => {
     const result = auditChinaDecisionStaticRegistrations(REPO_ROOT);
     assert.deepEqual(result.groupIds, [
@@ -166,7 +190,7 @@ describe('China decision-signal static and staging audit (#5580)', () => {
       // The lone unavailable group declares no cause, so it is not a proven
       // healthy quiet window and stays uncovered (#6060).
       healthyQuiet: 0,
-      operationallyCovered: 3,
+      operationallyCovered: 2,
     });
 
     const groups = CHINA_DECISION_PARITY_MANIFEST.map(({ groupId }) => ({

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -2300,8 +2300,10 @@ test('#6987 — the two aviation probes no longer share a meta key', () => {
 // A summary that is degraded for ONE hourly evaluation is far more often a
 // sampling miss than an outage — measured 2026-08-25, a two-minute miss on
 // market.china-stock-connect cost ~50 minutes of CHINA_DEGRADED while 13 of the
-// surrounding 16 monitor runs were clean. Requiring a second consecutive
-// observation trades one cycle of detection latency for that.
+// surrounding 16 monitor runs were clean. A three-hour validity window avoids
+// turning those brief sampling misses into fleet warnings.
+const CHINA_SUMMARY_AT = Date.parse('2026-08-25T17:03:23.563Z');
+const CHINA_LAST_HEALTHY_AT = CHINA_SUMMARY_AT - 3 * ONE_MIN_MS;
 const chinaSummary = (over = {}) => ({
   schemaVersion: 1,
   countryCode: 'CN',
@@ -2322,38 +2324,65 @@ const chinaSummary = (over = {}) => ({
     status: 'degraded',
     reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
   }]),
+  firstDegradedAt: CHINA_SUMMARY_AT,
+  lastDegradedAt: CHINA_SUMMARY_AT,
+  lastHealthyAt: CHINA_LAST_HEALTHY_AT,
   ...over,
 });
 
-test('china coverage: a single degraded evaluation does not alarm', () => {
-  const projected = projectChinaCoverageStatus(chinaSummary({ degradedStreak: 1 }));
-  assert.equal(projected.status, 'OK');
-});
-
-test('china coverage: a second consecutive degraded evaluation alarms', () => {
-  const projected = projectChinaCoverageStatus(chinaSummary({ degradedStreak: 2 }));
+test('china coverage: a recent degraded evaluation stays pending for three hours', () => {
+  const projected = projectChinaCoverageStatus(
+    chinaSummary({ degradedStreak: 1 }),
+    false,
+    CHINA_SUMMARY_AT + ONE_MIN_MS,
+  );
   assert.equal(projected.status, 'CHINA_DEGRADED');
+  assert.equal(
+    projected.chinaCoveragePendingUntil,
+    new Date(CHINA_LAST_HEALTHY_AT + 3 * 60 * ONE_MIN_MS).toISOString(),
+  );
+  assert.equal(__testing__.healthStatusBucket(projected, CHINA_SUMMARY_AT + ONE_MIN_MS), 'ok');
 });
 
-test('china coverage: nonpositive streaks cannot suppress a degraded alarm', () => {
-  for (const degradedStreak of [0, -1]) {
-    const projected = projectChinaCoverageStatus(chinaSummary({ degradedStreak }));
-    assert.equal(projected.status, 'CHINA_DEGRADED', `degradedStreak=${degradedStreak}`);
+test('china coverage: four rapid evaluations cannot exhaust the wall-clock window', () => {
+  for (const degradedStreak of [1, 2, 3, 4, 12]) {
+    const projected = projectChinaCoverageStatus(
+      chinaSummary({ degradedStreak }),
+      false,
+      CHINA_SUMMARY_AT + ONE_MIN_MS,
+    );
+    assert.equal(__testing__.healthStatusBucket(projected, CHINA_SUMMARY_AT + ONE_MIN_MS), 'ok');
   }
+});
+
+test('china coverage: the hold expires at exactly three hours after the last healthy evaluation', () => {
+  const deadline = CHINA_LAST_HEALTHY_AT + 3 * 60 * ONE_MIN_MS;
+  const projected = projectChinaCoverageStatus(chinaSummary({ degradedStreak: 12 }), false, deadline);
+  assert.equal(projected.status, 'CHINA_DEGRADED');
+  assert.equal(projected.chinaCoveragePendingUntil, undefined);
+  assert.equal(__testing__.healthStatusBucket(projected, deadline), 'warn');
 });
 
 test('china coverage: a held verdict stays visible rather than silent', () => {
   // The counterweight to the debounce. If holding the verdict also hid the
   // reason, a suppressed cycle would be indistinguishable from health.
-  const projected = projectChinaCoverageStatus(chinaSummary({ degradedStreak: 1 }));
-  assert.equal(projected.status, 'OK');
+  const projected = projectChinaCoverageStatus(
+    chinaSummary({ degradedStreak: 1 }),
+    false,
+    CHINA_SUMMARY_AT + ONE_MIN_MS,
+  );
+  assert.equal(projected.status, 'CHINA_DEGRADED');
   assert.equal(projected.chinaStatus, 'degraded', 'the summary verdict is still reported');
   assert.equal(projected.degradedStreak, 1);
   assert.ok(projected.problems?.some((p) => p.id === 'market.china-stock-connect'));
 });
 
 test('china coverage: a held verdict survives the compact health projection', () => {
-  const projected = projectChinaCoverageStatus(chinaSummary({ degradedStreak: 1 }));
+  const projected = projectChinaCoverageStatus(
+    chinaSummary({ degradedStreak: 1 }),
+    false,
+    CHINA_SUMMARY_AT + ONE_MIN_MS,
+  );
   const compact = healthResponseBody({
     status: 'HEALTHY',
     summary: { total: 1, ok: 1, warn: 0, crit: 0 },
@@ -2361,16 +2390,17 @@ test('china coverage: a held verdict survives the compact health projection', ()
     checks: { chinaCoverage: projected },
   }, true);
 
-  assert.equal(compact.problems?.chinaCoverage?.status, 'OK');
-  assert.equal(compact.problems?.chinaCoverage?.chinaStatus, 'degraded');
-  assert.equal(compact.problems?.chinaCoverage?.degradedStreak, 1);
-  assert.ok(compact.problems?.chinaCoverage?.problems?.some(
+  assert.equal(compact.pending?.chinaCoverage?.status, 'CHINA_DEGRADED');
+  assert.equal(compact.problems?.chinaCoverage, undefined);
+  assert.equal(compact.pending?.chinaCoverage?.chinaStatus, 'degraded');
+  assert.equal(compact.pending?.chinaCoverage?.degradedStreak, 1);
+  assert.ok(compact.pending?.chinaCoverage?.problems?.some(
     (problem) => problem.id === 'market.china-stock-connect',
   ));
   assert.deepEqual(healthResponseBody(compact, true), compact, 'cached compact snapshots remain stable');
 });
 
-test('china coverage: the derived decision check shares the first corporate failure hold', () => {
+test('china decision signals: aggregate degradation cannot replace producer success evidence', () => {
   const chinaCoverage = projectChinaCoverageStatus(chinaSummary({
     degradedStreak: 1,
     entries: [{
@@ -2387,7 +2417,6 @@ test('china coverage: the derived decision check shares the first corporate fail
   }));
   const evaluatedAt = Date.parse(chinaCoverage.evaluatedAt);
   const now = evaluatedAt + 60_000;
-  const pendingUntil = evaluatedAt + __testing__.CHINA_DECISION_SIGNALS_PENDING_MS;
   const decisionSignals = composeChinaDecisionSignalsStatus({
     status: 'COVERAGE_PARTIAL',
     records: 5,
@@ -2402,37 +2431,18 @@ test('china coverage: the derived decision check shares the first corporate fail
   }, chinaCoverage, now);
 
   assert.equal(decisionSignals.status, 'COVERAGE_PARTIAL', 'the diagnosis stays truthful');
-  assert.equal(decisionSignals.chinaCoveragePendingUntil, new Date(pendingUntil).toISOString());
-  assert.equal(__testing__.healthStatusBucket(decisionSignals, pendingUntil - 1), 'ok');
-  assert.equal(__testing__.healthStatusBucket(decisionSignals, pendingUntil), 'warn');
-
-  const compact = healthResponseBody({
-    status: 'HEALTHY',
-    summary: { total: 2, ok: 2, warn: 0, pending: 1, crit: 0 },
-    checkedAt: new Date(now).toISOString(),
-    checks: { chinaCoverage, chinaDecisionSignals: decisionSignals },
-  }, true);
-  assert.deepEqual(compact.pending?.chinaDecisionSignals, {
-    status: 'COVERAGE_PARTIAL',
-    chinaCoveragePendingUntil: new Date(pendingUntil).toISOString(),
-  });
-  assert.equal(compact.problems?.chinaDecisionSignals, undefined);
-  assert.equal(compact.problems?.chinaCoverage?.degradedStreak, 1);
-  assert.equal(__testing__.hasExpiredActivationGrace(compact, pendingUntil - 1), false);
-  assert.equal(__testing__.hasExpiredActivationGrace(compact, pendingUntil), true);
+  assert.equal(decisionSignals.chinaCoveragePendingUntil, undefined);
+  assert.equal(__testing__.healthStatusBucket(decisionSignals, now), 'warn');
 });
 
-test('china coverage: unrelated or repeated decision failures are never held', () => {
-  const firstCorporateFailure = projectChinaCoverageStatus(chinaSummary({
-    degradedStreak: 1,
-    entries: [{
-      id: 'market.china-corporate-disclosures',
-      launchStatus: 'launched',
-      status: 'degraded',
-      reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
-    }],
-  }));
-  const corporateDecisionFailure = {
+test('china decision signals: producer attempts cannot exhaust the three-hour validity window', () => {
+  const successAt = NOW - 15 * ONE_MIN_MS;
+  const firstAt = NOW;
+  const failureKey = JSON.stringify([{
+    id: 'corporate-disclosures',
+    unavailableCause: 'upstream_unavailable',
+  }]);
+  const candidate = (consecutiveFailures) => ({
     status: 'COVERAGE_PARTIAL',
     records: 5,
     minRecordCount: 6,
@@ -2442,89 +2452,111 @@ test('china coverage: unrelated or repeated decision failures are never held', (
         id: 'corporate-disclosures',
         unavailableCause: 'upstream_unavailable',
       }],
-    },
-  };
-  const activityFailure = {
-    ...corporateDecisionFailure,
-    decisionGroups: {
-      unavailableGroups: [{
-        id: 'activity-nowcast',
-        unavailableCause: 'insufficient_data',
-      }],
-    },
-  };
-  const secondCorporateFailure = {
-    ...firstCorporateFailure,
-    status: 'CHINA_DEGRADED',
-    degradedStreak: 2,
-  };
-
-  assert.equal(
-    composeChinaDecisionSignalsStatus(activityFailure, firstCorporateFailure, Date.parse(firstCorporateFailure.evaluatedAt)).chinaCoveragePendingUntil,
-    undefined,
-    'another decision group remains an immediate warning',
-  );
-  assert.equal(
-    composeChinaDecisionSignalsStatus(corporateDecisionFailure, secondCorporateFailure, Date.parse(firstCorporateFailure.evaluatedAt)).chinaCoveragePendingUntil,
-    undefined,
-    'the second same corporate failure remains a warning',
-  );
-  assert.equal(
-    composeChinaDecisionSignalsStatus(
-      corporateDecisionFailure,
-      {
-        ...firstCorporateFailure,
-        problems: [{
-          id: 'market.china-corporate-disclosures',
-          status: 'degraded',
-          reasonCodes: ['CHINA_COVERAGE_PARTIAL', 'CHINA_SOURCE_UNAVAILABLE'],
-        }],
+      coverageFailure: {
+        failureKey,
+        consecutiveFailures,
+        firstFailureAt: firstAt,
+        lastAttemptAt: NOW,
+        lastSuccessAt: successAt,
       },
-      Date.parse(firstCorporateFailure.evaluatedAt),
-    ).chinaCoveragePendingUntil,
-    undefined,
-    'a mixed corporate failure remains an immediate warning',
-  );
-  assert.equal(__testing__.healthStatusBucket(corporateDecisionFailure, NOW), 'warn');
-  assert.deepEqual(
-    composeChinaDecisionSignalsStatus(
-      { status: 'COVERAGE_PARTIAL', records: 5 },
-      { ...firstCorporateFailure, problems: undefined },
-      Date.parse(firstCorporateFailure.evaluatedAt),
-    ),
-    { status: 'COVERAGE_PARTIAL', records: 5 },
-    'missing diagnostics fail closed without throwing',
-  );
+    },
+  });
 
-  for (const malformedCoverage of [
-    { records: 1, minRecordCount: 6, operationallyCovered: 1 },
-    { records: 5, minRecordCount: 7, operationallyCovered: 5 },
-    { records: 5, minRecordCount: 6, operationallyCovered: 4 },
+  for (const consecutiveFailures of [1, 2, 3, 12]) {
+    const composed = composeChinaDecisionSignalsStatus(candidate(consecutiveFailures), null, NOW);
+    assert.equal(composed.status, 'COVERAGE_PARTIAL');
+    assert.equal(
+      composed.chinaCoveragePendingUntil,
+      new Date(successAt + SEED_META.chinaDecisionSignals.maxStaleMin * ONE_MIN_MS).toISOString(),
+    );
+    assert.equal(__testing__.healthStatusBucket(composed, NOW), 'ok');
+  }
+  assert.equal(
+    composeChinaDecisionSignalsStatus(candidate(12), null, successAt + 180 * ONE_MIN_MS)
+      .chinaCoveragePendingUntil,
+    undefined,
+    'the three-hour freshness ceiling still expires the hold',
+  );
+});
+
+test('china decision signals: missing or mismatched failure evidence fails closed', () => {
+  const failureKey = JSON.stringify([{
+    id: 'corporate-disclosures',
+    unavailableCause: 'upstream_unavailable',
+  }]);
+  const valid = {
+    status: 'COVERAGE_PARTIAL',
+    records: 5,
+    minRecordCount: 6,
+    decisionGroups: {
+      operationallyCovered: 5,
+      unavailableGroups: [{
+        id: 'corporate-disclosures',
+        unavailableCause: 'upstream_unavailable',
+      }],
+      coverageFailure: {
+        failureKey,
+        consecutiveFailures: 1,
+        firstFailureAt: NOW,
+        lastAttemptAt: NOW,
+        lastSuccessAt: NOW - 15 * ONE_MIN_MS,
+      },
+    },
+  };
+  for (const coverageFailure of [
+    undefined,
+    { ...valid.decisionGroups.coverageFailure, failureKey: 'different' },
+    { ...valid.decisionGroups.coverageFailure, lastSuccessAt: null },
   ]) {
     const candidate = {
-      ...corporateDecisionFailure,
-      records: malformedCoverage.records,
-      minRecordCount: malformedCoverage.minRecordCount,
-      decisionGroups: {
-        ...corporateDecisionFailure.decisionGroups,
-        operationallyCovered: malformedCoverage.operationallyCovered,
-      },
+      ...valid,
+      decisionGroups: { ...valid.decisionGroups, coverageFailure },
     };
     assert.equal(
-      composeChinaDecisionSignalsStatus(candidate, firstCorporateFailure, Date.parse(firstCorporateFailure.evaluatedAt))
-        .chinaCoveragePendingUntil,
+      composeChinaDecisionSignalsStatus(candidate, null, NOW).chinaCoveragePendingUntil,
       undefined,
-      JSON.stringify(malformedCoverage),
     );
   }
 });
 
-test('china coverage: a summary with no streak field alarms as before', () => {
-  // Rollout safety. Every summary written before the producer shipped the field
-  // has no streak; absent evidence must not read as evidence of health, or the
-  // rollout window would silence a genuine outage.
-  const projected = projectChinaCoverageStatus(chinaSummary({ degradedStreak: undefined, degradedProblemKey: undefined }));
+test('china decision signals: malformed producer evidence cannot use the legacy fallback', () => {
+  const chinaCoverage = projectChinaCoverageStatus(chinaSummary({
+    degradedStreak: 1,
+    entries: [{
+      id: 'market.china-corporate-disclosures',
+      launchStatus: 'launched',
+      status: 'degraded',
+      reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
+    }],
+  }));
+  const entry = {
+    status: 'COVERAGE_PARTIAL',
+    records: 5,
+    minRecordCount: 6,
+    decisionGroups: {
+      operationallyCovered: 5,
+      unavailableGroups: [{
+        id: 'corporate-disclosures',
+        unavailableCause: 'upstream_unavailable',
+      }],
+      coverageFailureInvalidReason: 'FAILURE_TIMESTAMP_MISSING',
+    },
+  };
+
+  assert.equal(
+    composeChinaDecisionSignalsStatus(entry, chinaCoverage, Date.parse(chinaCoverage.evaluatedAt)).chinaCoveragePendingUntil,
+    undefined,
+  );
+});
+
+test('china coverage: a summary with no episode clock alarms immediately', () => {
+  const projected = projectChinaCoverageStatus(chinaSummary({
+    firstDegradedAt: undefined,
+    lastDegradedAt: undefined,
+    lastHealthyAt: undefined,
+  }), false, CHINA_SUMMARY_AT + ONE_MIN_MS);
   assert.equal(projected.status, 'CHINA_DEGRADED');
+  assert.equal(projected.chinaCoveragePendingUntil, undefined);
 });
 
 test('china coverage: UNAVAILABLE is never debounced', () => {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -2324,8 +2324,6 @@ const chinaSummary = (over = {}) => ({
     status: 'degraded',
     reasonCodes: ['CHINA_COVERAGE_PARTIAL'],
   }]),
-  firstDegradedAt: CHINA_SUMMARY_AT,
-  lastDegradedAt: CHINA_SUMMARY_AT,
   lastHealthyAt: CHINA_LAST_HEALTHY_AT,
   ...over,
 });
@@ -2361,6 +2359,19 @@ test('china coverage: the hold expires at exactly three hours after the last hea
   assert.equal(projected.status, 'CHINA_DEGRADED');
   assert.equal(projected.chinaCoveragePendingUntil, undefined);
   assert.equal(__testing__.healthStatusBucket(projected, deadline), 'warn');
+});
+
+test('china coverage: stale evidence warns immediately', () => {
+  const projected = projectChinaCoverageStatus(chinaSummary({
+    entries: [{
+      id: 'market.china-stock-connect',
+      launchStatus: 'launched',
+      status: 'degraded',
+      reasonCodes: ['CONTENT_STALE'],
+    }],
+  }), false, CHINA_SUMMARY_AT + ONE_MIN_MS);
+  assert.equal(projected.chinaCoveragePendingUntil, undefined);
+  assert.equal(__testing__.healthStatusBucket(projected, CHINA_SUMMARY_AT + ONE_MIN_MS), 'warn');
 });
 
 test('china coverage: a held verdict stays visible rather than silent', () => {
@@ -2435,14 +2446,9 @@ test('china decision signals: aggregate degradation cannot replace producer succ
   assert.equal(__testing__.healthStatusBucket(decisionSignals, now), 'warn');
 });
 
-test('china decision signals: producer attempts cannot exhaust the three-hour validity window', () => {
+test('china decision signals: failed publications cannot extend the three-hour validity window', () => {
   const successAt = NOW - 15 * ONE_MIN_MS;
-  const firstAt = NOW;
-  const failureKey = JSON.stringify([{
-    id: 'corporate-disclosures',
-    unavailableCause: 'upstream_unavailable',
-  }]);
-  const candidate = (consecutiveFailures) => ({
+  const candidate = {
     status: 'COVERAGE_PARTIAL',
     records: 5,
     minRecordCount: 6,
@@ -2452,38 +2458,26 @@ test('china decision signals: producer attempts cannot exhaust the three-hour va
         id: 'corporate-disclosures',
         unavailableCause: 'upstream_unavailable',
       }],
-      coverageFailure: {
-        failureKey,
-        consecutiveFailures,
-        firstFailureAt: firstAt,
-        lastAttemptAt: NOW,
-        lastSuccessAt: successAt,
-      },
+      coverageLastSuccessAt: successAt,
     },
-  });
+  };
 
-  for (const consecutiveFailures of [1, 2, 3, 12]) {
-    const composed = composeChinaDecisionSignalsStatus(candidate(consecutiveFailures), null, NOW);
-    assert.equal(composed.status, 'COVERAGE_PARTIAL');
-    assert.equal(
-      composed.chinaCoveragePendingUntil,
-      new Date(successAt + SEED_META.chinaDecisionSignals.maxStaleMin * ONE_MIN_MS).toISOString(),
-    );
-    assert.equal(__testing__.healthStatusBucket(composed, NOW), 'ok');
-  }
+  const composed = composeChinaDecisionSignalsStatus(candidate, null, NOW);
+  assert.equal(composed.status, 'COVERAGE_PARTIAL');
   assert.equal(
-    composeChinaDecisionSignalsStatus(candidate(12), null, successAt + 180 * ONE_MIN_MS)
+    composed.chinaCoveragePendingUntil,
+    new Date(successAt + SEED_META.chinaDecisionSignals.maxStaleMin * ONE_MIN_MS).toISOString(),
+  );
+  assert.equal(__testing__.healthStatusBucket(composed, NOW), 'ok');
+  assert.equal(
+    composeChinaDecisionSignalsStatus(candidate, null, successAt + 180 * ONE_MIN_MS)
       .chinaCoveragePendingUntil,
     undefined,
     'the three-hour freshness ceiling still expires the hold',
   );
 });
 
-test('china decision signals: missing or mismatched failure evidence fails closed', () => {
-  const failureKey = JSON.stringify([{
-    id: 'corporate-disclosures',
-    unavailableCause: 'upstream_unavailable',
-  }]);
+test('china decision signals: missing or invalid last-success evidence fails closed', () => {
   const valid = {
     status: 'COVERAGE_PARTIAL',
     records: 5,
@@ -2494,23 +2488,13 @@ test('china decision signals: missing or mismatched failure evidence fails close
         id: 'corporate-disclosures',
         unavailableCause: 'upstream_unavailable',
       }],
-      coverageFailure: {
-        failureKey,
-        consecutiveFailures: 1,
-        firstFailureAt: NOW,
-        lastAttemptAt: NOW,
-        lastSuccessAt: NOW - 15 * ONE_MIN_MS,
-      },
+      coverageLastSuccessAt: NOW - 15 * ONE_MIN_MS,
     },
   };
-  for (const coverageFailure of [
-    undefined,
-    { ...valid.decisionGroups.coverageFailure, failureKey: 'different' },
-    { ...valid.decisionGroups.coverageFailure, lastSuccessAt: null },
-  ]) {
+  for (const coverageLastSuccessAt of [undefined, null, Number.NaN]) {
     const candidate = {
       ...valid,
-      decisionGroups: { ...valid.decisionGroups, coverageFailure },
+      decisionGroups: { ...valid.decisionGroups, coverageLastSuccessAt },
     };
     assert.equal(
       composeChinaDecisionSignalsStatus(candidate, null, NOW).chinaCoveragePendingUntil,
@@ -2549,10 +2533,8 @@ test('china decision signals: malformed producer evidence cannot use the legacy 
   );
 });
 
-test('china coverage: a summary with no episode clock alarms immediately', () => {
+test('china coverage: a summary with no last-healthy clock alarms immediately', () => {
   const projected = projectChinaCoverageStatus(chinaSummary({
-    firstDegradedAt: undefined,
-    lastDegradedAt: undefined,
     lastHealthyAt: undefined,
   }), false, CHINA_SUMMARY_AT + ONE_MIN_MS);
   assert.equal(projected.status, 'CHINA_DEGRADED');

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -6,6 +6,8 @@ process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
 process.env.WORLDMONITOR_VALID_KEYS = 'test-health-admin-key';
 
 const { default: handler, handleHealth, __testing__ } = await import('../api/health.js');
+const { nextChinaDecisionCoverageFailure } = await import('../scripts/seed-china-decision-signals.mjs');
+const { findOperationalProblems, findPendingDiagnostics } = await import('../scripts/check-seed-freshness.mjs');
 
 const {
   HEALTH_VERDICT_SNAPSHOT_KEY: HEALTH_SNAPSHOT_KEY,
@@ -736,10 +738,17 @@ function chinaCorporateCoverageSummary(now, degradedStreak) {
     entries: problems.map((problem) => ({ ...problem, launchStatus: 'launched' })),
     degradedStreak,
     degradedProblemKey: JSON.stringify(problems),
+    firstDegradedAt: now - 60_000,
+    lastDegradedAt: now - 60_000,
+    lastHealthyAt: now - 16 * 60_000,
   };
 }
 
-function chinaCorporateDecisionMeta(now) {
+function chinaCorporateDecisionMeta(now, consecutiveFailures = null) {
+  const unavailableGroups = [{
+    id: 'corporate-disclosures',
+    unavailableCause: 'upstream_unavailable',
+  }];
   return {
     fetchedAt: now - 60_000,
     recordCount: 5,
@@ -760,13 +769,143 @@ function chinaCorporateDecisionMeta(now) {
       operationallyCovered: 5,
     },
     unavailableCauses: { 'corporate-disclosures': 'upstream_unavailable' },
+    ...(consecutiveFailures == null ? {} : {
+      decisionCoverageFailureKey: JSON.stringify(unavailableGroups),
+      consecutiveDecisionCoverageFailures: consecutiveFailures,
+      firstDecisionCoverageFailureAt: now - 60_000,
+      lastDecisionCoverageAttemptAt: now - 60_000,
+      lastDecisionCoverageSuccessAt: now - 16 * 60_000,
+    }),
   };
 }
 
-test('handleHealth reconciles the duplicate China warning only for the first observation', async () => {
+function chinaDecisionFailureSnapshot(generatedAt) {
+  const groupIds = [
+    'macro',
+    'policy-enforcement',
+    'cross-strait-activity',
+    'corporate-disclosures',
+    'corridor-conditions',
+    'activity-nowcast',
+  ];
+  return {
+    generatedAt: new Date(generatedAt).toISOString(),
+    groups: groupIds.map((id) => ({
+      id,
+      state: id === 'corporate-disclosures' ? 'unavailable' : 'available',
+      metadata: id === 'corporate-disclosures'
+        ? { unavailableCause: 'upstream_unavailable' }
+        : {},
+    })),
+  };
+}
+
+function chinaHealthyCoverageSummary(now) {
+  return {
+    schemaVersion: 1,
+    countryCode: 'CN',
+    status: 'healthy',
+    evaluatedAt: new Date(now).toISOString(),
+    counts: {
+      total: 1,
+      launched: 1,
+      planned: 0,
+      blocked: 0,
+      healthy: 1,
+      degraded: 0,
+      unavailable: 0,
+    },
+    entries: [{
+      id: 'market.china-corporate-disclosures',
+      launchStatus: 'launched',
+      status: 'healthy',
+      reasonCodes: [],
+    }],
+    degradedStreak: 0,
+    degradedProblemKey: null,
+    firstDegradedAt: null,
+    lastDegradedAt: null,
+    lastHealthyAt: now,
+  };
+}
+
+test('producer evidence stays non-blocking through health and the monitor until the three-hour boundary', async () => {
+  const lastSuccessAt = Date.parse('2026-09-08T12:00:00.000Z');
+  const failureAt = lastSuccessAt + 15 * 60_000;
+  const deadline = lastSuccessAt + CHINA_DECISION_SIGNALS_PENDING_MS;
+  const failure = nextChinaDecisionCoverageFailure(
+    chinaDecisionFailureSnapshot(failureAt),
+    {
+      fetchedAt: lastSuccessAt,
+      recordCount: 6,
+      groupStates: {
+        macro: 'available',
+        'policy-enforcement': 'available',
+        'cross-strait-activity': 'available',
+        'corporate-disclosures': 'available',
+        'corridor-conditions': 'available',
+        'activity-nowcast': 'available',
+      },
+      unavailableCauses: {},
+    },
+    failureAt,
+  );
+  const seedMeta = {
+    ...chinaCorporateDecisionMeta(failureAt),
+    fetchedAt: failureAt,
+    ...failure,
+  };
+
+  Date.now = () => deadline - 1;
+  const pendingBody = await sweepCompactBody(sweepFetch({
+    chinaCoverageSummary: chinaHealthyCoverageSummary(deadline - 1),
+    chinaDecisionMeta: seedMeta,
+  }));
+  assert.ok(findPendingDiagnostics(pendingBody, deadline - 1).some(
+    ({ name }) => name === 'chinaDecisionSignals',
+  ));
+  assert.ok(!findOperationalProblems(pendingBody, deadline - 1).some(
+    ({ name }) => name === 'chinaDecisionSignals',
+  ));
+
+  Date.now = () => deadline;
+  const warningBody = await sweepCompactBody(sweepFetch({
+    chinaCoverageSummary: chinaHealthyCoverageSummary(deadline),
+    chinaDecisionMeta: seedMeta,
+  }));
+  assert.ok(findOperationalProblems(warningBody, deadline).some(
+    ({ name, status }) => name === 'chinaDecisionSignals' && status === 'COVERAGE_PARTIAL',
+  ));
+});
+
+test('handleHealth keeps repeated producer-owned China failures pending for three hours', async () => {
   const now = Date.parse('2026-09-08T16:01:57.702Z');
   Date.now = () => now;
-  const decisionMeta = chinaCorporateDecisionMeta(now);
+  const pipelines = [];
+  const body = await sweepCompactBody(sweepFetch({
+    chinaCoverageSummary: chinaCorporateCoverageSummary(now, 4),
+    chinaDecisionMeta: chinaCorporateDecisionMeta(now, 12),
+    onCommands: (commands) => pipelines.push(commands),
+  }));
+  const write = pipelines.flat().find(
+    ([op, key]) => op === 'SET' && key === HEALTH_SNAPSHOT_KEY,
+  );
+  const stored = JSON.parse(write[2]);
+  const deadline = new Date(now - 16 * 60_000 + CHINA_DECISION_SIGNALS_PENDING_MS).toISOString();
+
+  assert.deepEqual(body.pending?.chinaDecisionSignals, {
+    status: 'COVERAGE_PARTIAL',
+    chinaCoveragePendingUntil: deadline,
+  });
+  assert.equal(body.problems?.chinaDecisionSignals, undefined);
+  assert.equal(stored.checks.chinaDecisionSignals.decisionGroups.coverageFailure.consecutiveFailures, 12);
+  assert.equal(stored.checks.chinaDecisionSignals.chinaCoveragePendingUntil, deadline);
+});
+
+test('handleHealth keeps both China diagnoses pending for the same wall-clock window', async () => {
+  const now = Date.parse('2026-09-08T16:01:57.702Z');
+  Date.now = () => now;
+  const decisionMeta = chinaCorporateDecisionMeta(now, 12);
 
   const run = async (degradedStreak) => {
     const pipelines = [];
@@ -783,22 +922,32 @@ test('handleHealth reconciles the duplicate China warning only for the first obs
 
   const first = await run(1);
   const deadline = new Date(
-    now - 60_000 + CHINA_DECISION_SIGNALS_PENDING_MS,
+    now - 16 * 60_000 + CHINA_DECISION_SIGNALS_PENDING_MS,
   ).toISOString();
   assert.deepEqual(first.body.pending?.chinaDecisionSignals, {
     status: 'COVERAGE_PARTIAL',
     chinaCoveragePendingUntil: deadline,
   });
   assert.equal(first.body.problems?.chinaDecisionSignals, undefined);
-  assert.equal(first.body.problems?.chinaCoverage?.status, 'OK');
+  assert.equal(first.body.pending?.chinaCoverage?.status, 'CHINA_DEGRADED');
   assert.equal(first.stored.checks.chinaDecisionSignals.chinaCoveragePendingUntil, deadline);
 
   const repeated = await run(2);
-  assert.equal(repeated.body.pending?.chinaDecisionSignals, undefined);
-  assert.equal(repeated.body.problems?.chinaDecisionSignals?.status, 'COVERAGE_PARTIAL');
-  assert.equal(repeated.body.problems?.chinaCoverage?.status, 'CHINA_DEGRADED');
-  assert.equal(repeated.stored.checks.chinaDecisionSignals.chinaCoveragePendingUntil, undefined);
-  assert.equal(repeated.body.summary.warn, first.body.summary.warn + 2);
+  assert.deepEqual(repeated.body.pending?.chinaDecisionSignals, first.body.pending?.chinaDecisionSignals);
+  assert.equal(repeated.body.problems?.chinaDecisionSignals, undefined);
+  assert.equal(repeated.body.pending?.chinaCoverage?.status, 'CHINA_DEGRADED');
+  assert.equal(repeated.stored.checks.chinaDecisionSignals.chinaCoveragePendingUntil, deadline);
+
+  const third = await run(3);
+  assert.deepEqual(third.body.pending?.chinaDecisionSignals, first.body.pending?.chinaDecisionSignals);
+  assert.equal(third.body.pending?.chinaCoverage?.status, 'CHINA_DEGRADED');
+
+  const fourth = await run(4);
+  assert.deepEqual(fourth.body.pending?.chinaDecisionSignals, first.body.pending?.chinaDecisionSignals);
+  assert.equal(fourth.body.problems?.chinaDecisionSignals, undefined);
+  assert.equal(fourth.body.pending?.chinaCoverage?.status, 'CHINA_DEGRADED');
+  assert.equal(fourth.stored.checks.chinaDecisionSignals.chinaCoveragePendingUntil, deadline);
+  assert.equal(fourth.body.summary.warn, first.body.summary.warn);
 });
 
 test('handleHealth claims, publishes, and reuses one stale-content deadline', async () => {

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -738,13 +738,11 @@ function chinaCorporateCoverageSummary(now, degradedStreak) {
     entries: problems.map((problem) => ({ ...problem, launchStatus: 'launched' })),
     degradedStreak,
     degradedProblemKey: JSON.stringify(problems),
-    firstDegradedAt: now - 60_000,
-    lastDegradedAt: now - 60_000,
     lastHealthyAt: now - 16 * 60_000,
   };
 }
 
-function chinaCorporateDecisionMeta(now, consecutiveFailures = null) {
+function chinaCorporateDecisionMeta(now, withLastSuccess = false) {
   const unavailableGroups = [{
     id: 'corporate-disclosures',
     unavailableCause: 'upstream_unavailable',
@@ -769,13 +767,9 @@ function chinaCorporateDecisionMeta(now, consecutiveFailures = null) {
       operationallyCovered: 5,
     },
     unavailableCauses: { 'corporate-disclosures': 'upstream_unavailable' },
-    ...(consecutiveFailures == null ? {} : {
-      decisionCoverageFailureKey: JSON.stringify(unavailableGroups),
-      consecutiveDecisionCoverageFailures: consecutiveFailures,
-      firstDecisionCoverageFailureAt: now - 60_000,
-      lastDecisionCoverageAttemptAt: now - 60_000,
+    ...(withLastSuccess ? {
       lastDecisionCoverageSuccessAt: now - 16 * 60_000,
-    }),
+    } : {}),
   };
 }
 
@@ -823,8 +817,6 @@ function chinaHealthyCoverageSummary(now) {
     }],
     degradedStreak: 0,
     degradedProblemKey: null,
-    firstDegradedAt: null,
-    lastDegradedAt: null,
     lastHealthyAt: now,
   };
 }
@@ -898,7 +890,10 @@ test('handleHealth keeps repeated producer-owned China failures pending for thre
     chinaCoveragePendingUntil: deadline,
   });
   assert.equal(body.problems?.chinaDecisionSignals, undefined);
-  assert.equal(stored.checks.chinaDecisionSignals.decisionGroups.coverageFailure.consecutiveFailures, 12);
+  assert.equal(
+    stored.checks.chinaDecisionSignals.decisionGroups.coverageLastSuccessAt,
+    now - 16 * 60_000,
+  );
   assert.equal(stored.checks.chinaDecisionSignals.chinaCoveragePendingUntil, deadline);
 });
 

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -379,6 +379,10 @@ describe('scheduled seed freshness monitor', () => {
     }, true);
 
     assert.equal(isChinaCoveragePendingProblem(problem, now), true);
+    assert.equal(
+      isChinaCoveragePendingProblem({ ...problem, status: 'CHINA_DEGRADED' }, now),
+      true,
+    );
     assert.deepEqual(compact.pending, { chinaDecisionSignals: problem });
     assert.deepEqual(findOperationalProblems(compact, now), []);
     assert.deepEqual(findPendingDiagnostics(compact, now), [{

--- a/tests/seed-health-portwatch-port-activity.test.mjs
+++ b/tests/seed-health-portwatch-port-activity.test.mjs
@@ -117,10 +117,6 @@ function installSeedHealthPipelineMock(
             operationallyCovered: 6,
           },
           unavailableCauses: {},
-          decisionCoverageFailureKey: null,
-          consecutiveDecisionCoverageFailures: 0,
-          firstDecisionCoverageFailureAt: null,
-          lastDecisionCoverageAttemptAt: now,
           lastDecisionCoverageSuccessAt: now,
         }) };
       }
@@ -340,14 +336,6 @@ test('seed-health publishes partial and stale China decision groups like /api/he
         'corridor-conditions': 'insufficient_data',
         'activity-nowcast': 'upstream_unavailable',
       },
-      decisionCoverageFailureKey: JSON.stringify([
-        { id: 'activity-nowcast', unavailableCause: 'upstream_unavailable' },
-        { id: 'corridor-conditions', unavailableCause: 'insufficient_data' },
-        { id: 'policy-enforcement', unavailableCause: 'stale' },
-      ]),
-      consecutiveDecisionCoverageFailures: 2,
-      firstDecisionCoverageFailureAt: TEST_NOW - 15 * 60_000,
-      lastDecisionCoverageAttemptAt: TEST_NOW,
       lastDecisionCoverageSuccessAt: TEST_NOW - 30 * 60_000,
     },
   });
@@ -360,17 +348,7 @@ test('seed-health publishes partial and stale China decision groups like /api/he
   assert.deepEqual(entry.partialGroups, ['macro']);
   assert.deepEqual(entry.staleGroups, ['policy-enforcement']);
   assert.deepEqual(entry.quietGroups, ['corporate-disclosures']);
-  assert.deepEqual(entry.coverageFailure, {
-    failureKey: JSON.stringify([
-      { id: 'activity-nowcast', unavailableCause: 'upstream_unavailable' },
-      { id: 'corridor-conditions', unavailableCause: 'insufficient_data' },
-      { id: 'policy-enforcement', unavailableCause: 'stale' },
-    ]),
-    consecutiveFailures: 2,
-    firstFailureAt: TEST_NOW - 15 * 60_000,
-    lastAttemptAt: TEST_NOW,
-    lastSuccessAt: TEST_NOW - 30 * 60_000,
-  });
+  assert.equal(entry.coverageLastSuccessAt, TEST_NOW - 30 * 60_000);
 });
 
 test('seed-health warns when China decision diagnostics or failure evidence are invalid', async () => {
@@ -404,15 +382,9 @@ test('seed-health warns when China decision diagnostics or failure evidence are 
         groupStates: coveredStates,
         groupCounts: validCounts,
         unavailableCauses: {},
-        decisionCoverageFailureKey: JSON.stringify([
-          { id: 'macro', unavailableCause: 'upstream_unavailable' },
-        ]),
-        consecutiveDecisionCoverageFailures: 1,
-        firstDecisionCoverageFailureAt: TEST_NOW - 15 * 60_000,
-        lastDecisionCoverageAttemptAt: TEST_NOW,
-        lastDecisionCoverageSuccessAt: TEST_NOW - 5 * 60_000,
+        lastDecisionCoverageSuccessAt: TEST_NOW + 5 * 60_000,
       },
-      expectedReason: 'FAILURE_TIMESTAMP_ORDER_INVALID',
+      expectedReason: 'LAST_SUCCESS_INVALID',
     },
   ];
 

--- a/tests/seed-health-portwatch-port-activity.test.mjs
+++ b/tests/seed-health-portwatch-port-activity.test.mjs
@@ -96,8 +96,33 @@ function installSeedHealthPipelineMock(
           }),
         };
       }
-      if (key === DECISION_META_KEY && chinaDecisionMeta) {
-        return { result: JSON.stringify(chinaDecisionMeta) };
+      if (key === DECISION_META_KEY) {
+        return { result: JSON.stringify(chinaDecisionMeta ?? {
+          fetchedAt: now,
+          recordCount: 6,
+          groupStates: Object.fromEntries([
+            'macro',
+            'policy-enforcement',
+            'cross-strait-activity',
+            'corporate-disclosures',
+            'corridor-conditions',
+            'activity-nowcast',
+          ].map((id) => [id, 'available'])),
+          groupCounts: {
+            populated: 6,
+            partial: 0,
+            stale: 0,
+            unavailable: 0,
+            healthyQuiet: 0,
+            operationallyCovered: 6,
+          },
+          unavailableCauses: {},
+          decisionCoverageFailureKey: null,
+          consecutiveDecisionCoverageFailures: 0,
+          firstDecisionCoverageFailureAt: null,
+          lastDecisionCoverageAttemptAt: now,
+          lastDecisionCoverageSuccessAt: now,
+        }) };
       }
       if (key === PHYSICAL_DIVERGENCE_META_KEY && physicalDivergenceMeta) {
         return { result: JSON.stringify(physicalDivergenceMeta) };
@@ -330,6 +355,8 @@ test('seed-health publishes partial and stale China decision groups like /api/he
   const { body } = await readSeedHealth();
   const entry = body.seeds['intelligence:china-decision-signals'];
 
+  assert.equal(body.overall, 'warning');
+  assert.equal(entry.status, 'coverage_partial');
   assert.deepEqual(entry.partialGroups, ['macro']);
   assert.deepEqual(entry.staleGroups, ['policy-enforcement']);
   assert.deepEqual(entry.quietGroups, ['corporate-disclosures']);
@@ -344,4 +371,59 @@ test('seed-health publishes partial and stale China decision groups like /api/he
     lastAttemptAt: TEST_NOW,
     lastSuccessAt: TEST_NOW - 30 * 60_000,
   });
+});
+
+test('seed-health warns when China decision diagnostics or failure evidence are invalid', async () => {
+  const coveredStates = Object.fromEntries([
+    'macro',
+    'policy-enforcement',
+    'cross-strait-activity',
+    'corporate-disclosures',
+    'corridor-conditions',
+    'activity-nowcast',
+  ].map((id) => [id, 'available']));
+  const validCounts = {
+    populated: 6,
+    partial: 0,
+    stale: 0,
+    unavailable: 0,
+    healthyQuiet: 0,
+    operationallyCovered: 6,
+  };
+  const cases = [
+    {
+      name: 'group diagnostics',
+      meta: { fetchedAt: TEST_NOW, recordCount: 6 },
+      expectedReason: 'GROUP_DIAGNOSTICS_INVALID',
+    },
+    {
+      name: 'failure evidence',
+      meta: {
+        fetchedAt: TEST_NOW,
+        recordCount: 6,
+        groupStates: coveredStates,
+        groupCounts: validCounts,
+        unavailableCauses: {},
+        decisionCoverageFailureKey: JSON.stringify([
+          { id: 'macro', unavailableCause: 'upstream_unavailable' },
+        ]),
+        consecutiveDecisionCoverageFailures: 1,
+        firstDecisionCoverageFailureAt: TEST_NOW - 15 * 60_000,
+        lastDecisionCoverageAttemptAt: TEST_NOW,
+        lastDecisionCoverageSuccessAt: TEST_NOW - 5 * 60_000,
+      },
+      expectedReason: 'FAILURE_TIMESTAMP_ORDER_INVALID',
+    },
+  ];
+
+  for (const testCase of cases) {
+    installSeedHealthPipelineMock(174, { chinaDecisionMeta: testCase.meta });
+    const { res, body } = await readSeedHealth();
+    const entry = body.seeds['intelligence:china-decision-signals'];
+
+    assert.equal(res.status, 200, testCase.name);
+    assert.equal(body.overall, 'warning', testCase.name);
+    assert.equal(entry.status, 'coverage_partial', testCase.name);
+    assert.equal(entry.coverageFailureInvalidReason, testCase.expectedReason, testCase.name);
+  }
 });

--- a/tests/seed-health-portwatch-port-activity.test.mjs
+++ b/tests/seed-health-portwatch-port-activity.test.mjs
@@ -303,11 +303,11 @@ test('seed-health publishes partial and stale China decision groups like /api/he
         'activity-nowcast': 'unavailable',
       },
       groupCounts: {
-        populated: 1,
+        populated: 3,
         partial: 1,
         stale: 1,
         unavailable: 3,
-        healthyQuiet: 0,
+        healthyQuiet: 1,
         operationallyCovered: 3,
       },
       unavailableCauses: {
@@ -315,6 +315,15 @@ test('seed-health publishes partial and stale China decision groups like /api/he
         'corridor-conditions': 'insufficient_data',
         'activity-nowcast': 'upstream_unavailable',
       },
+      decisionCoverageFailureKey: JSON.stringify([
+        { id: 'activity-nowcast', unavailableCause: 'upstream_unavailable' },
+        { id: 'corridor-conditions', unavailableCause: 'insufficient_data' },
+        { id: 'policy-enforcement', unavailableCause: 'stale' },
+      ]),
+      consecutiveDecisionCoverageFailures: 2,
+      firstDecisionCoverageFailureAt: TEST_NOW - 15 * 60_000,
+      lastDecisionCoverageAttemptAt: TEST_NOW,
+      lastDecisionCoverageSuccessAt: TEST_NOW - 30 * 60_000,
     },
   });
 
@@ -324,4 +333,15 @@ test('seed-health publishes partial and stale China decision groups like /api/he
   assert.deepEqual(entry.partialGroups, ['macro']);
   assert.deepEqual(entry.staleGroups, ['policy-enforcement']);
   assert.deepEqual(entry.quietGroups, ['corporate-disclosures']);
+  assert.deepEqual(entry.coverageFailure, {
+    failureKey: JSON.stringify([
+      { id: 'activity-nowcast', unavailableCause: 'upstream_unavailable' },
+      { id: 'corridor-conditions', unavailableCause: 'insufficient_data' },
+      { id: 'policy-enforcement', unavailableCause: 'stale' },
+    ]),
+    consecutiveFailures: 2,
+    firstFailureAt: TEST_NOW - 15 * 60_000,
+    lastAttemptAt: TEST_NOW,
+    lastSuccessAt: TEST_NOW - 30 * 60_000,
+  });
 });

--- a/tests/seed-health-prediction-pools.test.mjs
+++ b/tests/seed-health-prediction-pools.test.mjs
@@ -25,6 +25,15 @@ const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v11:US';
 const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
 const EDUCATION_META_KEY = 'seed-meta:resilience:education-attainment';
 const EDUCATION_DATA_KEY = 'resilience:education-attainment:v1';
+const CHINA_DECISION_META_KEY = 'seed-meta:intelligence:china-decision-signals';
+const CHINA_DECISION_GROUP_IDS = [
+  'macro',
+  'policy-enforcement',
+  'cross-strait-activity',
+  'corporate-disclosures',
+  'corridor-conditions',
+  'activity-nowcast',
+];
 
 function educationPayload() {
   return {
@@ -114,6 +123,23 @@ function installSeedHealthPipelineMock(poolCounts, { fetchedAt = Date.now() } = 
         // #6845: the bases domain carries a 100k integrity floor the
         // generic fresh-and-healthy default does not clear.
         return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 125_380 }) };
+      }
+      if (key === CHINA_DECISION_META_KEY) {
+        return { result: JSON.stringify({
+          fetchedAt,
+          recordCount: CHINA_DECISION_GROUP_IDS.length,
+          groupStates: Object.fromEntries(CHINA_DECISION_GROUP_IDS.map((id) => [id, 'available'])),
+          groupCounts: {
+            populated: 6,
+            partial: 0,
+            stale: 0,
+            unavailable: 0,
+            healthyQuiet: 0,
+            operationallyCovered: 6,
+          },
+          unavailableCauses: {},
+          lastDecisionCoverageSuccessAt: fetchedAt,
+        }) };
       }
       return { result: JSON.stringify({
         fetchedAt: Date.now(),

--- a/tests/seed-history-ingest-health.test.mjs
+++ b/tests/seed-history-ingest-health.test.mjs
@@ -1232,10 +1232,6 @@ describe('a prolonged relay rejection is visible in /api/seed-health', () => {
               operationallyCovered: 6,
             },
             unavailableCauses: {},
-            decisionCoverageFailureKey: null,
-            consecutiveDecisionCoverageFailures: 0,
-            firstDecisionCoverageFailureAt: null,
-            lastDecisionCoverageAttemptAt: now,
             lastDecisionCoverageSuccessAt: now,
           }) };
         }

--- a/tests/seed-history-ingest-health.test.mjs
+++ b/tests/seed-history-ingest-health.test.mjs
@@ -1121,6 +1121,7 @@ describe('a prolonged relay rejection is visible in /api/health', () => {
 
 describe('a prolonged relay rejection is visible in /api/seed-health', () => {
   const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
+  const CHINA_DECISION_META_KEY = 'seed-meta:intelligence:china-decision-signals';
 
   /**
    * Answer every seed-meta GET with a fresh, healthy record so the assertions
@@ -1208,6 +1209,35 @@ describe('a prolonged relay rejection is visible in /api/seed-health', () => {
               poolCounts: { geopolitical: 18, tech: 12, finance: 8 },
             }),
           };
+        }
+        if (key === CHINA_DECISION_META_KEY) {
+          const now = Date.now();
+          return { result: JSON.stringify({
+            fetchedAt: now,
+            recordCount: 6,
+            groupStates: Object.fromEntries([
+              'macro',
+              'policy-enforcement',
+              'cross-strait-activity',
+              'corporate-disclosures',
+              'corridor-conditions',
+              'activity-nowcast',
+            ].map((id) => [id, 'available'])),
+            groupCounts: {
+              populated: 6,
+              partial: 0,
+              stale: 0,
+              unavailable: 0,
+              healthyQuiet: 0,
+              operationallyCovered: 6,
+            },
+            unavailableCauses: {},
+            decisionCoverageFailureKey: null,
+            consecutiveDecisionCoverageFailures: 0,
+            firstDecisionCoverageFailureAt: null,
+            lastDecisionCoverageAttemptAt: now,
+            lastDecisionCoverageSuccessAt: now,
+          }) };
         }
         return { result: JSON.stringify({
           fetchedAt: Date.now(),


### PR DESCRIPTION
## Summary

- Retain proven last-good China decision and aggregate coverage for a fixed three-hour window during transient upstream coverage shortfalls.
- Keep the decision producer on its 15-minute cadence. Failed publications do not advance the single last-success clock, so retries and changing failure identities cannot restart the deadline.
- Fail closed immediately for missing, stale, malformed, never-proven, or manifest-mismatched evidence, while keeping a qualifying active diagnosis visible as pending.

## Verification

- `npx tsx --test tests/china-decision-alerts.test.mjs tests/china-decision-coverage-classes.test.mjs tests/china-coverage-health.test.mjs tests/china-decision-parity-audit.test.mjs tests/health-classify.test.mjs tests/health-verdict-snapshot.test.mjs tests/seed-freshness-monitor.test.mjs tests/china-decision-access-contract.test.mts tests/seed-health-portwatch-port-activity.test.mjs tests/seed-health-prediction-pools.test.mjs tests/seed-history-ingest-health.test.mjs` (413 passed)
- `npm run typecheck:api`
- `npm run typecheck`
- `npm run lint:boundaries`
- Pre-push repository gates passed
- `ce-code-review`: no remaining P0-P2 findings
- Exact-head GitHub required gate and Vercel preview passed

## Post-Deploy Monitoring & Validation

- Surfaces: `/api/health?compact=1`, operator `/api/seed-health`, natural 15-minute decision runs, and natural hourly aggregate runs.
- Success: a qualifying transient shortfall remains visible in `pending` without increasing `warn`; its deadline stays fixed at the last healthy proof plus three hours; failed attempts do not move that deadline; recovery advances the last-success clock.
- Failure: missing, malformed, stale, or never-proven evidence is softened; a pending deadline moves after a failed attempt; a shortfall remains pending after three hours; or natural producer attempts stop.
- Observation window: at least three hours, covering 12 natural decision runs and four aggregate evaluations.
- Owner: WorldMonitor operations.
- Log and payload terms: `[china-decision-signals] group diagnostics`, `lastDecisionCoverageSuccessAt`, `chinaCoveragePendingUntil`, and `CHINA_COVERAGE_PARTIAL`.
- Rollback: revert this PR. Do not call seeders manually during acceptance.
- Rollout note: the API fails closed until natural producer runs publish valid timing evidence. Existing decision metadata bridges only when it proves complete fresh group coverage; an existing aggregate bridges only when its summary is internally consistent and matches the current launched manifest.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
