### PR TITLE
fix(md): preserve homepage stat pairs and unify index markdown

### DIFF
--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -108,10 +108,10 @@ function withoutTrackingParams(href: string): string {
   const hash = hashIndex < 0 ? '' : href.slice(hashIndex);
   const queryIndex = pathAndQuery.indexOf('?');
   if (queryIndex < 0) return href;
-  // Preserve functional parameters and their encoding, including HTML-escaped separators.
-  const params = pathAndQuery.slice(queryIndex + 1).split(/&(?:amp;)?/i)
+  // Preserve functional parameters and their URL encoding.
+  const params = pathAndQuery.slice(queryIndex + 1).split('&')
     .filter(param => !/^utm_/i.test(new URLSearchParams(param).keys().next().value ?? ''));
-  const query = params.filter(Boolean).join('&amp;');
+  const query = params.join('&');
   return `${pathAndQuery.slice(0, queryIndex)}${query ? `?${query}` : ''}${hash}`;
 }
 
@@ -137,7 +137,11 @@ export function htmlToMarkdown(html: string, fallbackTitle: string): string {
       /<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
       (_m, href: string, inner: string) => {
         const label = stripTags(inner) || href;
-        const link = `[${label}](${withoutTrackingParams(href)})`;
+        // Parse decoded separators, then protect the URL from tag stripping and
+        // the document's final entity pass so each reference is decoded once.
+        const target = withoutTrackingParams(decodeHtmlEntities(href))
+          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const link = `[${label}](${target})`;
         return /<div\b/i.test(inner) ? `\n\n${link}\n\n` : link;
       },
     )

--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -80,18 +80,18 @@ export function resolveMarkdownTwinPath(req: Request): string | null {
 }
 
 const HTML_ENTITIES: Record<string, string> = {
-  nbsp: ' ', amp: '&', lt: '<', gt: '>', quot: '"',
+  nbsp: ' ', amp: '&', lt: '<', gt: '>', quot: '"', apos: "'",
 };
 
 function decodeHtmlEntities(value: string): string {
-  return value.replace(/&(nbsp|amp|lt|gt|quot|#(\d+));/gi, (_, entity: string, code: string | undefined) => {
+  return value.replace(/&(nbsp|amp|lt|gt|quot|apos|#(x[\da-f]+|\d+));/gi, (_, entity: string, code: string | undefined) => {
     if (code === undefined) return HTML_ENTITIES[entity.toLowerCase()]!;
     // `fromCodePoint`, not `fromCharCode`: the latter coerces with ToUint16, so
     // a code point above 0xFFFF wraps back under the `>= 32` guard after passing
     // it — `&#65596;` yielded a literal `<` and `&#65536;` a NUL. It also
     // truncates astral characters, decoding `&#128512;` to a private-use glyph
     // instead of the emoji. Same reasoning as src/utils/html-entities.ts.
-    const n = Number(code);
+    const n = /^x/i.test(code) ? Number.parseInt(code.slice(1), 16) : Number(code);
     const decodable = Number.isInteger(n) && n >= 32 && n <= 0x10ffff
       && !(n >= 0xd800 && n <= 0xdfff);
     return decodable ? String.fromCodePoint(n) : '';
@@ -100,6 +100,19 @@ function decodeHtmlEntities(value: string): string {
 
 function stripTags(value: string): string {
   return value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function withoutTrackingParams(href: string): string {
+  const hashIndex = href.indexOf('#');
+  const pathAndQuery = hashIndex < 0 ? href : href.slice(0, hashIndex);
+  const hash = hashIndex < 0 ? '' : href.slice(hashIndex);
+  const queryIndex = pathAndQuery.indexOf('?');
+  if (queryIndex < 0) return href;
+  // Preserve functional parameters and their encoding, including HTML-escaped separators.
+  const params = pathAndQuery.slice(queryIndex + 1).split(/&(?:amp;)?/i)
+    .filter(param => !/^utm_/i.test(new URLSearchParams(param).keys().next().value ?? ''));
+  const query = params.filter(Boolean).join('&amp;');
+  return `${pathAndQuery.slice(0, queryIndex)}${query ? `?${query}` : ''}${hash}`;
 }
 
 export function htmlToMarkdown(html: string, fallbackTitle: string): string {
@@ -124,9 +137,12 @@ export function htmlToMarkdown(html: string, fallbackTitle: string): string {
       /<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
       (_m, href: string, inner: string) => {
         const label = stripTags(inner) || href;
-        return `[${label}](${href})`;
+        const link = `[${label}](${withoutTrackingParams(href)})`;
+        return /<div\b/i.test(inner) ? `\n\n${link}\n\n` : link;
       },
     )
+    .replace(/<dt\b[^>]*>([\s\S]*?)<\/dt>\s*<dd\b[^>]*>([\s\S]*?)<\/dd>/gi,
+      (_m, label: string, value: string) => `\n- ${stripTags(label)}: ${stripTags(value)}\n`)
     .replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_m, inner: string) => `\n- ${stripTags(inner)}`)
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<\/p>/gi, '\n\n')

--- a/pro-test/prerender.mjs
+++ b/pro-test/prerender.mjs
@@ -304,8 +304,9 @@ for (const { file, content, rootAttributes } of PAGES) {
 const agentContext = readFileSync(resolve(__dirname, '../public/home.md'), 'utf8');
 const metadata = agentContext.match(/^---\n[\s\S]*?\n---\n/);
 if (!metadata) throw new Error('Homepage agent context must have document metadata');
+const supplement = agentContext.slice(metadata[0].length).trim().replace(/^# .+\n+/, '');
 writeFileSync(
   resolve(__dirname, '../public/pro/home.md'),
-  `${metadata[0].replace('https://www.worldmonitor.app/home.md', 'https://www.worldmonitor.app/')}\n${welcomeMarkdown}\n\n${agentContext.slice(metadata[0].length).trim()}\n`,
+  `${metadata[0].replace('https://www.worldmonitor.app/home.md', 'https://www.worldmonitor.app/')}\n${welcomeMarkdown}\n\n${supplement}\n`,
   'utf8',
 );

--- a/pro-test/src/welcome/Depth.tsx
+++ b/pro-test/src/welcome/Depth.tsx
@@ -46,7 +46,7 @@ export const Depth = () => (
         title={t('welcome.depth.title')}
         subtitle={t('welcome.depth.sub')}
       />
-      <motion.div
+      <motion.dl
         initial={false}
         whileInView={{ opacity: 1 }}
         viewport={{ once: true, margin: '-60px' }}
@@ -54,12 +54,12 @@ export const Depth = () => (
         className="data-grid !grid-cols-2 sm:!grid-cols-3 xl:!grid-cols-5"
       >
         {DEPTH_PROOF_STATS.map(({ value, labelKey }) => (
-          <div key={labelKey} className="data-cell text-center">
-            <div className="text-3xl md:text-4xl font-display font-bold text-wm-green text-glow">{String(value)}</div>
-            <div className="font-mono text-[10px] uppercase tracking-widest text-wm-muted mt-2">{t(labelKey)}</div>
+          <div key={labelKey} className="data-cell text-center flex flex-col">
+            <dt className="font-mono text-[10px] uppercase tracking-widest text-wm-muted mt-2">{t(labelKey)}</dt>
+            <dd className="order-first text-3xl md:text-4xl font-display font-bold text-wm-green text-glow">{String(value)}</dd>
           </div>
         ))}
-      </motion.div>
+      </motion.dl>
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-10">
         {NUGGETS.map(({ icon: Icon, n }, i) => (
           <motion.a

--- a/tests/agent-readiness.test.mts
+++ b/tests/agent-readiness.test.mts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { load } from 'js-yaml';
 import middleware from '../middleware';
 import agentRequestPolicy from '../shared/agent-request-policy.json';
+import { decodeHtmlEntities } from '../src/utils/html-entities';
 import { guardProBuiltOutput, shouldSkipProBuiltOutput } from './_lib/pro-built-output.mjs';
 
 describe('public agent documents', () => {
@@ -77,6 +78,34 @@ describe('agent homepage routing', () => {
         assert.ok(markdown.includes(section), 'all rendered homepage sections must survive');
       }
     }
+  });
+
+  it('publishes clean homepage markdown with every rendered stat pair', { skip: shouldSkipProBuiltOutput() }, () => {
+    const html = readFileSync(new URL('../public/pro/welcome.html', import.meta.url), 'utf8');
+    const markdown = readFileSync(new URL('../public/pro/home.md', import.meta.url), 'utf8');
+    assert.equal([...markdown.matchAll(/^# /gm)].length, 1);
+    assert.doesNotMatch(markdown, /&(?:#(?:x[0-9a-f]+|\d+)|[a-z]+);/i);
+    assert.doesNotMatch(markdown, /[?&]utm_/i);
+    const band = html.match(/<section\b[^>]*\bid="depth"[^>]*>[\s\S]*?<\/section>/)?.[0];
+    assert.ok(band);
+    const pairs = [...band.matchAll(/<dt\b[^>]*>([^<]+)<\/dt>\s*<dd\b[^>]*>([^<]+)<\/dd>/g)];
+    assert.equal(pairs.length, 15, 'exercise every rendered stat, not just standalone numbers');
+    const section = markdown.slice(markdown.indexOf('Under the hood'));
+    const rows = section.match(/^- [^\n]+: \d+$/gm) ?? [];
+    assert.equal(rows.length, pairs.length);
+    for (const [, label, value] of pairs) {
+      const pair = `${decodeHtmlEntities(label)}: ${value}`;
+      assert.ok(rows.includes(`- ${pair}`), pair);
+    }
+  });
+
+  it('routes the advertised suffix to the complete negotiated document before the generic twin', async () => {
+    const config = JSON.parse(readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
+    const aliasIndex = config.rewrites.findIndex((rule: { source: string }) => rule.source === '/index.md');
+    const twinIndex = config.rewrites.findIndex((rule: { destination: string }) => rule.destination.startsWith('/api/md-twin?'));
+    const negotiated = await middleware(new Request('https://www.worldmonitor.app/', { headers: { Accept: 'text/markdown' } }));
+    assert.ok(aliasIndex >= 0 && aliasIndex < twinIndex);
+    assert.equal(config.rewrites[aliasIndex].destination, new URL(negotiated!.headers.get('x-middleware-rewrite')!).pathname);
   });
 
   it('honors explicit markdown media types and preserves HTML preferences', async () => {

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1266,7 +1266,7 @@ describe('welcome landing page routing', () => {
   // #4825: public/index.md became Vercel's DIRECTORY INDEX for `/` — filesystem
   // resolution beats the `/` → /pro/welcome.html rewrite, so the apex homepage
   // served raw text/markdown to browsers. No `index.*` file may exist in public/;
-  // the markdown homepage twin lives at public/home.md and keeps its scored URL
+  // the markdown homepage twin is built at public/pro/home.md and keeps its scored URL
   // through the /index.md rewrite below.
   it('keeps public/ free of index.* files so filesystem resolution cannot hijack the / rewrite', () => {
     const publicDir = resolve(__dirname, '../public');
@@ -1274,11 +1274,13 @@ describe('welcome landing page routing', () => {
     assert.deepEqual(offenders, [], `public/${offenders[0] ?? ''} would shadow the / welcome rewrite as a directory index`);
   });
 
-  it('serves the markdown homepage twin at /index.md via rewrite to the non-index home.md', () => {
-    assert.ok(existsSync(resolve(__dirname, '../public/home.md')), 'expected public/home.md (markdown homepage twin)');
+  it('serves the complete built markdown homepage at /index.md', () => {
+    if (!shouldSkipProBuiltOutput()) {
+      assert.ok(existsSync(resolve(__dirname, '../public/pro/home.md')), 'expected built public/pro/home.md');
+    }
     const rewrite = vercelConfig.rewrites.find((r) => r.source === '/index.md');
     assert.ok(rewrite, 'expected a rewrite for /index.md');
-    assert.equal(rewrite.destination, '/home.md');
+    assert.equal(rewrite.destination, '/pro/home.md');
     // #6575: the SPA catch-all this ordering guarded is gone; /index.md only
     // needs its own explicit rewrite to win over filesystem resolution.
     assert.equal(vercelConfig.rewrites.filter((r) => r.source === '/index.md').length, 1);
@@ -3735,7 +3737,7 @@ describe('agent readiness: generic markdown URL-fallback rewrite', () => {
     );
     const mdIdx = vercelConfig.rewrites.indexOf(mdTwinRewrite);
     assert.ok(mdIdx > rewriteIndex('/docs/:match*'), '/docs/:match* must stay ahead of the generic .md fallback');
-    assert.ok(mdIdx > rewriteIndex('/index.md'), '/index.md → /home.md must stay ahead of the generic .md fallback');
+    assert.ok(mdIdx > rewriteIndex('/index.md'), '/index.md → /pro/home.md must stay ahead of the generic .md fallback');
   });
 
   it('does not reintroduce a shadowing /api/:path* → /api/not-found rewrite', () => {
@@ -3749,7 +3751,7 @@ describe('agent readiness: generic markdown URL-fallback rewrite', () => {
     assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/dashboard.md' })?.destination, '/api/md-twin?path=:mdPath');
     assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/stocks/AAPL.md' })?.destination, '/api/md-twin?path=:mdPath');
     assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/docs/auth.md' })?.destination, 'https://worldmonitor.mintlify.dev/docs/:match*');
-    assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/index.md' })?.destination, '/home.md');
+    assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/index.md' })?.destination, '/pro/home.md');
     assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/api/health.md' }), null);
   });
 

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -26,6 +26,24 @@ it('does not decode entities produced by numeric ampersands', () => {
     '# Title\n\n&amp; &#38; &lt;');
 });
 
+it('decodes hexadecimal and apostrophe entities once with the numeric safety bounds', () => {
+  assert.equal(htmlToMarkdown('<main><h1>It&#x27;s &apos;ready&apos;</h1><p>&#X1F600; &#x26;lt; a&#x7;b&#xD800;&#x110000;</p></main>', 'Title'),
+    "# It's 'ready'\n\n 😀 &lt; ab");
+});
+
+it('keeps definition labels and values together across adjacent stat cells', () => {
+  const markdown = htmlToMarkdown('<main><dl><div><dt>Providers</dt><dd><a href="/sources/?utm_source=hero">748</a></dd></div><div><dt>Alert origins</dt><dd>5</dd></div></dl></main>', 'Title');
+  assert.equal(markdown, '# Title\n\n- Providers: [748](/sources/)\n\n- Alert origins: 5');
+});
+
+it('removes only tracking query parameters and separates block links from following values', () => {
+  const markdown = htmlToMarkdown('<main><a href="/sources/?utm_source=hero&amp;country=US&amp;utm_content=proof#catalog"><div>748</div><div>Providers</div></a><div>5</div><a href="https://example.com/?q=two%20words&amp;utm_medium=ref">External</a><a href="#depth">Depth</a></main>', 'Title');
+  assert.match(markdown, /\[748 Providers\]\(\/sources\/\?country=US#catalog\)\n/);
+  assert.match(markdown, /https:\/\/example.com\/\?q=two%20words/);
+  assert.match(markdown, /\[Depth\]\(#depth\)/);
+  assert.doesNotMatch(markdown, /utm_/);
+});
+
 // stripTags no longer decodes, so the <title> path carries its own
 // decodeHtmlEntities() call. Dropping that wrapper is an easy refactor mistake
 // and every other <title> fixture in this file is plain text, so pin it here.

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -44,6 +44,17 @@ it('removes only tracking query parameters and separates block links from follow
   assert.doesNotMatch(markdown, /utm_/);
 });
 
+it('preserves functional queries and fragments encoded as numeric HTML entities', () => {
+  for (const separator of ['&#38;', '&#x26;', '&#X26;', '&amp;']) {
+    for (const query of [`q=1${separator}utm_source=a${separator}page=2`, `utm_source=a${separator}q=1${separator}page=2`]) {
+      assert.equal(htmlToMarkdown(`<a href="/x?${query}&#35;results">Results</a>`, 'Title'),
+        '# Title\n\n[Results](/x?q=1&page=2#results)');
+    }
+  }
+  assert.equal(htmlToMarkdown('<a href="/x?q=&amp;lt;value&amp;gt;&amp;utm_source=a">Results</a>', 'Title'),
+    '# Title\n\n[Results](/x?q=&lt;value&gt;)');
+});
+
 // stripTags no longer decodes, so the <title> path carries its own
 // decodeHtmlEntities() call. Dropping that wrapper is an easy refactor mistake
 // and every other <title> fixture in this file is plain text, so pin it here.

--- a/vercel.json
+++ b/vercel.json
@@ -115,7 +115,7 @@
     { "source": "/docs/:match*", "destination": "https://worldmonitor.mintlify.dev/docs/:match*" },
     { "source": "/", "has": [{ "type": "query", "key": "mode", "value": "agent" }], "destination": "/agent-view.json" },
     { "source": "/", "has": [{ "type": "host", "value": "^(?:www\\.)?worldmonitor\\.app$" }], "destination": "/pro/welcome.html" },
-    { "source": "/index.md", "destination": "/home.md" },
+    { "source": "/index.md", "destination": "/pro/home.md" },
     { "source": "/:mdPath((?!api/).+).md", "destination": "/api/md-twin?path=:mdPath" },
     { "source": "/pro", "destination": "/pro/index.html" },
     { "source": "/mcp", "destination": "/api/mcp" },


### PR DESCRIPTION
## Summary

Crawler requests, Markdown content negotiation, and `/index.md` now select the complete homepage document. Its title reads normally, it has one H1, and all 15 “Under the hood” figures stay attached to their labels. The stat grid uses definition-list markup with the same visual layout; the shared converter emits `label: value` pairs and removes `utm_*` query parameters while preserving functional parameters and fragments.

Fixes #7943.

## Validation

- Regression checks reproduced the original defects and a review-found numeric URL-entity case. All 382 converter, homepage-routing, agent-view, and deployment-config tests pass with the homepage rebuilt; the focused homepage suite also passed with built-output checks required.
- Rebuilt the homepage and checked all 15 rendered stat pairs, one H1, zero encoded entities, and zero tracking parameters.
- Browser checks at desktop and 390px mobile width confirmed value/label order and no stat-cell overflow.
- All 474 sidecar tests and the repository pre-push gates pass, including API/browser/pro typechecks, boundary lint, Edge bundle checks, and generated-config freshness.
- Scoped local review found no blocking findings. Hosted rewrite behavior and production cache acceptance remain post-deployment checks.

## Post-Deploy Monitoring & Validation

After the normal deployment, the release owner should compare GET and HEAD responses for `/index.md`, `/` with `Accept: text/markdown`, and `/` with `User-Agent: GPTBot/1.0`. Within the first hour, expect matching GET bodies, one H1, 15 labeled stat rows, and no encoded entities or `utm_*` links. Check Vercel request logs for `/index.md` and `/pro/home.md`; a 404, thin body, or mismatched representation is a rollback or repair trigger. Merge and production deployment have not been performed by this task.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
