### PR TITLE
fix(gdelt): restore bulk content-age detection

### DIFF
--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -1141,7 +1141,7 @@ export const CACHE_TOOLS: ToolDef[] = [
     // matching api/health.js.
     _freshnessChecks: [
       { key: 'seed-meta:news:insights',                    maxStaleMin: 30 },  // 15min cron × 2
-      { key: 'seed-meta:intelligence:gdelt-intel',         maxStaleMin: 45 },  // 15min materializer; matches api/health.js
+      { key: 'seed-meta:intelligence:gdelt-intel',         maxStaleMin: 45, honorContentAge: true }, // 15min materializer; matches api/health.js
       { key: 'seed-meta:intelligence:cross-source-signals', maxStaleMin: 60 }, // 30min cron × 2
     ],
     _apiPaths: [

--- a/scripts/seed-gdelt-bulk-materializer.mjs
+++ b/scripts/seed-gdelt-bulk-materializer.mjs
@@ -54,6 +54,7 @@ const REQUEST_TIMEOUT_MS = 30_000;
 const FETCH_CONCURRENCY = 4;
 const MAX_CATCHUP_FILES_PER_KIND = 8;
 const RECENT_GKG_WINDOW_MS = 2 * 60 * 60 * 1000;
+export const GDELT_BULK_MAX_CONTENT_AGE_MIN = 3 * 60;
 const GDELT_SNAPSHOT_INTERVAL_MS = 15 * 60 * 1000;
 const MAX_RECENT_GEO_RECORDS = 5_000;
 
@@ -510,6 +511,20 @@ function validate(data) {
   return Array.isArray(data?.topics) && data.topics.length === 6;
 }
 
+export function gdeltBulkContentMeta(data, nowMs = Date.now()) {
+  if (!Number.isFinite(nowMs)) return null;
+  const requiredSourceTimes = ['gkg', 'export'].map((kind) => {
+    const sourceClock = data?._state?.cursor?.[kind];
+    return typeof sourceClock === 'string' && /^\d{14}$/.test(sourceClock)
+      ? gdeltTimestampToMs(sourceClock)
+      : NaN;
+  });
+  if (requiredSourceTimes.some((timestamp) =>
+    !Number.isFinite(timestamp) || timestamp <= 0 || timestamp > nowMs)) return null;
+  const observedAt = Math.min(...requiredSourceTimes);
+  return { newestItemAt: observedAt, oldestItemAt: observedAt };
+}
+
 export function declareRecords(data) {
   return (data?.topics ?? []).reduce(
     (total, topic) => total + (Array.isArray(topic?.articles) ? topic.articles.length : 0),
@@ -650,6 +665,10 @@ export const RUN_SEED_OPTS = {
   declareRecords,
   schemaVersion: 1,
   maxStaleMin: 45,
+  contentMeta: gdeltBulkContentMeta,
+  // The fetch boundary accepts a source cohort up to two hours old. One more
+  // hour lets the 15-minute worker recover without flapping at that boundary.
+  maxContentAgeMin: GDELT_BULK_MAX_CONTENT_AGE_MIN,
   preserveKeyTtls: [
     ...GDELT_BULK_TOPICS.flatMap(({ id }) => [
       { key: timelineKey('tone', id), ttlSeconds: TIMELINE_TTL },

--- a/tests/mcp-news-intelligence-description.test.mjs
+++ b/tests/mcp-news-intelligence-description.test.mjs
@@ -21,4 +21,11 @@ describe('get_news_intelligence credibility discovery (#6597)', () => {
     assert.ok(cardTool, 'get_news_intelligence must stay published in the server card');
     assert.equal(cardTool.description, tool.description);
   });
+
+  it('honors GDELT observation age as well as its seeder clock', () => {
+    const gdeltCheck = tool._freshnessChecks.find(
+      ({ key }) => key === 'seed-meta:intelligence:gdelt-intel',
+    );
+    assert.equal(gdeltCheck?.honorContentAge, true);
+  });
 });

--- a/tests/seed-gdelt-bulk-materializer.test.mjs
+++ b/tests/seed-gdelt-bulk-materializer.test.mjs
@@ -13,16 +13,19 @@ const {
   countryIndexRecordCount,
   fetchGdeltBulkFiles,
   fetchMaterializedGdelt,
+  GDELT_BULK_MAX_CONTENT_AGE_MIN,
   GDELT_BULK_ARTICLES_KEY,
   GDELT_BULK_CONFLICT_KEY,
   GDELT_BULK_COUNTRY_ARTICLES_KEY,
   GDELT_BULK_STATE_KEY,
   GDELT_BULK_UNREST_KEY,
   GDELT_INTEL_KEY,
+  gdeltBulkContentMeta,
   POSITIVE_EVENTS_BOOTSTRAP_KEY,
   POSITIVE_EVENTS_RPC_KEY,
   RUN_SEED_OPTS,
 } = await import('../scripts/seed-gdelt-bulk-materializer.mjs');
+const { __testing__: { classifyKey } } = await import('../api/health.js');
 
 function gkgRow({
   id = 'gkg-1',
@@ -877,6 +880,64 @@ describe('gdelt materializer freshness constants stay in lockstep (#5864)', () =
       `seed-health intervalMin ${intervalMin} (alerts at ${intervalMin * 2}min) must track`
       + ` the ${maxStaleMin}min health budget, not the retired 4h cron`,
     );
+  });
+
+  it('dates active materializer content from both required bulk source clocks', () => {
+    const nowMs = Date.parse('2026-07-30T12:05:00Z');
+    const meta = gdeltBulkContentMeta({
+      _state: {
+        cursor: {
+          gkg: '20260730120000',
+          export: '20260730114500',
+        },
+      },
+    }, nowMs);
+    const olderRequiredSource = Date.parse('2026-07-30T11:45:00Z');
+    assert.deepEqual(meta, {
+      newestItemAt: olderRequiredSource,
+      oldestItemAt: olderRequiredSource,
+    });
+    assert.equal(RUN_SEED_OPTS.contentMeta, gdeltBulkContentMeta);
+    assert.equal(RUN_SEED_OPTS.maxContentAgeMin, GDELT_BULK_MAX_CONTENT_AGE_MIN);
+    assert.equal(GDELT_BULK_MAX_CONTENT_AGE_MIN, 180);
+  });
+
+  it('fails content age closed for a missing, malformed, or future source clock', () => {
+    const nowMs = Date.parse('2026-07-30T12:05:00Z');
+    assert.equal(gdeltBulkContentMeta({ _state: { cursor: { gkg: '20260730120000' } } }, nowMs), null);
+    assert.equal(gdeltBulkContentMeta({ _state: { cursor: { gkg: 'bad', export: '20260730120000' } } }, nowMs), null);
+    assert.equal(gdeltBulkContentMeta({
+      _state: { cursor: { gkg: '20260730120000junk', export: '20260730120000' } },
+    }, nowMs), null);
+    assert.equal(gdeltBulkContentMeta({
+      _state: { cursor: { gkg: 20260730120000, export: '20260730120000' } },
+    }, nowMs), null);
+    assert.equal(gdeltBulkContentMeta({
+      _state: { cursor: { gkg: '20260730121500', export: '20260730121500' } },
+    }, nowMs), null);
+  });
+
+  it('turns a frozen active GDELT cohort into STALE_CONTENT after the budget', () => {
+    const sourceClock = '20260730120000';
+    const contentMeta = gdeltBulkContentMeta({
+      _state: { cursor: { gkg: sourceClock, export: sourceClock } },
+    }, Date.parse('2026-07-30T15:01:00Z'));
+    const classifyAt = (now) => classifyKey('gdeltIntel', GDELT_INTEL_KEY, {}, {
+      keyStrens: new Map([[GDELT_INTEL_KEY, 1024]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([['seed-meta:intelligence:gdelt-intel', JSON.stringify({
+        fetchedAt: now - 60_000,
+        recordCount: 6,
+        newestItemAt: contentMeta.newestItemAt,
+        oldestItemAt: contentMeta.oldestItemAt,
+        maxContentAgeMin: GDELT_BULK_MAX_CONTENT_AGE_MIN,
+      })]]),
+      keyMetaErrors: new Map(),
+      now,
+    });
+
+    assert.equal(classifyAt(Date.parse('2026-07-30T15:00:00Z')).status, 'OK');
+    assert.equal(classifyAt(Date.parse('2026-07-30T15:01:00Z')).status, 'STALE_CONTENT');
   });
 
   it('registers the per-country index as a standalone health dataset at the materializer budget (#7748)', () => {


### PR DESCRIPTION
Frozen GDELT source cohorts now age independently of successful materializer runs. The active bulk producer stamps the older required GKG/export clock, rejects missing, malformed, and future clocks, and changes health to `STALE_CONTENT` after the three-hour source budget without changing the canonical payload shape.

The MCP news-intelligence freshness result now honors the same content clock, so agent and browser health cannot disagree. Validation: focused materializer, health-content-age, MCP registry, and MCP integration suites pass (230/230); API typecheck and all pre-push gates also pass.

![Codex](https://img.shields.io/badge/GPT--5-000000)
