### PR TITLE
fix(canada): align Toronto road seeder execution budgets

### DIFF
--- a/scripts/seed-bundle-canada.mjs
+++ b/scripts/seed-bundle-canada.mjs
@@ -48,7 +48,9 @@ const CANADA_SECTIONS = [
   { label: 'Provincial-511', script: 'seed-provincial-511.mjs', seedMetaKey: 'seed-meta:infra:ontario-511', canonicalKey: 'infra:ontario-511:v1', completionMetaKey: 'seed-completion:infra:ontario-511', intervalMs: 15 * MIN, timeoutMs: 240_000 },
   // 3.62MB body, not strictly valid JSON, sanitized then parsed. Road
   // restrictions are construction permits, not live incidents.
-  { label: 'Toronto-Roads', script: 'seed-toronto-road-restrictions.mjs', seedMetaKey: 'seed-meta:infra:toronto-roads', canonicalKey: 'infra:toronto-roads:v1', intervalMs: 2 * HOUR, timeoutMs: 180_000 },
+  // A slow run published at 179.5s, then hit the old 180s limit in cleanup.
+  // Fetch has its own 135s deadline; leave time for Redis retries and exit.
+  { label: 'Toronto-Roads', script: 'seed-toronto-road-restrictions.mjs', seedMetaKey: 'seed-meta:infra:toronto-roads', canonicalKey: 'infra:toronto-roads:v1', intervalMs: 2 * HOUR, timeoutMs: 300_000 },
   // Open511 spec with next_url pagination; DriveBC returned the full active set
   // in one page, so budget one request per tick, not MAX_PAGES.
   { label: 'BC-Open511', script: 'seed-open511.mjs', seedMetaKey: 'seed-meta:infra:bc-open511', canonicalKey: 'infra:bc-open511:v1', intervalMs: 30 * MIN, timeoutMs: 120_000 },

--- a/scripts/seed-toronto-road-restrictions.mjs
+++ b/scripts/seed-toronto-road-restrictions.mjs
@@ -22,13 +22,28 @@ const CANONICAL_KEY = 'infra:toronto-roads:v1';
 // a quarter of every cycle. The cadence and this TTL have to move together.
 const CACHE_TTL = 21600;
 
-async function fetchTorontoRoads() {
-  return fetchTorontoRoadRestrictions({ userAgent: CHROME_UA });
+async function fetchTorontoRoads({ runStartedAtMs }) {
+  const startedAt = Date.now();
+  try {
+    const data = await fetchTorontoRoadRestrictions({ userAgent: CHROME_UA });
+    const finishedAt = Date.now();
+    // Compare elapsedMs with seed_complete.durationMs to isolate publication.
+    console.log(`  [toronto-roads] phase=fetch status=OK durationMs=${finishedAt - startedAt} elapsedMs=${finishedAt - runStartedAtMs}`);
+    return data;
+  } catch (err) {
+    console.warn(`  [toronto-roads] phase=fetch status=FAILED durationMs=${Date.now() - startedAt}`);
+    throw err;
+  }
 }
 
 runSeed('infra', 'toronto-roads', CANONICAL_KEY, fetchTorontoRoads, {
   validateFn: validateTorontoRoadEnvelope,
   ttlSeconds: CACHE_TTL,
+  // Four 30s requests plus 1s/2s/4s retry waits fit before this deadline.
+  // The bundle's 300s hard limit must leave publication and cleanup time.
+  fetchPhaseTimeoutMs: 135_000,
+  // Hold ownership through the hard limit plus the runner's 10s kill grace.
+  lockTtlMs: 330_000,
   sourceVersion: 'toronto-roads-v1',
   declareRecords: declareTorontoRoadRecords,
   zeroIsValid: true,

--- a/tests/toronto-road-seed-timeout.test.mjs
+++ b/tests/toronto-road-seed-timeout.test.mjs
@@ -1,0 +1,146 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { extractBundleSections, resolveExpr } from './helpers/bundle-section-parser.mjs';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const bundle = readFileSync(join(root, 'scripts/seed-bundle-canada.mjs'), 'utf8');
+const section = extractBundleSections(bundle).find(({ label }) => label === 'Toronto-Roads');
+const timeoutMs = resolveExpr(bundle, section.timeoutMsExpr);
+const runnerUrl = pathToFileURL(join(root, 'scripts/_bundle-runner.mjs')).href;
+const fixture = readFileSync(join(root, 'tests/fixtures/toronto-road-restrictions.json'), 'utf8');
+
+// Exercise the real runner -> seeder -> adapter -> runSeed chain. Only external
+// I/O and wall time are replaced; no production keys or credentials are used.
+async function runScenario(t, mode) {
+  const dir = mkdtempSync(join(tmpdir(), 'wm-toronto-timeout-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const preload = join(dir, 'transport.mjs');
+  writeFileSync(preload, `
+    const timer = globalThis.setTimeout;
+    const abortTimeout = AbortSignal.timeout;
+    globalThis.setTimeout = (fn, ms, ...args) => timer(fn, ms / 20, ...args);
+    AbortSignal.timeout = (ms) => abortTimeout(Math.ceil(ms / 20));
+    const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+    const hang = () => new Promise(() => { setInterval(() => {}, 1_000); });
+    const mode = ${JSON.stringify(mode)};
+    const lastGood = JSON.stringify({ records: [{ id: 'last-good' }] });
+    const values = new Map([['infra:toronto-roads:v1', lastGood]]);
+    process.on('exit', () => {
+      if (process.argv[1]?.endsWith('seed-toronto-road-restrictions.mjs')) {
+        console.log('TEST_CANONICAL ' + values.get('infra:toronto-roads:v1'));
+      }
+    });
+    let upstreamAttempts = 0;
+    let stagingAttempts = 0;
+    const response = result => new Response(JSON.stringify({ result }));
+    globalThis.fetch = async (url, init = {}) => {
+      if (String(url).startsWith('https://secure.toronto.ca/')) {
+        if (mode === 'fetch-hang') return hang();
+        if (mode === 'slow-success') {
+          await sleep(29_000);
+          if (++upstreamAttempts < 3) throw new Error('synthetic upstream timeout');
+        }
+        return new Response(${JSON.stringify(fixture)});
+      }
+      if (!String(url).startsWith('https://redis.test')) {
+        throw new Error('Unexpected external request: ' + url);
+      }
+      if (String(url).includes('/get/')) {
+        if (mode === 'slow-success') await sleep(4_000);
+        const key = decodeURIComponent(String(url).split('/get/')[1]);
+        return response(values.get(key) || null);
+      }
+      const command = JSON.parse(init.body);
+      if (String(url).endsWith('/pipeline')) {
+        console.log('TEST_PRESERVE ' + JSON.stringify(command));
+        return new Response(JSON.stringify(command.map(() => ({ result: 1 }))));
+      }
+      const [op, key, value] = command;
+      if (op === 'SET' && key.startsWith('seed-lock:')) {
+        console.log('TEST_LOCK ' + JSON.stringify(command));
+        return response('OK');
+      }
+      if (op === 'SET' && key.includes(':staging:') && mode === 'slow-success') {
+        await sleep(14_000);
+        if (++stagingAttempts < 3) throw new Error('synthetic Redis timeout');
+      } else if (op === 'SET' && key === 'infra:toronto-roads:v1' && mode === 'publish-hang') {
+        return hang();
+      } else if (mode === 'slow-success' && !String(key).startsWith('bundle:')) {
+        await sleep(14_000);
+      }
+      if (op === 'SET') {
+        values.set(key, value);
+        console.log('TEST_SET ' + key);
+        return response('OK');
+      }
+      if (op === 'EVAL') console.log('TEST_RELEASE');
+      return response(1);
+    };
+  `);
+  const source = `
+    import { runBundle } from ${JSON.stringify(runnerUrl)};
+    await runBundle('Canada-timeout-test', [{
+      label: 'Toronto-Roads', script: 'seed-toronto-road-restrictions.mjs',
+      timeoutMs: ${timeoutMs},
+    }], { maxBundleMs: 570_000 });
+  `;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--input-type=module', '--eval', source], {
+      cwd: dir,
+      env: {
+        PATH: process.env.PATH,
+        NODE_OPTIONS: '--import=' + pathToFileURL(preload).href,
+        UPSTASH_REDIS_REST_URL: 'https://redis.test',
+        UPSTASH_REDIS_REST_TOKEN: 'synthetic-token',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    t.after(() => { if (child.exitCode == null) child.kill('SIGKILL'); });
+    let output = '';
+    child.stdout.on('data', data => { output += data; });
+    child.stderr.on('data', data => { output += data; });
+    child.on('error', reject);
+    child.on('close', code => resolve({ code, output }));
+  });
+}
+
+test('Toronto road retry, publication, and cleanup fit the section deadline', { timeout: 30_000 }, async (t) => {
+  const { code, output } = await runScenario(t, 'slow-success');
+  assert.equal(code, 0, output);
+  assert.match(output, /section=Toronto-Roads status=OK/);
+  assert.match(output, /TEST_SET infra:toronto-roads:v1/);
+  assert.match(output, /"recordCount":3/);
+  assert.match(output, /Verified: data present in Redis/);
+  assert.match(output, /TEST_RELEASE/);
+  assert.doesNotMatch(output, /SIGTERM|section=Toronto-Roads status=FAILED/);
+  assert.match(output, /phase=fetch status=FAILED durationMs=\d+/);
+  assert.match(output, /phase=fetch status=OK durationMs=\d+ elapsedMs=\d+/);
+  const lock = JSON.parse(output.match(/TEST_LOCK (\[.*\])/)[1]);
+  assert.ok(lock[lock.indexOf('PX') + 1] > timeoutMs + 10_000,
+    'lock must remain valid through the section timeout and termination grace');
+});
+
+test('Toronto road fetch deadline preserves last-good before the parent timeout', { timeout: 30_000 }, async (t) => {
+  const { code, output } = await runScenario(t, 'fetch-hang');
+  assert.equal(code, 0, output);
+  assert.match(output, /section=Toronto-Roads status=GRACEFUL_FAIL/);
+  assert.match(output, /TEST_PRESERVE .*infra:toronto-roads:v1/);
+  assert.match(output, /TEST_RELEASE/);
+  assert.doesNotMatch(output, /TEST_SET infra:toronto-roads:v1$|SIGTERM/m);
+  assert.match(output, /TEST_CANONICAL {"records":\[{"id":"last-good"}\]}/);
+});
+
+test('Toronto road stalled publication still fails at the hard deadline', { timeout: 30_000, skip: process.platform === 'win32' }, async (t) => {
+  const { code, output } = await runScenario(t, 'publish-hang');
+  assert.equal(code, 1, output);
+  assert.match(output, /section=Toronto-Roads status=FAILED.*timeout/);
+  assert.match(output, /SIGTERM received during publish phase/);
+  assert.match(output, /TEST_RELEASE/);
+  assert.doesNotMatch(output, /TEST_SET infra:toronto-roads:v1$|"event":"seed_complete"/m);
+  assert.match(output, /TEST_CANONICAL {"records":\[{"id":"last-good"}\]}/);
+});


### PR DESCRIPTION
## Summary

The Canada seeder reported a crash after Toronto-Roads had published 1,961 records: the 2026-09-10 run logged completion at 179.524 seconds, then hit its 180-second section deadline during cleanup. The section now has a 300-second limit, a separate 135-second fetch deadline that permits all four bounded upstream attempts, and a 330-second lock covering execution and termination grace.

Fetch failures retain last-good data and exit gracefully; stalled publication still fails at the hard deadline. Per-attempt fetch duration and total elapsed time can be compared with the existing completion event to distinguish upstream delay from publication and metadata work. The original slow phase remains unproved by production logs.

## Validation

- Reproduced the old post-publication timeout through the real bundle runner, Toronto adapter, and shared seed writer with synthetic upstream/Redis responses and accelerated timers.
- 223 focused tests passed, covering Canada contracts, bundle admission, completion attestation, watch paths, and adapter behavior.
- The three process-level regression cases also confirm successful retry/cleanup, graceful fetch timeout with the previous cache value retained, and hard publication timeout with lock release.
- Changed-file Biome lint passed. Production recovery requires a fresh Toronto-Roads run after deployment; a green tick that skips this section is insufficient.

## Post-Deploy Monitoring & Validation

Owner: PR author/operator. After merge and deployment approval, verify the deployed commit and inspect the first two due Toronto-Roads runs (allow four hours; unrelated five-minute ticks may skip it).

Use bounded Railway logs for `seed-bundle-canada`, filtering for `Toronto-Roads`, `phase=fetch`, `seed_complete`, and `Finished`. Expect `section=Toronto-Roads status=OK`, Redis verification, and `failed:0`; fetch outages may report `GRACEFUL_FAIL` while retaining the canonical value. Inspect canonical record count/freshness and section duration. Any repeat SIGTERM after a completion event, missing retained data, or expiry before the next scheduled publish blocks acceptance and requires investigation or rollback of this commit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
