### PR TITLE
fix(energy): keep JODI gas within its freshness budget

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1384,7 +1384,7 @@ const SEED_META = {
   ieaOilStocks:         { key: 'seed-meta:energy:iea-oil-stocks',        maxStaleMin: 60 * 24 * 40 }, // monthly cron on 15th; 40d threshold = TTL_SECONDS
   oilStocksAnalysis:    { key: 'seed-meta:energy:oil-stocks-analysis',   maxStaleMin: 60 * 24 * 50 }, // afterPublish of ieaOilStocks; 50d = matches seed-meta TTL (exceeds 40d data TTL)
   eiaPetroleum:         { key: 'seed-meta:energy:eia-petroleum',         maxStaleMin: 4320 }, // daily bundle cron (seed-bundle-energy-sources); 72h = 3× interval, well under 7d data TTL
-  jodiGas:              { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // monthly 35d cadence; 40d = cadence + 5d late-publisher grace. Data/meta TTL is 70d (2× cadence) so last-good outlives this gate and one missed monthly publish.
+  jodiGas:              { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // 15d bundle interval; 40d allows missed runs. Data/meta TTL is 70d so last-good outlives this gate and several intervals.
   lngVulnerability:     { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // written by jodi-gas seeder afterPublish; shares seed-meta key and the 70d GAS_TTL
   chokepointBaselines:  { key: 'seed-meta:energy:chokepoint-baselines', maxStaleMin: 60 * 24 * 400 }, // 400 days
   // maxStaleMin is 120d = 2x the 60-day bundle interval, matching the repo's

--- a/scripts/seed-bundle-energy-sources.mjs
+++ b/scripts/seed-bundle-energy-sources.mjs
@@ -5,7 +5,7 @@ import { OWID_SOURCE_VERSION } from './seed-owid-energy-mix.mjs';
 await runBundle('energy-sources', [
   { label: 'GIE-Gas-Storage', script: 'seed-gie-gas-storage.mjs', seedMetaKey: 'economic:eu-gas-storage', canonicalKey: 'economic:eu-gas-storage:v1', intervalMs: DAY, timeoutMs: 180_000 },
   { label: 'Gas-Storage-Countries', script: 'seed-gas-storage-countries.mjs', seedMetaKey: 'energy:gas-storage-countries', intervalMs: DAY, timeoutMs: 600_000 },
-  { label: 'JODI-Gas', script: 'seed-jodi-gas.mjs', seedMetaKey: 'energy:jodi-gas', canonicalKey: 'energy:jodi-gas:v1:_countries', completionMetaKey: 'seed-completion:energy:jodi-gas', intervalMs: 35 * DAY, timeoutMs: 600_000 },
+  { label: 'JODI-Gas', script: 'seed-jodi-gas.mjs', seedMetaKey: 'energy:jodi-gas', canonicalKey: 'energy:jodi-gas:v1:_countries', completionMetaKey: 'seed-completion:energy:jodi-gas', intervalMs: 15 * DAY, timeoutMs: 600_000 },
   { label: 'JODI-Oil', script: 'seed-jodi-oil.mjs', seedMetaKey: 'energy:jodi-oil', canonicalKey: 'energy:jodi-oil:v1:_countries', intervalMs: 35 * DAY, timeoutMs: 600_000 },
   { label: 'OWID-Energy-Mix', script: 'seed-owid-energy-mix.mjs', seedMetaKey: 'economic:owid-energy-mix', expectedSourceVersion: OWID_SOURCE_VERSION, intervalMs: 35 * DAY, timeoutMs: 600_000 },
   { label: 'IEA-Oil-Stocks', script: 'seed-iea-oil-stocks.mjs', seedMetaKey: 'energy:iea-oil-stocks', canonicalKey: 'energy:iea-oil-stocks:v1:index', completionMetaKey: 'seed-completion:energy:iea-oil-stocks', intervalMs: 40 * DAY, timeoutMs: 300_000 },

--- a/scripts/seed-jodi-gas.mjs
+++ b/scripts/seed-jodi-gas.mjs
@@ -28,7 +28,7 @@ const inflateRawAsync = promisify(inflateRaw);
 export const CANONICAL_KEY = 'energy:jodi-gas:v1:_countries';
 export const KEY_PREFIX = 'energy:jodi-gas:v1:';
 export const LNG_VULNERABILITY_KEY = 'energy:lng-vulnerability:v1';
-export const GAS_TTL = 70 * 24 * 3600; // 70 days: 2× 35d cadence so one missed monthly publish still serves last-good through the 40d STALE_SEED window (#7273)
+export const GAS_TTL = 70 * 24 * 3600; // 70d keeps last-good through the 40d STALE_SEED window and several 15d bundle intervals (#7273)
 
 const ZIP_URL = 'https://www.jodidata.org/jodi-publisher/gas/17/GAS_world_NewFormat.zip';
 const CSV_FILENAME = 'STAGING_world_NewFormat.csv';
@@ -371,7 +371,7 @@ if (isMain) {
 
     declareRecords,
     schemaVersion: 1,
-    maxStaleMin: 40 * 24 * 60, // 40d: 35d cadence + 5d late-publisher grace; must stay below GAS_TTL (#7273)
+    maxStaleMin: 40 * 24 * 60, // 40d allows missed 15d bundle intervals and must stay below GAS_TTL (#7273)
     sourceVersion: 'jodi-gas-v1',
   });
 }

--- a/scripts/shared/jodi-content-age.mjs
+++ b/scripts/shared/jodi-content-age.mjs
@@ -47,9 +47,10 @@ export const MAX_JODI_CONTENT_AGE_MIN = MAX_JODI_CONTENT_AGE_MONTHS * 31 * 24 * 
  *
  * 230 days rather than a figure closer to the observed 197: the gas age climbs
  * daily until JODI publishes the next month, so a threshold set near the
- * observed peak clears today and re-alarms on the first missed publish. 230
- * absorbs one skipped month while still surfacing a genuine stall — the file
- * would have to fall a further month behind its own worst observed lag.
+ * observed peak clears today and re-alarms on the first missed publish. The
+ * gas bundle interval is 15 days, so 230 days leaves enough time to observe an
+ * unchanged file once and fetch again after the publisher advances, while
+ * still surfacing a genuine stall.
  */
 export const MAX_JODI_GAS_CONTENT_AGE_MIN = 230 * 24 * 60;
 

--- a/tests/jodi-ttl-outlives-staleness.test.mjs
+++ b/tests/jodi-ttl-outlives-staleness.test.mjs
@@ -7,9 +7,10 @@
 // day 35 (EMPTY, crit) before health was willing to warn (STALE_SEED).
 //
 // The co-pin:
-//   cadence        35d  (bundle intervalMs)
-//   maxStaleMin    40d  (35d cadence + 5d late-publisher grace)
-//   data/meta TTL  70d  (2× cadence: last-good survives one missed monthly publish)
+//   gas interval   15d  (two runner eligibility windows fit in content headroom)
+//   oil interval   35d
+//   maxStaleMin    40d
+//   data/meta TTL  70d  (last-good survives one missed monthly publish)
 //
 // Escalation with data still served:
 //   day 0–40   OK (or STALE_CONTENT if the upstream file is frozen)
@@ -39,8 +40,10 @@ const { classifyKey, STANDALONE_KEYS, SEED_META } = __testing__;
 const DAY_SECONDS = 24 * 3600;
 const DAY_MIN = 24 * 60;
 const ONE_MIN_MS = 60_000;
-const CADENCE_DAYS = 35;
-const CADENCE_SECONDS = CADENCE_DAYS * DAY_SECONDS;
+const GAS_INTERVAL_DAYS = 15;
+const OIL_INTERVAL_DAYS = 35;
+const GAS_OBSERVED_LAG_DAYS = 197;
+const DAILY_CRON_MAX_DELAY_DAYS = 1;
 const NOW = Date.parse('2026-08-28T00:00:00.000Z');
 
 const CHINA_ROW = {
@@ -103,6 +106,16 @@ function jodiBundleIntervals() {
   return found;
 }
 
+function bundleFreshnessRatio() {
+  const runnerSrc = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'scripts', '_bundle-runner.mjs'),
+    'utf8',
+  );
+  const match = /elapsed\s*<\s*section\.intervalMs\s*\*\s*(\d+(?:\.\d+)?)/.exec(runnerSrc);
+  assert.ok(match, 'expected the bundle runner freshness threshold');
+  return Number(match[1]);
+}
+
 test('JODI oil, gas, and LNG data TTLs outlive the 40-day STALE_SEED gate', () => {
   for (const { name, ttl } of JODI_CHECKS) {
     const maxStaleSeconds = SEED_META[name].maxStaleMin * 60;
@@ -115,30 +128,37 @@ test('JODI oil, gas, and LNG data TTLs outlive the 40-day STALE_SEED gate', () =
   }
 });
 
-test('JODI TTLs cover one missed 35-day publisher cycle', () => {
-  // Bundle cadence is 35d. A missed monthly publish means the next successful
-  // write is ~70d after the last one. Last-good must still be on the key when
-  // health starts warning at 40d, and through that missed cycle.
+test('JODI TTLs cover multiple bundle intervals', () => {
   assert.ok(
-    JODI_TTL >= 2 * CADENCE_SECONDS,
-    `JODI_TTL (${JODI_TTL}s) must cover at least two 35-day cadences (${2 * CADENCE_SECONDS}s)`,
+    JODI_TTL >= 2 * OIL_INTERVAL_DAYS * DAY_SECONDS,
+    `JODI_TTL must cover at least two ${OIL_INTERVAL_DAYS}-day oil intervals`,
   );
   assert.ok(
-    GAS_TTL >= 2 * CADENCE_SECONDS,
-    `GAS_TTL (${GAS_TTL}s) must cover at least two 35-day cadences (${2 * CADENCE_SECONDS}s)`,
+    GAS_TTL >= 2 * GAS_INTERVAL_DAYS * DAY_SECONDS,
+    `GAS_TTL must cover at least two ${GAS_INTERVAL_DAYS}-day gas intervals`,
   );
 });
 
-test('the energy-sources bundle still throttles both JODI members at 35 days', () => {
+test('JODI gas and LNG content budget covers an unchanged fetch plus the next eligible fetch', () => {
+  const eligibilityGapDays = GAS_INTERVAL_DAYS * bundleFreshnessRatio()
+    + DAILY_CRON_MAX_DELAY_DAYS;
+  assert.ok(
+    MAX_JODI_GAS_CONTENT_AGE_MIN
+      >= (GAS_OBSERVED_LAG_DAYS + 2 * eligibilityGapDays) * DAY_MIN,
+    `the ${MAX_JODI_GAS_CONTENT_AGE_MIN / DAY_MIN}-day gas/LNG budget must cover two ${eligibilityGapDays}-day eligibility gaps after the observed ${GAS_OBSERVED_LAG_DAYS}-day lag`,
+  );
+});
+
+test('the energy-sources bundle uses the budget-safe JODI intervals', () => {
   const intervals = jodiBundleIntervals();
   assert.equal(intervals.length, 2, 'expected JODI-Gas and JODI-Oil bundle sections');
-  for (const { label, intervalMs } of intervals) {
-    assert.equal(
-      intervalMs,
-      CADENCE_SECONDS * 1000,
-      `${label} cadence drifted from the 35-day monthly throttle`,
-    );
-  }
+  assert.deepEqual(
+    Object.fromEntries(intervals.map(({ label, intervalMs }) => [label, intervalMs])),
+    {
+      'JODI-Gas': GAS_INTERVAL_DAYS * DAY_SECONDS * 1000,
+      'JODI-Oil': OIL_INTERVAL_DAYS * DAY_SECONDS * 1000,
+    },
+  );
 });
 
 test('oil and gas write seed-meta with the same TTL as the data keys', () => {
@@ -168,9 +188,9 @@ test('oil and gas write seed-meta with the same TTL as the data keys', () => {
   );
 });
 
-test('the 35–40 day boundary keeps last-good and does not report EMPTY', () => {
-  // Day 37: past the 35d cadence, still inside the 40d grace. Data is present
-  // because TTL is 70d. Health must not jump to EMPTY.
+test('the interval-to-40-day boundary keeps last-good and does not report EMPTY', () => {
+  // Day 37: past both the 15d gas and 35d oil intervals, but still inside the
+  // 40d health grace. The 70d TTL must keep data present instead of EMPTY.
   const ageMin = 37 * DAY_MIN;
   for (const { name } of JODI_CHECKS) {
     const entry = classify(name, { ageMin });

--- a/tests/seeder-canonical-ttl-vs-cron.test.mjs
+++ b/tests/seeder-canonical-ttl-vs-cron.test.mjs
@@ -90,9 +90,6 @@ const KNOWN_VIOLATIONS = {
   'Reexport-Share:seed-recovery-reexport-share.mjs': '35d TTL vs 30d cron (1.17×)',
   'Sovereign-Wealth:seed-sovereign-wealth.mjs': '35d TTL vs 30d cron (1.17×)',
 
-  // ── Energy ──
-  'JODI-Gas:seed-jodi-gas.mjs': '70d TTL vs 35d cron (2×) — one missed-cycle buffer; 3× would be 105d',
-
   // ── Portwatch ──
   'PW-Disruptions:seed-portwatch-disruptions.mjs': '2h TTL vs 1h cron (2×) — borderline',
   'PW-Main:seed-portwatch.mjs': '12h TTL vs 6h cron (2×) — borderline',


### PR DESCRIPTION
JODI Gas can no longer cross its content-age limit between normal bundle runs. Its 15-day interval now leaves enough room for one unchanged fetch and the following eligible fetch, including the bundle runner's 80% admission gate and one day of cron delay; oil remains at 35 days.

The regression test binds the provider's observed 197-day lag, the active runner gate, the daily cron allowance, and the 230-day gas/LNG budget. The shorter interval also clears the repository's canonical TTL safety rule instead of adding another exception.

Validation: focused JODI and TTL-versus-cron tests pass (9/9), API typecheck passes, and all pre-push gates pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
