### PR TITLE
fix(panels): stop the queued panel-call replay dropping updates

### DIFF
--- a/src/app/pending-panel-data.ts
+++ b/src/app/pending-panel-data.ts
@@ -65,15 +65,35 @@ export function enqueuePanelCall(key: string, method: string, args: unknown[]): 
 // Race-safe: panels[key] is set BEFORE replay starts (panel-layout.ts line 1147),
 // so any concurrent callPanel() during async replay takes the direct-call path
 // (not the queue). delete() before iteration prevents double-replay.
-export async function replayPendingCalls(key: string, panel: unknown): Promise<void> {
+//
+// Failures are reported per call rather than propagated (WORLDMONITOR-125 — the
+// residual half of WORLDMONITOR-11N, which hardened only `invokePanelMethod`
+// above). A bare `await result` here rejected `replayPendingCalls` itself, and
+// its sole production caller — `lazyPanel().load` in panel-layout.ts — does not
+// catch, so the rejection escaped to `onunhandledrejection` carrying the awaited
+// loader's async stack. It also threw out of the `for`, silently dropping every
+// method still queued for that panel. Both are fixed by catching per iteration.
+//
+// The `await` is deliberately KEPT: `lazyPanel().load` runs `setup(panel)` after
+// this resolves, so replaying fire-and-forget (the shape `invokePanelMethod`
+// uses) would reorder setup ahead of the queued update it depends on.
+export async function replayPendingCalls(
+  key: string,
+  panel: unknown,
+  report: PanelCallFailureReporter = reportPanelCallFailure,
+): Promise<void> {
   const methods = pendingCalls.get(key);
   if (!methods) return;
   pendingCalls.delete(key);
   for (const [method, args] of methods) {
     const fn = (panel as Record<string, unknown>)[method];
-    if (typeof fn === 'function') {
+    if (typeof fn !== 'function') continue;
+    try {
       const result = fn.apply(panel, args);
       if (result instanceof Promise) await result;
+    } catch (error) {
+      // A throwing reporter must not re-reject and recreate the leak.
+      try { report(key, method, error); } catch { /* reporting is best-effort */ }
     }
   }
 }

--- a/src/app/pending-panel-data.ts
+++ b/src/app/pending-panel-data.ts
@@ -2,7 +2,8 @@ import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 
 const pendingCalls = new Map<string, Map<string, unknown[]>>();
 
-export type PanelCallFailureReporter = (key: string, method: string, error: unknown) => void;
+type PanelCallDispatch = 'direct' | 'queued';
+export type PanelCallFailureReporter = (key: string, method: string, error: unknown, dispatch: PanelCallDispatch) => void;
 
 /**
  * Default sink for a rejected panel update.
@@ -10,11 +11,11 @@ export type PanelCallFailureReporter = (key: string, method: string, error: unkn
  * Swallowing the rejection silently would trade an unhandled rejection for an
  * invisible failure, so the panel that failed and the error are reported.
  */
-export function reportPanelCallFailure(key: string, method: string, error: unknown): void {
+export function reportPanelCallFailure(key: string, method: string, error: unknown, dispatch: PanelCallDispatch): void {
   console.error(`[panel-call] ${key}.${method}() rejected:`, error);
   enqueueSentryCall((s) => {
     s.captureException(error instanceof Error ? error : new Error(String(error)), {
-      tags: { kind: 'panel_call_rejected', panel: key, method },
+      tags: { kind: 'panel_call_rejected', panel: key, method, dispatch },
     });
   });
 }
@@ -47,7 +48,7 @@ export function invokePanelMethod(
   if (result && typeof (result as { then?: unknown }).then === 'function') {
     void (result as Promise<unknown>).catch((error: unknown) => {
       // A throwing reporter must not re-reject and recreate the leak.
-      try { report(key, method, error); } catch { /* reporting is best-effort */ }
+      try { report(key, method, error, 'direct'); } catch { /* reporting is best-effort */ }
     });
   }
   return true;
@@ -62,21 +63,11 @@ export function enqueuePanelCall(key: string, method: string, args: unknown[]): 
   methods.set(method, args);
 }
 
-// Race-safe: panels[key] is set BEFORE replay starts (panel-layout.ts line 1147),
-// so any concurrent callPanel() during async replay takes the direct-call path
-// (not the queue). delete() before iteration prevents double-replay.
-//
-// Failures are reported per call rather than propagated (WORLDMONITOR-125 — the
-// residual half of WORLDMONITOR-11N, which hardened only `invokePanelMethod`
-// above). A bare `await result` here rejected `replayPendingCalls` itself, and
-// its sole production caller — `lazyPanel().load` in panel-layout.ts — does not
-// catch, so the rejection escaped to `onunhandledrejection` carrying the awaited
-// loader's async stack. It also threw out of the `for`, silently dropping every
-// method still queued for that panel. Both are fixed by catching per iteration.
-//
-// The `await` is deliberately KEPT: `lazyPanel().load` runs `setup(panel)` after
-// this resolves, so replaying fire-and-forget (the shape `invokePanelMethod`
-// uses) would reorder setup ahead of the queued update it depends on.
+// lazyPanel().load assigns panels[key] before replay, so concurrent callPanel()
+// calls dispatch directly. Deleting the queue first prevents double replay.
+// Catch both synchronous throws and async rejections per call: propagating to
+// loadRegisteredPanel()'s catch would skip the remaining updates and setup(panel).
+// Keep awaiting each call so setup runs only after replay finishes.
 export async function replayPendingCalls(
   key: string,
   panel: unknown,
@@ -93,7 +84,7 @@ export async function replayPendingCalls(
       if (result instanceof Promise) await result;
     } catch (error) {
       // A throwing reporter must not re-reject and recreate the leak.
-      try { report(key, method, error); } catch { /* reporting is best-effort */ }
+      try { report(key, method, error, 'queued'); } catch { /* reporting is best-effort */ }
     }
   }
 }

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -886,7 +886,9 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       if (
         !hasFirstParty
         && (
-          /signal timed out/.test(msg)
+          // Explicit panel reports identify an app failure even when the
+          // browser-created timeout has no first-party stack frames.
+          (/signal timed out/.test(msg) && event.tags?.kind !== 'panel_call_rejected')
           || /NotSupportedError/.test(msg)
           || /out of memory/i.test(msg)
           || /\.(?:toLowerCase|trim|indexOf|findIndex) is not a function/.test(msg)

--- a/tests/one-shot-loader-panel-delivery.test.mts
+++ b/tests/one-shot-loader-panel-delivery.test.mts
@@ -53,6 +53,57 @@ describe('pending panel-call queue', () => {
 
     assert.equal(calls, 1);
   });
+
+  // WORLDMONITOR-125 — the residual half of WORLDMONITOR-11N.
+  //
+  // #11N hardened the DIRECT dispatch path (`invokePanelMethod`, which attaches
+  // a `.catch` to the returned promise) but left the QUEUED path in this same
+  // file bare: `replayPendingCalls` did `if (result instanceof Promise) await
+  // result`, so a rejecting panel method rejected `replayPendingCalls` itself.
+  // Its only production caller (`panel-layout.ts` `lazyPanel().load`) does not
+  // catch, so the rejection escaped to `onunhandledrejection` with exactly the
+  // signature #11N describes: the insights loader's shared abort reason
+  // (`TimeoutError: signal timed out`) carrying that loader's async stack, even
+  // though the loader itself always catches.
+  //
+  // A late-mounting InsightsPanel is the live path — `loadNews` queues
+  // `updateInsights` when the panel has not mounted yet, and that method awaits
+  // `fetchServerInsights()`, whose shared abort fires on a slow connection.
+  it('reports a rejecting queued call instead of leaking an unhandled rejection', async () => {
+    clearAllPendingCalls();
+    const reported: Array<[string, string, unknown]> = [];
+    const boom = new Error('signal timed out');
+    const panel = { updateInsights: () => Promise.reject(boom) };
+
+    enqueuePanelCall('insights', 'updateInsights', [[]]);
+    await assert.doesNotReject(
+      () => replayPendingCalls('insights', panel, (key, method, error) => {
+        reported.push([key, method, error]);
+      }),
+      'a rejecting panel method must not reject the replay — that is the unhandled-rejection leak',
+    );
+
+    assert.deepEqual(reported, [['insights', 'updateInsights', boom]]);
+  });
+
+  // Same defect, second symptom: `await`ing the rejection inside the loop threw
+  // out of the `for`, so every method still queued for that panel was silently
+  // dropped. Map iteration is insertion-ordered, so `updateInsights` (queued
+  // first) precedes `refresh`.
+  it('still delivers the remaining queued methods after one of them rejects', async () => {
+    clearAllPendingCalls();
+    let refreshed = 0;
+    const panel = {
+      updateInsights: () => Promise.reject(new Error('signal timed out')),
+      refresh: () => { refreshed++; },
+    };
+
+    enqueuePanelCall('insights', 'updateInsights', [[]]);
+    enqueuePanelCall('insights', 'refresh', [[]]);
+    await replayPendingCalls('insights', panel, () => {});
+
+    assert.equal(refreshed, 1, 'a rejecting method must not abort the rest of the queue');
+  });
 });
 
 const DATA_LOADER = new URL('../src/app/data-loader.ts', import.meta.url);

--- a/tests/one-shot-loader-panel-delivery.test.mts
+++ b/tests/one-shot-loader-panel-delivery.test.mts
@@ -54,22 +54,7 @@ describe('pending panel-call queue', () => {
     assert.equal(calls, 1);
   });
 
-  // WORLDMONITOR-125 — the residual half of WORLDMONITOR-11N.
-  //
-  // #11N hardened the DIRECT dispatch path (`invokePanelMethod`, which attaches
-  // a `.catch` to the returned promise) but left the QUEUED path in this same
-  // file bare: `replayPendingCalls` did `if (result instanceof Promise) await
-  // result`, so a rejecting panel method rejected `replayPendingCalls` itself.
-  // Its only production caller (`panel-layout.ts` `lazyPanel().load`) does not
-  // catch, so the rejection escaped to `onunhandledrejection` with exactly the
-  // signature #11N describes: the insights loader's shared abort reason
-  // (`TimeoutError: signal timed out`) carrying that loader's async stack, even
-  // though the loader itself always catches.
-  //
-  // A late-mounting InsightsPanel is the live path — `loadNews` queues
-  // `updateInsights` when the panel has not mounted yet, and that method awaits
-  // `fetchServerInsights()`, whose shared abort fires on a slow connection.
-  it('reports a rejecting queued call instead of leaking an unhandled rejection', async () => {
+  it('reports a rejecting queued call without aborting replay', async () => {
     clearAllPendingCalls();
     const reported: Array<[string, string, unknown, string]> = [];
     const boom = new Error('signal timed out');
@@ -80,7 +65,7 @@ describe('pending panel-call queue', () => {
       () => replayPendingCalls('insights', panel, (key, method, error, dispatch) => {
         reported.push([key, method, error, dispatch]);
       }),
-      'a rejecting panel method must not reject the replay — that is the unhandled-rejection leak',
+      'a rejecting panel method must not abort replay or skip panel setup',
     );
 
     assert.deepEqual(reported, [['insights', 'updateInsights', boom, 'queued']]);

--- a/tests/one-shot-loader-panel-delivery.test.mts
+++ b/tests/one-shot-loader-panel-delivery.test.mts
@@ -71,19 +71,19 @@ describe('pending panel-call queue', () => {
   // `fetchServerInsights()`, whose shared abort fires on a slow connection.
   it('reports a rejecting queued call instead of leaking an unhandled rejection', async () => {
     clearAllPendingCalls();
-    const reported: Array<[string, string, unknown]> = [];
+    const reported: Array<[string, string, unknown, string]> = [];
     const boom = new Error('signal timed out');
     const panel = { updateInsights: () => Promise.reject(boom) };
 
     enqueuePanelCall('insights', 'updateInsights', [[]]);
     await assert.doesNotReject(
-      () => replayPendingCalls('insights', panel, (key, method, error) => {
-        reported.push([key, method, error]);
+      () => replayPendingCalls('insights', panel, (key, method, error, dispatch) => {
+        reported.push([key, method, error, dispatch]);
       }),
       'a rejecting panel method must not reject the replay — that is the unhandled-rejection leak',
     );
 
-    assert.deepEqual(reported, [['insights', 'updateInsights', boom]]);
+    assert.deepEqual(reported, [['insights', 'updateInsights', boom, 'queued']]);
   });
 
   // Same defect, second symptom: `await`ing the rejection inside the loop threw
@@ -103,6 +103,41 @@ describe('pending panel-call queue', () => {
     await replayPendingCalls('insights', panel, () => {});
 
     assert.equal(refreshed, 1, 'a rejecting method must not abort the rest of the queue');
+  });
+
+  it('reports a synchronous throw and delivers the remaining queued methods', async () => {
+    clearAllPendingCalls();
+    const boom = new Error('sync failure');
+    const reported: unknown[] = [];
+    let refreshed = false;
+    enqueuePanelCall('insights', 'updateInsights', []);
+    enqueuePanelCall('insights', 'refresh', []);
+    await replayPendingCalls('insights', {
+      updateInsights() { throw boom; },
+      refresh() { refreshed = true; },
+    }, (_key, _method, error) => { reported.push(error); });
+    assert.deepEqual(reported, [boom]);
+    assert.equal(refreshed, true);
+  });
+
+  it('preserves replay order and continues when the failure reporter throws', async () => {
+    clearAllPendingCalls();
+    const calls: string[] = [];
+    enqueuePanelCall('insights', 'updateInsights', []);
+    enqueuePanelCall('insights', 'refresh', []);
+    await replayPendingCalls('insights', {
+      async updateInsights() {
+        await Promise.resolve();
+        calls.push('update');
+        throw new Error('update failure');
+      },
+      refresh() { calls.push('refresh'); },
+    }, () => {
+      calls.push('report');
+      throw new Error('report failure');
+    });
+    calls.push('setup');
+    assert.deepEqual(calls, ['update', 'report', 'refresh', 'setup']);
   });
 });
 

--- a/tests/panel-call-rejection.test.mts
+++ b/tests/panel-call-rejection.test.mts
@@ -15,7 +15,8 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { invokePanelMethod } from '../src/app/pending-panel-data';
+import { enqueuePanelCall, invokePanelMethod, replayPendingCalls } from '../src/app/pending-panel-data';
+import { _resetSentryDeferStateForTests, _setSentryLoaderForTests, scheduleSentryInit } from '../src/bootstrap/sentry-defer';
 
 /** Let queued microtasks and one macrotask turn so a leak would be flagged. */
 function settle(): Promise<void> {
@@ -124,4 +125,36 @@ describe('invokePanelMethod — dispatch contract callPanel depends on', () => {
 
     assert.throws(() => invokePanelMethod(panel, 'giving', 'setData', [], () => {}), /sync boom/);
   });
+});
+
+it('sends distinct dispatch tags through the default Sentry sink', async (t) => {
+  _resetSentryDeferStateForTests();
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const captured: Array<{ error: unknown; tags: Record<string, string> }> = [];
+  t.mock.method(console, 'error', () => {});
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  Object.defineProperty(globalThis, 'window', { configurable: true, value: { removeEventListener() {} } });
+  _setSentryLoaderForTests(async () => ({
+    captureException(error: unknown, context: { tags: Record<string, string> }) {
+      captured.push({ error, tags: context.tags });
+    },
+  } as never));
+  try {
+    const reason = new DOMException('signal timed out', 'TimeoutError');
+    const panel = { updateInsights: async () => { throw reason; } };
+    invokePanelMethod(panel, 'insights', 'updateInsights', []);
+    enqueuePanelCall('insights', 'updateInsights', []);
+    await replayPendingCalls('insights', panel);
+    const init = scheduleSentryInit();
+    t.mock.timers.tick(10_000);
+    await init;
+    assert.deepEqual(captured, ['direct', 'queued'].map((dispatch) => ({
+      error: reason,
+      tags: { kind: 'panel_call_rejected', panel: 'insights', method: 'updateInsights', dispatch },
+    })));
+  } finally {
+    _resetSentryDeferStateForTests();
+    if (previousWindow) Object.defineProperty(globalThis, 'window', previousWindow);
+    else Reflect.deleteProperty(globalThis, 'window');
+  }
 });

--- a/tests/panel-call-rejection.test.mts
+++ b/tests/panel-call-rejection.test.mts
@@ -48,18 +48,19 @@ describe('invokePanelMethod — async panel rejections must not escape', () => {
   });
 
   it('reports the rejection so the failure stays observable', async () => {
-    const seen: Array<{ key: string; method: string; error: unknown }> = [];
+    const seen: Array<{ key: string; method: string; error: unknown; dispatch: string }> = [];
     const boom = new Error('boom');
     const panel = { updateInsights: async () => { throw boom; } };
 
-    invokePanelMethod(panel, 'insights', 'updateInsights', [], (key, method, error) => {
-      seen.push({ key, method, error });
+    invokePanelMethod(panel, 'insights', 'updateInsights', [], (key, method, error, dispatch) => {
+      seen.push({ key, method, error, dispatch });
     });
     await settle();
 
     assert.equal(seen.length, 1, 'exactly one report per rejected call');
     assert.equal(seen[0]?.key, 'insights');
     assert.equal(seen[0]?.method, 'updateInsights');
+    assert.equal(seen[0]?.dispatch, 'direct');
     assert.equal(seen[0]?.error, boom, 'the original error must reach the reporter');
   });
 

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -389,6 +389,15 @@ describe('dynamic-module-import failures (stale chunk after deploy)', () => {
 // (WORLDMONITOR-66 / WORLDMONITOR-62).
 
 describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DOM-walker / wrapper-injected timeout)', () => {
+  for (const dispatch of ['direct', 'queued']) {
+    it(`preserves a zero-frame timeout explicitly reported by ${dispatch} panel dispatch`, () => {
+      const event = makeEvent('signal timed out', 'TimeoutError');
+      event.tags = { kind: 'panel_call_rejected', panel: 'insights', method: 'updateInsights', dispatch };
+      assert.equal(isIgnored('signal timed out'), false);
+      assert.equal(beforeSend(event), event);
+    });
+  }
+
   const zeroFrameErrors = [
     ['signal timed out', 'TimeoutError'],
     ['NotSupportedError: The operation is not supported.', 'Error'],

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { BrowserClient, defaultStackParser } from '@sentry/browser';
 import { isDebugBearRumScriptFrame } from '../src/bootstrap/debugbear-rum.ts';
 import { isIosLikeUserAgent } from '../src/bootstrap/platform-ua.ts';
 import { isolateNonProductionSentryEvent } from '../shared/sentry-build-metadata.ts';
@@ -424,8 +425,14 @@ describe('dynamic-module-import failures (stale chunk after deploy)', () => {
 
 describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DOM-walker / wrapper-injected timeout)', () => {
   for (const dispatch of ['direct', 'queued']) {
-    it(`preserves a zero-frame timeout explicitly reported by ${dispatch} panel dispatch`, () => {
-      const event = makeEvent('signal timed out', 'TimeoutError');
+    it(`preserves a zero-frame timeout explicitly reported by ${dispatch} panel dispatch`, async () => {
+      const client = new BrowserClient({ stackParser: defaultStackParser, integrations: [] });
+      const reason = new DOMException('signal timed out', 'TimeoutError');
+      // Model the browser timer boundary, without Node's constructor frames.
+      Object.defineProperty(reason, 'stack', { value: '' });
+      assert.ok(reason instanceof Error);
+      const event = await client.eventFromException(reason);
+      assert.equal(event.exception.values[0].stacktrace?.frames?.length ?? 0, 0);
       event.tags = { kind: 'panel_call_rejected', panel: 'insights', method: 'updateInsights', dispatch };
       assert.equal(isIgnored('signal timed out'), false);
       assert.equal(beforeSend(event), event);


### PR DESCRIPTION
## Summary

When a late-mounted panel's queued update failed, replay stopped before later updates and `setup(panel)`. The outer `loadRegisteredPanel()` handler caught the rejection, but the panel was already registered, so a later load could return it without completing setup.

Replay now reports each synchronous throw or asynchronous rejection and continues in order. It still awaits each call before setup runs, and a throwing reporter cannot abort replay.

Both direct and queued failures include a `dispatch` tag in the existing Sentry sink. Explicitly reported panel timeouts survive the timeout filter even when the browser-created error has no first-party stack frames. Other filters still apply. Comments describe the actual failure and use method names instead of stale line references.

This fixes dropped replay updates and skipped setup. It is not evidence that WORLDMONITOR-125 is resolved: the queued rejection was already caught by the outer load handler. Production Sentry behavior remains unverified.

## Validation

- New timeout-filter and dispatch-tag assertions failed before the follow-up fix and pass afterward.
- 337 focused tests pass across panel replay, direct dispatch, Sentry beforeSend, and deferred Sentry replay. This includes the installed browser SDK's handling of a zero-frame DOMException fixture and the real reporting sink with a mocked SDK.
- Typecheck, architectural boundary lint, Biome on the five affected files, and `git diff --check` pass.
- Current main merged into the existing PR branch.

No live Sentry events were sent. Browser timeout stack shape and production acceptance were not tested.
