### PR TITLE
fix(wm-session): stop a browser-cancelled mint blacking out the session

### DIFF
--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -431,6 +431,14 @@ type RecoveryVerdict =
  */
 function noteRecoveryFailure(verdict: RecoveryVerdict, rawPath: string): void {
   const cause = verdict.reason === 'mint_failed' ? verdict.cause : null;
+  // A mint the browser cancelled says nothing about the session — the request
+  // was never answered because we stopped asking. It is weaker evidence than
+  // the transport causes below, which at least reached the network, so it does
+  // not even earn a route strike: banking one would let two navigations inside
+  // the corroboration window tip the quorum on a demonstrably healthy session.
+  // Production 2026-09-06..08 is the case: the `network` rate stepped ~25x
+  // while /api/wm-session answered 100% 200 with a flat p95 throughout.
+  if (cause === 'aborted') return;
   // A mint the SERVER refused (or answered unusably) is session-wide by
   // construction, exactly as before: no route can succeed against an endpoint
   // that will not issue a token, so this still skips the quorum.
@@ -529,12 +537,19 @@ function noteMintCookieEvidence(hadSession: boolean, aCookieExistedWhenSent: boo
  * about whether the next attempt will work, and must not be read as one
  * (WORLDMONITOR-WG — see mintCauseIsTransport).
  *
+ * `aborted` is weaker still: the browser cancelled the request before anything
+ * could fail. A navigation, a bfcache entry, or a page unload mid-mint produces
+ * it. Nothing was asked, so nothing was refused, and unlike the transport pair
+ * it does not even take the corroboration route — it earns no route strike at
+ * all (see noteRecoveryFailure). Folding it into `network` is what let an
+ * ordinary link click suppress every anonymous panel for 15 minutes.
+ *
  * `unknown` is the defensive floor: the mint path threw somewhere it was not
  * expected to. It is not a server verdict either, so it takes the corroboration
  * route rather than blacking out the tab on a client-side bug — but it is not
  * retried, because we cannot say what would be retried.
  */
-type MintFailureCause = 'refused' | 'malformed' | 'timeout' | 'network' | 'unknown';
+type MintFailureCause = 'refused' | 'malformed' | 'timeout' | 'network' | 'aborted' | 'unknown';
 // What the `mint_cause` Sentry tag may say. `none` is the explicit "this
 // episode has no mint cause" — see markWmSessionDead (#6804).
 type MintCauseTag = MintFailureCause | 'none';
@@ -565,6 +580,25 @@ function mintCauseIsTransport(cause: MintFailureCause | null): boolean {
  */
 function mintCauseIsServerVerdict(cause: MintFailureCause | null): boolean {
   return cause === 'refused' || cause === 'malformed';
+}
+
+/**
+ * Did the BROWSER cancel this fetch, rather than our own budget timer?
+ *
+ * Checked against the controller we own rather than the error name alone: a
+ * timed-out mint also rejects with `AbortError`, and `timedOut` is already the
+ * discriminator for that one. An un-aborted controller plus an `AbortError` can
+ * only mean the abort came from outside this module.
+ *
+ * Duck-typed on `name` because a browser-issued abort is a `DOMException` in
+ * every engine we ship to, but the constructor is not reliably identifiable
+ * across realms (an iframe, a bfcache restore), and `instanceof` fails there.
+ */
+function isBrowserIssuedAbort(err: unknown, signal: AbortSignal): boolean {
+  if (signal.aborted) return false;
+  return typeof err === 'object'
+    && err !== null
+    && (err as { name?: unknown }).name === 'AbortError';
 }
 
 async function mintSession(body?: { widgetKey?: string; proKey?: string }): Promise<MintOutcome> {
@@ -618,8 +652,18 @@ async function mintSession(body?: { widgetKey?: string; proKey?: string }): Prom
       }
     }
     return { ok: true, session: { exp: data.exp } };
-  } catch {
+  } catch (err) {
     // The request never completed. Nothing here is evidence about the session.
+    //
+    // `timeoutController` is the ONLY abort this module issues, so an
+    // AbortError raised while that controller is still un-aborted was issued by
+    // the browser, not by us: the user navigated away, the tab entered
+    // bfcache, or the page unloaded mid-mint. That is a cancelled question, not
+    // a failed one, and folding it into `network` is what let an ordinary link
+    // click black out every anonymous panel for 15 minutes (WORLDMONITOR-WG).
+    if (!timedOut && isBrowserIssuedAbort(err, timeoutController.signal)) {
+      return { ok: false, cause: 'aborted' };
+    }
     return { ok: false, cause: timedOut ? 'timeout' : 'network' };
   } finally {
     clearTimeout(timeoutId);

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -2301,6 +2301,58 @@ describe('wm-session mint failure cause (WORLDMONITOR-WG)', () => {
     assert.equal(dead.length, 1);
     assert.equal(dead[0].ctx.tags?.mint_cause, 'timeout', 'an aborted mint is a timeout, not a network error');
   });
+
+  it('does not black out the tab when the BROWSER aborted the mint', async () => {
+    // A mint cancelled by the browser — the user navigated away, the tab went
+    // into bfcache, the page unloaded mid-request — rejects with AbortError
+    // while our own budget timer has NOT fired. `timedOut` is false, so the
+    // catch at wm-session.ts:623 labelled it `network`, the one cause that
+    // still earns a route strike. Two of those inside the corroboration window
+    // tipped the quorum and suppressed every anonymous panel for 15 minutes,
+    // for a user who simply clicked a link.
+    //
+    // This is WORLDMONITOR-WG's live half. Production 2026-09-06..08: the
+    // `mint_cause=network` rate stepped ~25x (0.94 -> 25.78 per 100k mints)
+    // while Axiom showed /api/wm-session answering 100% 200 with a flat p95
+    // through the same window. The server was healthy; the client cancelled
+    // its own requests and then declared the session dead.
+    //
+    // A browser-issued abort is not evidence about the session at all — it is
+    // weaker than the transport causes that already need corroboration, so it
+    // must not strike the route in the first place.
+    memoryStorage.clear();
+    const captures = captureSink();
+    // Long enough that our own timer cannot fire: the only abort here is the
+    // browser's, which is the whole point of the test.
+    mod.__setWmSessionFetchTimeoutForTests(5000);
+
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    let third: Response;
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+      await wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health');
+      third = await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(
+      isDegraded(third),
+      false,
+      'a mint the browser cancelled must not suppress anonymous calls',
+    );
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 0, 'no blackout, so no wm_session_dead capture');
+  });
 });
 
 describe('wm-session cookie-persistence detection (Layer 3)', () => {


### PR DESCRIPTION
## The bug

A mint the **browser** cancelled — the user navigated away, the tab entered bfcache, the page unloaded mid-request — rejects with `AbortError` while our own budget timer has not fired. `timedOut` is false, so the catch at `wm-session.ts:645` labelled it `network`, the one transport cause that still earns a route strike. Two of those inside the 60s corroboration window tipped `SESSION_DEAD_ROUTE_QUORUM` and suppressed **every anonymous panel for 15 minutes**, for a user who clicked a link.

## Evidence it is real

Client and server disagree, which is the tell.

| Day | Successful mints | `mint_cause=network` | Per 100k mints |
|---|---|---|---|
| Sep 3 | 111,662 | 2 | 1.79 |
| Sep 4 | 110,385 | 0 | 0.00 |
| Sep 5 | 106,215 | 1 | 0.94 |
| **Sep 6** | 99,556 | 24 | **24.11** |
| **Sep 7** | 73,709 | 19 | **25.78** |
| **Sep 8** | 102,062 | 13 | **12.74** |

A ~25x step in the per-request failure rate **while successful mints fell**, so it is not traffic. Through the same window Axiom shows `/api/wm-session` answering **100% `200`**, flat ~240ms p95, zero 5xx: the server was minting normally for everyone else while these clients declared the session dead. That is precisely the premise `mintCauseIsTransport` was written against — this change finishes the job for the cause that was still slipping through.

Two candidates I chased and **ruled out**: the `fix(cdn)` rule claiming `/dashboard` (landed ~14h after the step began) and the Sep 6 `429` burst (8,118 of 8,521 at 15:00Z from 3 IPs — a bot the limiter correctly blocked, twelve hours off).

## The fix

`timeoutController` is the only abort this module issues, so an `AbortError` raised while that controller is still un-aborted came from outside. That becomes its own cause, `aborted`, and it earns **no route strike at all** — weaker evidence than the transport pair, which at least reached the network.

`isBrowserIssuedAbort` duck-types on `name` rather than using `instanceof DOMException`, because the constructor is not reliably identifiable across realms (an iframe, a bfcache restore).

## Verification

- **Reproduced first.** The new test fails on the unfixed tree with `a mint the browser cancelled must not suppress anonymous calls: true !== false`, then passes.
- **Mutation-checked.** Replacing the `cause === 'aborted'` guard with a non-matching literal turns the test red again (60 pass / 1 fail), so it is load-bearing rather than passing incidentally.
- `npx tsx --test tests/wm-session-auto-refresh.test.mts` — **61 pass, 0 fail**. The pre-existing `network` and `timeout` cases keep their tags and their assertions, proving the new branch does not widen into either.
- Sibling suites green: `wm-session-degraded-copy` / `-interceptor-target` / `-premium-intent` (24 pass), `api/wm-session.test.mjs` (31 pass).
- `npx tsc --noEmit` clean, Biome clean, all pre-push gates passed.

## Scope

Diagnostic only for the other half of that Sentry issue: the `retry_401` bulk that dominates its lifetime count stopped on its own 2026-09-07 and is untouched here.

https://claude.ai/code/session_01V3DgPEt6UEYLLeRAAUoDSg
