### PR TITLE
perf(seo): split sources into bounded static catalog pages

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -26,7 +26,8 @@ import {
   USE_CASES_CONTENT_VERSION,
   writeUseCasesSection,
 } from './build-use-cases.mjs';
-import { buildSourceCatalog, renderSourcesIndex } from './crawlable-sources-page.mjs';
+import { buildSourceCatalog, buildSourcePages, renderSourcesIndex, sourceCardAnchors } from './crawlable-sources-page.mjs';
+import { sourceOriginFilterValue } from './source-origin.mjs';
 import {
   attachCoverageToCatalog,
   FEED_DECLARATION_FILES,
@@ -124,6 +125,7 @@ const SOURCE_PAGE_RENDERER_PATH = 'scripts/crawlable-sources-page.mjs';
 const SOURCE_ORIGIN_PATH = 'scripts/source-origin.mjs';
 const SHARED_PAGE_TEMPLATE_PATH = 'scripts/build-crawlable-corpus.mjs';
 export const SOURCE_CATALOG_LASTMOD_PATHS = Object.freeze([
+  'scripts/crawlable-sources-search.mjs',
   'scripts/source-catalog-identity.mjs',
   'shared/source-geography.json',
   'shared/publisher-families.js',
@@ -5023,9 +5025,9 @@ function buildManifest({ data, baseUrl, changelogPageCount }) {
         routes: COMPARISON_PAGES.map((page) => page.path),
       },
       sources: {
-        count: 1,
+        count: buildSourcePages(data.sourceCatalog).length + 1,
         index: '/sources/',
-        routes: [],
+        routes: buildSourcePages(data.sourceCatalog).map((page) => page.path),
       },
       glossary: {
         count: glossaryRoutes.length,
@@ -5063,6 +5065,9 @@ export async function buildCorpus({
     },
   ];
 
+  const sourcePages = buildSourcePages(data.sourceCatalog);
+  const catalogAnchors = sourceCardAnchors(data.sourceCatalog);
+  const sourceHelpers = { absoluteUrl, breadcrumbLd, dataCatalogLd, escapeHtml, pageDocument, withUtmSource };
   writeGeneratedFile(
     outDir,
     'sources/index.html',
@@ -5072,16 +5077,35 @@ export async function buildCorpus({
       catalogDatasets: sourcesCatalogDatasets,
       baseUrl,
       lastmod: data.lastmod.sources,
-      helpers: {
-        absoluteUrl,
-        breadcrumbLd,
-        dataCatalogLd,
-        escapeHtml,
-        pageDocument,
-        withUtmSource,
-      },
+      helpers: sourceHelpers,
+      directoryPages: sourcePages,
+      catalogAnchors,
     }),
   );
+  for (const sourcePage of sourcePages) {
+    writeGeneratedFile(outDir, routeFile(sourcePage.path), renderSourcesIndex({
+      sourceStats: data.sourceStats,
+      sourceCatalog: sourcePage.providers,
+      baseUrl,
+      lastmod: data.lastmod.sources,
+      helpers: sourceHelpers,
+      sourcePage,
+      catalogAnchors,
+      siblingPages: sourcePages.filter((page) => page.domainId === sourcePage.domainId),
+    }));
+  }
+  writeGeneratedFile(outDir, 'sources/search-index.json', JSON.stringify(sourcePages.flatMap((page) => (
+    page.providers.map((provider) => ({
+      name: provider.displayName,
+      hosts: provider.hosts,
+      search: [provider.displayName, provider.provider, ...provider.hosts].join(' ').toLowerCase(),
+      domain: provider.domainId,
+      kinds: provider.kinds,
+      country: sourceOriginFilterValue(provider.originCountry),
+      coverage: (provider.coveredCountries || []).map(sourceOriginFilterValue),
+      url: `${page.path}#${catalogAnchors.get(provider.provider)}`,
+    }))
+  ))));
 
   writeGeneratedFile(
     outDir,

--- a/scripts/crawlable-sources-page.mjs
+++ b/scripts/crawlable-sources-page.mjs
@@ -3,6 +3,7 @@
 // template does not obscure the corpus orchestration and other page families.
 
 import { createHash } from 'node:crypto';
+import { sourcesBookmarkScript, sourcesSearchScript } from './crawlable-sources-search.mjs';
 
 import {
   catalogCoverageCountryOptions,
@@ -782,11 +783,30 @@ export function sourceCardAnchors(sourceCatalog) {
   return anchors;
 }
 
-export function renderSourcesIndex({ sourceStats, sourceCatalog, catalogDatasets = [], baseUrl, lastmod, helpers }) {
+export function buildSourcePages(sourceCatalog) {
+  return SOURCE_DOMAINS.flatMap((domain) => {
+    const providers = sourceCatalog.filter((provider) => provider.domainId === domain.id);
+    const pages = [];
+    for (let offset = 0; offset < providers.length; offset += 60) {
+      const number = offset / 60 + 1;
+      pages.push({
+        path: `/sources/${domain.id}/${number === 1 ? '' : `page/${number}/`}`,
+        name: `${domain.name}${number === 1 ? '' : ` — page ${number}`}`,
+        domainId: domain.id,
+        providers: providers.slice(offset, offset + 60),
+      });
+    }
+    return pages;
+  });
+}
+
+export function renderSourcesIndex({ sourceStats, sourceCatalog, catalogDatasets = [], baseUrl, lastmod, helpers, directoryPages = null, sourcePage = null, catalogAnchors = sourceCardAnchors(sourceCatalog), siblingPages = [] }) {
   const { absoluteUrl, breadcrumbLd, dataCatalogLd, escapeHtml, pageDocument, withUtmSource } = helpers;
-  const path = '/sources/';
+  const path = sourcePage?.path || '/sources/';
   const pageUrl = absoluteUrl(baseUrl, path);
-  const description = `Explore ${sourceStats.providerCount} active providers and ${sourceStats.activeHosts} source hosts across World Monitor's global intelligence, markets, energy, cyber, aviation, climate and news coverage.`;
+  const description = sourcePage
+    ? `Browse ${sourceCatalog.length} providers in ${sourcePage.name}, with source hosts, origins and coverage. Part of World Monitor's complete source catalog.`
+    : `Explore ${sourceStats.providerCount} active providers and ${sourceStats.activeHosts} source hosts across World Monitor's global intelligence, markets, energy, cyber, aviation, climate and news coverage.`;
   // Query precedes the fragment — withUtmSource() would append after the
   // anchor and push the query into the fragment, so build these by hand.
   const docsHref = (anchor) => `/docs/data-sources?utm_source=seo-sources${anchor ? `#${anchor}` : ''}`;
@@ -800,20 +820,20 @@ export function renderSourcesIndex({ sourceStats, sourceCatalog, catalogDatasets
     structured: 'Structured data',
     'operational-status': 'Operational status',
   };
-  const domainCards = SOURCE_DOMAINS.map((domain, index) => `        <article class="source-domain-card">
-          <button type="button" data-source-filter="${domain.id}" aria-controls="source-catalog" aria-pressed="false">
+  const domainCards = SOURCE_DOMAINS.filter((domain) => !directoryPages || domainCounts.get(domain.id) > 0).map((domain, index) => `        <article class="source-domain-card">
+          ${directoryPages ? `<a class="domain-browse" href="/sources/${domain.id}/">` : `<button type="button" data-source-filter="${domain.id}" aria-controls="source-catalog" aria-pressed="false">`}
             <span class="domain-index">${String(index + 1).padStart(2, '0')}</span>
             <span class="domain-count">${domainCounts.get(domain.id)} providers</span>
             <strong>${escapeHtml(domain.name)}</strong>
             <span class="domain-blurb">${escapeHtml(domain.blurb)}</span>
             <span class="domain-examples">${domain.providers.slice(0, 4).map((provider) => `<span>${escapeHtml(provider)}</span>`).join('')}</span>
-          </button>
+          ${directoryPages ? '</a>' : '</button>'}
           <a class="domain-docs" href="${docsHref(domain.anchor)}">Methodology &amp; coverage <span aria-hidden="true">↗</span></a>
         </article>`).join('\n');
   const countryOptions = catalogCountryOptions(sourceCatalog);
   const coverageOptions = catalogCoverageCountryOptions(sourceCatalog);
-  const cardAnchors = sourceCardAnchors(sourceCatalog);
-  const providerCards = sourceCatalog.map((provider) => {
+  const cardAnchors = catalogAnchors;
+  const providerCards = (directoryPages ? [] : sourceCatalog).map((provider) => {
     const domain = domainById.get(provider.domainId);
     const countryLabel = sourceOriginLabel(provider.originCountry);
     const countryFilter = sourceOriginFilterValue(provider.originCountry);
@@ -852,13 +872,14 @@ export function renderSourcesIndex({ sourceStats, sourceCatalog, catalogDatasets
       <span><strong>WORLD MONITOR</strong><small>Open-source global intelligence</small></span>
       <span class="source-footer-links"><a href="/sources/">Sources</a><a href="${docsHref('')}">Data docs</a><a href="${withUtmSource('/docs/source-attribution', 'seo-sources')}">Attribution ledger</a><a href="/docs/terms">Terms</a></span>
     </div>`;
+  const catalogNavigation = `<nav class="source-pages" aria-label="Source catalog pages">${(directoryPages || siblingPages).map((page) => `<a href="${page.path}"${page.path === path ? ' aria-current="page"' : ''}>${escapeHtml(page.name)}</a>`).join(' ')}</nav>`;
   const body = `      <section class="sources-hero">
         <div class="hero-copy">
           <p class="eyebrow"><span></span> Live provider inventory</p>
-          <h1>See every source behind World Monitor.</h1>
-          <p class="lede">The map is only as useful as the signals behind it. World Monitor combines ${sourceStats.providerCount} active providers across ${sourceStats.activeHosts} observed source hosts spanning news, conflict, markets, military, climate, aviation, infrastructure and technology — with every provider listed below.</p>
+          <h1>${sourcePage ? escapeHtml(sourcePage.name) : 'See every source behind World Monitor.'}</h1>
+          <p class="lede">The map is only as useful as the signals behind it. World Monitor combines ${sourceStats.providerCount} active providers across ${sourceStats.activeHosts} observed source hosts spanning news, conflict, markets, military, climate, aviation, infrastructure and technology. ${sourcePage ? 'This page lists ' + sourceCatalog.length + ' providers. <a href="/sources/#catalog">Search all providers</a> or browse the pages below.' : 'Browse providers by domain, or search the full inventory below.'}</p>
           <div class="hero-actions">
-            <a class="cta" href="#catalog">Browse all ${sourceStats.providerCount} providers <span aria-hidden="true">↓</span></a>
+            <a class="cta" href="#catalog">${sourcePage ? 'Browse this page' : 'Find a provider'} <span aria-hidden="true">↓</span></a>
             <a class="secondary-cta" href="${withUtmSource('/dashboard', 'sources-hero')}">Open the live dashboard <span aria-hidden="true">→</span></a>
           </div>
           <p class="trust-line"><span>Manifest-derived</span><span>Build-checked</span><span>Source-attributed</span></p>
@@ -881,7 +902,7 @@ export function renderSourcesIndex({ sourceStats, sourceCatalog, catalogDatasets
         <span><strong>${sourceStats.structuredHosts}</strong><small>Structured endpoints</small></span>
         <span><strong>${sourceStats.feedHosts}</strong><small>News &amp; OSINT feeds</small></span>
       </section>
-      <section class="domain-section" aria-labelledby="domains-heading">
+      ${sourcePage ? '' : `<section class="domain-section" aria-labelledby="domains-heading">
         <div class="section-heading">
           <p class="eyebrow">Coverage architecture</p>
           <h2 id="domains-heading">Ten domains. One operating picture.</h2>
@@ -890,7 +911,7 @@ export function renderSourcesIndex({ sourceStats, sourceCatalog, catalogDatasets
         <div class="source-domains">
 ${domainCards}
         </div>
-      </section>
+      </section>`}
       <section class="trust-section" aria-labelledby="trust-heading">
         <div><p class="eyebrow">Trust through traceability</p><h2 id="trust-heading">The count follows the code.</h2></div>
         <div>
@@ -902,15 +923,16 @@ ${domainCards}
         <div class="section-heading">
           <p class="eyebrow">Provenance</p>
           <h2 id="provenance-heading">Where does World Monitor get its data?</h2>
-          <p>World Monitor fuses licensed data feeds, official statistics, open-source intelligence, and live sensor networks into one operating picture. Every provider below is named, attributed, and reconciled against the code that queries it, so models and analysts can verify each claim. Counts update at build time from the tracked inventory.</p>
+          <p>World Monitor fuses licensed data feeds, official statistics, open-source intelligence, and live sensor networks into one operating picture. Every listed provider is named, attributed, and reconciled against the code that queries it, so models and analysts can verify each claim. Counts update at build time from the tracked inventory.</p>
         </div>
       </section>
       <section class="catalog-section" id="catalog" aria-labelledby="catalog-heading">
         <div class="section-heading catalog-heading">
           <p class="eyebrow">Complete catalog</p>
-          <h2 id="catalog-heading">All ${sourceStats.providerCount} active providers.</h2>
-          <p>Search by provider or host. Filter by signal domain, source type, country of origin, or country covered. Every provider remains in the static HTML for people, search engines and no-script browsers.</p>
+          <h2 id="catalog-heading">${sourcePage ? escapeHtml(sourcePage.name) : `Search all ${sourceStats.providerCount} providers.`}</h2>
+          <p>${directoryPages ? 'Search by provider or host, with filters for domain, type, origin and coverage. Open a result for its full source details. You can also browse every provider on the linked domain pages without JavaScript.' : 'Filter the providers on this page. For the complete inventory, <a href="/sources/#catalog">search all providers</a>. Every provider on this page is included in the static HTML.'}</p>
         </div>
+        ${directoryPages ? '' : catalogNavigation}
         <div class="catalog-controls">
           <label class="search-control" for="source-search"><span>Search providers</span><input id="source-search" type="search" placeholder="Reuters, USGS, coingecko…" autocomplete="off"></label>
           <label for="source-domain"><span>Domain</span><select id="source-domain"><option value="all">All domains</option>${SOURCE_DOMAINS.map((domain) => `<option value="${domain.id}">${escapeHtml(domain.name)}</option>`).join('')}</select></label>
@@ -919,13 +941,15 @@ ${domainCards}
           <label for="source-coverage"><span>Country covered</span><select id="source-coverage"><option value="all">All coverage</option>${coverageOptions.map((country) => `<option value="${country.code}">${escapeHtml(country.name)}</option>`).join('')}</select></label>
           <button type="button" class="reset-filter" data-source-filter="all">Reset</button>
         </div>
-        <div class="catalog-meta"><p id="source-results" aria-live="polite">${sourceStats.providerCount} providers shown</p><a href="${withUtmSource('/docs/source-attribution', 'seo-sources')}">Open the host-by-host ledger <span aria-hidden="true">↗</span></a></div>
+        <div class="catalog-meta"><p id="source-results" aria-live="polite">${directoryPages ? 'Choose a filter or enter a provider name.' : `${sourceCatalog.length} providers shown`}</p><a href="${withUtmSource('/docs/source-attribution', 'seo-sources')}">Open the host-by-host ledger <span aria-hidden="true">↗</span></a></div>
         <p class="catalog-country-note" id="source-country-note" aria-live="polite" hidden></p>
         <div class="provider-grid" id="source-catalog" data-source-catalog>
 ${providerCards}
         </div>
         <p class="no-results" id="source-no-results" hidden>No providers match those filters.</p>
-        <noscript><p class="noscript-note">Filtering needs JavaScript. The complete catalog is already shown above.</p></noscript>
+        ${directoryPages ? '<button type="button" class="reset-filter" id="source-more" hidden>Show next results</button>' : ''}
+        <noscript><p class="noscript-note">Filtering needs JavaScript. Use the catalog page links to browse every provider.</p></noscript>
+        ${directoryPages ? '<h3>Browse every source by domain</h3>' + catalogNavigation : ''}
       </section>
       <section class="sources-final-cta">
         <p class="eyebrow">From source to signal</p>
@@ -993,7 +1017,12 @@ ${providerCards}
       .section-heading > p:last-child { margin: 20px 0 0; font-size: 16px; line-height: 1.7; }
       .source-domains { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); border-left: 1px solid var(--line); border-top: 1px solid var(--line); }
       .source-domain-card { position: relative; min-width: 0; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: rgba(9,13,11,.55); }
-      .source-domain-card button { width: 100%; min-height: 260px; padding: 20px; display: flex; flex-direction: column; align-items: flex-start; border: 0; background: transparent; color: inherit; text-align: left; cursor: pointer; }
+      .source-domain-card button, .domain-browse { width: 100%; min-height: 260px; padding: 20px; display: flex; flex-direction: column; align-items: flex-start; border: 0; background: transparent; color: inherit; text-align: left; cursor: pointer; }
+      .source-pages { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 24px; }
+      .source-pages a { padding: 8px; border: 1px solid var(--line); }
+      .source-pages [aria-current="page"] { color: var(--accent); }
+      .source-result { padding: 16px; border: 1px solid var(--line); overflow-wrap: anywhere; }
+      .source-result small { display: block; color: var(--muted); }
       .source-domain-card:hover, .source-domain-card:has(button[aria-pressed="true"]) { z-index: 1; background: var(--panel-2); box-shadow: inset 0 0 0 1px rgba(74,222,128,.5); }
       .domain-index, .domain-count { color: #526057; font: 9px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .1em; text-transform: uppercase; }
       .domain-count { margin: -13px 0 24px auto; color: var(--accent); }
@@ -1005,7 +1034,7 @@ ${providerCards}
       .domain-docs:hover { color: var(--accent); text-decoration: none; }
       .trust-section { margin: 0; padding: 100px max(24px, calc((100% - 1192px)/2)); display: grid; grid-template-columns: .8fr 1.2fr; gap: 90px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); background: linear-gradient(100deg, rgba(74,222,128,.045), transparent 55%); }
       .trust-section p { margin-top: 0; font-size: 15px; line-height: 1.75; }
-      .catalog-section { padding-bottom: 100px; }
+      .catalog-section { padding-bottom: 100px; scroll-margin-top: 146px; }
       .catalog-heading { max-width: 790px; }
       .catalog-controls { position: sticky; top: 68px; z-index: 10; margin-bottom: 0; padding: 18px; display: grid; grid-template-columns: minmax(200px, 1.2fr) minmax(150px, .8fr) minmax(140px, .7fr) minmax(160px, .85fr) minmax(160px, .85fr) auto; gap: 12px; align-items: end; border: 1px solid var(--line); background: rgba(6,9,7,.94); backdrop-filter: blur(18px); }
       .catalog-controls label { display: grid; gap: 7px; color: var(--muted); font: 9px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .1em; text-transform: uppercase; }
@@ -1117,7 +1146,7 @@ ${providerCards}
   return pageDocument({
     baseUrl,
     path,
-    title: 'Data Source Catalog | World Monitor',
+    title: sourcePage ? `${sourcePage.name} sources | World Monitor` : 'Data Source Catalog | World Monitor',
     description,
     lastmod,
     jsonLd: [
@@ -1130,9 +1159,11 @@ ${providerCards}
         inLanguage: 'en-US',
         mainEntity: {
           '@type': 'ItemList',
-          numberOfItems: sourceCatalog.length,
+          numberOfItems: directoryPages ? directoryPages.length : sourceCatalog.length,
           itemListOrder: 'https://schema.org/ItemListUnordered',
-          itemListElement: sourceCatalog.map((provider, index) => ({
+          itemListElement: directoryPages ? directoryPages.map((page, index) => ({
+            '@type': 'ListItem', position: index + 1, name: page.name, url: absoluteUrl(baseUrl, page.path),
+          })) : sourceCatalog.map((provider, index) => ({
             '@type': 'ListItem',
             position: index + 1,
             name: provider.displayName,
@@ -1140,18 +1171,19 @@ ${providerCards}
           })),
         },
       },
-      catalogLd,
+      ...(sourcePage ? [] : [catalogLd]),
     ],
     breadcrumbs: breadcrumbLd(baseUrl, [
       { name: 'Home', path: '/' },
-      { name: 'Sources', path },
+      { name: 'Sources', path: '/sources/' },
+      ...(sourcePage ? [{ name: sourcePage.name, path }] : []),
     ]),
     body,
     bodyClass: 'sources-page',
     headerNav: sourceNav,
     footerBody: sourceFooter,
     extraStyles,
-    inlineScript,
+    inlineScript: directoryPages ? sourcesSearchScript : inlineScript + sourcesBookmarkScript,
     ogType: 'website',
   });
 }

--- a/scripts/crawlable-sources-search.mjs
+++ b/scripts/crawlable-sources-search.mjs
@@ -1,0 +1,97 @@
+// Runs only on the sources directory. Provider details stay on static pages.
+function initSourcesSearch() {
+  const search = document.getElementById('source-search');
+  const fields = ['domain', 'kind', 'country', 'coverage'].map((name) => document.getElementById('source-' + name));
+  const results = document.getElementById('source-results');
+  const grid = document.getElementById('source-catalog');
+  const more = document.getElementById('source-more');
+  const note = document.getElementById('source-country-note');
+  const noResults = document.getElementById('source-no-results');
+  let indexPromise;
+  let revision = 0;
+  let offset = 0;
+  const loadIndex = () => {
+    if (!indexPromise) indexPromise = fetch('/sources/search-index.json')
+      .then((response) => {
+        if (!response.ok) throw new Error('Search unavailable');
+        return response.json();
+      }).catch((error) => { indexPromise = null; throw error; });
+    return indexPromise;
+  };
+  const apply = async (nextPage = false) => {
+    const request = ++revision;
+    if (!nextPage) offset = 0;
+    const query = search.value.trim().toLowerCase();
+    const [domain, kind, country, coverage] = fields.map((field) => field.value);
+    grid.replaceChildren();
+    more.hidden = true;
+    noResults.hidden = true;
+    note.hidden = country === 'all' || country === 'intl';
+    note.textContent = note.hidden ? '' : 'This list shows monitored sources based in the selected country or region. Sources based elsewhere also cover it.';
+    if (!query && fields.every((field) => field.value === 'all')) {
+      results.textContent = 'Choose a filter or enter a provider name.';
+      return;
+    }
+    results.textContent = 'Searching…';
+    try {
+      const index = await loadIndex();
+      if (request !== revision) return;
+      const matches = index.filter((entry) =>
+        (!query || entry.search.includes(query))
+        && (domain === 'all' || entry.domain === domain)
+        && (kind === 'all' || entry.kinds.includes(kind))
+        && (country === 'all' || entry.country === country)
+        && (coverage === 'all' || entry.coverage.includes(coverage)));
+      for (const entry of matches.slice(offset, offset + 60)) {
+        const link = document.createElement('a');
+        link.className = 'source-result';
+        link.href = entry.url;
+        link.textContent = entry.name;
+        const detail = document.createElement('small');
+        detail.textContent = entry.hosts.join(', ');
+        link.append(detail);
+        grid.append(link);
+      }
+      results.textContent = matches.length + ' providers found' + (matches.length ? '; showing ' + (offset + 1) + '–' + Math.min(offset + 60, matches.length) : '');
+      noResults.hidden = matches.length !== 0;
+      more.hidden = offset + 60 >= matches.length;
+      if (nextPage) grid.querySelector('a')?.focus();
+    } catch {
+      if (request !== revision) return;
+      results.textContent = 'Search is unavailable. Try again or browse the domain pages above.';
+    }
+  };
+  search.addEventListener('input', () => apply());
+  for (const field of fields) field.addEventListener('change', () => apply());
+  document.querySelector('[data-source-filter="all"]').addEventListener('click', () => {
+    search.value = '';
+    for (const field of fields) field.value = 'all';
+    apply();
+  });
+  more.addEventListener('click', () => { offset += 60; apply(true); });
+
+}
+
+function initSourceBookmark() {
+  const followBookmark = async () => {
+    const fragment = location.hash;
+    if (!fragment.startsWith('#provider-') || document.getElementById(fragment.slice(1))) return;
+    const results = document.getElementById('source-results');
+    try {
+      const response = await fetch('/sources/search-index.json');
+      if (!response.ok) throw new Error('Catalog unavailable');
+      const index = await response.json();
+      if (location.hash !== fragment) return;
+      const entry = index.find((item) => item.url.endsWith(fragment));
+      if (entry && entry.url !== location.pathname + fragment) location.replace(entry.url);
+      else results.textContent = 'This provider is no longer on this page. Search or browse the current catalog.';
+    } catch {
+      results.textContent = 'This provider link could not be opened. Try search or browse the domain pages.';
+    }
+  };
+  addEventListener('hashchange', followBookmark);
+  followBookmark();
+}
+
+export const sourcesBookmarkScript = `(${initSourceBookmark.toString()})();`;
+export const sourcesSearchScript = `(${initSourcesSearch.toString()})();${sourcesBookmarkScript}`;

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -1767,6 +1767,7 @@ describe('crawlable corpus generator', () => {
 
   it('advances the sources lastmod for every catalog identity input', () => {
     assert.deepEqual(SOURCE_CATALOG_LASTMOD_PATHS, [
+      'scripts/crawlable-sources-search.mjs',
       'scripts/source-catalog-identity.mjs',
       'shared/source-geography.json',
       'shared/publisher-families.js',
@@ -1946,7 +1947,8 @@ describe('crawlable corpus generator', () => {
       assert.equal(manifest.sections.research.count, 1);
       assert.equal(manifest.sections.useCases.count, 3);
   assert.equal(manifest.sections.comparisons.count, 13);
-      assert.equal(manifest.sections.sources.count, 1);
+      assert.equal(manifest.sections.sources.count, manifest.sections.sources.routes.length + 1);
+      assert.ok(manifest.sections.sources.routes.length > 1);
       assert.equal(manifest.generatorContentVersion, '2026-09-01');
       const sitemapEntries = buildSitemapEntries({
         repoRoot,
@@ -1964,6 +1966,9 @@ describe('crawlable corpus generator', () => {
           .map((entry) => new URL(entry.loc).pathname),
       );
       assert.ok(corpusLocations.has('/sources/'), 'root sitemap must publish the sources catalog');
+      for (const route of manifest.sections.sources.routes) {
+        assert.ok(corpusLocations.has(route), `${route} must be published in the sitemap`);
+      }
       const manifestLocations = new Set([
         manifest.sections.countries.index,
         ...manifest.sections.countries.routes,
@@ -3666,65 +3671,51 @@ describe('crawlable corpus generator', () => {
       );
 
       const sourcesPage = read(outDir, 'sources/index.html');
-      // #7883: 2026-09-09 baseline: 761,255 raw bytes, 52,584 Brotli q11 bytes.
-      // Fixed ceilings allow ~18-24% catalog growth. Review rendering cost before
-      // raising them; do not derive the budget from the current catalog size.
-      const sourcesRawBytes = Buffer.byteLength(sourcesPage, 'utf8');
-      const sourcesBrotliBytes = brotliCompressSync(Buffer.from(sourcesPage, 'utf8'), {
-        params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 11 },
-      }).length;
-      assert.ok(
-        sourcesRawBytes <= 900_000,
-        `/sources/ raw size ${sourcesRawBytes} B exceeds the 900000 B parse budget`,
-      );
-      assert.ok(
-        sourcesBrotliBytes <= 65_000,
-        `/sources/ Brotli q11 size ${sourcesBrotliBytes} B exceeds the 65000 B delivery budget`,
-      );
+      const sourcePages = manifest.sections.sources.routes.map((route) => ({
+        route, html: read(outDir, `${route.slice(1)}index.html`),
+      }));
+      const sourcesCatalogHtml = sourcePages.map(({ html }) => html).join('\n');
+      for (const { route, html } of [{ route: '/sources/', html: sourcesPage }, ...sourcePages]) {
+        const rawBytes = Buffer.byteLength(html, 'utf8');
+        const brotliBytes = brotliCompressSync(Buffer.from(html), {
+          params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 11 },
+        }).length;
+        // After splitting: hub 60 KB; largest leaf 100 KB / 12.3 KB Brotli.
+        // New providers add pages automatically. These limits guard template bloat.
+        assert.ok(rawBytes <= 150_000, `${route} raw size ${rawBytes} B exceeds 150000 B`);
+        assert.ok(brotliBytes <= 20_000, `${route} Brotli size ${brotliBytes} B exceeds 20000 B`);
+        assert.ok((html.match(/<[a-z][^>]*>/gi) || []).length <= 1_200, `${route} exceeds the 1200 opening-tag rendering budget`);
+        assert.ok((html.match(/class="provider-card"/g) || []).length <= 60, `${route} must paginate beyond 60 providers`);
+        assert.ok(html.includes(`rel="canonical" href="https://www.worldmonitor.app${route}"`));
+      }
+      assert.doesNotMatch(sourcesPage, /class="provider-card"/, 'the directory must not eagerly render all provider cards');
       const sourceNodes = jsonLdObjects(sourcesPage);
-      const providerList = sourceNodes.find((node) => node['@type'] === 'CollectionPage').mainEntity;
-      assert.equal(providerList.itemListOrder, 'https://schema.org/ItemListUnordered');
-      // #7869: ListItems, not bare strings. Display names repeat across the real
-      // catalog (one publisher reached through several hosts), so the anchor url
-      // is what keeps the elements distinct and the count honest.
-      assert.deepEqual(
-        providerList.itemListElement.map((entry) => ({ type: entry['@type'], name: entry.name, position: entry.position })),
-        corpusData.sourceCatalog.map((provider, index) => ({ type: 'ListItem', name: provider.displayName, position: index + 1 })),
-      );
-      assert.equal(providerList.numberOfItems, providerList.itemListElement.length);
-      const providerAnchors = providerList.itemListElement.map((entry) => {
-        const url = new URL(entry.url);
-        assert.equal(url.pathname, '/sources/', `${entry.name} must point at the page that enumerates it`);
-        assert.ok(url.hash.startsWith('#provider-'), `${entry.name} must carry a provider fragment`);
-        return url.hash.slice(1);
-      });
-      assert.equal(new Set(providerAnchors).size, providerAnchors.length, 'two entries must never share one anchor');
-      // Land each fragment on the card for THAT provider, not merely on some
-      // card: an anchor map that permuted its urls across the catalog would
-      // satisfy "every fragment resolves" while sending every citation to the
-      // wrong source. data-provider is the card's own copy of the catalog key.
-      // Decode rather than re-escape: the generator's escapeHtml also covers `'`
-      // (L'Orient Today), and a second copy of that table in the test would be
-      // one more thing to keep in step with the one that matters.
-      const unescapeAttribute = (value) => value
-        .replace(/&quot;/g, '"').replace(/&#39;/g, "'")
-        .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
-      const cardProviderByAnchor = new Map(
-        [...sourcesPage.matchAll(/<article class="provider-card" id="([^"]+)" data-provider="([^"]*)"/g)]
-          .map((match) => [match[1], unescapeAttribute(match[2])]),
-      );
-      providerAnchors.forEach((anchor, index) => {
-        const expected = corpusData.sourceCatalog[index].provider;
-        assert.ok(
-          cardProviderByAnchor.has(anchor),
-          `${anchor} must name a card in the rendered page, or the ListItem url is a dead fragment`,
-        );
-        assert.equal(
-          cardProviderByAnchor.get(anchor),
-          expected,
-          `the ListItem for ${expected} must point at that provider's own card`,
-        );
-      });
+      const directoryList = sourceNodes.find((node) => node['@type'] === 'CollectionPage').mainEntity;
+      assert.equal(directoryList.numberOfItems, sourcePages.length);
+      assert.deepEqual(directoryList.itemListElement.map((entry) => new URL(entry.url).pathname), manifest.sections.sources.routes);
+      const unescapeAttribute = decodeHtmlAttribute;
+      const listedProviders = [];
+      const listedUrls = [];
+      for (const { route, html } of sourcePages) {
+        assert.ok(sourcesPage.includes(`href="${route}"`), `${route} must be linked from the no-script directory`);
+        const list = jsonLdObjects(html).find((node) => node['@type'] === 'CollectionPage').mainEntity;
+        const cards = new Map([...html.matchAll(/<article class="provider-card" id="([^"]+)" data-provider="([^"]*)"/g)]
+          .map((match) => [match[1], unescapeAttribute(match[2])]));
+        assert.equal(list.numberOfItems, cards.size);
+        assert.equal(list.itemListOrder, 'https://schema.org/ItemListUnordered');
+        list.itemListElement.forEach((entry, index) => {
+          assert.equal(entry['@type'], 'ListItem');
+          assert.equal(entry.position, index + 1);
+          const url = new URL(entry.url);
+          assert.equal(url.pathname, route);
+          const provider = cards.get(url.hash.slice(1));
+          assert.ok(provider, `${entry.url} must resolve to its static provider card`);
+          assert.equal(entry.name, corpusData.sourceCatalog.find((item) => item.provider === provider).displayName);
+          listedProviders.push(provider);
+          listedUrls.push(url.pathname + url.hash);
+        });
+      }
+      assert.deepEqual([...listedProviders].sort(), corpusData.sourceCatalog.map((provider) => provider.provider).sort());
       const catalog = sourceNodes.find((node) => node['@type'] === 'DataCatalog');
       assert.equal(catalog.dataset.length, corpusData.crises.length + 1);
       for (const dataset of catalog.dataset) {
@@ -3763,7 +3754,7 @@ describe('crawlable corpus generator', () => {
       assert.match(sourcesPage, />Country covered</);
       assert.match(sourcesPage, /data-source-catalog/);
       assert.match(sourcesPage, /data-source-filter="all"/);
-      const renderedProviders = [...sourcesPage.matchAll(/data-provider="([^"]+)"/g)]
+      const renderedProviders = [...sourcesCatalogHtml.matchAll(/data-provider="([^"]+)"/g)]
         .map((match) => match[1]);
       assert.equal(
         renderedProviders.length,
@@ -3781,203 +3772,166 @@ describe('crawlable corpus generator', () => {
         'sources page must render the exact active provider set from the attribution manifest',
       );
       assert.match(
-        sourcesPage,
+        sourcesCatalogHtml,
         /data-provider="L&#39;Orient Today"[\s\S]*?lorientlejour\.com/,
         "sources page must list L'Orient Today under its own host",
       );
       assert.match(
-        sourcesPage,
+        sourcesCatalogHtml,
         /data-provider="Annahar"[\s\S]*?annahar\.com/,
         'sources page must list Annahar under its own host',
       );
       assert.match(
-        sourcesPage,
+        sourcesCatalogHtml,
         /data-provider="OKO.press"[\s\S]*?oko\.press/,
         'sources page must list OKO.press under its own host',
       );
       assert.match(
-        sourcesPage,
+        sourcesCatalogHtml,
         /data-provider="PAP"[\s\S]*?pap\.pl/,
         'sources page must list PAP under its own host',
       );
       assert.doesNotMatch(
-        sourcesPage,
+        sourcesCatalogHtml,
         /data-provider="news\.google\.com"|<h3>Google News<\/h3>/,
         'sources page must not list Google News as a publisher',
       );
       assert.doesNotMatch(
-        sourcesPage,
+        sourcesCatalogHtml,
         /FeedBurner-hosted publishers|<h3>FeedBurner/,
         'sources page must not list FeedBurner as a publisher',
       );
       assert.match(
-        sourcesPage,
+        sourcesCatalogHtml,
         /data-provider="NDTV"[\s\S]*?Origin: India[\s\S]*?Covers: India/,
         'NDTV must appear as an Indian publisher with India coverage',
       );
       assert.match(
-        sourcesPage,
+        sourcesCatalogHtml,
         /<h3>BBC<\/h3>[\s\S]*?Origin: United Kingdom[\s\S]*?Covers:[^<]*India/,
         'BBC Hindi must keep BBC origin while declaring India coverage',
       );
       assert.match(
-        sourcesPage,
+        sourcesCatalogHtml,
         /<h3>Reuters<\/h3>[\s\S]*?Origin: United Kingdom[\s\S]*?Covers:[^<]*India/,
         'India-focused Reuters routes must stay Reuters with India coverage',
       );
       assert.doesNotMatch(
-        sourcesPage,
+        sourcesCatalogHtml,
         /via Google News|acquisition transport/i,
         'the public catalog must not expose feed transport mechanics',
       );
-      const renderedDomains = [...sourcesPage.matchAll(/data-source-domain="([^"]+)"/g)]
+      const renderedDomains = [...sourcesCatalogHtml.matchAll(/data-source-domain="([^"]+)"/g)]
         .map((match) => match[1]);
       assert.equal(renderedDomains.length, activeProviderNames.size);
       assert.ok(renderedDomains.every((domain) => SOURCE_DOMAIN_IDS.has(domain)));
-      const renderedKinds = [...sourcesPage.matchAll(/data-source-kind="([^"]+)"/g)]
+      const renderedKinds = [...sourcesCatalogHtml.matchAll(/data-source-kind="([^"]+)"/g)]
         .map((match) => match[1]);
-      const renderedCountries = [...sourcesPage.matchAll(/data-source-country="([^"]+)"/g)]
+      const renderedCountries = [...sourcesCatalogHtml.matchAll(/data-source-country="([^"]+)"/g)]
         .map((match) => match[1]);
       assert.equal(renderedCountries.length, activeProviderNames.size);
       assert.ok(renderedCountries.every((country) => /^[a-z]{2}$|^intl$/.test(country)));
-      const renderedCoverage = [...sourcesPage.matchAll(/data-source-coverage="([^"]*)"/g)]
+      const renderedCoverage = [...sourcesCatalogHtml.matchAll(/data-source-coverage="([^"]*)"/g)]
         .map((match) => match[1]);
       assert.equal(renderedCoverage.length, activeProviderNames.size);
       assert.doesNotMatch(
-        sourcesPage,
+        sourcesCatalogHtml,
         /audited upstream|audited &amp; attributed/i,
         'inventory reconciliation must not be presented as completed rights review',
       );
+      const searchIndex = JSON.parse(read(outDir, 'sources/search-index.json'));
+      assert.equal(searchIndex.length, activeProviderNames.size);
+      assert.deepEqual(searchIndex.map((entry) => entry.url).sort(), listedUrls.sort(), 'search must index every static provider exactly once');
+      for (const entry of searchIndex) {
+        const url = new URL(entry.url, 'https://www.worldmonitor.app');
+        const html = read(outDir, `${url.pathname.slice(1)}index.html`);
+        assert.ok(html.includes(`id="${url.hash.slice(1)}"`), `${entry.url} must resolve`);
+      }
       const filterScript = [...sourcesPage.matchAll(/<script nonce="wm-static-bootstrap">([\s\S]*?)<\/script>/g)].at(-1)?.[1];
-      assert.ok(filterScript, 'sources page must ship its progressive filter script');
+      assert.ok(filterScript);
       const window = new Window({ url: 'https://www.worldmonitor.app/sources/' });
       window.document.write(sourcesPage);
-      window.HTMLElement.prototype.scrollIntoView = () => {};
+      let fetchCount = 0;
+      let failSearch = true;
+      window.fetch = async (url) => {
+        assert.equal(url, '/sources/search-index.json');
+        fetchCount += 1;
+        return { ok: !failSearch, json: async () => searchIndex };
+      };
       window.eval(filterScript);
-      const providerTitle = (provider) => (
-        window.document.querySelector(`.provider-card[data-provider="${provider}"] h3`)?.textContent
-      );
-      assert.equal(providerTitle('acleddata.com'), 'ACLED');
-      assert.equal(providerTitle('en.wikipedia.org'), 'Wikipedia');
-      assert.equal(providerTitle('it.usembassy.gov'), 'U.S. Embassy & Consulates in Italy');
-      assert.equal(providerTitle('airlinegeeks.com'), 'AirlineGeeks');
-      assert.equal(
-        window.document.querySelector('.provider-card[data-provider="acleddata.com"] .provider-hosts a')?.textContent,
-        'acleddata.com',
-        'the exact hostname must remain available as the traceability link',
-      );
-      const visibleProviderCount = () => (
-        [...window.document.querySelectorAll('.provider-card')].filter((card) => !card.hidden).length
-      );
-      const financeCount = renderedDomains.filter((domain) => domain === 'finance').length;
-      const financeButton = window.document.querySelector('[data-source-filter="finance"]');
-      financeButton.click();
-      assert.equal(visibleProviderCount(), financeCount, 'domain cards must filter the complete catalog');
-      assert.equal(financeButton.getAttribute('aria-pressed'), 'true');
-      const resetButton = window.document.querySelector('[data-source-filter="all"]');
-      resetButton.click();
-      assert.equal(visibleProviderCount(), activeProviderNames.size, 'reset must restore all providers');
-      const kindSelect = window.document.getElementById('source-kind');
-      kindSelect.value = 'structured';
-      kindSelect.dispatchEvent(new window.Event('change'));
-      assert.equal(
-        visibleProviderCount(),
-        renderedKinds.filter((kinds) => kinds.split(' ').includes('structured')).length,
-        'source type selection must filter the complete catalog',
-      );
-      resetButton.click();
-      const countrySelect = window.document.getElementById('source-country');
-      const countryNote = window.document.getElementById('source-country-note');
-      assert.equal(countryNote.hidden, true, 'country coverage note must stay hidden without a country filter');
-      countrySelect.value = 'hu';
-      countrySelect.dispatchEvent(new window.Event('change'));
-      assert.equal(
-        visibleProviderCount(),
-        renderedCountries.filter((country) => country === 'hu').length,
-        'country selection must filter the complete catalog',
-      );
-      assert.ok(visibleProviderCount() > 0, 'Hungary must have at least one classified source');
-      assert.equal(
-        window.document.querySelector('.provider-card[data-provider="24.hu"] .provider-country')?.textContent,
-        'Origin: Hungary',
-      );
-      assert.equal(countryNote.hidden, false, 'country selection must show the coverage clarification');
-      assert.equal(countryNote.textContent, SOURCE_COUNTRY_FILTER_NOTE);
-      for (const country of ['us', 'eu']) {
-        countrySelect.value = country;
-        countrySelect.dispatchEvent(new window.Event('change'));
-        assert.equal(countryNote.hidden, false, `${country} selection must show the coverage clarification`);
-        assert.equal(countryNote.textContent, SOURCE_COUNTRY_FILTER_NOTE);
-      }
-      countrySelect.value = 'intl';
-      countrySelect.dispatchEvent(new window.Event('change'));
-      assert.equal(countryNote.hidden, true, 'international selection must hide the coverage clarification');
-      assert.equal(countryNote.textContent, '', 'international selection must clear the coverage clarification');
-      countrySelect.value = 'eu';
-      countrySelect.dispatchEvent(new window.Event('change'));
-      resetButton.click();
-      assert.equal(countryNote.hidden, true, 'reset must hide the country coverage clarification');
-      assert.equal(countryNote.textContent, '', 'reset must clear the country coverage clarification');
-      const coverageSelect = window.document.getElementById('source-coverage');
-      coverageSelect.value = 'in';
-      coverageSelect.dispatchEvent(new window.Event('change'));
-      const indiaCoverageCount = [...window.document.querySelectorAll('.provider-card')].filter((card) => (
-        !card.hidden && (card.dataset.sourceCoverage || '').split(' ').includes('in')
-      )).length;
-      assert.equal(visibleProviderCount(), indiaCoverageCount, 'coverage selection must filter the complete catalog');
-      assert.ok(indiaCoverageCount > 0, 'India coverage must include at least one provider');
-      const bbcCard = [...window.document.querySelectorAll('.provider-card')]
-        .find((card) => card.querySelector('h3')?.textContent === 'BBC');
-      const ndtvCard = window.document.querySelector('.provider-card[data-provider="NDTV"]');
-      assert.ok(bbcCard && !bbcCard.hidden, 'BBC Hindi must remain visible under India coverage');
-      assert.ok(ndtvCard && !ndtvCard.hidden, 'NDTV must remain visible under India coverage');
-      const catalogSize = window.document.querySelectorAll('.provider-card').length;
-      resetButton.click();
-      assert.equal(coverageSelect.value, 'all', 'reset must clear the coverage filter');
-      assert.equal(visibleProviderCount(), catalogSize, 'reset from coverage must show the full catalog');
-      const countryOriginSelect = window.document.getElementById('source-country');
-      countryOriginSelect.value = 'in';
-      countryOriginSelect.dispatchEvent(new window.Event('change'));
-      assert.ok(ndtvCard && !ndtvCard.hidden, 'NDTV origin is India');
-      assert.ok(bbcCard?.hidden, 'BBC origin stays United Kingdom when filtering India origin');
-      resetButton.click();
-      const searchInput = window.document.getElementById('source-search');
-      searchInput.value = 'Hyperliquid';
-      searchInput.dispatchEvent(new window.Event('input'));
-      assert.equal(visibleProviderCount(), 1, 'search must match provider names and hosts');
-      searchInput.value = 'a provider that cannot exist';
-      searchInput.dispatchEvent(new window.Event('input'));
-      assert.equal(visibleProviderCount(), 0);
+      const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+      await settle();
+      assert.equal(fetchCount, 0, 'initial render must not download the global search index');
+      const search = window.document.getElementById('source-search');
+      const results = () => [...window.document.querySelectorAll('.source-result')];
+      const change = async (id, value) => {
+        const field = window.document.getElementById(id);
+        field.value = value;
+        field.dispatchEvent(new window.Event(id === 'source-search' ? 'input' : 'change'));
+        await settle();
+      };
+      await change('source-search', 'Hyperliquid');
+      assert.match(window.document.getElementById('source-results').textContent, /Search is unavailable/);
+      assert.equal(window.document.getElementById('source-no-results').hidden, true, 'failure must not claim no matching providers');
+      failSearch = false;
+      await change('source-search', 'Hyperliquid');
+      assert.equal(results().length, 1, 'global search must find providers across domain pages');
+      assert.ok(results()[0].href.includes('/sources/finance/'));
+      await change('source-search', 'a provider that cannot exist');
+      assert.equal(results().length, 0);
       assert.equal(window.document.getElementById('source-no-results').hidden, false);
-      resetButton.click();
-      const composableCard = [...window.document.querySelectorAll('.provider-card')]
-        .find((card) => card.dataset.sourceKind.split(' ').length > 0);
-      assert.ok(composableCard, 'the catalog must contain a provider for the combined-filter test');
-      const combinedDomain = composableCard.dataset.sourceDomain;
-      const combinedKind = composableCard.dataset.sourceKind.split(' ')[0];
-      const combinedCountry = composableCard.dataset.sourceCountry;
-      const combinedQuery = composableCard.dataset.provider;
-      window.document.getElementById('source-domain').value = combinedDomain;
-      kindSelect.value = combinedKind;
-      countrySelect.value = combinedCountry;
-      searchInput.value = combinedQuery;
-      searchInput.dispatchEvent(new window.Event('input'));
-      const combinedMatches = [...window.document.querySelectorAll('.provider-card')].filter((card) => (
-        card.dataset.sourceDomain === combinedDomain
-        && card.dataset.sourceKind.split(' ').includes(combinedKind)
-        && card.dataset.sourceCountry === combinedCountry
-        && card.textContent.toLowerCase().includes(combinedQuery.toLowerCase())
-      ));
-      assert.ok(combinedMatches.length > 0, 'the selected filters must retain at least one provider');
-      assert.equal(
-        visibleProviderCount(),
-        combinedMatches.length,
-        'domain, type, country, and search filters must compose with AND semantics',
-      );
+      await change('source-search', '');
+      await change('source-domain', 'news');
+      assert.equal(results().length, 60, 'search must cap live result nodes');
+      const firstResults = results().map((link) => link.href);
+      window.document.getElementById('source-more').click();
+      await settle();
+      assert.equal(results().length, 60);
+      assert.ok(results().every((link) => !firstResults.includes(link.href)), 'next page must advance results');
+      window.document.querySelector('[data-source-filter="all"]').click();
+      await settle();
+      assert.equal(results().length, 0, 'reset must restore the small directory');
+      await change('source-country', 'hu');
+      assert.equal(results().length, searchIndex.filter((entry) => entry.country === 'hu').length);
+      assert.equal(window.document.getElementById('source-country-note').textContent, SOURCE_COUNTRY_FILTER_NOTE);
+      await change('source-country', 'all');
+      await change('source-coverage', 'in');
+      assert.ok(results().some((link) => link.textContent.startsWith('BBC')));
+      assert.ok(results().some((link) => link.textContent.startsWith('NDTV')));
+      await change('source-country', 'in');
+      assert.ok(results().some((link) => link.textContent.startsWith('NDTV')));
+      assert.ok(results().every((link) => !link.textContent.startsWith('BBC')));
+      await change('source-domain', 'news');
+      await change('source-kind', 'feed');
+      await change('source-search', 'NDTV');
+      const expected = searchIndex.filter((entry) => entry.search.includes('ndtv') && entry.country === 'in'
+        && entry.coverage.includes('in') && entry.domain === 'news' && entry.kinds.includes('feed'));
+      assert.deepEqual(results().map((link) => new URL(link.href).pathname + new URL(link.href).hash), expected.map((entry) => entry.url));
+      assert.ok(expected.length > 0, 'combined filters must retain a real provider');
+      assert.equal(fetchCount, 2, 'a failed fetch must retry, then filter changes reuse the index');
       window.close();
-      assert.doesNotMatch(sourcesPage, /[?&]ref=/, 'sources CTAs must never use the affiliate ref= param');
-      // Domain cards deep-link into the docs catalog with the query BEFORE the
-      // fragment (utm after the anchor would be swallowed by the fragment).
+      const bookmark = searchIndex.find((entry) => entry.name === 'Hyperliquid');
+      const bookmarkWindow = new Window({ url: `https://www.worldmonitor.app/sources/${new URL(bookmark.url, 'https://www.worldmonitor.app').hash}` });
+      bookmarkWindow.document.write(sourcesPage);
+      bookmarkWindow.fetch = async () => ({ ok: true, json: async () => searchIndex });
+      bookmarkWindow.eval(filterScript);
+      await settle();
+      assert.equal(bookmarkWindow.location.pathname + bookmarkWindow.location.hash, bookmark.url, 'old provider bookmarks must reach the new static card');
+      bookmarkWindow.close();
+      const raceWindow = new Window({ url: 'https://www.worldmonitor.app/sources/' });
+      raceWindow.document.write(sourcesPage);
+      let finishFetch;
+      raceWindow.fetch = () => new Promise((resolve) => { finishFetch = resolve; });
+      raceWindow.eval(filterScript);
+      const raceSearch = raceWindow.document.getElementById('source-search');
+      raceSearch.value = 'Hyperliquid';
+      raceSearch.dispatchEvent(new raceWindow.Event('input'));
+      raceWindow.document.querySelector('[data-source-filter="all"]').click();
+      finishFetch({ ok: true, json: async () => searchIndex });
+      await settle();
+      assert.equal(raceWindow.document.querySelectorAll('.source-result').length, 0, 'a late search response must not undo reset');
+      raceWindow.close();
+      assert.doesNotMatch(sourcesPage, /[?&]ref=/);
       assert.match(sourcesPage, /href="\/docs\/data-sources\?utm_source=seo-sources#finance-%26-economics"/);
       assert.match(sourcesPage, /href="\/docs\/source-attribution\?utm_source=seo-sources"/);
 

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, it } from 'node:test';
+import { brotliCompressSync, constants as zlibConstants } from 'node:zlib';
 
 import { Window } from 'happy-dom';
 import ts from 'typescript';
@@ -3665,6 +3666,21 @@ describe('crawlable corpus generator', () => {
       );
 
       const sourcesPage = read(outDir, 'sources/index.html');
+      // #7883: 2026-09-09 baseline: 761,255 raw bytes, 52,584 Brotli q11 bytes.
+      // Fixed ceilings allow ~18-24% catalog growth. Review rendering cost before
+      // raising them; do not derive the budget from the current catalog size.
+      const sourcesRawBytes = Buffer.byteLength(sourcesPage, 'utf8');
+      const sourcesBrotliBytes = brotliCompressSync(Buffer.from(sourcesPage, 'utf8'), {
+        params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 11 },
+      }).length;
+      assert.ok(
+        sourcesRawBytes <= 900_000,
+        `/sources/ raw size ${sourcesRawBytes} B exceeds the 900000 B parse budget`,
+      );
+      assert.ok(
+        sourcesBrotliBytes <= 65_000,
+        `/sources/ Brotli q11 size ${sourcesBrotliBytes} B exceeds the 65000 B delivery budget`,
+      );
       const sourceNodes = jsonLdObjects(sourcesPage);
       const providerList = sourceNodes.find((node) => node['@type'] === 'CollectionPage').mainEntity;
       assert.equal(providerList.itemListOrder, 'https://schema.org/ItemListUnordered');

--- a/tests/crawlable-sources-pagination.test.mjs
+++ b/tests/crawlable-sources-pagination.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { it } from 'node:test';
+import { buildSourcePages } from '../scripts/crawlable-sources-page.mjs';
+import { sourcesBookmarkScript } from '../scripts/crawlable-sources-search.mjs';
+import { Window } from 'happy-dom';
+
+it('adds a static page when a domain exceeds 60 providers, without losing providers', () => {
+  const catalog = Array.from({ length: 121 }, (_, i) => ({
+    provider: `source-${i}.example`, displayName: `Source ${i}`, domainId: 'news',
+  }));
+  const pages = buildSourcePages(catalog);
+  assert.deepEqual(pages.map(({ path }) => path), [
+    '/sources/news/', '/sources/news/page/2/', '/sources/news/page/3/',
+  ]);
+  assert.deepEqual(pages.map(({ providers }) => providers.length), [60, 60, 1]);
+  assert.deepEqual(pages.flatMap(({ providers }) => providers), catalog);
+  assert.deepEqual(buildSourcePages([]), []);
+});
+
+it('recovers a provider bookmark moved by pagination without fetching for a current card', async () => {
+  const window = new Window({ url: 'https://www.worldmonitor.app/sources/news/#provider-example' });
+  window.document.write('<p id="source-results"></p>');
+  let fetches = 0;
+  window.fetch = async () => {
+    fetches += 1;
+    return { ok: true, json: async () => [{ url: '/sources/news/page/2/#provider-example' }] };
+  };
+  window.eval(sourcesBookmarkScript);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(window.location.pathname, '/sources/news/page/2/');
+  assert.equal(window.location.hash, '#provider-example');
+  assert.equal(fetches, 1);
+  window.document.write('<article id="provider-example"></article>');
+  window.eval(sourcesBookmarkScript);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(fetches, 1, 'an existing static card needs no search download');
+  window.close();
+});


### PR DESCRIPTION
## Summary

Opening `/sources/` rendered all 748 providers in one document. It is now a small directory with global search and 17 static domain pages, capped at 60 providers per page. When a domain grows, the build adds another page automatically; the size budget now guards template growth rather than forcing a manual split when providers are added.

| Built artifact | Before | After |
|---|---:|---:|
| Directory HTML | 761,255 B | 60,186 B |
| Directory Brotli q11 | 52,584 B | 10,835 B |
| Directory elements | 7,487 | 508 |
| Largest provider page | — | 99,890 B / 826 elements |

Every provider remains in static HTML, linked from the directory and sitemap. Search loads its index only on use and renders at most 60 results. Existing directory bookmarks and provider links that move between numbered pages recover through the current index. Browsing does not require JavaScript; search and moved-bookmark recovery do.

Fixes #7883.

Related: #7869.

## Validation

- Corpus, sitemap and pagination tests cover exact provider membership, canonical links, ItemList targets, global search filters, result pagination, fetch failure/retry, stale-response suppression, and bookmark recovery.
- A 121-provider fixture creates pages of 60, 60 and 1 automatically.
- Each generated sources page is checked against 150 KB raw, 20 KB Brotli q11, 1,200 opening tags and 60 provider cards.
- TypeScript, API type checking, full lint and boundary checks passed. Lint reports existing warnings outside this change.
- Local browser checks at desktop and 390 px mobile width verified search-to-card navigation and bookmark recovery, with no horizontal overflow. This measures document size and element count, not CPU time on a physical mobile device. The shared remote thumbnail was unavailable in the local preview.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the maintainer should check `/sources/`, `/sources/search-index.json`, a domain page and a later news page, then search for a provider and open an old bookmark. During the first 24 hours, check Vercel request logs for `/sources/` 404/5xx responses. Healthy behavior is a complete static catalog, working search and resolvable provider links. Missing providers, failed index downloads or broken navigation require correction or rollback of this change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
