### PR TITLE
fix(sources): expose catalog pages in AI discovery files

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -37,6 +37,7 @@ The project is built with TypeScript, Vite, MapLibre GL JS, deck.gl, D3.js, and 
 - [Key Features Summary](#corpus-key-features-summary)
 - [Optional](#corpus-optional)
 - [Generated corpus](#corpus-generated-corpus)
+- [Source provider directory](#corpus-source-provider-directory)
 - [Comparisons](#corpus-comparisons)
 - [Glossary](#corpus-glossary)
 - [Monitored chokepoints](#corpus-monitored-chokepoints)
@@ -424,7 +425,30 @@ Native desktop app built with Tauri (Rust + Node.js sidecar). The sidecar mirror
 <a id="corpus-generated-corpus"></a>
 ## Generated corpus
 
-The sections below are produced by `npm run build:llms-full` from the comparison-page registry, glossary terms, chokepoint methodology, published chokepoint explainers, the Country Resilience Index methodology, the corrections log, and the current published ranking snapshot.
+The sections below are produced by `npm run build:llms-full` from the source catalog, comparison-page registry, glossary terms, chokepoint methodology, published chokepoint explainers, the Country Resilience Index methodology, the corrections log, and the current published ranking snapshot.
+
+<a id="corpus-source-provider-directory"></a>
+## Source provider directory
+
+World Monitor publishes 748 named providers across 17 source catalog pages. Each linked page contains provider names, source hosts, origins and coverage in static HTML; no search or JavaScript is required.
+
+- [Geopolitics & Conflict](https://www.worldmonitor.app/sources/geopolitics/): 41 providers.
+- [Military & Strategic](https://www.worldmonitor.app/sources/military/): 21 providers.
+- [News & OSINT](https://www.worldmonitor.app/sources/news/): 60 providers.
+- [News & OSINT — page 2](https://www.worldmonitor.app/sources/news/page/2/): 60 providers.
+- [News & OSINT — page 3](https://www.worldmonitor.app/sources/news/page/3/): 60 providers.
+- [News & OSINT — page 4](https://www.worldmonitor.app/sources/news/page/4/): 60 providers.
+- [News & OSINT — page 5](https://www.worldmonitor.app/sources/news/page/5/): 60 providers.
+- [News & OSINT — page 6](https://www.worldmonitor.app/sources/news/page/6/): 60 providers.
+- [News & OSINT — page 7](https://www.worldmonitor.app/sources/news/page/7/): 60 providers.
+- [News & OSINT — page 8](https://www.worldmonitor.app/sources/news/page/8/): 44 providers.
+- [Finance & Economics](https://www.worldmonitor.app/sources/finance/): 48 providers.
+- [Energy & Commodities](https://www.worldmonitor.app/sources/energy/): 23 providers.
+- [Infrastructure & Cyber](https://www.worldmonitor.app/sources/infrastructure/): 52 providers.
+- [Environment & Disasters](https://www.worldmonitor.app/sources/environment/): 43 providers.
+- [Aviation & Airspace](https://www.worldmonitor.app/sources/aviation/): 14 providers.
+- [China Coverage](https://www.worldmonitor.app/sources/china/): 12 providers.
+- [Tech Ecosystem](https://www.worldmonitor.app/sources/technology/): 30 providers.
 
 <a id="corpus-comparisons"></a>
 ## Comparisons

--- a/scripts/build-llms-full.mjs
+++ b/scripts/build-llms-full.mjs
@@ -24,6 +24,8 @@ import { COMPARISON_MATRIX_COLUMNS, comparisonDiscoveryEntries } from './build-c
 import { resolveLatestResilienceSnapshotPath, slugify } from './build-crawlable-corpus.mjs';
 import { CHOKEPOINT_CONTENT } from './chokepoint-page-content.mjs';
 import { SITE_ORIGIN } from './discover-content-corpus-pages.mjs';
+import { buildSourceCatalog, buildSourcePages } from './crawlable-sources-page.mjs';
+import { activeSourceAttributionEntries, loadManifest } from './source-attribution.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const OUTPUT_PATH = 'public/llms-full.txt';
@@ -238,6 +240,21 @@ export function renderComparisons() {
   ].join('\n');
 }
 
+function renderSourceDirectory(rootDir) {
+  const manifest = loadManifest(rootDir);
+  const catalog = buildSourceCatalog(activeSourceAttributionEntries(manifest), {
+    logicalProviders: manifest.logicalProviders || [],
+  });
+  const pages = buildSourcePages(catalog);
+  return [
+    '## Source provider directory',
+    '',
+    `World Monitor publishes ${catalog.length} named providers across ${pages.length} source catalog pages. Each linked page contains provider names, source hosts, origins and coverage in static HTML; no search or JavaScript is required.`,
+    '',
+    ...pages.map((page) => `- [${page.name}](${SITE_ORIGIN}${page.path}): ${page.providers.length} providers.`),
+  ].join('\n');
+}
+
 /**
  * Splice the generated Comparisons section into the hand-maintained
  * llms.txt: replace the existing section in place, or insert it ahead of
@@ -272,7 +289,9 @@ export function buildLlmsFullText({ rootDir = ROOT } = {}) {
   const introduction = [
     LLMS_FULL_GENERATED_HEADING,
     '',
-    'The sections below are produced by `npm run build:llms-full` from the comparison-page registry, glossary terms, chokepoint methodology, published chokepoint explainers, the Country Resilience Index methodology, the corrections log, and the current published ranking snapshot.',
+    'The sections below are produced by `npm run build:llms-full` from the source catalog, comparison-page registry, glossary terms, chokepoint methodology, published chokepoint explainers, the Country Resilience Index methodology, the corrections log, and the current published ranking snapshot.',
+    '',
+    renderSourceDirectory(rootDir),
     '',
     renderComparisons().trim(),
     '',

--- a/scripts/crawlable-sources-page.mjs
+++ b/scripts/crawlable-sources-page.mjs
@@ -872,7 +872,9 @@ export function renderSourcesIndex({ sourceStats, sourceCatalog, catalogDatasets
       <span><strong>WORLD MONITOR</strong><small>Open-source global intelligence</small></span>
       <span class="source-footer-links"><a href="/sources/">Sources</a><a href="${docsHref('')}">Data docs</a><a href="${withUtmSource('/docs/source-attribution', 'seo-sources')}">Attribution ledger</a><a href="/docs/terms">Terms</a></span>
     </div>`;
-  const catalogNavigation = `<nav class="source-pages" aria-label="Source catalog pages">${(directoryPages || siblingPages).map((page) => `<a href="${page.path}"${page.path === path ? ' aria-current="page"' : ''}>${escapeHtml(page.name)}</a>`).join(' ')}</nav>`;
+  const catalogNavigation = directoryPages
+    ? `<ul class="source-pages source-directory">${directoryPages.map((page) => `<li><a href="${page.path}">${escapeHtml(page.name)}</a> (${page.providers.length} providers)</li>`).join('')}</ul>`
+    : `<nav class="source-pages" aria-label="Source catalog pages">${siblingPages.map((page) => `<a href="${page.path}"${page.path === path ? ' aria-current="page"' : ''}>${escapeHtml(page.name)}</a>`).join(' ')}</nav>`;
   const body = `      <section class="sources-hero">
         <div class="hero-copy">
           <p class="eyebrow"><span></span> Live provider inventory</p>
@@ -1020,6 +1022,8 @@ ${providerCards}
       .source-domain-card button, .domain-browse { width: 100%; min-height: 260px; padding: 20px; display: flex; flex-direction: column; align-items: flex-start; border: 0; background: transparent; color: inherit; text-align: left; cursor: pointer; }
       .source-pages { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 24px; }
       .source-pages a { padding: 8px; border: 1px solid var(--line); }
+      .source-directory { list-style: none; padding: 0; }
+      .source-directory a { display: inline-block; }
       .source-pages [aria-current="page"] { color: var(--accent); }
       .source-result { padding: 16px; border: 1px solid var(--line); overflow-wrap: anywhere; }
       .source-result small { display: block; color: var(--muted); }

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -82,6 +82,8 @@ import {
   COMPARISON_PAGES,
 } from '../scripts/build-comparison-pages.mjs';
 import { buildSitemapEntries } from '../scripts/build-sitemap.mjs';
+import { buildLlmsFullText } from '../scripts/build-llms-full.mjs';
+import { htmlToMarkdown } from '../api/_md-url-twin.ts';
 import {
   auditMicrostateCorpusSimilarity,
   maskedSentences,
@@ -3691,6 +3693,15 @@ describe('crawlable corpus generator', () => {
         route, html: read(outDir, `${route.slice(1)}index.html`),
       }));
       const sourcesCatalogHtml = sourcePages.map(({ html }) => html).join('\n');
+      // The deployed Markdown converter omits navigation. The directory must
+      // survive as content, including later pages that have no domain card.
+      const contentHtml = sourcesPage.replace(/<nav\b[^>]*>[\s\S]*?<\/nav>/gi, '');
+      const sourceMarkdown = htmlToMarkdown(contentHtml, 'Sources');
+      const llmsFull = buildLlmsFullText({ rootDir: repoRoot });
+      for (const { route } of sourcePages) {
+        assert.ok(sourceMarkdown.includes(`](${route})`), `${route} must be a Markdown content link`);
+        assert.ok(llmsFull.includes(`](https://www.worldmonitor.app${route})`), `${route} must be linked in llms-full.txt`);
+      }
       for (const { route, html } of [{ route: '/sources/', html: sourcesPage }, ...sourcePages]) {
         const rawBytes = Buffer.byteLength(html, 'utf8');
         const brotliBytes = brotliCompressSync(Buffer.from(html), {
@@ -3732,6 +3743,7 @@ describe('crawlable corpus generator', () => {
         });
       }
       assert.deepEqual([...listedProviders].sort(), corpusData.sourceCatalog.map((provider) => provider.provider).sort());
+      assert.equal(listedProviders.length, corpusData.sourceStats.providerCount, 'the linked static inventory must match the published provider count');
       const catalog = sourceNodes.find((node) => node['@type'] === 'DataCatalog');
       assert.equal(catalog.dataset.length, corpusData.crises.length + 1);
       for (const dataset of catalog.dataset) {


### PR DESCRIPTION
## Summary

AI readers can reach every source catalog page directly from the source hub's Markdown and `llms-full.txt`. The hub directory previously lived in navigation, which the deployed Markdown conversion omitted; the full AI file had no child-page index. Publish the directory as content and derive the AI index from the same catalog pagination.

All 748 providers remain on 17 child pages (18 source URLs including the hub). The hub stays small at 60,670 bytes.

Fixes #7941

## Validation

- Reproduced missing AI-file links and missing Markdown links to page 2 before each fix.
- 166 tests passed across `crawlable-corpus`, `crawlable-sources-pagination`, and `seo-geo-residue`; the corpus integration test checks all child links, sitemaps, provider identities/counts, and existing page size limits. Local Markdown proof excludes navigation to reproduce the observed omission.
- Corpus build, `build:llms-full:check`, typecheck, boundary lint, syntax checks, and `git diff --check` passed.
- Inspected the directory at mobile and desktop widths and followed the page 2 link. Sequential code review found no actionable issues.

CI repair: merged current main, including the browser dependency setup fix. Playwright now installs OS libraries from Ubuntu repositories, so an unrelated Google Chrome apt-index hash mismatch cannot block the tests. The combined branch passed 210 local tests. All CI checks passed on `aa3820ca11323007635e4040b43dbf74b5580457`, including both browser smoke shards, Pro WebMCP, and the required smoke gate.

## Post-Deploy Monitoring & Validation

Owner: PR author, during the first hour after an authorized deployment. Fetch `/sources.md` and `/llms-full.txt`; confirm all 17 child URLs appear as content links, including `/sources/news/page/8/`. Follow the linked sitemap set and confirm its static provider cards match the published count. Check `/sources/` remains within the existing 150 KB raw / 20 KB Brotli budgets. Missing links, non-200 child pages, or count drift require investigation and correction before acceptance. Deployed Markdown conversion is not yet verified.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-Codex-000000)
