### PR TITLE
fix(tenders): bound Contracts Finder timeout recovery and health

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -169,6 +169,7 @@ const HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY = healthVerdictRedisKey(
   process.env.VERCEL_GIT_COMMIT_SHA,
 );
 const HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS = 60;
+const CONTRACTS_FINDER_CANONICAL_KEY = 'economic:global-tenders:v1';
 // Edge runtime mirror of scripts/china-coverage-manifest.mjs. Edge functions
 // cannot import scripts/; tests enforce key and status-projection parity.
 const CHINA_COVERAGE_SUMMARY_KEY = 'health:china-coverage:v1';
@@ -3175,7 +3176,70 @@ function isContainedHealthWarning(entry, evidence, now = Date.now()) {
     && evidence?.status === entry.status
     && evidence.records === entry.records
     && evidence.usable === true
+    && (entry.containmentUntil === undefined || !isExpiredDeadline(entry.containmentUntil, now))
     && entry.readModelReady !== false;
+}
+
+function composeContractsFinderHealth(entry, meta, snapshot, readFailed, now) {
+  // Source-status bytes prove a diagnostic exists, not that its tender rows
+  // still exist. Replace the generic containment proof with the served data.
+  const evidence = { status: entry.status, records: entry.records, usable: false };
+  const source = Array.isArray(snapshot?.sourceStatuses)
+    ? snapshot.sourceStatuses.find((status) => status?.source === 'contracts-finder') : null;
+  const error = meta?.error ?? source?.error;
+  const lastAttemptAt = meta?.lastAttemptAt ?? source?.fetchedAt;
+  const lastSuccessAt = meta?.lastSuccessfulAt ?? source?.lastSuccessfulAt;
+  entry = { ...entry };
+  if (typeof meta?.sourceState === 'string') entry.sourceState = meta.sourceState;
+  if (typeof error === 'string') entry.error = error.slice(0, 200);
+  if (typeof lastAttemptAt === 'string') entry.lastAttemptAt = lastAttemptAt;
+  if (typeof lastSuccessAt === 'string') entry.lastSuccessAt = lastSuccessAt;
+  if (typeof meta?.firstFailureAt === 'string') entry.firstFailureAt = meta.firstFailureAt;
+  if (Number.isSafeInteger(meta?.consecutiveFailures) && meta.consecutiveFailures >= 0) {
+    entry.consecutiveSourceFailures = meta.consecutiveFailures;
+  }
+  if (readFailed) return { entry: { ...entry, status: 'REDIS_PARTIAL' }, evidence };
+  if (snapshot === null) return { entry: { ...entry, status: 'EMPTY', records: 0 }, evidence };
+  if (meta?.sourceState === 'ok') return { entry, evidence };
+  if (['OK', 'NOT_CONFIGURED'].includes(entry.status)) entry.status = 'SEED_ERROR';
+  if (snapshot.dataAvailable !== true || !Array.isArray(snapshot.tenders) || !Array.isArray(snapshot.sourceStatuses)) {
+    return { entry: { ...entry, status: 'EMPTY_DATA', records: 0 }, evidence };
+  }
+  const sourceRows = snapshot.tenders.filter((tender) => tender?.source === 'contracts-finder');
+  const records = sourceRows.filter((tender) => {
+    if (typeof tender.id !== 'string' || !tender.id.trim()
+      || typeof tender.title !== 'string' || !tender.title.trim()
+      || ![tender.categoryCodes, tender.sectors].every((values) => Array.isArray(values) && values.every((value) => typeof value === 'string'))
+      || !['active', 'open'].includes(tender.status) || !(Date.parse(tender.deadline) > now)) return false;
+    try {
+      const url = new URL(tender.officialUrl);
+      return url.protocol === 'https:' && !url.username && !url.password
+        && (url.hostname === 'contractsfinder.service.gov.uk' || url.hostname.endsWith('.contractsfinder.service.gov.uk'));
+    } catch { return false; }
+  });
+  // Count only the currently usable rows; expiry or corruption must not be
+  // hidden by the count written at the previous scheduled attempt.
+  entry.records = records.length;
+  const success = Date.parse(meta?.lastSuccessfulAt || '');
+  const first = Date.parse(meta?.firstFailureAt || '');
+  const attempt = Date.parse(meta?.lastAttemptAt || '');
+  const validEpisode = success > 0 && success <= first && first <= attempt && attempt <= now
+    && meta.fetchedAt === success && meta.consecutiveFailures === 1;
+  const aligned = source?.state === 'stale' && meta?.sourceState === 'stale'
+    && source.lastSuccessfulAt === meta.lastSuccessfulAt && source.fetchedAt === meta.lastAttemptAt
+    && source.firstFailureAt === meta.firstFailureAt && source.consecutiveFailures === meta.consecutiveFailures
+    && source.recordCount === records.length && meta.recordCount === records.length
+    && sourceRows.length === records.length && new Set(records.map((tender) => tender.id)).size === records.length;
+  const deadline = validEpisode && records.length > 0
+    ? Math.min(first + 90 * 60_000, success + SEED_META.globalTendersContractsFinder.maxStaleMin * 60_000,
+      ...records.map((tender) => Date.parse(tender.deadline))) : NaN;
+  if (entry.status === 'SEED_ERROR' && aligned && now < deadline) {
+    entry.containmentUntil = new Date(deadline).toISOString();
+    evidence.usable = true;
+  }
+  evidence.status = entry.status;
+  evidence.records = entry.records;
+  return { entry, evidence };
 }
 
 // Orders the buckets above so classifyKey can compare two candidate verdicts
@@ -3453,6 +3517,7 @@ const ENTRY_SOFTENING_DEADLINES = [
   { field: 'staleContentGraceUntil', kind: 'content', status: null },
   { field: 'sourceFailurePendingUntil', kind: 'source', status: 'SEED_ERROR' },
   { field: 'chinaCoveragePendingUntil', kind: 'source', status: null },
+  { field: 'containmentUntil', kind: 'source', status: null },
 ];
 
 function entryDeadlineRaw(entry, { field, status }) {
@@ -3952,6 +4017,7 @@ export async function handleHealth(req, ctx, options = {}) {
   for (const key of CANADA_ALERTS_CUTOVER_FALLBACK_KEYS) {
     if (!allDataKeys.includes(key)) allDataKeys.push(key);
   }
+  if (!allDataKeys.includes(CONTRACTS_FINDER_CANONICAL_KEY)) allDataKeys.push(CONTRACTS_FINDER_CANONICAL_KEY);
   const allMetaKeys = Object.values(SEED_META).map(s => s.key);
   const activationEntries = Object.entries(ACTIVATION_MARKERS);
   const fredRolloutCommands = fredRatesRolloutCommands(now);
@@ -4001,6 +4067,19 @@ export async function handleHealth(req, ctx, options = {}) {
   // sweep finished, so a request that spends time awaiting Redis cannot keep a
   // grace it has already outlived. Injected clocks stay fixed so unit tests
   // remain deterministic.
+  // Only a failed Contracts Finder refresh needs a row-level proof. Keep
+  // ordinary sweeps on STRLEN; a failure reads this one canonical snapshot.
+  const contractsFinderMetaResult = results[allDataKeys.length + allMetaKeys.indexOf(SEED_META.globalTendersContractsFinder.key)];
+  const contractsFinderMeta = unwrapEnvelope(parseRedisValue(contractsFinderMetaResult?.result)).data;
+  const contractsFinderDataResult = results[allDataKeys.indexOf(CONTRACTS_FINDER_CANONICAL_KEY)];
+  const contractsFinderHasData = keyHasData(CONTRACTS_FINDER_CANONICAL_KEY, contractsFinderDataResult?.result ?? 0);
+  let contractsFinderSnapshot = contractsFinderHasData ? undefined : null;
+  let contractsFinderReadFailed = Boolean(contractsFinderMetaResult?.error || contractsFinderDataResult?.error);
+  if (!contractsFinderReadFailed && contractsFinderHasData && contractsFinderMeta?.sourceState !== 'ok') {
+    const payload = await redisPipeline([['GET', CONTRACTS_FINDER_CANONICAL_KEY]], 4_000, true).catch(() => null);
+    contractsFinderReadFailed = !payload || Boolean(payload[0]?.error);
+    contractsFinderSnapshot = unwrapEnvelope(parseRedisValue(payload?.[0]?.result)).data;
+  }
   const evaluationNow = snapshotNow();
 
   // keyStrens: byte length per data key (0 = missing/empty/sentinel)
@@ -4098,6 +4177,11 @@ export async function handleHealth(req, ctx, options = {}) {
     for (const [name, redisKey] of Object.entries(registry)) {
       totalChecks++;
       let entry = classifyKey(name, redisKey, opts, classifyCtx);
+      if (name === 'globalTendersContractsFinder') {
+        const composed = composeContractsFinderHealth(entry, contractsFinderMeta, contractsFinderSnapshot, contractsFinderReadFailed, evaluationNow);
+        entry = composed.entry;
+        containmentEvidenceByName.set(name, composed.evidence);
+      }
       if (name === 'chinaCoverage') {
         entry = composeChinaCoverageStatus(
           entry,
@@ -4290,6 +4374,15 @@ export async function handleHealth(req, ctx, options = {}) {
   // only the verdict payload is reused, for at most 60 seconds. All other
   // responses already carry the no-store defaults from `headers` (a cached
   // 401 pins an auth failure; a cached 503 masks REDIS_DOWN recovery).
+  // Persistence can cross a tender deadline after classification. The cached
+  // snapshot is already rejected at that deadline; recheck the cold response too.
+  const contractsFinder = checks.globalTendersContractsFinder;
+  if (contractsFinder?.containmentUntil
+    && isContainedHealthWarning(contractsFinder, containmentEvidenceByName.get('globalTendersContractsFinder'), evaluationNow)
+    && isExpiredDeadline(contractsFinder.containmentUntil, snapshotNow())) {
+    verdictSnapshot.summary.containedWarn--;
+    verdictSnapshot.status = computeOverallStatus({ ...counts, containedWarn: verdictSnapshot.summary.containedWarn }, totalChecks).overall;
+  }
   return healthResponse(verdictSnapshot, compact, headers);
 }
 
@@ -4302,6 +4395,7 @@ export default async function handler(req, ctx) {
 // the classifier without standing up the full bootstrap-keys + Redis pipeline.
 // 2026-05-04 health-readiness plan, Sprint 1 test plan (Codex round 2 P1).
 export const __testing__ = {
+  composeContractsFinderHealth,
   readSeedMeta,
   classifyKey,
   healthResponseBody,

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -72,6 +72,14 @@ The cable-health handler recomputes its response after 30 minutes but retains th
 
 Cache hits migrate legacy short TTLs to the snapshot's original 90-minute deadline and retry missing or incorrect metadata. The repair checks the current payload atomically before changing its expiry or metadata, so an older reader cannot alter a newer publication. Concurrent requests within one runtime share the full refresh, including cache publication when NGA data is already cached.
 
+### Contracts Finder refresh failures
+
+The hourly Global Tenders member runs within the half-hourly `seed-bundle-relay-backup` scheduler. Contracts Finder uses two 45-second attempts for its documented OCDS query; a valid response was observed taking 23.6 seconds to first byte, beyond the previous 20-second limit. This stays within the member's 180-second timeout.
+
+Failed refreshes retain only validated open Contracts Finder records less than 180 minutes after that source's last success. Attempts never advance the success clock, and successful sibling sources cannot renew this limit. Malformed releases, including active notices without a usable closing date, fail validation instead of replacing last-good data with an empty success. An actual successful response, including a verified empty result, clears the failure episode. Legacy failure metadata with no count does not qualify as a first failure.
+
+`globalTendersContractsFinder` keeps `SEED_ERROR`, the warning count, source error, attempt time, success time, and consecutive failure count visible. Availability can contain the first failed refresh only after reading and checking its records in the canonical tender snapshot. `containmentUntil` is the earliest of 90 minutes after the first failure, 180 minutes after source success, or a retained tender's closing time. The second failed refresh, missing or unreadable canonical data, malformed records, inconsistent metadata, or an expired deadline cannot qualify. Full and compact verdict caches expire at the same deadline; this does not change other sources' health policy.
+
 ### BC active evacuation lists
 
 `canadaAlertsBcSource` uses successful active-list ingestion with a 45-minute freshness budget. BC orders remain active until their status changes or they are removed. Their event modification age is not an expiry rule. See [BC evacuation guidance](https://www2.gov.bc.ca/gov/content/safety/wildfire-status/partners/evacuation).

--- a/scripts/_global-tenders.mjs
+++ b/scripts/_global-tenders.mjs
@@ -230,7 +230,8 @@ export function buildSnapshot({ results, sourceStatuses, fetchedAt = Date.now() 
 
 export function mergeTenderSourceResults({ settled, sourceNames, previousSnapshot, attemptedAt = new Date().toISOString() }) {
   const previousTenders = Array.isArray(previousSnapshot?.tenders) ? previousSnapshot.tenders : [];
-  const previousStatuses = new Map((previousSnapshot?.sourceStatuses || []).map((status) => [status.source, status]));
+  const previousStatuses = new Map((Array.isArray(previousSnapshot?.sourceStatuses) ? previousSnapshot.sourceStatuses : [])
+    .filter((status) => status?.source).map((status) => [status.source, status]));
   const records = [];
   const sourceStatuses = [];
 
@@ -244,15 +245,38 @@ export function mergeTenderSourceResults({ settled, sourceNames, previousSnapsho
         fetchedAt: result.value.status.fetchedAt || attemptedAt,
         lastSuccessfulAt: result.value.status.lastSuccessfulAt || result.value.status.fetchedAt || attemptedAt,
         stale: false,
+        ...(source === 'contracts-finder' ? { consecutiveFailures: 0, firstFailureAt: '' } : {}),
       });
       continue;
     }
 
     const attemptedAtMs = Date.parse(attemptedAt);
-    const priorRecords = previousTenders.filter((tender) => tender.source === source && isOpenOpportunity(tender, attemptedAtMs));
+    const priorRecords = previousTenders.filter((tender) => tender?.source === source && isOpenOpportunity(tender, attemptedAtMs));
     const priorStatus = previousStatuses.get(source);
     const fulfilledStatus = result.status === 'fulfilled' ? result.value?.status : null;
     const error = string(fulfilledStatus?.error || result.reason?.message || 'upstream request failed').slice(0, 200);
+    if (source === 'contracts-finder') {
+      // A bundle success or a failed source attempt is not a source success.
+      const lastSuccessfulAt = firstString(priorStatus?.lastSuccessfulAt,
+        priorStatus?.state === 'ok' ? priorStatus.fetchedAt : '');
+      const successMs = Date.parse(lastSuccessfulAt);
+      const fresh = successMs > 0 && successMs <= attemptedAtMs && attemptedAtMs < successMs + 180 * 60_000;
+      const retained = fresh ? priorRecords.filter((tender) =>
+        string(tender.id) && string(tender.title) && safeOfficialUrl(tender.officialUrl, source)
+        && ['active', 'open'].includes(tender.status)
+        && [tender.categoryCodes, tender.sectors].every((values) => Array.isArray(values) && values.every((value) => typeof value === 'string'))) : [];
+      const alreadyFailed = priorStatus && priorStatus.state !== 'ok';
+      const previousFailures = Number.isSafeInteger(priorStatus?.consecutiveFailures) && priorStatus.consecutiveFailures >= 1
+        ? priorStatus.consecutiveFailures : 1;
+      records.push(...retained);
+      sourceStatuses.push({
+        source, state: retained.length ? 'stale' : 'error', recordCount: retained.length,
+        fetchedAt: attemptedAt, lastSuccessfulAt, stale: retained.length > 0, error,
+        consecutiveFailures: alreadyFailed ? Math.min(previousFailures + 1, 100) : 1,
+        firstFailureAt: alreadyFailed ? string(priorStatus.firstFailureAt) : attemptedAt,
+      });
+      continue;
+    }
     if (priorRecords.length > 0) {
       const lastSuccessfulAt = firstString(priorStatus?.lastSuccessfulAt, priorStatus?.fetchedAt,
         isoTimestamp(previousSnapshot?.fetchedAt));

--- a/scripts/seed-global-tenders.mjs
+++ b/scripts/seed-global-tenders.mjs
@@ -221,10 +221,16 @@ export async function fetchContractsFinder({ now = Date.now(), fetchJsonFn = fet
   url.searchParams.set('publishedTo', new Date(now).toISOString());
   url.searchParams.set('stages', 'tender');
   url.searchParams.set('limit', String(MAX_PER_SOURCE));
-  const payload = await fetchJsonFn(url);
+  // The documented 100-release query has returned valid data after 24s to
+  // first byte. Two 45s attempts (plus bounded backoff) fit the 180s section.
+  const payload = await fetchJsonFn(url, { timeoutMs: 45_000, maxRetries: 1 });
   const releases = payload?.releases ?? payload?.records;
   if (!Array.isArray(releases)) throw new Error('Contracts Finder response is missing releases');
-  const records = releases.map(normalizeContractsFinderRelease).filter((tender) => isOpenOpportunity(tender, now));
+  const normalized = releases.map(normalizeContractsFinderRelease);
+  if (normalized.some((tender) => !tender || (['active', 'open'].includes(tender.status) && !tender.deadline))) {
+    throw new Error('Contracts Finder response contains malformed releases');
+  }
+  const records = normalized.filter((tender) => isOpenOpportunity(tender, now));
   return { records, status: sourceStatus('contracts-finder', 'ok', records, '', now) };
 }
 
@@ -378,18 +384,31 @@ async function recordUnavailableSourceHealth(snapshot) {
   await Promise.all((snapshot?.sourceStatuses || []).map(writeSourceStatus));
 }
 
-async function writeSourceStatus(status) {
-  const key = `economic:global-tenders:v1:source:${status.source}`;
-  const metaKey = `seed-meta:economic:global-tenders:${status.source}`;
-  const successfulAt = Date.parse(status.lastSuccessfulAt || status.fetchedAt || '');
+export function sourceHealthMeta(status) {
+  const contractsFinder = status.source === 'contracts-finder';
+  const successTime = status.lastSuccessfulAt || ((!contractsFinder || status.state === 'ok') ? status.fetchedAt : '');
+  const successfulAt = Date.parse(successTime || '');
   const failed = status.state !== 'ok';
-  await writeExtraKey(key, status, SOURCE_STATUS_TTL_SECONDS);
-  await writeExtraKey(metaKey, {
+  return {
     fetchedAt: Number.isFinite(successfulAt) ? successfulAt : 0,
     recordCount: status.recordCount || 0,
     sourceState: status.state,
     stale: Boolean(status.stale || failed),
-  }, SOURCE_STATUS_TTL_SECONDS);
+    ...(contractsFinder ? {
+      lastAttemptAt: status.fetchedAt,
+      lastSuccessfulAt: status.lastSuccessfulAt || '',
+      consecutiveFailures: status.consecutiveFailures,
+      firstFailureAt: status.firstFailureAt,
+      ...(status.error ? { error: status.error } : {}),
+    } : {}),
+  };
+}
+
+async function writeSourceStatus(status) {
+  const key = `economic:global-tenders:v1:source:${status.source}`;
+  const metaKey = `seed-meta:economic:global-tenders:${status.source}`;
+  await writeExtraKey(key, status, SOURCE_STATUS_TTL_SECONDS);
+  await writeExtraKey(metaKey, sourceHealthMeta(status), SOURCE_STATUS_TTL_SECONDS);
 }
 
 async function main() {

--- a/tests/fred-rates-rollout-health.test.mjs
+++ b/tests/fred-rates-rollout-health.test.mjs
@@ -187,6 +187,7 @@ function installHealthPipelineMock(recordCount, {
       fetchedAt: DEPLOYED_AT,
       recordCount: Math.max(10_000, ...configs.map((config) => config.minRecordCount ?? 0)),
     };
+    if (key === SEED_META.globalTendersContractsFinder.key) meta.sourceState = 'ok';
     for (const config of configs) {
       if (config.requiredRedistributionPolicyVersion != null) {
         meta.redistributionPolicyVersion = config.requiredRedistributionPolicyVersion;

--- a/tests/global-tender-health.test.mjs
+++ b/tests/global-tender-health.test.mjs
@@ -200,3 +200,148 @@ test('a source that actually failed still reports SEED_ERROR', () => {
     assert.equal(entry.status, 'SEED_ERROR', `sourceState=${sourceState} must still warn`);
   }
 });
+
+const CF_NAME = 'globalTendersContractsFinder';
+const CF_KEY = 'economic:global-tenders:v1';
+const CF_NOW = Date.parse('2026-07-13T06:00:00Z');
+
+async function failedContractsFinder() {
+  const { fetchGlobalTenders, sourceStatus } = await import('../scripts/seed-global-tenders.mjs');
+  const { normalizeContractsFinderRelease } = await import('../scripts/_global-tenders.mjs');
+  const success = CF_NOW - 60 * 60_000;
+  const record = normalizeContractsFinderRelease({
+    id: 'health-fixture', date: new Date(success).toISOString(),
+    tender: { title: 'Network services', status: 'active', tenderPeriod: { endDate: new Date(CF_NOW + 4 * 60 * 60_000).toISOString() } },
+  });
+  return fetchGlobalTenders({
+    now: CF_NOW, previousSnapshot: {
+      fetchedAt: success, dataAvailable: true, tenders: [record],
+      sourceStatuses: [sourceStatus('contracts-finder', 'ok', [record], '', success)],
+    },
+    adapters: [['contracts-finder', async () => { throw new Error('The operation was aborted due to timeout'); }]],
+  });
+}
+
+async function classifyContractsFinder(snapshot, now = CF_NOW, readFailed = false, metaOverride = {}) {
+  const seed = await import('../scripts/seed-global-tenders.mjs');
+  const meta = { ...seed.sourceHealthMeta(snapshot.sourceStatuses[0]), ...metaOverride };
+  const evidence = new Map();
+  const dataKey = __testing__.STANDALONE_KEYS[CF_NAME];
+  const entry = __testing__.classifyKey(CF_NAME, dataKey, { allowOnDemand: true }, {
+    keyStrens: new Map([[dataKey, 256]]), keyErrors: new Map(),
+    keyMetaValues: new Map([[__testing__.SEED_META[CF_NAME].key, JSON.stringify(meta)]]),
+    keyMetaErrors: new Map(), containmentEvidenceByName: evidence, now,
+  });
+  const composed = __testing__.composeContractsFinderHealth(entry, meta, snapshot, readFailed, now);
+  evidence.set(CF_NAME, composed.evidence);
+  return { ...composed, contained: __testing__.isContainedHealthWarning(composed.entry, composed.evidence, now) };
+}
+
+test('Contracts Finder producer-to-health retains every diagnostic during bounded first-failure containment', async () => {
+  const snapshot = await failedContractsFinder();
+  const { entry, contained } = await classifyContractsFinder(snapshot);
+  assert.equal(contained, true);
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(entry.records, 1);
+  assert.equal(entry.consecutiveSourceFailures, 1);
+  assert.equal(entry.lastSuccessAt, snapshot.sourceStatuses[0].lastSuccessfulAt);
+  assert.equal(entry.lastAttemptAt, snapshot.sourceStatuses[0].fetchedAt);
+  assert.match(entry.error, /timeout/);
+  assert.equal(entry.containmentUntil, new Date(CF_NOW + 90 * 60_000).toISOString());
+  const verdict = __testing__.computeOverallStatus({ warn: 1, containedWarn: 1, onDemandWarn: 0, crit: 0 }, 292);
+  assert.equal(verdict.overall, 'HEALTHY');
+  assert.equal(verdict.realWarnCount, 1);
+  const full = { status: verdict.overall, summary: { total: 292, warn: 1, containedWarn: 1 }, checkedAt: new Date(CF_NOW).toISOString(), checks: { [CF_NAME]: entry } };
+  const compact = __testing__.healthResponseBody(full, true);
+  assert.deepEqual(compact.problems[CF_NAME], entry);
+  assert.deepEqual(__testing__.collectFailureLogProblems(full.checks, CF_NOW).sigKeys, [`${CF_NAME}:SEED_ERROR`]);
+  const expiry = Date.parse(entry.containmentUntil);
+  for (const view of [full, compact]) {
+    assert.equal(__testing__.snapshotTtlSeconds(view, expiry - 10_500), 10);
+    assert.equal(__testing__.hasExpiredActivationGrace(view, expiry), true);
+  }
+  assert.equal((await classifyContractsFinder(snapshot, expiry)).contained, false);
+});
+
+test('Contracts Finder cannot contain repeated, stale, malformed, mismatched, or unusable evidence', async () => {
+  const fixture = await failedContractsFinder();
+  const cases = [
+    ['second failure', s => { s.sourceStatuses[0].consecutiveFailures = 2; }],
+    ['missing failure count', s => { delete s.sourceStatuses[0].consecutiveFailures; }],
+    ['missing success', s => { s.sourceStatuses[0].lastSuccessfulAt = ''; }],
+    ['future attempt', s => { s.sourceStatuses[0].fetchedAt = new Date(CF_NOW + 60_000).toISOString(); }],
+    ['false dataAvailable', s => { s.dataAvailable = false; }],
+    ['empty', s => { s.tenders = []; }],
+    ['malformed row', s => { s.tenders[0].officialUrl = 'https://example.com'; }],
+    ['unreadable categories', s => { s.tenders[0].categoryCodes = null; }],
+    ['expired row', s => { s.tenders[0].deadline = new Date(CF_NOW).toISOString(); }],
+    ['mismatched count', s => { s.sourceStatuses[0].recordCount = 2; }],
+  ];
+  for (const [label, mutate] of cases) {
+    const snapshot = structuredClone(fixture);
+    mutate(snapshot);
+    assert.equal((await classifyContractsFinder(snapshot)).contained, false, label);
+  }
+  assert.equal((await classifyContractsFinder(fixture, CF_NOW, true)).contained, false);
+  assert.equal((await classifyContractsFinder(fixture, CF_NOW, false, { fetchedAt: CF_NOW })).contained, false);
+  const legacy = await classifyContractsFinder(fixture, CF_NOW, false, {
+    error: undefined, lastAttemptAt: undefined, lastSuccessfulAt: undefined, consecutiveFailures: undefined,
+  });
+  assert.equal(legacy.contained, false);
+  assert.equal(legacy.entry.error, fixture.sourceStatuses[0].error, 'legacy warnings retain their canonical source detail');
+  const deadline = structuredClone(fixture);
+  deadline.tenders[0].deadline = new Date(CF_NOW + 30_000).toISOString();
+  assert.equal((await classifyContractsFinder(deadline)).entry.containmentUntil, deadline.tenders[0].deadline);
+});
+
+test('Contracts Finder health checks the canonical payload, not the positive source-status count', async (t) => {
+  const { default: handler } = await import('../api/health.js');
+  const seed = await import('../scripts/seed-global-tenders.mjs');
+  const snapshot = await failedContractsFinder();
+  const meta = seed.sourceHealthMeta(snapshot.sourceStatuses[0]);
+  const realEnv = { ...process.env };
+  Object.assign(process.env, { UPSTASH_REDIS_REST_URL: 'https://mock-upstash.test', UPSTASH_REDIS_REST_TOKEN: 'mock-token' });
+  t.after(() => {
+    for (const key of ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN']) {
+      if (realEnv[key] === undefined) delete process.env[key]; else process.env[key] = realEnv[key];
+    }
+  });
+  let clock = CF_NOW;
+  t.mock.method(Date, 'now', () => clock);
+  let canonical = snapshot;
+  let canonicalReads = 0;
+  let expireDuringWrite = false;
+  t.mock.method(globalThis, 'fetch', async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    return new Response(JSON.stringify(commands.map(([op, key]) => {
+      if (expireDuringWrite && op === 'SET' && key === __testing__.HEALTH_VERDICT_SNAPSHOT_KEY) clock = CF_NOW + 90 * 60_000;
+      if (op === 'STRLEN') return { result: key === CF_KEY && canonical === null ? 0 : 256 };
+      if (op === 'GET' && key === CF_KEY) { canonicalReads++; return { result: canonical === null ? null : JSON.stringify(canonical) }; }
+      if (op === 'GET' && key === __testing__.SEED_META[CF_NAME].key) return { result: JSON.stringify(meta) };
+      if (op === 'GET' && key.startsWith('seed-meta:')) return { result: JSON.stringify({ fetchedAt: CF_NOW, recordCount: 1 }) };
+      if (op === 'GET') return { result: null };
+      if (op === 'LLEN') return { result: 1 };
+      return { result: 'OK' };
+    })));
+  });
+  const read = async () => (await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'))).json();
+  const initial = await read();
+  assert.equal(initial.problems[CF_NAME].containmentUntil, new Date(CF_NOW + 90 * 60_000).toISOString());
+  expireDuringWrite = true;
+  const slow = await read();
+  assert.equal(slow.summary.containedWarn, initial.summary.containedWarn - 1,
+    'a slow snapshot write must not extend the cold response containment');
+  expireDuringWrite = false;
+  clock = CF_NOW;
+  canonical = null;
+  const missing = (await read()).problems[CF_NAME];
+  assert.equal(missing.status, 'EMPTY');
+  assert.equal(missing.records, 0);
+  assert.equal(missing.containmentUntil, undefined);
+  meta.sourceState = 'ok';
+  assert.equal((await read()).problems[CF_NAME].status, 'EMPTY', 'fresh source metadata cannot hide an absent canonical payload');
+  canonical = snapshot;
+  delete meta.sourceState;
+  assert.equal((await read()).problems[CF_NAME].status, 'SEED_ERROR', 'unusable source metadata never reads OK');
+  assert.ok(canonicalReads >= 2);
+});

--- a/tests/global-tender-sources.test.mjs
+++ b/tests/global-tender-sources.test.mjs
@@ -68,6 +68,17 @@ test('Contracts Finder adapter requests current tender-stage OCDS releases', asy
   assert.equal(result.records[0].region, 'Europe');
 });
 
+test('Contracts Finder rejects unusable releases instead of clearing last-good records as valid empty', async () => {
+  for (const release of [{}, {
+    id: 'missing-deadline', tender: { title: 'Network services', status: 'active' },
+  }]) {
+    await assert.rejects(fetchContractsFinder({ now: NOW, fetchJsonFn: async () => ({ releases: [release] }) }), /malformed releases/);
+  }
+  const empty = await fetchContractsFinder({ now: NOW, fetchJsonFn: async () => ({ releases: [] }) });
+  assert.equal(empty.status.state, 'ok');
+  assert.equal(empty.records.length, 0);
+});
+
 test('World Bank adapter uses the current v2 opportunity fields', async () => {
   let requested;
   const result = await fetchWorldBank({

--- a/tests/global-tenders-transient-retry.test.mjs
+++ b/tests/global-tenders-transient-retry.test.mjs
@@ -20,7 +20,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { fetchCanadaBuys } from '../scripts/seed-global-tenders.mjs';
+import { fetchCanadaBuys, fetchContractsFinder } from '../scripts/seed-global-tenders.mjs';
 
 const CSV = [
   '"title-titre-eng","referenceNumber-numeroReference","noticeURL-URLavis-eng",'
@@ -48,6 +48,37 @@ function stubFetch(responses) {
 }
 
 const realFetch = globalThis.fetch;
+
+test('Contracts Finder accepts a valid response slower than the old 20-second limit', async (t) => {
+  // Production query: first byte 23.6s, valid OCDS body at 24.2s. Advance the
+  // provider clock without sleeping; use the real adapter and timeout option.
+  const timeouts = [];
+  t.mock.method(AbortSignal, 'timeout', (ms) => {
+    timeouts.push(ms);
+    return { timeoutMs: ms };
+  });
+  t.mock.method(globalThis, 'fetch', async (_url, { signal }) => {
+    if (signal.timeoutMs < 24_200) throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    return new Response(JSON.stringify({ releases: [] }));
+  });
+  process.env.WM_SEED_RETRY_DELAY_MS = '0';
+  t.after(() => { delete process.env.WM_SEED_RETRY_DELAY_MS; });
+  const result = await fetchContractsFinder();
+  assert.equal(result.status.state, 'ok');
+  assert.deepEqual(timeouts, [45_000]);
+});
+
+test('Contracts Finder bounds persistent timeouts to two attempts', async (t) => {
+  let attempts = 0;
+  t.mock.method(globalThis, 'fetch', async () => {
+    attempts++;
+    throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+  });
+  process.env.WM_SEED_RETRY_DELAY_MS = '0';
+  t.after(() => { delete process.env.WM_SEED_RETRY_DELAY_MS; });
+  await assert.rejects(fetchContractsFinder(), /timeout/);
+  assert.equal(attempts, 2);
+});
 
 test('a transient CanadaBuys failure is retried, not surfaced as a source error', async () => {
   // First attempt dies the way a real blip dies (connection reset / timeout),

--- a/tests/global-tenders.test.mjs
+++ b/tests/global-tenders.test.mjs
@@ -240,6 +240,76 @@ test('official URLs are HTTPS and restricted to the source host', () => {
   assert.equal(safeOfficialUrl('https://sam.gov.attacker.example/notice', 'sam'), '');
 });
 
+const CF_SUCCESS = '2026-07-13T05:00:00.000Z';
+function contractsFinderSnapshot() {
+  const record = normalizeContractsFinderRelease({
+    id: 'fixture', date: CF_SUCCESS,
+    tender: { title: 'Network services', status: 'active', tenderPeriod: { endDate: '2026-07-14T12:00:00Z' } },
+  });
+  return {
+    fetchedAt: Date.parse(CF_SUCCESS), dataAvailable: true, tenders: [record],
+    sourceStatuses: [{ source: 'contracts-finder', state: 'ok', recordCount: 1, fetchedAt: CF_SUCCESS, lastSuccessfulAt: CF_SUCCESS }],
+  };
+}
+function failContractsFinder(previousSnapshot, attemptedAt = '2026-07-13T06:00:00.000Z') {
+  return mergeTenderSourceResults({
+    previousSnapshot, attemptedAt, sourceNames: ['contracts-finder'],
+    settled: [{ status: 'rejected', reason: new Error('The operation was aborted due to timeout') }],
+  });
+}
+
+test('Contracts Finder retains usable data with a durable failure episode and truthful clocks', () => {
+  const first = failContractsFinder(contractsFinderSnapshot());
+  const status = first.sourceStatuses[0];
+  assert.equal(first.tenders.length, 1);
+  assert.equal(status.state, 'stale');
+  assert.equal(status.lastSuccessfulAt, CF_SUCCESS);
+  assert.equal(status.consecutiveFailures, 1);
+  assert.equal(status.firstFailureAt, status.fetchedAt);
+  assert.match(status.error, /timeout/);
+  const second = failContractsFinder(first, '2026-07-13T07:00:00.000Z');
+  assert.equal(second.sourceStatuses[0].consecutiveFailures, 2);
+  assert.equal(second.sourceStatuses[0].firstFailureAt, status.firstFailureAt);
+  assert.equal(second.sourceStatuses[0].lastSuccessfulAt, CF_SUCCESS);
+  const expired = failContractsFinder(second, '2026-07-13T08:00:00.000Z');
+  assert.equal(expired.tenders.length, 0, 'source retention ends at 180 minutes, even while other sources keep publishing');
+  assert.equal(expired.sourceStatuses[0].lastSuccessfulAt, CF_SUCCESS);
+  const recovered = mergeTenderSourceResults({
+    previousSnapshot: second, sourceNames: ['contracts-finder'], attemptedAt: '2026-07-13T07:05:00Z',
+    settled: [{ status: 'fulfilled', value: { records: [], status: {
+      source: 'contracts-finder', state: 'ok', recordCount: 0, fetchedAt: '2026-07-13T07:05:00Z',
+    } } }],
+  });
+  assert.equal(recovered.sourceStatuses[0].consecutiveFailures, 0);
+  assert.equal(recovered.sourceStatuses[0].firstFailureAt, '');
+  assert.equal(recovered.availability, 'empty', 'verified empty is a real recovery');
+});
+
+test('Contracts Finder cannot borrow a bundle timestamp or a failed attempt as a source success', () => {
+  for (const patch of [
+    { state: 'stale', lastSuccessfulAt: '', fetchedAt: '2026-07-13T06:00:00Z' },
+    { lastSuccessfulAt: 'bad-date' },
+    { lastSuccessfulAt: '2026-07-13T07:00:00Z' },
+  ]) {
+    const prior = contractsFinderSnapshot();
+    Object.assign(prior.sourceStatuses[0], patch);
+    assert.equal(failContractsFinder(prior).tenders.length, 0, JSON.stringify(patch));
+  }
+  for (const patch of [{ title: '' }, { officialUrl: 'https://example.com' }, { deadline: 'bad' }, { status: 'awarded' }]) {
+    const prior = contractsFinderSnapshot();
+    Object.assign(prior.tenders[0], patch);
+    assert.equal(failContractsFinder(prior).tenders.length, 0, JSON.stringify(patch));
+  }
+  const legacyFailure = contractsFinderSnapshot();
+  legacyFailure.sourceStatuses[0].state = 'stale';
+  assert.equal(failContractsFinder(legacyFailure).sourceStatuses[0].consecutiveFailures, 2,
+    'a legacy failure must not restart as the first failure');
+  for (const sourceStatuses of [null, {}, [null]]) {
+    const prior = { ...contractsFinderSnapshot(), sourceStatuses };
+    assert.equal(failContractsFinder(prior).tenders.length, 0);
+  }
+});
+
 test('keeps historical awards and records with unknown closing dates out of the open-opportunity feed', () => {
   const future = normalizeSamOpportunity({ noticeId: 'future', title: 'Current opportunity', responseDeadLine: '2026-07-30T00:00:00Z', uiLink: 'https://sam.gov/future' });
   const award = { ...future, status: 'awarded' };


### PR DESCRIPTION
## Summary

The existing Contracts Finder timeout is 20 seconds per attempt. A read-only request to the documented public endpoint returned valid data with 23.6 seconds to first byte and 24.2 seconds total, beyond that limit. This change gives that source two 45-second attempts within the existing 180-second bundle budget.

A failed refresh keeps only validated open records within 180 minutes of their original source success. Health verifies canonical data before containing the first failed refresh, for at most 90 minutes from its first failure, also capped by source freshness and tender closing times. A second failure or missing, malformed, inconsistent, or expired data remains actionable. `SEED_ERROR`, warning counts, error details, and truthful source clocks remain visible throughout. Malformed releases cannot erase last-good data as an empty success; a verified empty response still clears the episode.

This PR repairs the timeout and bounds that source's existing availability containment. Other sources' policy and scheduler configuration remain unchanged.

## Validation

- All required CI passed at `349e7fb6f5ec7993d1b3ab8dc59ac2f56876771e`; final snapshot confirms current main is included and the PR is mergeable.
- Reproduced the old timeout with a controlled 24.2-second response and observed the production query exceed 20 seconds.
- 334 focused health/tender tests and 4 reader tests pass, covering recurrence, recovery, missing canonical data, invalid records/clocks, warning projection, and exact cache/cold-response expiry.
- 474 sidecar tests; TypeScript and API typechecks; boundary lint; docs checks.
- Updated the healthy-fleet integration fixture to declare Contracts Finder source success; existing warning and incident-history assertions pass unchanged.
- ce-code-review completed; applicable findings fixed. Review ran sequentially in the main task under repository instructions.
- No production seed execution, Redis mutation, deployment, or production acceptance claim.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the maintainer should observe two natural hourly Global-Tenders runs and inspect the Railway `Global-Tenders` logs plus `/api/health?compact=1`. Expect a real successful Contracts Finder response to clear the failure episode. If a later attempt fails, confirm the warning/error stays visible, the success time does not advance, and containment ends at its published deadline or second failure. Missing/unusable data must never be contained. Repeated timeouts or incorrect containment require investigation before acceptance; do not run an extra production seed to force the result.

[Contracts Finder query contract](https://www.contractsfinder.service.gov.uk/apidocumentation/Notices/1/GET-Published-Notice-OCDS-Search).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
