### PR TITLE
Add build workflow for the self-hosted stack's three custom images

### DIFF
--- a/.github/workflows/build-self-hosted-stack.yml
+++ b/.github/workflows/build-self-hosted-stack.yml
@@ -1,0 +1,65 @@
+name: Build self-hosted stack images
+
+# Builds the three images the self-hosted docker-compose.yml stack actually
+# needs (worldmonitor, ais-relay, redis-rest) and pushes them to this fork's
+# own GHCR namespace. Deliberately does NOT reuse docker-publish.yml, which
+# builds docker/Dockerfile — a thin frontend-only client pointed at the
+# hosted SaaS API (api.worldmonitor.app), not the self-hosted path. See
+# SELF_HOSTING.md / docker-compose.yml for the authoritative service list.
+#
+# linux/amd64 only — the target k3s cluster is all x86_64.
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - image: worldmonitor
+            dockerfile: Dockerfile
+            context: .
+          - image: worldmonitor-ais-relay
+            dockerfile: Dockerfile.relay
+            context: .
+          - image: worldmonitor-redis-rest
+            dockerfile: docker/Dockerfile.redis-rest
+            context: .
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}


### PR DESCRIPTION
Builds worldmonitor, worldmonitor-ais-relay, and worldmonitor-redis-rest from their actual Dockerfiles (root Dockerfile, Dockerfile.relay, docker/Dockerfile.redis-rest) and pushes to this fork's own GHCR namespace. Deliberately separate from the existing docker-publish.yml, which builds docker/Dockerfile — a thin frontend client pointed at the hosted SaaS API, not the self-hosted path this stack needs.

linux/amd64 only, matching the target k3s cluster's architecture. Runs on GitHub-hosted runners (this is a public fork, so free) rather than the project's own self-hosted Pi runner, since a multi-stage TypeScript build benefits from more CPU/RAM than that Pi has.

## Summary

<!-- Brief description of what this PR does -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

<!-- Required for documentation-alignment PRs that touch methodology, API/MCP contracts, generated docs, examples, Redis keys, CII, CRI, news, digest, or briefing. Mark N/A only when this PR does not publish or change documentation claims. -->

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->
