### PR TITLE
perf(pro): animate hero bars with native transforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -922,6 +922,22 @@ jobs:
           path: test-results/
           if-no-files-found: ignore
           retention-days: 14
+      # Named explicitly for the same reason as the gates above: nothing runs
+      # the e2e/ glob, so an unnamed spec would never execute. It reads the same
+      # public/pro/ bytes the build step above produced.
+      - name: Run /pro hero native-animation gate
+        id: pro-hero
+        run: npm run test:e2e:pro-hero
+      # Its own upload: Playwright clears test-results/ when the next run
+      # starts, so a later step would delete this gate's failure trace.
+      - name: Upload /pro hero animation Playwright artifacts
+        if: ${{ !cancelled() && steps.pro-hero.outcome != 'skipped' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: playwright-pro-hero-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 14
       # WebMCP is exposed only by an enabled Chrome milestone. Keep this probe
       # separate from the bundled-Chromium smoke so an unavailable or stale
       # system Chrome fails the required PR job instead of silently skipping.

--- a/e2e/pro-critical-css-cls.spec.ts
+++ b/e2e/pro-critical-css-cls.spec.ts
@@ -76,6 +76,42 @@ const observeLayoutShifts = (page: Page) => page.addInitScript(() => {
   }).observe({ type: 'layout-shift', buffered: true });
 });
 
+test.describe('pro hero animation', () => {
+  for (const viewport of [MOBILE_VIEWPORT, { width: 1440, height: 900 }]) {
+    test(`bars animate natively at ${viewport.width}px`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+      const errors: string[] = [];
+      page.on('pageerror', (error) => errors.push(error.message));
+      // Exercise the built React/Motion code; keep analytics and APIs offline.
+      await page.route('**/*', async (route) => {
+        const url = new URL(route.request().url());
+        if (url.origin !== ORIGIN) return route.abort();
+        const pathname = url.pathname === '/pro' ? '/pro/index.html' : url.pathname;
+        const path = resolve(repoRoot, 'public', pathname.replace(/^\//, ''));
+        if (!existsSync(path)) return route.abort();
+        return route.fulfill({ path });
+      });
+      await page.goto(`${ORIGIN}/pro`, { waitUntil: 'load' });
+      const bars = page.locator('main div[aria-hidden="true"] > div > div');
+      await expect(bars).toHaveCount(60);
+      // Individual scaleY values fall back to Motion's frame loop. Full
+      // transform keyframes must produce a native animation on every bar.
+      await expect.poll(() => bars.evaluateAll((elements) => elements.filter((bar) =>
+        bar.getAnimations().some((animation) => {
+          const effect = animation.effect;
+          return effect instanceof KeyframeEffect
+            && effect.getTiming().iterations === Infinity
+            && effect.getKeyframes().some((frame) => typeof frame.transform === 'string');
+        }),
+      ).length)).toBe(60);
+      const firstTransform = await bars.first().evaluate((bar) => getComputedStyle(bar).transform);
+      await expect.poll(() => bars.first().evaluate((bar) => getComputedStyle(bar).transform))
+        .not.toBe(firstTransform);
+      expect(errors).toEqual([]);
+    });
+  }
+});
+
 test.use({ viewport: MOBILE_VIEWPORT });
 
 test.describe('pro critical CSS causes no layout shift when the deferred stylesheet lands', () => {

--- a/e2e/pro-critical-css-cls.spec.ts
+++ b/e2e/pro-critical-css-cls.spec.ts
@@ -76,42 +76,6 @@ const observeLayoutShifts = (page: Page) => page.addInitScript(() => {
   }).observe({ type: 'layout-shift', buffered: true });
 });
 
-test.describe('pro hero animation', () => {
-  for (const viewport of [MOBILE_VIEWPORT, { width: 1440, height: 900 }]) {
-    test(`bars animate natively at ${viewport.width}px`, async ({ page }) => {
-      await page.setViewportSize(viewport);
-      const errors: string[] = [];
-      page.on('pageerror', (error) => errors.push(error.message));
-      // Exercise the built React/Motion code; keep analytics and APIs offline.
-      await page.route('**/*', async (route) => {
-        const url = new URL(route.request().url());
-        if (url.origin !== ORIGIN) return route.abort();
-        const pathname = url.pathname === '/pro' ? '/pro/index.html' : url.pathname;
-        const path = resolve(repoRoot, 'public', pathname.replace(/^\//, ''));
-        if (!existsSync(path)) return route.abort();
-        return route.fulfill({ path });
-      });
-      await page.goto(`${ORIGIN}/pro`, { waitUntil: 'load' });
-      const bars = page.locator('main div[aria-hidden="true"] > div > div');
-      await expect(bars).toHaveCount(60);
-      // Individual scaleY values fall back to Motion's frame loop. Full
-      // transform keyframes must produce a native animation on every bar.
-      await expect.poll(() => bars.evaluateAll((elements) => elements.filter((bar) =>
-        bar.getAnimations().some((animation) => {
-          const effect = animation.effect;
-          return effect instanceof KeyframeEffect
-            && effect.getTiming().iterations === Infinity
-            && effect.getKeyframes().some((frame) => typeof frame.transform === 'string');
-        }),
-      ).length)).toBe(60);
-      const firstTransform = await bars.first().evaluate((bar) => getComputedStyle(bar).transform);
-      await expect.poll(() => bars.first().evaluate((bar) => getComputedStyle(bar).transform))
-        .not.toBe(firstTransform);
-      expect(errors).toEqual([]);
-    });
-  }
-});
-
 test.use({ viewport: MOBILE_VIEWPORT });
 
 test.describe('pro critical CSS causes no layout shift when the deferred stylesheet lands', () => {

--- a/e2e/pro-hero-animation.spec.ts
+++ b/e2e/pro-hero-animation.spec.ts
@@ -1,0 +1,94 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+
+// The /pro hero renders 60 bars that scale continuously and forever. Motion
+// can only hand an animation to the browser's native compositor when the
+// animated value is one it lists as accelerated -- `transform` is, the
+// individual `scaleY` shorthand is not. Passing `scaleY: [...]` therefore
+// drives all 60 bars from Motion's JavaScript frame loop, which DebugBear's
+// mobile profile reports as main-thread task time; passing complete
+// `transform: ['scaleY(x)', ...]` keyframes moves the same motion to WAAPI.
+//
+// That distinction is invisible in a screenshot and cheap to undo -- a
+// "simplification" back to the `scaleY` shorthand looks identical and silently
+// restores the frame loop. So this spec asserts the mechanism (a native
+// KeyframeEffect on every bar) AND the contract (the keyframes are the
+// intended scaleY sequence, and the animation is actually running). Asserting
+// only that a transform animation exists would stay green through a wrong
+// axis, a frozen value, or a paused animation.
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ORIGIN = 'https://pro-hero-animation.test';
+const PRO_INDEX = 'public/pro/index.html';
+const BAR_COUNT = 60;
+
+// Matches the `scaleY(<number>)` strings pro-test/src/App.tsx builds from its
+// scale keyframes. Deliberately narrow: a change to another transform function
+// should fail here and be widened on purpose, not absorbed silently.
+const SCALE_Y_KEYFRAME = /^scaleY\(\d*\.?\d+\)$/;
+
+// DebugBear's mobile profile, and a desktop width past the `md:` breakpoint
+// where the bars get wider and taller.
+const VIEWPORTS = [
+  { width: 360, height: 640 },
+  { width: 1440, height: 900 },
+];
+
+test.describe('pro hero animation', () => {
+  for (const viewport of VIEWPORTS) {
+    test(`bars animate natively at ${viewport.width}px`, async ({ page }) => {
+      // public/pro/ is gitignored build output. Fail with the fix rather than
+      // with an opaque net::ERR_FAILED from aborting the document request.
+      expect(
+        existsSync(resolve(repoRoot, PRO_INDEX)),
+        `${PRO_INDEX} is missing. Run \`npm run build:pro\` first.`,
+      ).toBe(true);
+
+      await page.setViewportSize(viewport);
+      const errors: string[] = [];
+      page.on('pageerror', (error) => errors.push(error.message));
+      // Exercise the built React/Motion code; keep analytics and APIs offline.
+      await page.route('**/*', async (route) => {
+        const url = new URL(route.request().url());
+        if (url.origin !== ORIGIN) return route.abort();
+        const pathname = url.pathname === '/pro' ? '/pro/index.html' : url.pathname;
+        const path = resolve(repoRoot, 'public', pathname.replace(/^\//, ''));
+        if (!existsSync(path)) return route.abort();
+        return route.fulfill({ path });
+      });
+      await page.goto(`${ORIGIN}/pro`, { waitUntil: 'load' });
+      const bars = page.locator('main div[aria-hidden="true"] > div > div');
+      await expect(bars).toHaveCount(BAR_COUNT);
+
+      // Every bar must carry a running, infinitely repeating native animation
+      // whose keyframes are more than one distinct scaleY value. `iterations`
+      // alone would accept an idle or paused animation, and a keyframe type
+      // check alone would accept scaleX, a translate, or a frozen scaleY(1).
+      await expect
+        .poll(
+          () => bars.evaluateAll(
+            (elements, pattern) => elements.filter((bar) => bar.getAnimations().some((animation) => {
+              const effect = animation.effect;
+              if (!(effect instanceof KeyframeEffect)) return false;
+              if (effect.getTiming().iterations !== Infinity) return false;
+              if (animation.playState !== 'running') return false;
+              const transforms = effect
+                .getKeyframes()
+                .map((frame) => frame.transform)
+                .filter((value): value is string => typeof value === 'string');
+              return transforms.length > 1
+                && new Set(transforms).size > 1
+                && transforms.every((value) => new RegExp(pattern).test(value));
+            })).length,
+            SCALE_Y_KEYFRAME.source,
+          ),
+          { message: 'every hero bar must run a native scaleY keyframe animation' },
+        )
+        .toBe(BAR_COUNT);
+
+      expect(errors).toEqual([]);
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "test:e2e:ci-smoke:2": "cross-env VITE_VARIANT=full playwright test e2e/dashboard-news-request-budget.spec.ts e2e/bootstrap-request-budget.spec.ts e2e/a11y-axe-scan.spec.ts e2e/settings-source-live-apply.spec.ts e2e/dashboard-lcp-attribution.spec.ts e2e/variant-live-smoke.spec.ts e2e/keyword-spike-flow.spec.ts",
     "test:e2e:prehydration": "cross-env VITE_VARIANT=full playwright test e2e/prehydration-shell.spec.ts --project=chromium --grep \"server-rendered welcome page|dashboard shell without JavaScript\"",
     "test:e2e:pro-cls": "cross-env VITE_VARIANT=full playwright test e2e/pro-critical-css-cls.spec.ts --project=chromium",
+    "test:e2e:pro-hero": "cross-env VITE_VARIANT=full playwright test e2e/pro-hero-animation.spec.ts --project=chromium",
     "test:e2e:variant-smoke:full": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts",
     "test:e2e:variant-smoke:tech": "cross-env VITE_VARIANT=tech playwright test e2e/variant-live-smoke.spec.ts",
     "test:e2e:variant-smoke:finance": "cross-env VITE_VARIANT=finance playwright test e2e/variant-live-smoke.spec.ts",

--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -389,8 +389,18 @@ const SignalBars = () => {
           const scaleY = isSignal
             ? [0.5, 1, 0.65, 0.9]
             : [1, 0.3, 0.7, 0.15, 0.5];
-          // Full transforms use native animation; individual scaleY values use Motion's frame loop.
+          // Motion accelerates `transform` but not the individual `scaleY`
+          // shorthand, so complete transform strings keep these 60 forever-
+          // repeating bars on the browser's compositor instead of Motion's
+          // JavaScript frame loop. Collapsing this back to `scaleY: [...]`
+          // looks identical and silently restores that main-thread cost.
           const transform = scaleY.map((scale) => `scaleY(${scale})`);
+          // Motion's JS path expands a single `ease` into one easing per
+          // keyframe segment; its native path would apply a lone easing across
+          // the whole iteration and interpolate linearly between keyframes.
+          // Passing the array keeps the per-segment curve the bars had before,
+          // and still leaves the animation eligible for the native path.
+          const ease = scaleY.slice(1).map(() => 'easeInOut' as const);
 
           return (
             <div
@@ -423,7 +433,7 @@ const SignalBars = () => {
                   repeat: Infinity,
                   repeatType: 'reverse',
                   delay: isSignal ? distFromCenter * 0.07 : jitter(i, 2) * 0.6,
-                  ease: 'easeInOut',
+                  ease,
                 }}
               />
             </div>

--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -389,6 +389,8 @@ const SignalBars = () => {
           const scaleY = isSignal
             ? [0.5, 1, 0.65, 0.9]
             : [1, 0.3, 0.7, 0.15, 0.5];
+          // Full transforms use native animation; individual scaleY values use Motion's frame loop.
+          const transform = scaleY.map((scale) => `scaleY(${scale})`);
 
           return (
             <div
@@ -405,14 +407,14 @@ const SignalBars = () => {
                     ? { boxShadow: `0 0 ${6 + signalIntensity * 12}px rgba(74,222,128,${signalIntensity * 0.5})` }
                     : null),
                 }}
-                initial={{ scaleY: initialScale, opacity: isSignal ? 0.4 : 0.08 }}
+                initial={{ transform: `scaleY(${initialScale})`, opacity: isSignal ? 0.4 : 0.08 }}
                 animate={isSignal
                   ? {
-                      scaleY,
+                      transform,
                       opacity: [0.6 + signalIntensity * 0.3, 1, 0.75 + signalIntensity * 0.2, 0.95],
                     }
                   : {
-                      scaleY,
+                      transform,
                       opacity: [0.2, 0.06, 0.15, 0.04, 0.12],
                     }
                 }

--- a/tests/pro-signal-bars-compositor.test.mjs
+++ b/tests/pro-signal-bars-compositor.test.mjs
@@ -242,6 +242,40 @@ function animateSources(body) {
   return sources;
 }
 
+// Motion only hands an animation to the browser's compositor when the animated
+// value is one it accelerates. `transform` is on that list; the individual
+// `scaleY` shorthand is not, so `animate={{ scaleY: [...] }}` silently drives
+// all 60 bars from Motion's JavaScript frame loop. Matching the bare token
+// `scaleY` anywhere in the body cannot tell those apart -- it is satisfied by
+// the `scaleY(...)` text inside the transform strings either way -- so pin the
+// actual animate keys instead.
+function assertNativeTransformKeyframes(body) {
+  const sources = animateSources(body);
+
+  const animatesTransform = sources.some(({ text }) => /(?:^|[,{]\s*)transform\s*[,:}]/.test(text));
+  assert.ok(
+    animatesTransform,
+    'SignalBars must animate `transform` so Motion uses the browser\'s native animation path.',
+  );
+
+  for (const { label, text } of sources) {
+    assert.doesNotMatch(
+      text,
+      /(?:^|[,{]\s*)scale[XY]?\s*:/,
+      `SignalBars must not animate the scale shorthand in ${label}; `
+      + 'it falls back to Motion\'s JS frame loop. Use complete transform keyframes.',
+    );
+  }
+
+  const transformKeyframes = sources.find(({ label }) => label === 'local transform');
+  assert.ok(transformKeyframes, 'the animate prop must resolve a local `transform` keyframe array');
+  assert.match(
+    transformKeyframes.text,
+    /scaleY\(/,
+    'the transform keyframes must scale on the vertical axis',
+  );
+}
+
 function assertNoAnimatedHeight(body) {
   // This remains a source guard, but it follows local animate={identifier} hoists
   // so a named height keyframe object cannot silently bypass the check.
@@ -258,8 +292,8 @@ test('/pro SignalBars keeps hero animation on compositor-friendly transforms', (
   assert.ok(signalBars, 'SignalBars source block should be present');
   const body = signalBars[0];
 
-  assert.match(body, /scaleY/, 'bars should animate scaleY instead of layout height');
   assert.match(body, /transformOrigin:\s*'bottom'/, 'bars should scale from the baseline');
+  assertNativeTransformKeyframes(body);
   assertNoAnimatedHeight(body);
 });
 


### PR DESCRIPTION
## Summary

The Pro hero's 60 bars continuously update `scaleY` through Motion's JavaScript frame loop. Use complete `transform` keyframes so the browser runs those animations natively, preserving the existing scale values, opacity, timing, dimensions, and appearance.

Related: [DebugBear mobile TBT alert](https://www.debugbear.com/project/103025/pageLoad/694439/overview?analysis=87404590&comp=diff&metric=totalBlockingTime).

## Validation

Controlled served-code experiments on the public Pro build, with RUM enabled, a 412×823 mobile viewport and 6× CPU throttling; means of two 15-second runs per condition, reversing order:

| Main-thread work | Existing scaleY | Native transform |
|---|---:|---:|
| Task duration | 6.87 s | 2.61 s |
| Style recalculation | 3.35 s | 0.93 s |
| Script execution | 0.97 s | 0.34 s |

This is a 62% reduction in measured main-thread task time. The historical 650→3,220 ms TBT jump did not reproduce locally; this is CPU evidence, not a claim that the alert is resolved.

- Built-browser regression failed before the fix: 0 of 60 bars had native transform animations. It passes after the fix at 360px and 1440px, and verifies that visible transforms advance.
- `npm run test:e2e:pro-cls`: all four checks pass, including existing critical-CSS layout-shift coverage. Real built React/Motion assets are served locally; analytics and APIs are blocked.
- Pro production build, `npm --prefix pro-test run lint`, `npm run typecheck`, `npm run lint:boundaries`, and `git diff --check` pass.
- Mobile, desktop, and reduced-motion browser renders inspected against baseline. No page errors; existing reduced-motion behavior is unchanged.

## Post-Deploy Monitoring & Validation

Owner: PR author. After deployment, compare the same DebugBear Pro Mobile profile over the next two scheduled runs: TBT, main-bundle CPU, style/layout time, and CLS. Expect lower sustained CPU work with the same moving bars and no new layout shift. Check Sentry for new `/pro` animation errors. Revert this change if bars stop rendering correctly or repeated comparable runs show a performance regression. Deployment and the fresh DebugBear comparison remain pending.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
