### PR TITLE
fix(health): expose optional Radar target degradation

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -2579,6 +2579,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   return {
     hasMeta: meta != null,
     seedFetchedAt: fetchedAt,
+    targetLocationsDegraded: meta?.targetLocationsDegraded === true,
     seedAge,
     seedStale,
     seedError: sourceDegraded || failedDatasets.length > 0,
@@ -2935,6 +2936,8 @@ function classifyKey(name, redisKey, opts, ctx) {
   else status = 'OK';
 
   const entry = { status, records };
+  // Target locations are optional; expose their failure without changing status.
+  if (name === 'ddosAttacks' && meta.targetLocationsDegraded) entry.targetLocationsDegraded = true;
   // Source-level on-demand marker: "this key is RPC-populated or awaiting its
   // first producer run", NOT "any failure here is acceptable". The status suffix
   // (`EMPTY_ON_DEMAND`) cannot carry that, because it only covers the

--- a/docs/solutions/logic-errors/bootstrap-key-health-missing-payload.md
+++ b/docs/solutions/logic-errors/bootstrap-key-health-missing-payload.md
@@ -30,7 +30,9 @@ tags: [bootstrap-hydration, seed-meta, freshness-tracking, redis, health]
 
 ## What Didn't Work
 
-Making every `EMPTY_DATA_OK` key fail when the payload was missing would have fixed the projection blind spot, but it would also have broken normal quiet-source behavior. `ddosAttacks`, `trafficAnomalies`, `weatherAlerts`, and `newsThreatSummary` legitimately write fresh metadata without a payload after a successful quiet cycle; they must remain healthy in that state. The test contract at `tests/health-empty-data-ok.test.mjs:16-92` covers this distinction.
+Making every `EMPTY_DATA_OK` key fail when the payload was missing would have fixed the projection blind spot, but it would also have broken normal quiet-source behavior. `weatherAlerts` and `newsThreatSummary` legitimately write fresh metadata without a payload after a successful quiet cycle; they must remain healthy in that state. CF Radar's `ddosAttacks` and `trafficAnomalies` now publish explicit payloads on confirmed-empty cycles. They remain in `EMPTY_DATA_OK_KEYS` for cold-start grace and are also in `MISSING_DATA_IS_FAILURE_KEYS` so fresh metadata cannot excuse a missing payload. `tests/health-empty-data-ok.test.mjs` covers this distinction.
+
+CF Radar payload TTLs must exceed their health staleness thresholds, including the rounded-minute boundary. DDoS retains three hours and traffic anomalies two hours against a 60-minute gate. The optional DDoS target-location slice reports `targetLocationsDegraded: true` on its health entry when the producer marks it degraded; this diagnostic does not change status. Production acceptance for #7864 still requires paired payload and metadata observations over several natural publications, including a confirmed-empty cycle.
 
 Earlier bootstrap work had correctly added compact dashboard-shaped side keys, but it also showed that a side key needs its own availability signal; healthy metadata alone cannot prove that a required projection is present (session history).
 

--- a/scripts/seed-internet-outages.mjs
+++ b/scripts/seed-internet-outages.mjs
@@ -466,7 +466,7 @@ runSeed('infra', 'outages', CANONICAL_KEY, fetchAll, {
   // The companion keys are written by publishCompanion(), outside runSeed's own
   // extra-key phase, so runSeed does not know to retain them when the
   // annotations leg fails, times out or is SIGTERMed. Each is declared at its
-  // OWN TTL — the canonical 3h would quietly triple the anomalies key's 1h
+  // OWN TTL — the canonical 3h would extend the anomalies key's 2h
   // contract, and each meta key resolves through the same `resolveSeedMetaTtl`
   // that wrote it, so an EXPIRE can never shorten one. Meta is listed so a
   // retained payload can never outlive the clock that reports on it (see

--- a/tests/cloudflare-radar-companion-publication.test.mjs
+++ b/tests/cloudflare-radar-companion-publication.test.mjs
@@ -524,6 +524,10 @@ test('an optional slice that could not be confirmed is recorded on the success m
     JSON.parse(healthy.store.get(DDOS_KEY))._targetLocationsDegraded, undefined,
     'the diagnostic stays on seed-meta and never reaches the published payload',
   );
+  const healthyEntry = classifyCompanion('ddosAttacks', DDOS_KEY, DDOS_META_KEY, healthy.store);
+  const degradedEntry = classifyCompanion('ddosAttacks', DDOS_KEY, DDOS_META_KEY, degraded.store);
+  assert.equal(healthyEntry.status, 'OK');
+  assert.deepEqual(degradedEntry, { ...healthyEntry, targetLocationsDegraded: true });
 });
 
 test('runSeed retains both companion keys at their own TTLs when the fetch phase fails', () => {

--- a/tests/health-empty-data-ok.test.mjs
+++ b/tests/health-empty-data-ok.test.mjs
@@ -78,6 +78,30 @@ function classifyPresent(name, meta) {
   });
 }
 
+test('optional DDoS target degradation is diagnostic only across health states', () => {
+  for (const [classify, age, expected] of [
+    [classifyPresent, 1, 'OK'],
+    [classifyPresent, 61, 'STALE_SEED'],
+    [classifyMissing, 1, 'EMPTY'],
+  ]) {
+    const meta = { fetchedAt: NOW - age * 60_000, recordCount: 0 };
+    const baseline = classify('ddosAttacks', meta);
+    const degraded = classify('ddosAttacks', { ...meta, targetLocationsDegraded: true });
+    assert.equal(degraded.status, expected);
+    assert.deepEqual(degraded, { ...baseline, targetLocationsDegraded: true });
+  }
+  for (const value of [undefined, false, 'true', 1, {}]) {
+    const entry = classifyPresent('ddosAttacks', {
+      fetchedAt: NOW, recordCount: 0, targetLocationsDegraded: value,
+    });
+    assert.equal(Object.hasOwn(entry, 'targetLocationsDegraded'), false);
+  }
+  const unrelated = classifyPresent('trafficAnomalies', {
+    fetchedAt: NOW, recordCount: 0, targetLocationsDegraded: true,
+  });
+  assert.equal(Object.hasOwn(unrelated, 'targetLocationsDegraded'), false);
+});
+
 test('published strict projections escalate when their data key vanishes', () => {
   for (const name of STRICT_PROJECTIONS) {
     const seedCfg = SEED_META[name];

--- a/tests/seed-ttl-outlives-health-staleness.test.mjs
+++ b/tests/seed-ttl-outlives-health-staleness.test.mjs
@@ -22,9 +22,34 @@
 // and must stay a crit — it just must not fire spuriously.
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import { ACLED_TTL } from '../scripts/seed-conflict-intel.mjs';
 import { __testing__ } from '../api/health.js';
+
+const radarSeeder = readFileSync(new URL('../scripts/seed-internet-outages.mjs', import.meta.url), 'utf8');
+for (const [name, constant] of [['ddosAttacks', 'DDOS_TTL'], ['trafficAnomalies', 'ANOMALIES_TTL']]) {
+  test(`${name} payload survives the rounded health staleness boundary`, () => {
+    const match = radarSeeder.match(new RegExp(`^const ${constant} = (\\d+);`, 'm'));
+    assert.ok(match, `${constant} must remain discoverable in the seeder`);
+    const ttl = Number(match[1]);
+    const { SEED_META, BOOTSTRAP_KEYS, classifyKey } = __testing__;
+    const config = SEED_META[name];
+    assert.ok(ttl > (config.maxStaleMin + 0.5) * 60,
+      `${constant} must outlive the rounded staleness boundary`);
+    const now = 1_700_000_000_000;
+    const redisKey = BOOTSTRAP_KEYS[name];
+    for (const ageSeconds of [config.maxStaleMin * 60 + 29, config.maxStaleMin * 60 + 31]) {
+      assert.ok(ttl > ageSeconds);
+      const entry = classifyKey(name, redisKey, { allowOnDemand: false }, {
+        keyStrens: new Map([[redisKey, 128]]), keyErrors: new Map(),
+        keyMetaValues: new Map([[config.key, JSON.stringify({ fetchedAt: now - ageSeconds * 1000, recordCount: 0 })]]),
+        keyMetaErrors: new Map(), now,
+      });
+      assert.equal(entry.status, ageSeconds < (config.maxStaleMin + 0.5) * 60 ? 'OK' : 'STALE_SEED');
+    }
+  });
+}
 
 test('the ACLED conflict key outlives its own health staleness threshold', () => {
   const { SEED_META } = __testing__;


### PR DESCRIPTION
## Summary

DDoS health now exposes `targetLocationsDegraded: true` when the optional target-location request fails. The diagnostic leaves status and record counts unchanged, including healthy, stale, and missing-payload states.

Adds regression coverage for the producer-to-health diagnostic path and both CF Radar TTL rounding boundaries. Corrects stale publication and TTL documentation. Strict missing-payload classification and the two-hour anomalies TTL already shipped in #7876; this patch does not tighten classification again.

Related: #7864

## Validation

- 28 focused tests passed. The diagnostic test failed before implementation and passes afterward; producer output reaches the real health classifier.
- All 474 sidecar tests passed with local socket access; the sandbox-only attempt could not bind test servers.
- API typecheck and `git diff --check` passed.
- Sequential inline code review found no remaining code defects.
- Read-only production observation at 2026-09-10 06:51:32 UTC found both payloads present: DDoS 14 records, TTL 10484s; traffic anomalies 48 records, TTL 6884s. This is one non-empty publication, not multi-tick or confirmed-empty acceptance evidence. Keep the issue open pending those observations.

## Post-Deploy Monitoring & Validation

Owner: repository maintainer. After an authorized deployment, inspect `/api/health` DDoS entries and `seed-meta:cf:radar:ddos` over at least three natural seeder publications. Compare both companion metadata clocks with their payloads, including a natural confirmed-empty publication. Expected: optional target failures add the diagnostic without changing status; recovery removes it; fresh missing payloads remain `EMPTY`. Inspect `seed-internet-outages` logs for target-location failures when the marker appears. Unexpected status changes caused only by the marker require reverting this patch. Do not close production acceptance until the natural empty cycle is observed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
