### PR TITLE
fix(disease): align content age with source cadence

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -2911,8 +2911,7 @@ function classifyKey(name, redisKey, opts, ctx) {
   // Fires AFTER all earlier failure paths so STALE_SEED, COVERAGE_PARTIAL,
   // EMPTY_*, etc. take precedence — STALE_CONTENT is "the seeder is healthy
   // and the data set is sized correctly, but the content itself is older than
-  // the seeder's content-age budget" (e.g. WHO Disease Outbreak News hasn't
-  // published in >9 days for the disease-outbreaks pilot).
+  // the seeder's content-age budget".
   // The opt-in signal is contentAge being non-null in seed-meta (presence of
   // meta.maxContentAgeMin); legacy seeders without it skip this branch.
   // 2026-05-04 health-readiness plan, Sprint 1.

--- a/docs/health-variant-full.md
+++ b/docs/health-variant-full.md
@@ -184,7 +184,7 @@ message PathogenAlert {
 
 | Script | Interval | Key | TTL |
 |--------|----------|-----|-----|
-| `seed-disease-outbreaks.mjs` | Every 6h (existing) | `health:disease-outbreaks:v1` | 72h |
+| `seed-disease-outbreaks.mjs` | Daily bundle member; hourly tick, eligible after 19.2h | `health:disease-outbreaks:v1` | 72h |
 | `seed-vpd-tracker.mjs` | Daily (existing) | `health:vpd-tracker:realtime:v1` | 72h |
 | `seed-epidemic-trends.mjs` | Daily | `health:epidemic-trends:v1` | 24h |
 | `seed-vaccination-coverage.mjs` | Weekly (Sunday 02:00 UTC) | `health:vaccination-coverage:v1` | 7 days |

--- a/scripts/_disease-outbreaks-helpers.mjs
+++ b/scripts/_disease-outbreaks-helpers.mjs
@@ -274,6 +274,4 @@ export function diseasePublishTransform(data) {
   };
 }
 
-/** Sprint 2 pilot threshold (9 days). Single source of truth — exported so the
- *  seeder uses the same constant the test asserts against. */
-export const DISEASE_MAX_CONTENT_AGE_MIN = 9 * 24 * 60;
+export const DISEASE_MAX_CONTENT_AGE_MIN = 14 * 24 * 60;

--- a/scripts/seed-disease-outbreaks.mjs
+++ b/scripts/seed-disease-outbreaks.mjs
@@ -243,12 +243,9 @@ async function main() {
 
     // ── Content-age contract (Sprint 2 of the 2026-05-04 health-readiness plan) ──
     //
-    // 9-day budget chosen so the 2026-05-04 incident — where the cache held
-    // 50 outbreaks all 11+ days old — would have correctly tripped STALE_CONTENT
-    // in /api/health. WHO Disease Outbreak News publishes 1-2/week (typical gap
-    // 3-5d), CDC HAN is sporadic but rarely silent for a full week, and TGH
-    // (post-#3593) provides daily ProMED items. 9 days tolerates a single quiet
-    // WHO/CDC week without paging on normal cadence.
+    // TGH releases its bundle about weekly, and the newest event commonly trails
+    // release by 3 to 5 days. Valid content can therefore approach 12 days old
+    // before the next release.
     //
     // diseaseContentMeta + diseasePublishTransform live in
     // `_disease-outbreaks-helpers.mjs` so the test suite imports the same code

--- a/tests/disease-outbreaks-seed.test.mjs
+++ b/tests/disease-outbreaks-seed.test.mjs
@@ -303,32 +303,29 @@ test('end-to-end: contentMeta runs on raw data WITH helpers, publishTransform st
   assert.equal((json.match(/_originalPublishedMs/g) || []).length, 0, 'no _originalPublishedMs in JSON');
 });
 
-// ── Pilot threshold sanity (anti-drift on the 9-day budget) ──────────────
-
-test('DISEASE_MAX_CONTENT_AGE_MIN constant is 9 days', () => {
-  assert.equal(DISEASE_MAX_CONTENT_AGE_MIN, 9 * 24 * 60, 'budget is 9 days — chosen so the 2026-05-04 11d incident trips STALE_CONTENT');
+test('DISEASE_MAX_CONTENT_AGE_MIN constant is 14 days', () => {
+  assert.equal(DISEASE_MAX_CONTENT_AGE_MIN, 14 * 24 * 60, 'budget matches the observed weekly release cadence and 3 to 5 day event lag');
 });
 
-test('pilot threshold: 9-day maxContentAgeMin would have tripped on 2026-05-04 incident pattern (11d-old items)', () => {
-  // Simulate the production incident: newest item 11 days old, content-age budget 9 days.
-  const ELEVEN_DAYS_AGO = FIXED_NOW - 11 * 24 * 60 * 60 * 1000;
+test('12-day-old disease content remains within the 14-day budget', () => {
+  const TWELVE_DAYS_AGO = FIXED_NOW - 12 * 24 * 60 * 60 * 1000;
   const data = {
     outbreaks: [
-      { _publishedAtIsSynthetic: false, _originalPublishedMs: ELEVEN_DAYS_AGO },
+      { _publishedAtIsSynthetic: false, _originalPublishedMs: TWELVE_DAYS_AGO },
     ],
   };
   const cm = diseaseContentMeta(data, FIXED_NOW);
   assert.ok(cm, 'contentMeta returns a result');
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
-  assert.ok(ageMin > DISEASE_MAX_CONTENT_AGE_MIN, `${Math.round(ageMin)}min > budget ${DISEASE_MAX_CONTENT_AGE_MIN}min — STALE_CONTENT would fire (ANTI-DRIFT for the pilot threshold)`);
+  assert.ok(ageMin < DISEASE_MAX_CONTENT_AGE_MIN, '12-day-old content remains healthy');
 });
 
-test('pilot threshold: 5-day-old items are within 9-day budget (no false positive)', () => {
-  const FIVE_DAYS_AGO = FIXED_NOW - 5 * 24 * 60 * 60 * 1000;
-  const data = { outbreaks: [{ _publishedAtIsSynthetic: false, _originalPublishedMs: FIVE_DAYS_AGO }] };
+test('15-day-old disease content exceeds the 14-day budget', () => {
+  const FIFTEEN_DAYS_AGO = FIXED_NOW - 15 * 24 * 60 * 60 * 1000;
+  const data = { outbreaks: [{ _publishedAtIsSynthetic: false, _originalPublishedMs: FIFTEEN_DAYS_AGO }] };
   const cm = diseaseContentMeta(data, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
-  assert.ok(ageMin < DISEASE_MAX_CONTENT_AGE_MIN, '5d < 9d — STALE_CONTENT does NOT fire on normal upstream rhythm');
+  assert.ok(ageMin > DISEASE_MAX_CONTENT_AGE_MIN, '15-day-old content triggers STALE_CONTENT');
 });
 
 // ── detectAlertLevel — keyword classifier (#3791) ─────────────────────────

--- a/tests/health-content-age.test.mjs
+++ b/tests/health-content-age.test.mjs
@@ -190,17 +190,17 @@ test('classifyKey returns STALE_CONTENT when content stale + no other failure mo
     keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
       fetchedAt: NOW - 10 * ONE_MIN_MS,    // fresh seeder run (10 min)
       recordCount: 50,
-      newestItemAt: NOW - 11 * ONE_DAY_MS, // 11d old content
+      newestItemAt: NOW - 15 * ONE_DAY_MS,
       oldestItemAt: NOW - 60 * ONE_DAY_MS,
-      maxContentAgeMin: 12960,             // 9 days
+      maxContentAgeMin: 20160,
     })]]),
   });
 
   const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
-  assert.equal(entry.status, 'STALE_CONTENT', 'fresh seeder run + 11d-old content + 9d budget → STALE_CONTENT');
+  assert.equal(entry.status, 'STALE_CONTENT', 'fresh seeder run with 15-day-old content exceeds the 14-day budget');
   assert.equal(entry.records, 50, 'records still surfaced from metaCount');
-  assert.equal(entry.contentAgeMin, 11 * 24 * 60, 'contentAgeMin in minutes');
-  assert.equal(entry.maxContentAgeMin, 12960);
+  assert.equal(entry.contentAgeMin, 15 * 24 * 60, 'contentAgeMin in minutes');
+  assert.equal(entry.maxContentAgeMin, 20160);
 });
 
 test('classifyKey: opted-in seeder with FRESH content returns OK', () => {
@@ -209,15 +209,16 @@ test('classifyKey: opted-in seeder with FRESH content returns OK', () => {
     keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
       fetchedAt: NOW - 10 * ONE_MIN_MS,
       recordCount: 50,
-      newestItemAt: NOW - 1 * ONE_DAY_MS,   // 1 day, within 9-day budget
+      newestItemAt: NOW - 12 * ONE_DAY_MS,
       oldestItemAt: NOW - 60 * ONE_DAY_MS,
-      maxContentAgeMin: 12960,
+      maxContentAgeMin: 20160,
     })]]),
   });
 
   const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
   assert.equal(entry.status, 'OK', 'fresh content → OK, not STALE_CONTENT');
-  assert.equal(entry.contentAgeMin, 1 * 24 * 60);
+  assert.equal(entry.contentAgeMin, 12 * 24 * 60);
+  assert.equal(entry.maxContentAgeMin, 20160);
 });
 
 test('classifyKey: legacy seeder (no maxContentAgeMin) reaches OK without STALE_CONTENT', () => {

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -565,7 +565,7 @@ test('Sprint 1: validation failure with canonical contentAge MIRRORS newestItemA
     contentAge: {
       newestItemAt: FROZEN_NEWEST_AT,
       oldestItemAt: FROZEN_OLDEST_AT,
-      maxContentAgeMin: 12960,    // 9 days, matching disease-outbreaks pilot
+      maxContentAgeMin: 12960,
     },
   });
 


### PR DESCRIPTION
## Why

Production reported `diseaseOutbreaks` as `STALE_CONTENT` while the seeder was fresh and had 159 records. The newest accepted report was about 9.3 days old against a 9-day budget.

The 9-day budget assumed that ThinkGlobalHealth supplied daily-fresh ProMED items. Recent ThinkGlobalHealth releases are about 5.8 to 7.8 days apart, and their newest event is already about 3 to 5 days old. Valid content can therefore approach 12 days old before the next release.

## Change

- Increase only the disease content-age budget from 9 days to 14 days.
- Keep the daily bundle interval, 48-hour seed-age budget, 72-hour cache TTL, and global 3-hour stale-content grace unchanged.
- Verify that 12-day disease content remains healthy and 15-day content reports `STALE_CONTENT`.
- Correct the operator schedule table to match the hourly bundle tick and 19.2-hour disease eligibility gate.

The 14-day budget covers the observed normal cadence with about two days of margin. It still reports a warning during a longer upstream freeze.

## Verification

- `node --test tests/disease-outbreaks-seed.test.mjs tests/health-content-age.test.mjs tests/seed-utils-empty-data-failure.test.mjs`
- `npm run typecheck:api`
- `npm run lint:boundaries`
- `npm run docs:check`
- `npm run lint:md`
- Full pre-push gate, including TypeScript, seed tests, edge tests, Unicode checks, and version checks

## Production acceptance

Merge alone will not clear the warning. The existing Redis envelope still carries the 9-day budget. After deployment, the next successful disease seed must publish `maxContentAgeMin: 20160`. Acceptance requires `diseaseOutbreaks` to leave `problems` without a manual seed call.
