### PR TITLE
fix(corpus): normalize brief headings by country identity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -742,6 +742,15 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ steps.playwright-version.outputs.version }}
+      - name: Use Ubuntu repositories for browser OS libraries
+        # Playwright needs Ubuntu libraries. Unrelated Chrome repository index
+        # failures must not prevent their installation on this disposable runner.
+        run: |
+          test -s /etc/apt/sources.list.d/ubuntu.sources
+          printf '%s\n' \
+            'Dir::Etc::sourcelist "/etc/apt/sources.list.d/ubuntu.sources";' \
+            'Dir::Etc::sourceparts "-";' \
+            | sudo tee /etc/apt/apt.conf.d/99-playwright-sources
       - run: npx playwright install --with-deps chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       # The cache restores only browser binaries (~/.cache/ms-playwright), not
@@ -846,6 +855,15 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ steps.playwright-version.outputs.version }}
+      - name: Use Ubuntu repositories for browser OS libraries
+        # Playwright needs Ubuntu libraries. Unrelated Chrome repository index
+        # failures must not prevent their installation on this disposable runner.
+        run: |
+          test -s /etc/apt/sources.list.d/ubuntu.sources
+          printf '%s\n' \
+            'Dir::Etc::sourcelist "/etc/apt/sources.list.d/ubuntu.sources";' \
+            'Dir::Etc::sourceparts "-";' \
+            | sudo tee /etc/apt/apt.conf.d/99-playwright-sources
       - run: npx playwright install --with-deps chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       # The cache restores only browser binaries (~/.cache/ms-playwright), not

--- a/public/sitemap-main.xml
+++ b/public/sitemap-main.xml
@@ -7,7 +7,7 @@
   </url>
   <url>
     <loc>https://www.worldmonitor.app/dashboard</loc>
-    <lastmod>2026-09-08</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://www.worldmonitor.app/pro</loc>
@@ -15,7 +15,7 @@
   </url>
   <url>
     <loc>https://worldmonitor.app/mcp</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://www.worldmonitor.app/pricing.md</loc>
@@ -67,23 +67,23 @@
   </url>
   <url>
     <loc>https://tech.worldmonitor.app/dashboard</loc>
-    <lastmod>2026-09-08</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://finance.worldmonitor.app/dashboard</loc>
-    <lastmod>2026-09-08</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://commodity.worldmonitor.app/dashboard</loc>
-    <lastmod>2026-09-08</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://happy.worldmonitor.app/dashboard</loc>
-    <lastmod>2026-09-08</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://energy.worldmonitor.app/dashboard</loc>
-    <lastmod>2026-09-08</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://www.worldmonitor.app/chokepoints/</loc>

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -3373,7 +3373,7 @@ function intelBriefHtml(html) {
 // crawlers saw literal `**` and `WHAT THIS MEANS FOR NO`. Fail the build
 // when either artifact reaches <main>, including section titles that are
 // still plain text rather than <h*> tags.
-const MEANS_FOR_ISO_RE = /\bwhat this means for [a-z]{2}\b/i;
+const MEANS_FOR_ISO_RE = /^\s*what this means for [a-z]{2}\s*:?\s*$/im;
 
 export function assertCountryBriefPresentation({ pagePath, html, sources }) {
   const main = corpusMainHtml(html);
@@ -3399,7 +3399,10 @@ export function assertCountryBriefPresentation({ pagePath, html, sources }) {
       throw new Error(`${pagePath} heading leaks ISO code: ${text}`);
     }
   }
-  if (MEANS_FOR_ISO_RE.test(corpusVisibleText(brief ?? html))) {
+  const briefLines = corpusMainHtml(brief ?? html)
+    .replace(/<br\b[^>]*>|<\/(?:p|h[1-6]|li|div)>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+  if (MEANS_FOR_ISO_RE.test(briefLines)) {
     throw new Error(`${pagePath} brief heading leaks an ISO-3166 alpha-2 code`);
   }
 }

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -3373,7 +3373,7 @@ function intelBriefHtml(html) {
 // crawlers saw literal `**` and `WHAT THIS MEANS FOR NO`. Fail the build
 // when either artifact reaches <main>, including section titles that are
 // still plain text rather than <h*> tags.
-const MEANS_FOR_ISO_RE = /^\s*what this means for [a-z]{2}\s*:?\s*$/im;
+const MEANS_FOR_ISO_RE = /^\s*what this means for [a-z]{2}(?=\s*(?::|$))/im;
 
 export function assertCountryBriefPresentation({ pagePath, html, sources }) {
   const main = corpusMainHtml(html);

--- a/scripts/crawlable-developments.mjs
+++ b/scripts/crawlable-developments.mjs
@@ -4,11 +4,11 @@
 // snapshot frozen before a rule existed renders under the same rule as one
 // frozen after it.
 //
-// Plain .mjs importing only plain-JS shared modules: the freeze runs under
-// bare `node`.
+// The freeze imports this module under bare Node.js.
 
 import { publisherFamilyFor, publisherFamilyForDomain } from '../shared/publisher-families.js';
 import { validateNoHallucinatedProperNouns } from '../shared/brief-llm-core.js';
+import { resolveIso2 } from './_country-resolver.mjs';
 const BRIEF_SECTION_HEADERS = ['SITUATION NOW', 'KEY RISKS', 'OUTLOOK', 'WATCH ITEMS'];
 
 // Provenance stamp on a headline row the freeze took from the per-country
@@ -47,11 +47,10 @@ export function isBriefSectionHeader(line, { countryCode = '', countryName = '' 
   const upper = String(line || '').trim().toUpperCase().replace(/:\s*$/, '');
   if (BRIEF_SECTION_HEADERS.includes(upper)) return true;
   const country = upper.match(/^WHAT THIS MEANS FOR (.+)$/)?.[1];
-  // Legacy ISO headings are rewritten by the renderer. Named headings must
-  // equal the page's country; a section prefix alone is ordinary claim text.
   return Boolean(country && (/^[A-Z]{2}$/.test(country)
     || country === String(countryCode).trim().toUpperCase()
-    || country === String(countryName).trim().toUpperCase()));
+    || country === String(countryName).trim().toUpperCase()
+    || resolveIso2({ name: country }) === String(countryCode).trim().toUpperCase()));
 }
 
 // Briefs need grounding from at least this many DISTINCT PUBLISHERS before
@@ -153,10 +152,7 @@ export function hasBriefGrounding(rows) {
   return Array.isArray(rows) && briefGroundingGap(rows) === null;
 }
 
-// "WHAT THIS MEANS FOR NO" — the server interpolated the ISO code where the
-// name belongs (#7738). Repaired only when the code is this page's own code,
-// so a brief that genuinely discusses another country is left alone.
-const BARE_CODE_HEADING_RE = /^(WHAT THIS MEANS FOR)\s+([A-Z]{2})\s*:?$/i;
+const COUNTRY_HEADING_RE = /^(WHAT THIS MEANS FOR)\s+(.+?)\s*:?$/i;
 // Markdown the model emits and the corpus injects as text: bold/italic
 // marker pairs and ATX heading hashes. Kept as a list so the next marker is
 // one entry, not a new guard (the first round pinned `**` alone).
@@ -171,7 +167,7 @@ const MARKDOWN_HEADING_RE = /^#{1,6}\s+/;
  * - any preamble before the first contract section dropped ("INTELLIGENCE
  *   BRIEF: GE (GEORGIA) / CLASSIFICATION: CONFIDENTIAL" is model theatre, not
  *   content, and must not reach a public page);
- * - the "WHAT THIS MEANS FOR <CODE>" heading repaired to the country name.
+ * - exact country-code and country-alias headings repaired to the page name.
  * Idempotent: normalizing normalized text is a no-op.
  */
 export function normalizeBriefText(text, { countryCode = '', countryName = '' } = {}) {
@@ -189,8 +185,9 @@ export function normalizeBriefText(text, { countryCode = '', countryName = '' } 
     && !lines.slice(0, firstHeader).some((line) => /\[\d+\]/.test(line));
   const body = preambleIsTheatre ? lines.slice(firstHeader) : lines;
   const repaired = body.map((line) => {
-    const match = line.trim().match(BARE_CODE_HEADING_RE);
-    if (!match || !code || !name || match[2].toUpperCase() !== code) return line;
+    const match = line.trim().match(COUNTRY_HEADING_RE);
+    if (!match || !code || !name) return line;
+    if (match[2].toUpperCase() !== code && resolveIso2({ name: match[2] }) !== code) return line;
     return `${match[1].toUpperCase()} ${name.toUpperCase()}`;
   });
   return repaired.join('\n').trim();

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -5665,6 +5665,16 @@ describe('country recent developments', () => {
   });
 
   it('rejects literal markdown emphasis and ISO brief-heading leaks (#7738)', () => {
+    for (const tag of ['h3', 'p']) {
+      assert.throws(() => assertCountryBriefPresentation({
+        pagePath: '/countries/norway/',
+        html: `<main><${tag}>WHAT THIS MEANS FOR NO: Shipping risks remain [1].</${tag}></main>`,
+      }), /heading leaks/);
+      assert.doesNotThrow(() => assertCountryBriefPresentation({
+        pagePath: '/countries/dr-congo/',
+        html: `<main><${tag}>What this means for DR Congo: Shipping risks remain [1].</${tag}></main>`,
+      }));
+    }
     assert.throws(
       () => assertCountryBriefPresentation({
         pagePath: '/countries/norway/',

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -7155,11 +7155,12 @@ it('retains API country-name aliases through the final country page renderer', a
   const { renderSourceBoundCountryBrief } = await import('../server/worldmonitor/intelligence/v1/get-country-intel-brief.ts');
   const { displayNameForIso2 } = await import('../server/_shared/country-normalize.ts');
   const data = await loadCorpusData({ rootDir: repoRoot });
+  const capturedAt = new Date(data.livePulse.capturedAt).toISOString();
   for (const [code, name] of [['HK', 'Hong Kong'], ['CD', 'DR Congo']]) {
     const country = data.countries.find((entry) => entry.code === code);
     const sources = [
-      { title: `${name} announces new trade rules`, source: 'Reuters', url: 'https://www.reuters.com/world/trade', publishedAt: '2026-09-09T04:00:00.000Z' },
-      { title: `${name} reviews trade rules`, source: 'BBC News', url: 'https://www.bbc.com/news/trade', publishedAt: '2026-09-09T05:00:00.000Z' },
+      { title: `${name} announces new trade rules`, source: 'Reuters', url: 'https://www.reuters.com/world/trade', publishedAt: capturedAt },
+      { title: `${name} reviews trade rules`, source: 'BBC News', url: 'https://www.bbc.com/news/trade', publishedAt: capturedAt },
     ];
     const text = renderSourceBoundCountryBrief(JSON.stringify({
       situation: [{ text: `${name} announces new trade rules.`, source: 1 }],
@@ -7167,7 +7168,7 @@ it('retains API country-name aliases through the final country page renderer', a
     }), sources, displayNameForIso2(code));
     assert.ok(text);
     const livePulse = structuredClone(data.livePulse);
-    livePulse.countries[code].developments = { headlines: sources, brief: { text, sources, model: 'fixture', generatedAt: '2026-09-09T06:00:00.000Z' }, timeline: [] };
+    livePulse.countries[code].developments = { headlines: sources, brief: { text, sources, model: 'fixture', generatedAt: capturedAt }, timeline: [] };
     const html = renderCountryPage({
       country, baseUrl: 'https://www.worldmonitor.app', capturedAt: data.resilience.capturedAt,
       lastmod: data.lastmod.countries, methodologyFormula: data.resilience.methodologyFormula,
@@ -7177,7 +7178,7 @@ it('retains API country-name aliases through the final country page renderer', a
       ciiEntry: data.ciiRanking.byCode.get(code),
     });
     assert.ok(html.includes('data-intel-brief'), `${code} must retain the API brief`);
-    assert.ok(html.includes(`<h4>What this means for ${name}</h4>`), `${code} must use the page name`);
+    assert.ok(html.includes(`<h3>What this means for ${name}</h3>`), `${code} must use the page name`);
     assert.ok(html.includes(`${name} announces new trade rules. [1]`));
   }
 });

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -7150,3 +7150,34 @@ it('checks rendered brief claims as visible text after HTML escaping', () => {
   assert.doesNotThrow(() => assertCountryBriefPresentation({ pagePath: '/countries/greece/', html, sources }));
   assert.throws(() => assertCountryBriefPresentation({ pagePath: '/countries/greece/', html: html.replace('Atlantis', 'Olympus'), sources }), /unsupported citation/);
 });
+
+it('retains API country-name aliases through the final country page renderer', async () => {
+  const { renderSourceBoundCountryBrief } = await import('../server/worldmonitor/intelligence/v1/get-country-intel-brief.ts');
+  const { displayNameForIso2 } = await import('../server/_shared/country-normalize.ts');
+  const data = await loadCorpusData({ rootDir: repoRoot });
+  for (const [code, name] of [['HK', 'Hong Kong'], ['CD', 'DR Congo']]) {
+    const country = data.countries.find((entry) => entry.code === code);
+    const sources = [
+      { title: `${name} announces new trade rules`, source: 'Reuters', url: 'https://www.reuters.com/world/trade', publishedAt: '2026-09-09T04:00:00.000Z' },
+      { title: `${name} reviews trade rules`, source: 'BBC News', url: 'https://www.bbc.com/news/trade', publishedAt: '2026-09-09T05:00:00.000Z' },
+    ];
+    const text = renderSourceBoundCountryBrief(JSON.stringify({
+      situation: [{ text: `${name} announces new trade rules.`, source: 1 }],
+      implications: [], risks: [], outlook: [], watch: [],
+    }), sources, displayNameForIso2(code));
+    assert.ok(text);
+    const livePulse = structuredClone(data.livePulse);
+    livePulse.countries[code].developments = { headlines: sources, brief: { text, sources, model: 'fixture', generatedAt: '2026-09-09T06:00:00.000Z' }, timeline: [] };
+    const html = renderCountryPage({
+      country, baseUrl: 'https://www.worldmonitor.app', capturedAt: data.resilience.capturedAt,
+      lastmod: data.lastmod.countries, methodologyFormula: data.resilience.methodologyFormula,
+      rankedCount: data.countries.filter((entry) => entry.rank != null).length,
+      snapshotNote: data.resilience.snapshotNote, snapshotPath: data.sources.resilienceSnapshot,
+      bbox: data.countryBboxByCode.get(code), livePulse,
+      ciiEntry: data.ciiRanking.byCode.get(code),
+    });
+    assert.ok(html.includes('data-intel-brief'), `${code} must retain the API brief`);
+    assert.ok(html.includes(`<h4>What this means for ${name}</h4>`), `${code} must use the page name`);
+    assert.ok(html.includes(`${name} announces new trade rules. [1]`));
+  }
+});

--- a/tests/crawlable-developments.test.mjs
+++ b/tests/crawlable-developments.test.mjs
@@ -370,3 +370,25 @@ describe('normalizeFrozenDevelopments', () => {
     assert.equal(normalizeFrozenDevelopments(undefined, {}), undefined);
   });
 });
+
+describe('brief heading country identity', () => {
+  it('rewrites exact aliases to the page name and is idempotent', () => {
+    for (const [countryCode, countryName, alias] of [
+      ['HK', 'Hong Kong', 'Hong Kong SAR China'],
+      ['CD', 'DR Congo', 'Congo - Kinshasa'],
+    ]) {
+      const input = `WHAT THIS MEANS FOR ${alias}\nA supported claim [1].`;
+      const expected = `WHAT THIS MEANS FOR ${countryName.toUpperCase()}\nA supported claim [1].`;
+      const country = { countryCode, countryName };
+      assert.equal(normalizeBriefText(input, country), expected);
+      assert.equal(normalizeBriefText(expected, country), expected);
+    }
+  });
+  it('leaves foreign names and prose unchanged', () => {
+    const country = { countryCode: 'CD', countryName: 'DR Congo' };
+    for (const heading of ['Congo - Brazzaville', 'Kinshasa', 'Congo - Kinshasa faces new risks [1]']) {
+      const input = `SITUATION NOW\nA claim [1].\nWHAT THIS MEANS FOR ${heading}`;
+      assert.equal(normalizeBriefText(input, country), input);
+    }
+  });
+});


### PR DESCRIPTION
## Why

Hong Kong and DR Congo lost valid country briefs because the API's display names differed from the page names. Exact country aliases now resolve through the existing country registry before heading validation and rendering. This repairs stored briefs as well as future captures.

The final HTML check also treated `DR Congo` as a bare two-letter code. It now rejects a bare ISO heading followed by a colon or the end of the line, including inline claims, while accepting full names such as `DR Congo`. Foreign aliases and unsupported claim text remain rejected.

Browser CI also failed before tests because an unrelated Google Chrome apt index had a hash mismatch. The two browser job definitions now use the runner's Ubuntu repositories for OS libraries. This applies to cache hits, misses, and the existing recovery path; the installed Chrome browser remains available for WebMCP.

## Verification

- The new regression first failed with `HK must retain the API brief` and exposed the second `DR Congo` heading check.
- 233 targeted tests pass, including API-formatted output through the final country renderer.
- Rebuilding the unchanged snapshot renders all 72 briefs across 196 country pages, up from 70.
- Hong Kong and DR Congo pass browser checks at desktop and mobile widths without horizontal overflow.
- Review regression suite passes all 165 tests, including inline ISO headings and full country names.
- All 43 workflow contract tests pass. A disposable Ubuntu 24.04 container verifies OS library installation with an intentionally broken third-party repository excluded.
- Typecheck, import boundaries, corpus build, and diff checks pass. Biome reports no errors.

Related: #7748

## Post-Deploy Monitoring & Validation

After an authorized merge and deployment, verify that the public Hong Kong and DR Congo pages retain their briefs and use the canonical headings. Check a fresh capture's eligible and accepted counts before closing #7748. Allow for the observed one-hour CDN cache lifetime when checking deployment visibility.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
