### PR TITLE
feat(seo): connect country, crisis, tracker, and editorial pages

### DIFF
--- a/blog-site/src/content/blog/build-supply-chain-early-warning-system-api.md
+++ b/blog-site/src/content/blog/build-supply-chain-early-warning-system-api.md
@@ -6,7 +6,7 @@ keywords: "supply chain risk API, chokepoint monitoring API, shipping disruption
 audience: "Supply chain engineers, logistics developers, procurement analysts, platform teams, risk managers"
 heroImage: "/blog/images/blog/build-supply-chain-early-warning-system-api.jpg"
 pubDate: "2026-06-08"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
 When the Strait of Hormuz shut down this spring, companies found out in one of two ways. Some read about it in the news and started calling freight forwarders. Others had already received a webhook hours earlier, when the disruption score crossed their alert threshold, and were quoting Cape of Good Hope routings before their competitors knew there was a problem.
@@ -57,13 +57,15 @@ The response tells you everything a routing decision needs:
 }
 ```
 
-Read it like this: this tanker lane is 100% exposed to both Hormuz and Suez, the current disruption score on the primary chokepoint is 68/100, and the documented bypass adds 12 transit days at a 1.35× cost multiplier. `cargoType` matters because bypass options are filtered to corridors suitable for your cargo (`container`, `tanker`, `bulk`, or `roro`), and `hs2` lets you scope by commodity chapter.
+Read it like this: this tanker lane is 100% exposed to both [Hormuz](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) and [Suez](https://www.worldmonitor.app/chokepoints/suez-canal/), the current disruption score on the primary chokepoint is 68/100, and the documented bypass adds 12 transit days at a 1.35× cost multiplier. `cargoType` matters because bypass options are filtered to corridors suitable for your cargo (`container`, `tanker`, `bulk`, or `roro`), and `hs2` lets you scope by commodity chapter.
+
+The [Cape of Good Hope](https://www.worldmonitor.app/chokepoints/cape-of-good-hope/) alternative avoids Suez and Bab el-Mandeb. A vessel leaving the Persian Gulf still has to clear Hormuz.
 
 Run this once for every lane in your network and you have an exposure matrix: which chokepoints, at what percentage, with what fallback. Most teams discover that 70% of their volume funnels through a small set of waterways.
 
 ## Step 2: Subscribe to Disruption Webhooks
 
-Polling is for prototypes. Register a webhook for the chokepoints your matrix surfaced:
+Polling is for prototypes. Register a webhook for the chokepoints your matrix surfaced. The example also includes [Bab el-Mandeb](https://www.worldmonitor.app/chokepoints/bab-el-mandeb/), the southern entrance to the Red Sea:
 
 ```bash
 curl -s -X POST 'https://api.worldmonitor.app/api/v2/shipping/webhooks' \
@@ -144,7 +146,7 @@ The `lanesExposedTo()` lookup is your exposure matrix from Step 1. That is what 
 
 ## Step 4: Add Country Context
 
-Chokepoints are not the only failure mode. A supplier country sliding into instability disrupts production before anything reaches a port. Pull structural resilience for your origin countries:
+Chokepoints are not the only failure mode. A supplier country sliding into instability disrupts production before anything reaches a port. Pull structural resilience for your origin countries. For the route example, inspect the [United Arab Emirates](https://www.worldmonitor.app/countries/united-arab-emirates/) and [Netherlands](https://www.worldmonitor.app/countries/netherlands/) profiles. The request below uses [Egypt](https://www.worldmonitor.app/countries/egypt/), the Suez transit country:
 
 ```bash
 curl -s 'https://api.worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=EG' \

--- a/blog-site/src/content/blog/country-risk-monitoring-due-diligence-worldmonitor.md
+++ b/blog-site/src/content/blog/country-risk-monitoring-due-diligence-worldmonitor.md
@@ -6,7 +6,7 @@ keywords: "country risk monitoring, country risk API, geopolitical due diligence
 audience: "Risk teams, investors, security managers, compliance analysts, consultants"
 heroImage: "/blog/images/blog/country-risk-monitoring-due-diligence-worldmonitor.jpg"
 pubDate: "2026-06-10"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
 Country risk due diligence is the process of asking: "What could go wrong because this deal, supplier, shipment, facility, or trip depends on a country?"
@@ -93,7 +93,7 @@ Group countries by exposure type:
 
 ### 2. Pull country risk
 
-With MCP, start with:
+For the Turkish logistics example below, start with the [Turkey country profile](https://www.worldmonitor.app/countries/turkey/) and check its observation dates. With MCP, use:
 
 ```json
 {

--- a/blog-site/src/content/blog/country-risk-monitoring-workflow-for-analysts.md
+++ b/blog-site/src/content/blog/country-risk-monitoring-workflow-for-analysts.md
@@ -6,7 +6,7 @@ keywords: "country risk monitoring, geopolitical risk assessment workflow, polit
 audience: "Risk analysts, corporate security teams, procurement and supply chain managers, investors, NGO security officers"
 heroImage: "/blog/images/blog/country-risk-monitoring-workflow-for-analysts.jpg"
 pubDate: "2026-06-06"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
 Most organizations monitor country risk the same way: an annual PDF from a consultancy, a quarterly review meeting, and then a frantic scramble when something actually happens. The PDF was accurate the day it was written. Risk is not.
@@ -66,10 +66,10 @@ Developers can go further: poll country scores on a schedule via the REST API, o
 
 ## A Worked Example: Five-Country Supplier Footprint
 
-Say your exposure is Taiwan (semiconductors), Mexico (assembly), Poland (logistics hub), Egypt (Suez transit and cable landings), and Vietnam (electronics).
+Say your exposure is [Taiwan](https://www.worldmonitor.app/countries/taiwan/) (semiconductors), [Mexico](https://www.worldmonitor.app/countries/mexico/) (assembly), [Poland](https://www.worldmonitor.app/countries/poland/) (logistics hub), [Egypt](https://www.worldmonitor.app/countries/egypt/) (Suez transit and cable landings), and [Vietnam](https://www.worldmonitor.app/countries/vietnam/) (electronics). Open each profile for its published evidence and observation dates.
 
 - **Baseline:** Taiwan has moderate CII and very high resilience, but a single chokepoint (Taiwan Strait) dominates the risk picture. Egypt sits in an elevated CII band with mid-table resilience: the fragile-calm quadrant. Vietnam has low instability; your watch there is purely infrastructure and weather.
-- **Dossier signals:** for Taiwan, PLA exercise activity and Taiwan Strait transit changes; for Egypt, Suez disruption score and internet outages; for Mexico, cartel-related unrest events near your specific corridors, not the national average.
+- **Dossier signals:** for Taiwan, PLA exercise activity and [Taiwan Strait](https://www.worldmonitor.app/chokepoints/taiwan-strait/) transit changes; for Egypt, [Suez](https://www.worldmonitor.app/chokepoints/suez-canal/) disruption score and internet outages; for Mexico, cartel-related unrest events near your specific corridors, not the national average.
 - **Daily watch:** CII deltas plus a keyword monitor per supplier city.
 - **Automation:** chokepoint webhooks on Taiwan Strait and Suez at threshold 60; weekly resilience-change report on all five.
 

--- a/blog-site/src/content/blog/energy-shock-monitoring-chokepoints-worldmonitor.md
+++ b/blog-site/src/content/blog/energy-shock-monitoring-chokepoints-worldmonitor.md
@@ -6,7 +6,7 @@ keywords: "energy shock monitoring, oil chokepoint dashboard, fuel shortage trac
 audience: "Energy analysts, commodity traders, policy teams, infrastructure risk managers"
 heroImage: "/blog/images/blog/energy-shock-monitoring-chokepoints-worldmonitor.jpg"
 pubDate: "2026-06-10"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
 An energy shock rarely starts as a chart. It starts as a closure rumor, a tanker reroute, a fuel shortage, a policy announcement, a port delay, a pipeline disruption, or a military signal near a chokepoint. By the time the price chart explains it, the operational window has already narrowed.
@@ -14,6 +14,8 @@ An energy shock rarely starts as a chart. It starts as a closure rumor, a tanker
 WorldMonitor helps energy analysts watch the chain before it becomes one number on a terminal: maritime chokepoints, fuel shortages, energy disruptions, commodity prices, country risk, news intelligence, and policy response. For the route side of the problem, start with the guide to [tracking chokepoints and freight costs](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/); for the market side, pair it with [real-time market intelligence for traders](/blog/posts/real-time-market-intelligence-for-traders-and-analysts/).
 
 This is a practical workflow for monitoring energy-shock risk.
+
+For a worked example, open the [Strait of Hormuz tracker](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) to inspect its latest published transit and disruption readings. The [historical Strait of Hormuz Transit Report for July 2026](https://www.worldmonitor.app/research/strait-of-hormuz-transit-report-2026-07/) provides a dated comparison with Suez, Bab el-Mandeb, and the Cape of Good Hope. Its figures describe that report's observation period, not current traffic.
 
 ## What is energy shock monitoring?
 

--- a/blog-site/src/content/blog/energy-shock-monitoring-chokepoints-worldmonitor.md
+++ b/blog-site/src/content/blog/energy-shock-monitoring-chokepoints-worldmonitor.md
@@ -17,6 +17,8 @@ This is a practical workflow for monitoring energy-shock risk.
 
 For a worked example, open the [Strait of Hormuz tracker](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) to inspect its latest published transit and disruption readings. The [historical Strait of Hormuz Transit Report for July 2026](https://www.worldmonitor.app/research/strait-of-hormuz-transit-report-2026-07/) provides a dated comparison with Suez, Bab el-Mandeb, and the Cape of Good Hope. Its figures describe that report's observation period, not current traffic.
 
+For country context, open the [Iran](https://www.worldmonitor.app/countries/iran/) and [Oman](https://www.worldmonitor.app/countries/oman/) profiles. The [Gulf security tracker](https://www.worldmonitor.app/crises/hormuz-gulf-security/) summarizes conflict data for its stated regional coverage. The separate [Iran–Israel escalation tracker](https://www.worldmonitor.app/crises/iran-israel-escalation/) covers those two countries only.
+
 ## What is energy shock monitoring?
 
 Energy shock monitoring is the process of tracking the signals that can disrupt oil, gas, electricity, fuel distribution, or energy-linked commodities before the disruption fully appears in price or inventory data.

--- a/blog-site/src/content/blog/monitor-global-supply-chains-and-commodity-disruptions.md
+++ b/blog-site/src/content/blog/monitor-global-supply-chains-and-commodity-disruptions.md
@@ -6,10 +6,10 @@ keywords: "supply chain monitoring tool, commodity price dashboard, supply chain
 audience: "Supply chain managers, commodity traders, logistics professionals, procurement teams, risk analysts"
 heroImage: "/blog/images/blog/monitor-global-supply-chains-and-commodity-disruptions.jpg"
 pubDate: "2026-02-26"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
-In March 2021, the Ever Given blocked the Suez Canal for six days. Global trade lost an estimated $9.6 billion per day. Most supply chain teams learned about it from Twitter.
+In March 2021, the Ever Given blocked the [Suez Canal](https://www.worldmonitor.app/chokepoints/suez-canal/) for six days. Global trade lost an estimated $9.6 billion per day. Most supply chain teams learned about it from Twitter.
 
 The companies that recovered fastest were the ones that already had multi-source monitoring in place: ship positions, port congestion data, commodity prices, and alternative route analysis, all visible before the situation hit mainstream news.
 
@@ -19,9 +19,9 @@ World Monitor's Commodity Monitor (commodity.worldmonitor.app) gives every suppl
 
 Modern supply chains are global, interconnected, and fragile. A single disruption can cascade across industries:
 
-- A drought in Taiwan affects semiconductor fabrication water supply
-- A coup in Niger disrupts uranium supply for European nuclear plants
-- Houthi attacks in the Red Sea force rerouting around the Cape of Good Hope
+- A drought in [Taiwan](https://www.worldmonitor.app/countries/taiwan/) affects semiconductor fabrication water supply
+- A coup in [Niger](https://www.worldmonitor.app/countries/niger/) disrupts uranium supply for European nuclear plants
+- Houthi attacks in the [Red Sea](https://www.worldmonitor.app/crises/red-sea-security/) force rerouting around the [Cape of Good Hope](https://www.worldmonitor.app/chokepoints/cape-of-good-hope/)
 - A port strike in Montreal affects grain exports to North Africa
 - GPS jamming in the Baltic disrupts automated shipping navigation
 

--- a/blog-site/src/content/blog/stress-test-supply-chain-scenario-engine-worldmonitor.md
+++ b/blog-site/src/content/blog/stress-test-supply-chain-scenario-engine-worldmonitor.md
@@ -6,7 +6,7 @@ keywords: "supply chain scenario engine, geopolitical stress test, chokepoint sc
 audience: "Supply chain teams, commodity desks, risk managers, policy analysts"
 heroImage: "/blog/images/blog/stress-test-supply-chain-scenario-engine-worldmonitor.jpg"
 pubDate: "2026-06-13"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
 Most supply-chain dashboards answer a live-state question: which ports, corridors, commodities, or countries are under pressure right now?
@@ -41,12 +41,14 @@ The live template catalog is defined in the codebase, and the API response shoul
 
 | Template | Core question |
 |---|---|
-| Taiwan Strait Full Closure | What happens to electronics, machinery, and vehicle routes if East Asia traffic is blocked? |
-| Suez + Bab el-Mandeb Simultaneous Disruption | What happens if the Red Sea corridor is heavily impaired? |
-| Panama Canal Drought - 50% Capacity | What happens when climate stress cuts a key canal's throughput? |
-| Hormuz Strait Tanker Blockade | What happens when Persian Gulf energy and petrochemical exports are severed? |
+| [Taiwan Strait](https://www.worldmonitor.app/chokepoints/taiwan-strait/) Full Closure | What happens to electronics, machinery, and vehicle routes if East Asia traffic is blocked? |
+| [Suez](https://www.worldmonitor.app/chokepoints/suez-canal/) + [Bab el-Mandeb](https://www.worldmonitor.app/chokepoints/bab-el-mandeb/) Simultaneous Disruption | What happens if the Red Sea corridor is heavily impaired? |
+| [Panama Canal](https://www.worldmonitor.app/chokepoints/panama-canal/) Drought - 50% Capacity | What happens when climate stress cuts a key canal's throughput? |
+| [Hormuz Strait](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) Tanker Blockade | What happens when Persian Gulf energy and petrochemical exports are severed? |
 | Russia Baltic Grain Export Suspension | What happens to cereals and oilseeds when a grain route is suspended? |
 | US Tariff Escalation - Electronics | What happens when a tariff shock hits electronics without a physical chokepoint closure? |
+
+Open a linked waterway to compare its published observations with the hypothetical scenario.
 
 The templates cover conflict, weather, sanctions, and tariff-shock categories. The type system leaves room for infrastructure and pandemic categories, but those categories do not ship templates today.
 

--- a/blog-site/src/content/blog/supply-chain-early-warning-dashboard-worldmonitor-api.md
+++ b/blog-site/src/content/blog/supply-chain-early-warning-dashboard-worldmonitor-api.md
@@ -6,7 +6,7 @@ keywords: "supply chain early warning dashboard, supply chain risk API, chokepoi
 audience: "Supply chain teams, logistics analysts, procurement leaders, data engineers"
 heroImage: "/blog/images/blog/supply-chain-early-warning-dashboard-worldmonitor-api.jpg"
 pubDate: "2026-06-10"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
 A supply chain early warning dashboard should answer one question before the weekly operations meeting: which routes, commodities, suppliers, or countries need attention now?
@@ -51,7 +51,7 @@ This turns WorldMonitor's broad data surface into a dashboard that matches your 
 
 ### 1. Chokepoint status
 
-Use chokepoint data for direct route stress. WorldMonitor tracks major corridors such as Hormuz, Suez, Malacca, Bab-el-Mandeb, Panama, and others.
+Use chokepoint data for direct route stress. WorldMonitor tracks major corridors such as [Hormuz](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/), [Suez](https://www.worldmonitor.app/chokepoints/suez-canal/), [Malacca](https://www.worldmonitor.app/chokepoints/strait-of-malacca/), [Bab-el-Mandeb](https://www.worldmonitor.app/chokepoints/bab-el-mandeb/), [Panama](https://www.worldmonitor.app/chokepoints/panama-canal/), and others.
 
 MCP path:
 
@@ -70,7 +70,7 @@ REST path: start from the [API reference](https://www.worldmonitor.app/docs/api-
 
 Country risk is the context layer. A port can be open while the surrounding political, sanctions, or conflict environment worsens.
 
-For each country in your watchlist, pull:
+For the transit-country examples in this watchlist, inspect the [Egypt](https://www.worldmonitor.app/countries/egypt/) and [Singapore](https://www.worldmonitor.app/countries/singapore/) profiles before choosing alert thresholds. For each country in your watchlist, pull:
 
 - Country Instability Index score and band
 - Component breakdown

--- a/blog-site/src/content/blog/track-global-conflicts-in-real-time.md
+++ b/blog-site/src/content/blog/track-global-conflicts-in-real-time.md
@@ -6,7 +6,7 @@ keywords: "real-time conflict map, geopolitical intelligence map, military track
 audience: "Geopolitical analysts, defense researchers, policy makers, journalists covering conflict"
 heroImage: "/blog/images/blog/track-global-conflicts-in-real-time.jpg"
 pubDate: "2026-02-14"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
 When a military escalation begins, the first 24 hours define the narrative. Analysts who see the signals early, the unusual flight patterns, the naval repositioning, the news velocity spike, have a decisive advantage over those waiting for the morning briefing.
@@ -34,15 +34,17 @@ Each layer can be toggled independently. Combine them to build a multi-source pi
 
 World Monitor maintains real-time posture assessments for its operational-theater registry:
 
-1. **Iran / Persian Gulf:** Strait of Hormuz chokepoint, IRGC activity, proxy conflict indicators
-2. **Taiwan Strait:** PLA military exercises, naval deployments, airspace incursions
+1. **[Iran](https://www.worldmonitor.app/countries/iran/) / Persian Gulf:** [Strait of Hormuz](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) chokepoint, IRGC activity, proxy conflict indicators
+2. **[Taiwan Strait](https://www.worldmonitor.app/chokepoints/taiwan-strait/):** PLA military exercises, naval deployments, airspace incursions
 3. **Baltic Region:** NATO-Russia friction, Kaliningrad corridor, submarine activity
 4. **Korean Peninsula:** DMZ incidents, missile tests, force posture changes
 5. **Eastern Mediterranean:** Israel-Hezbollah dynamics, energy disputes, naval presence
 6. **Horn of Africa:** Houthi maritime threats, Red Sea shipping disruption, piracy
 7. **South China Sea:** Island militarization, fishing militia, freedom of navigation operations
 8. **Arctic:** Resource competition, Northern Sea Route, military basing
-9. **Black Sea:** Ukraine conflict, grain corridor, naval mine risk
+9. **Black Sea:** [Ukraine](https://www.worldmonitor.app/countries/ukraine/) conflict, grain corridor, naval mine risk
+
+For dated country-level conflict summaries, open the [Gulf security](https://www.worldmonitor.app/crises/hormuz-gulf-security/), [Red Sea security](https://www.worldmonitor.app/crises/red-sea-security/), and [Ukraine war](https://www.worldmonitor.app/crises/ukraine-war/) trackers. Each states its country coverage and observation period; that scope differs from the broader theaters above.
 
 Each theater's posture level is synthesized from news velocity, military movements, CII scores of involved nations, and historical escalation patterns.
 

--- a/blog-site/src/content/blog/tracking-global-trade-routes-chokepoints-freight-costs.md
+++ b/blog-site/src/content/blog/tracking-global-trade-routes-chokepoints-freight-costs.md
@@ -6,7 +6,7 @@ keywords: "chokepoint monitoring, Strait of Hormuz shipping, freight index dashb
 audience: "Supply chain professionals, commodity traders, logistics analysts, maritime intelligence, geopolitical risk analysts"
 heroImage: "/blog/images/blog/hormuz-chokepoint-crisis.png"
 pubDate: "2026-03-15"
-modifiedDate: "2026-07-22"
+modifiedDate: "2026-09-10"
 ---
 
 > **Key Takeaways:** In the March 15, 2026 snapshot, Strait of Hormuz traffic was down 94.4%. World Monitor combines its canonical waterway registry, freight indices, WTO trade policy, and critical-mineral concentration in one dashboard.
@@ -35,18 +35,18 @@ The chart tells the story: tanker and cargo traffic that had been steady at 40-7
 
 The Hormuz crisis was the most severe in this snapshot, but it was not the only corridor under pressure. World Monitor tracks 13 critical maritime chokepoints, each scored by disruption level, vessel traffic, and [conflict intensity](/blog/posts/track-global-conflicts-in-real-time/):
 
-The following table highlights eight of the 13 monitored corridors as of mid-March 2026:
+The following table highlights eight of the 13 monitored corridors as of mid-March 2026. Open a corridor name to check its latest published observations; the table remains a dated case study:
 
 | Corridor | Status | Key Risk |
 |----------|--------|----------|
-| **Strait of Hormuz** | Critical | Iran-Israel war, naval blockade, mines |
-| **Kerch Strait** | Red | Russia controls Kerch Bridge, Azov grain exports restricted |
-| **Bab el-Mandeb** | Yellow | Houthi attacks on commercial shipping |
-| **Suez Canal** | Yellow | Red Sea conflict spillover, Iran-Israel war adjacency |
-| **Bosporus Strait** | Elevated | Black Sea grain corridor tensions |
-| **Taiwan Strait** | Yellow | PLA military exercises, semiconductor supply risk |
-| **Cape of Good Hope** | Green | Rerouting destination for Hormuz/Suez diversions |
-| **Dover Strait** | Green | Europe's busiest shipping lane, currently stable |
+| **[Strait of Hormuz](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/)** | Critical | Iran-Israel war, naval blockade, mines |
+| **[Kerch Strait](https://www.worldmonitor.app/chokepoints/kerch-strait/)** | Red | Russia controls Kerch Bridge, Azov grain exports restricted |
+| **[Bab el-Mandeb](https://www.worldmonitor.app/chokepoints/bab-el-mandeb/)** | Yellow | Houthi attacks on commercial shipping |
+| **[Suez Canal](https://www.worldmonitor.app/chokepoints/suez-canal/)** | Yellow | Red Sea conflict spillover, Iran-Israel war adjacency |
+| **[Bosporus Strait](https://www.worldmonitor.app/chokepoints/bosporus-strait/)** | Elevated | Black Sea grain corridor tensions |
+| **[Taiwan Strait](https://www.worldmonitor.app/chokepoints/taiwan-strait/)** | Yellow | PLA military exercises, semiconductor supply risk |
+| **[Cape of Good Hope](https://www.worldmonitor.app/chokepoints/cape-of-good-hope/)** | Green | Rerouting destination for Hormuz/Suez diversions |
+| **[Dover Strait](https://www.worldmonitor.app/chokepoints/dover-strait/)** | Green | Europe's busiest shipping lane, currently stable |
 
 Each corridor shows live vessel counts, week-over-week traffic changes, disruption percentages, and risk levels. When you click a corridor, you get the full AI-generated situation assessment with specific shipping recommendations.
 
@@ -148,7 +148,7 @@ About 20% of global petroleum liquids consumption and a major share of LNG trade
 
 **What are the world's most critical shipping chokepoints?**
 
-World Monitor monitors its canonical waterway registry, including Hormuz, Malacca, Suez/SUMED, Bab el-Mandeb, Panama, Taiwan, Cape of Good Hope, Gibraltar, Bosporus, Korea, Dover, Kerch, and Lombok. Entries with EIA-backed oil or gas baselines publish flow estimates; every entry can carry traffic, warning, threat, and disruption context. See the [maritime chokepoint methodology](/blog/posts/what-is-a-maritime-chokepoint/) for the registry and coverage limits.
+World Monitor monitors its canonical waterway registry, including Hormuz, Malacca, Suez/SUMED, Bab el-Mandeb, Panama, Taiwan, Cape of Good Hope, [Gibraltar](https://www.worldmonitor.app/chokepoints/strait-of-gibraltar/), Bosporus, Korea, Dover, Kerch, and Lombok. Entries with EIA-backed oil or gas baselines publish flow estimates; every entry can carry traffic, warning, threat, and disruption context. See the [maritime chokepoint methodology](/blog/posts/what-is-a-maritime-chokepoint/) for the registry and coverage limits.
 
 ---
 

--- a/blog-site/src/content/blog/what-is-a-maritime-chokepoint.md
+++ b/blog-site/src/content/blog/what-is-a-maritime-chokepoint.md
@@ -6,7 +6,7 @@ keywords: "maritime chokepoint, shipping chokepoint, Strait of Hormuz, Suez Cana
 audience: "Logistics teams, maritime analysts, commodity traders, students, geopolitical risk readers"
 heroImage: "/blog/images/blog/what-is-a-maritime-chokepoint.jpg"
 pubDate: "2026-06-13"
-modifiedDate: "2026-09-04"
+modifiedDate: "2026-09-10"
 ---
 
 A maritime chokepoint is a narrow passage where a large share of global trade, energy, food, or military movement must pass through a small physical space.
@@ -41,19 +41,19 @@ WorldMonitor's canonical chokepoint registry includes:
 
 | Canonical id | Public name |
 |---|---|
-| `hormuz_strait` | Strait of Hormuz |
-| `malacca_strait` | Strait of Malacca |
-| `suez` | Suez Canal / SUMED |
-| `bab_el_mandeb` | Bab el-Mandeb |
-| `panama` | Panama Canal |
-| `taiwan_strait` | Taiwan Strait |
-| `cape_of_good_hope` | Cape of Good Hope |
-| `gibraltar` | Strait of Gibraltar |
-| `bosphorus` | Bosporus Strait |
-| `korea_strait` | Korea Strait |
-| `dover_strait` | Dover Strait |
-| `kerch_strait` | Kerch Strait |
-| `lombok_strait` | Lombok Strait |
+| `hormuz_strait` | [Strait of Hormuz](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) |
+| `malacca_strait` | [Strait of Malacca](https://www.worldmonitor.app/chokepoints/strait-of-malacca/) |
+| `suez` | [Suez Canal / SUMED](https://www.worldmonitor.app/chokepoints/suez-canal/) |
+| `bab_el_mandeb` | [Bab el-Mandeb](https://www.worldmonitor.app/chokepoints/bab-el-mandeb/) |
+| `panama` | [Panama Canal](https://www.worldmonitor.app/chokepoints/panama-canal/) |
+| `taiwan_strait` | [Taiwan Strait](https://www.worldmonitor.app/chokepoints/taiwan-strait/) |
+| `cape_of_good_hope` | [Cape of Good Hope](https://www.worldmonitor.app/chokepoints/cape-of-good-hope/) |
+| `gibraltar` | [Strait of Gibraltar](https://www.worldmonitor.app/chokepoints/strait-of-gibraltar/) |
+| `bosphorus` | [Bosporus Strait](https://www.worldmonitor.app/chokepoints/bosporus-strait/) |
+| `korea_strait` | [Korea Strait](https://www.worldmonitor.app/chokepoints/korea-strait/) |
+| `dover_strait` | [Dover Strait](https://www.worldmonitor.app/chokepoints/dover-strait/) |
+| `kerch_strait` | [Kerch Strait](https://www.worldmonitor.app/chokepoints/kerch-strait/) |
+| `lombok_strait` | [Lombok Strait](https://www.worldmonitor.app/chokepoints/lombok-strait/) |
 
 All 13 can receive status, threat classification, warning context, AIS-disruption matching, disruption score, and war-risk tier.
 

--- a/blog-site/src/data/glossary.ts
+++ b/blog-site/src/data/glossary.ts
@@ -243,6 +243,9 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
       'Its width and traffic density make it a textbook chokepoint: alternative routes exist but are longer and lower-capacity, so congestion or disruption in Malacca reverberates through Asian supply chains and freight costs.',
     ],
     related: ['maritime-chokepoint', 'suez-canal', 'ais'],
+    learnMore: [
+      { label: 'Strait of Malacca tracker', href: 'https://www.worldmonitor.app/chokepoints/strait-of-malacca/' },
+    ],
   },
   {
     slug: 'suez-canal',
@@ -256,6 +259,7 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     ],
     related: ['maritime-chokepoint', 'strait-of-malacca', 'chokepoint-congestion'],
     learnMore: [
+      { label: 'Suez Canal tracker', href: 'https://www.worldmonitor.app/chokepoints/suez-canal/' },
       { label: 'Tracking global trade routes (blog)', href: 'https://www.worldmonitor.app/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/' },
     ],
   },

--- a/blog-site/src/data/glossary.ts
+++ b/blog-site/src/data/glossary.ts
@@ -228,6 +228,7 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     ],
     related: ['maritime-chokepoint', 'ais', 'chokepoint-congestion'],
     learnMore: [
+      { label: 'Strait of Hormuz tracker', href: 'https://www.worldmonitor.app/chokepoints/strait-of-hormuz/' },
       { label: 'Energy shock monitoring (blog)', href: 'https://www.worldmonitor.app/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/' },
     ],
   },

--- a/docs/methodology/chokepoints.mdx
+++ b/docs/methodology/chokepoints.mdx
@@ -15,6 +15,8 @@ here, and who would feel it?**
 
 ### What a chokepoint row tells you
 
+Open the [Strait of Hormuz tracker](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) for a worked example. Read its published disruption score, available inputs, and observation dates alongside the method below.
+
 Each waterway carries four separate readings, and it is worth keeping them
 apart:
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1158,18 +1158,18 @@ The chart tells the story: tanker and cargo traffic that had been steady at 40-7
 
 The Hormuz crisis was the most severe in this snapshot, but it was not the only corridor under pressure. World Monitor tracks 13 critical maritime chokepoints, each scored by disruption level, vessel traffic, and [conflict intensity](/blog/posts/track-global-conflicts-in-real-time/):
 
-The following table highlights eight of the 13 monitored corridors as of mid-March 2026:
+The following table highlights eight of the 13 monitored corridors as of mid-March 2026. Open a corridor name to check its latest published observations; the table remains a dated case study:
 
 | Corridor | Status | Key Risk |
 |----------|--------|----------|
-| **Strait of Hormuz** | Critical | Iran-Israel war, naval blockade, mines |
-| **Kerch Strait** | Red | Russia controls Kerch Bridge, Azov grain exports restricted |
-| **Bab el-Mandeb** | Yellow | Houthi attacks on commercial shipping |
-| **Suez Canal** | Yellow | Red Sea conflict spillover, Iran-Israel war adjacency |
-| **Bosporus Strait** | Elevated | Black Sea grain corridor tensions |
-| **Taiwan Strait** | Yellow | PLA military exercises, semiconductor supply risk |
-| **Cape of Good Hope** | Green | Rerouting destination for Hormuz/Suez diversions |
-| **Dover Strait** | Green | Europe's busiest shipping lane, currently stable |
+| **[Strait of Hormuz](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/)** | Critical | Iran-Israel war, naval blockade, mines |
+| **[Kerch Strait](https://www.worldmonitor.app/chokepoints/kerch-strait/)** | Red | Russia controls Kerch Bridge, Azov grain exports restricted |
+| **[Bab el-Mandeb](https://www.worldmonitor.app/chokepoints/bab-el-mandeb/)** | Yellow | Houthi attacks on commercial shipping |
+| **[Suez Canal](https://www.worldmonitor.app/chokepoints/suez-canal/)** | Yellow | Red Sea conflict spillover, Iran-Israel war adjacency |
+| **[Bosporus Strait](https://www.worldmonitor.app/chokepoints/bosporus-strait/)** | Elevated | Black Sea grain corridor tensions |
+| **[Taiwan Strait](https://www.worldmonitor.app/chokepoints/taiwan-strait/)** | Yellow | PLA military exercises, semiconductor supply risk |
+| **[Cape of Good Hope](https://www.worldmonitor.app/chokepoints/cape-of-good-hope/)** | Green | Rerouting destination for Hormuz/Suez diversions |
+| **[Dover Strait](https://www.worldmonitor.app/chokepoints/dover-strait/)** | Green | Europe's busiest shipping lane, currently stable |
 
 Each corridor shows live vessel counts, week-over-week traffic changes, disruption percentages, and risk levels. When you click a corridor, you get the full AI-generated situation assessment with specific shipping recommendations.
 
@@ -1278,7 +1278,7 @@ About 20% of global petroleum liquids consumption and a major share of LNG trade
 
 **What are the world's most critical shipping chokepoints?**
 
-World Monitor monitors its canonical waterway registry, including Hormuz, Malacca, Suez/SUMED, Bab el-Mandeb, Panama, Taiwan, Cape of Good Hope, Gibraltar, Bosporus, Korea, Dover, Kerch, and Lombok. Entries with EIA-backed oil or gas baselines publish flow estimates; every entry can carry traffic, warning, threat, and disruption context. See the [maritime chokepoint methodology](/blog/posts/what-is-a-maritime-chokepoint/) for the registry and coverage limits.
+World Monitor monitors its canonical waterway registry, including Hormuz, Malacca, Suez/SUMED, Bab el-Mandeb, Panama, Taiwan, Cape of Good Hope, [Gibraltar](https://www.worldmonitor.app/chokepoints/strait-of-gibraltar/), Bosporus, Korea, Dover, Kerch, and Lombok. Entries with EIA-backed oil or gas baselines publish flow estimates; every entry can carry traffic, warning, threat, and disruption context. See the [maritime chokepoint methodology](/blog/posts/what-is-a-maritime-chokepoint/) for the registry and coverage limits.
 
 ---
 
@@ -1294,6 +1294,8 @@ WorldMonitor helps energy analysts watch the chain before it becomes one number 
 This is a practical workflow for monitoring energy-shock risk.
 
 For a worked example, open the [Strait of Hormuz tracker](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) to inspect its latest published transit and disruption readings. The [historical Strait of Hormuz Transit Report for July 2026](https://www.worldmonitor.app/research/strait-of-hormuz-transit-report-2026-07/) provides a dated comparison with Suez, Bab el-Mandeb, and the Cape of Good Hope. Its figures describe that report's observation period, not current traffic.
+
+For country context, open the [Iran](https://www.worldmonitor.app/countries/iran/) and [Oman](https://www.worldmonitor.app/countries/oman/) profiles. The [Gulf security tracker](https://www.worldmonitor.app/crises/hormuz-gulf-security/) summarizes conflict data for its stated regional coverage. The separate [Iran–Israel escalation tracker](https://www.worldmonitor.app/crises/iran-israel-escalation/) covers those two countries only.
 
 <a id="corpus-what-is-energy-shock-monitoring"></a>
 ## What is energy shock monitoring?

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -739,6 +739,8 @@ here, and who would feel it?**
 <a id="corpus-what-a-chokepoint-row-tells-you"></a>
 ### What a chokepoint row tells you
 
+Open the [Strait of Hormuz tracker](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) for a worked example. Read its published disruption score, available inputs, and observation dates alongside the method below.
+
 Each waterway carries four separate readings, and it is worth keeping them
 apart:
 
@@ -1290,6 +1292,8 @@ An energy shock rarely starts as a chart. It starts as a closure rumor, a tanker
 WorldMonitor helps energy analysts watch the chain before it becomes one number on a terminal: maritime chokepoints, fuel shortages, energy disruptions, commodity prices, country risk, news intelligence, and policy response. For the route side of the problem, start with the guide to [tracking chokepoints and freight costs](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/); for the market side, pair it with [real-time market intelligence for traders](/blog/posts/real-time-market-intelligence-for-traders-and-analysts/).
 
 This is a practical workflow for monitoring energy-shock risk.
+
+For a worked example, open the [Strait of Hormuz tracker](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) to inspect its latest published transit and disruption readings. The [historical Strait of Hormuz Transit Report for July 2026](https://www.worldmonitor.app/research/strait-of-hormuz-transit-report-2026-07/) provides a dated comparison with Suez, Bab el-Mandeb, and the Cape of Good Hope. Its figures describe that report's observation period, not current traffic.
 
 <a id="corpus-what-is-energy-shock-monitoring"></a>
 ## What is energy shock monitoring?

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1038,19 +1038,19 @@ WorldMonitor's canonical chokepoint registry includes:
 
 | Canonical id | Public name |
 |---|---|
-| `hormuz_strait` | Strait of Hormuz |
-| `malacca_strait` | Strait of Malacca |
-| `suez` | Suez Canal / SUMED |
-| `bab_el_mandeb` | Bab el-Mandeb |
-| `panama` | Panama Canal |
-| `taiwan_strait` | Taiwan Strait |
-| `cape_of_good_hope` | Cape of Good Hope |
-| `gibraltar` | Strait of Gibraltar |
-| `bosphorus` | Bosporus Strait |
-| `korea_strait` | Korea Strait |
-| `dover_strait` | Dover Strait |
-| `kerch_strait` | Kerch Strait |
-| `lombok_strait` | Lombok Strait |
+| `hormuz_strait` | [Strait of Hormuz](https://www.worldmonitor.app/chokepoints/strait-of-hormuz/) |
+| `malacca_strait` | [Strait of Malacca](https://www.worldmonitor.app/chokepoints/strait-of-malacca/) |
+| `suez` | [Suez Canal / SUMED](https://www.worldmonitor.app/chokepoints/suez-canal/) |
+| `bab_el_mandeb` | [Bab el-Mandeb](https://www.worldmonitor.app/chokepoints/bab-el-mandeb/) |
+| `panama` | [Panama Canal](https://www.worldmonitor.app/chokepoints/panama-canal/) |
+| `taiwan_strait` | [Taiwan Strait](https://www.worldmonitor.app/chokepoints/taiwan-strait/) |
+| `cape_of_good_hope` | [Cape of Good Hope](https://www.worldmonitor.app/chokepoints/cape-of-good-hope/) |
+| `gibraltar` | [Strait of Gibraltar](https://www.worldmonitor.app/chokepoints/strait-of-gibraltar/) |
+| `bosphorus` | [Bosporus Strait](https://www.worldmonitor.app/chokepoints/bosporus-strait/) |
+| `korea_strait` | [Korea Strait](https://www.worldmonitor.app/chokepoints/korea-strait/) |
+| `dover_strait` | [Dover Strait](https://www.worldmonitor.app/chokepoints/dover-strait/) |
+| `kerch_strait` | [Kerch Strait](https://www.worldmonitor.app/chokepoints/kerch-strait/) |
+| `lombok_strait` | [Lombok Strait](https://www.worldmonitor.app/chokepoints/lombok-strait/) |
 
 All 13 can receive status, threat classification, warning context, AIS-disruption matching, disruption score, and war-risk tier.
 

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -173,7 +173,7 @@ const AVAILABLE_EVIDENCE_LIMIT = 6;
 // This floor is published on country pages, so keep it aligned with
 // docs/methodology/country-resilience-index.mdx#supported-readings-on-unranked-country-pages.
 export const SUPPORTED_READING_MIN_COVERAGE = 0.5;
-export const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-09-04';
+export const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-09-10';
 const SOURCES_PAGE_CONTENT_VERSION = '2026-08-20';
 // Dataset schema versions stamp Dataset JSON-LD shape changes, per family. They
 // must NOT fold into every family's sitemap/page lastmod — that made ~90% of main
@@ -188,12 +188,12 @@ export const DATASET_SCHEMA_CONTENT_VERSION = {
   crisis: '2026-09-03',
   tools: '2026-09-03',
 };
-export const CRISIS_PAGE_CONTENT_VERSION = '2026-09-03';
+export const CRISIS_PAGE_CONTENT_VERSION = '2026-09-10';
 // TOOLS_PAGE_CONTENT_VERSION and RESEARCH_PAGE_CONTENT_VERSION are exported
 // for the same reason as the constants above: the #7533 guard recomputes
 // their families' clocks from the real values.
 export const TOOLS_PAGE_CONTENT_VERSION = '2026-09-03';
-export const RESEARCH_PAGE_CONTENT_VERSION = '2026-09-03';
+export const RESEARCH_PAGE_CONTENT_VERSION = '2026-09-10';
 const DATASET_LICENSE = {
   '@type': 'CreativeWork',
   name: 'World Monitor Terms of Service (27 July 2026)',
@@ -4120,8 +4120,11 @@ function renderChokepointPage({
 
   const relatedItems = [];
   for (const { report } of researchReports) {
-    if (report.focusChokepointId === chokepoint.id) {
-      relatedItems.push(`<a href="/research/${report.slug}/">${escapeHtml(report.title)}</a>`);
+    const role = report.focusChokepointId === chokepoint.id
+      ? 'Focus'
+      : report.contextChokepointIds.includes(chokepoint.id) ? 'Comparison' : null;
+    if (role) {
+      relatedItems.push(`${role} in historical research published ${escapeHtml(report.datePublished)}: <a href="/research/${report.slug}/">${escapeHtml(report.title)}</a>`);
     }
   }
   if (content.glossarySlug) {
@@ -4381,6 +4384,7 @@ ${crises.map((crisis) => `        <a class="card" href="/crises/${escapeHtml(cri
 
 function renderCrisisPage({
   crisis,
+  countrySlugByCode,
   baseUrl,
   lastmod,
   livePulse = null,
@@ -4410,11 +4414,15 @@ function renderCrisisPage({
     fallback,
   );
   const countryRows = crisis.coverage.map((country) => {
+    const slug = countrySlugByCode.get(country.code);
+    const name = slug
+      ? `<a href="/countries/${escapeHtml(slug)}/">${escapeHtml(country.name)}</a>`
+      : escapeHtml(country.name);
     const row = rowByCode.get(country.code);
     const value = row
       ? `${formatCount(row.events, OBSERVED_EVIDENCE)} events · ${formatCount(row.fatalities, OBSERVED_EVIDENCE)} fatalities · ${row.referencePeriod}`
       : (hasPulse ? 'Unavailable' : 'Waiting for published pulse');
-    return `          <li data-crisis-country data-country-code="${escapeHtml(country.code)}" data-country-name="${escapeHtml(country.name)}"><strong>${escapeHtml(country.name)}</strong><br><span data-crisis-country-value>${escapeHtml(value)}</span></li>`;
+    return `          <li data-crisis-country data-country-code="${escapeHtml(country.code)}" data-country-name="${escapeHtml(country.name)}"><strong>${name}</strong><br><span data-crisis-country-value>${escapeHtml(value)}</span></li>`;
   }).join('\n');
   const liveGrid = hasPulse
     ? `        <div class="grid" data-live-grid aria-label="Current crisis metrics" aria-busy="false">
@@ -5052,6 +5060,7 @@ export async function buildCorpus({
   livePulseSnapshotPath,
 } = {}) {
   const data = await loadCorpusData({ rootDir, livePulseSnapshotPath });
+  const countrySlugByCode = new Map(data.countries.map((country) => [country.code, country.slug]));
   if (clean) {
     for (const dir of GENERATED_DIRS) {
       rmSync(join(outDir, dir), { recursive: true, force: true });
@@ -5370,6 +5379,7 @@ export async function buildCorpus({
       routeFile(pagePath),
       renderCrisisPage({
         crisis,
+        countrySlugByCode,
         baseUrl,
         lastmod: data.lastmod.crises,
         livePulse: data.livePulse,

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -1254,7 +1254,7 @@ function normalizeChokepoints(entries) {
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
 }
 
-export function buildChokepointPageLinks({ chokepoints, countries, crises, content = CHOKEPOINT_CONTENT }) {
+export function buildChokepointPageLinks({ chokepoints, countries, crises, blogPostPaths = new Set(), content = CHOKEPOINT_CONTENT }) {
   const countryByCode = new Map(countries.map((country) => [country.code, country]));
   const crisisBySlug = new Map(crises.map((crisis) => [crisis.slug, crisis]));
   const byChokepointId = new Map();
@@ -1262,6 +1262,15 @@ export function buildChokepointPageLinks({ chokepoints, countries, crises, conte
   const byCrisisSlug = new Map();
   for (const chokepoint of chokepoints) {
     const declaration = content[chokepoint.id] || {};
+    const editorialLinks = declaration.editorialLinks ?? [];
+    if (!Array.isArray(editorialLinks)) throw new Error(`${chokepoint.id}: editorialLinks must be an array`);
+    const editorial = new Map();
+    for (const link of editorialLinks) {
+      if (!blogPostPaths.has(link?.href) || typeof link.label !== 'string' || !link.label.trim()) {
+        throw new Error(`${chokepoint.id}: editorialLinks requires a canonical blog post path and label: ${link?.href}`);
+      }
+      if (!editorial.has(link.href)) editorial.set(link.href, link);
+    }
     const resolve = (field, targets, inverse) => {
       const ids = declaration[field] ?? [];
       if (!Array.isArray(ids)) throw new Error(`${chokepoint.id}: ${field} must be an array`);
@@ -1277,6 +1286,7 @@ export function buildChokepointPageLinks({ chokepoints, countries, crises, conte
     byChokepointId.set(chokepoint.id, {
       countries: resolve('countryCodes', countryByCode, byCountryCode),
       crises: resolve('crisisSlugs', crisisBySlug, byCrisisSlug),
+      editorial: [...editorial.values()],
     });
   }
   return { byChokepointId, byCountryCode, byCrisisSlug };
@@ -4123,6 +4133,7 @@ function renderChokepointPage({
   chokepoint,
   relatedCountries = [],
   relatedCrises = [],
+  editorialLinks = [],
   baseUrl,
   lastmod,
   tradeRoutesById,
@@ -4171,6 +4182,9 @@ function renderChokepointPage({
     relatedItems.push(`<a href="/blog/glossary/${content.glossarySlug}/">${escapeHtml(chokepoint.displayName)} in the glossary</a>`);
   }
   relatedItems.push('<a href="/blog/glossary/maritime-chokepoint/">What is a maritime chokepoint?</a>');
+  for (const link of editorialLinks) {
+    relatedItems.push(`<a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a>`);
+  }
 
   const pulse = livePulse?.chokepoints?.[chokepoint.id] || null;
   const hasPulse = hasObservedValue(pulse?.disruptionScore, { coverage: pulse != null });
@@ -5111,7 +5125,12 @@ export async function buildCorpus({
 } = {}) {
   const data = await loadCorpusData({ rootDir, livePulseSnapshotPath });
   const countrySlugByCode = new Map(data.countries.map((country) => [country.code, country.slug]));
-  const chokepointPageLinks = buildChokepointPageLinks(data);
+  const chokepointPageLinks = buildChokepointPageLinks({
+    ...data,
+    blogPostPaths: new Set(readdirSync(join(rootDir, 'blog-site/src/content/blog'))
+      .filter((file) => file.endsWith('.md'))
+      .map((file) => `/blog/posts/${file.slice(0, -3)}/`)),
+  });
   if (clean) {
     for (const dir of GENERATED_DIRS) {
       rmSync(join(outDir, dir), { recursive: true, force: true });
@@ -5319,6 +5338,7 @@ export async function buildCorpus({
         chokepoint,
         relatedCountries: chokepointPageLinks.byChokepointId.get(chokepoint.id).countries,
         relatedCrises: chokepointPageLinks.byChokepointId.get(chokepoint.id).crises,
+        editorialLinks: chokepointPageLinks.byChokepointId.get(chokepoint.id).editorial,
         baseUrl,
         lastmod: data.lastmod.chokepoints,
         tradeRoutesById: data.tradeRoutesById,

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -148,7 +148,7 @@ export const COMPARISON_PAGE_LASTMOD_PATHS = Object.freeze([
 // families take the later of this version and their own committed source date,
 // so template changes are reflected without pretending every deploy is fresh.
 export const CORPUS_GENERATOR_CONTENT_VERSION = '2026-09-01';
-export const COUNTRY_PAGE_CONTENT_VERSION = '2026-09-08';
+export const COUNTRY_PAGE_CONTENT_VERSION = '2026-09-10';
 export const CII_COUNTRY_PAGE_CONTENT_VERSION = '2026-09-03';
 // Exported so the #7533 guard test can recompute every family clock without
 // re-implementing the version constants themselves.
@@ -1252,6 +1252,42 @@ function normalizeChokepoints(entries) {
     }))
     .filter((entry) => entry.id && entry.displayName)
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+export function buildChokepointPageLinks({ chokepoints, countries, crises, content = CHOKEPOINT_CONTENT }) {
+  const countryByCode = new Map(countries.map((country) => [country.code, country]));
+  const crisisBySlug = new Map(crises.map((crisis) => [crisis.slug, crisis]));
+  const byChokepointId = new Map();
+  const byCountryCode = new Map();
+  const byCrisisSlug = new Map();
+  for (const chokepoint of chokepoints) {
+    const declaration = content[chokepoint.id] || {};
+    const resolve = (field, targets, inverse) => {
+      const ids = declaration[field] ?? [];
+      if (!Array.isArray(ids)) throw new Error(`${chokepoint.id}: ${field} must be an array`);
+      return [...new Set(ids)].map((id) => {
+        const target = targets.get(id);
+        if (!target) throw new Error(`${chokepoint.id}: ${field} contains unknown target ${id}`);
+        const entries = inverse.get(id) || [];
+        entries.push(chokepoint);
+        inverse.set(id, entries);
+        return target;
+      });
+    };
+    byChokepointId.set(chokepoint.id, {
+      countries: resolve('countryCodes', countryByCode, byCountryCode),
+      crises: resolve('crisisSlugs', crisisBySlug, byCrisisSlug),
+    });
+  }
+  return { byChokepointId, byCountryCode, byCrisisSlug };
+}
+
+function renderRelatedChokepoints(chokepoints) {
+  if (!chokepoints.length) return '';
+  return `      <h2>Related chokepoint trackers</h2>
+      <ul class="related">
+${chokepoints.map((chokepoint) => `        <li><a href="/chokepoints/${escapeHtml(chokepoint.slug)}/">${escapeHtml(chokepoint.displayName)} tracker</a></li>`).join('\n')}
+      </ul>`;
 }
 
 function normalizeCountry(item, sourceStatus, seen, reverseNames) {
@@ -3494,6 +3530,7 @@ export function snapshotAttemptedCountryIndex(livePulse) {
 
 export function renderCountryPage({
   country,
+  relatedChokepoints = [],
   baseUrl,
   capturedAt,
   lastmod,
@@ -3597,6 +3634,7 @@ ${renderCountryDevelopments({ countryCode: country.code, countryName: country.na
         <div class="metric"><span>Confidence</span><strong>${country.lowConfidence ? 'Low' : 'Standard'}</strong></div>
       </section>${scoreDisclosure}
 ${analysis.html}
+${renderRelatedChokepoints(relatedChokepoints)}
 ${analysis.readingGuide ? `      <h2>How to use this evidence</h2>
       <p>${escapeHtml(analysis.readingGuide)} <a href="/docs/methodology/country-resilience-index">Full CRI method</a> · <a href="/docs/corrections">revision log</a>.</p>` : `      <h2>How to read this page</h2>
       <p>The 0-100 index records the ${escapeHtml(prettyDate(capturedAt))} snapshot under ${escapeHtml(methodologyFormula)}. See the <a href="/docs/methodology/country-resilience-index">Country Resilience Index methodology</a> for dimensions, sources and confidence rules. Published revisions that affect ${escapeHtml(country.name)} are in the <a href="/docs/corrections">corrections log</a>.</p>
@@ -4083,6 +4121,8 @@ function optionalChokepointMetric(label, attribute, value, available) {
 
 function renderChokepointPage({
   chokepoint,
+  relatedCountries = [],
+  relatedCrises = [],
   baseUrl,
   lastmod,
   tradeRoutesById,
@@ -4231,6 +4271,14 @@ ${liveGrid}
 ${tiles}
       </section>
 ${analysis.html}
+${relatedCountries.length ? `      <h2>Related country profiles</h2>
+      <ul class="related">
+${relatedCountries.map((country) => `        <li><a href="/countries/${escapeHtml(country.slug)}/">${escapeHtml(country.name)} country profile</a></li>`).join('\n')}
+      </ul>` : ''}
+${relatedCrises.length ? `      <h2>Crisis context</h2>
+      <ul class="related">
+${relatedCrises.map((crisis) => `        <li><a href="/crises/${escapeHtml(crisis.slug)}/">${escapeHtml(crisis.title)}</a></li>`).join('\n')}
+      </ul>` : ''}
       <h2>Related</h2>
       <ul class="related">
 ${relatedItems.map((item) => `        <li>${item}</li>`).join('\n')}
@@ -4385,6 +4433,7 @@ ${crises.map((crisis) => `        <a class="card" href="/crises/${escapeHtml(cri
 function renderCrisisPage({
   crisis,
   countrySlugByCode,
+  relatedChokepoints = [],
   baseUrl,
   lastmod,
   livePulse = null,
@@ -4480,6 +4529,7 @@ ${countryRows}
 ${snapshotSection}
       <h2>Coverage boundary</h2>
       <p>${escapeHtml(crisis.coverage.map((country) => `${country.name} (${country.code})`).join(', '))}. Events outside this list are not included in the live totals on this page.</p>
+${renderRelatedChokepoints(relatedChokepoints)}
       <h2>How to read this tracker</h2>
       <p>Use these monthly country summaries as a bounded pulse, then inspect the dashboard for event-level context, map layers, and other independent signals. The figures are not forecasts and should not be interpreted as a complete casualty or incident ledger.</p>
       <p class="source">Download: <a href="${escapeHtml(datasetDownloadHref(path, CRISIS_DATASET_DOWNLOAD))}">${CRISIS_DATASET_DOWNLOAD}</a>. Scope source: <a href="${CRISIS_REGISTRY_URL}">${CRISIS_REGISTRY_PATH}</a>. Maintained metrics: HAPI/HDX humanitarian conflict summaries from the UN OCHA <a href="https://data.humdata.org/hapi">Humanitarian API</a>.</p>`;
@@ -5061,6 +5111,7 @@ export async function buildCorpus({
 } = {}) {
   const data = await loadCorpusData({ rootDir, livePulseSnapshotPath });
   const countrySlugByCode = new Map(data.countries.map((country) => [country.code, country.slug]));
+  const chokepointPageLinks = buildChokepointPageLinks(data);
   if (clean) {
     for (const dir of GENERATED_DIRS) {
       rmSync(join(outDir, dir), { recursive: true, force: true });
@@ -5178,6 +5229,7 @@ export async function buildCorpus({
       routeFile(pagePath),
       renderCountryPage({
         country,
+        relatedChokepoints: chokepointPageLinks.byCountryCode.get(country.code),
         baseUrl,
         capturedAt: data.resilience.capturedAt,
         lastmod: ciiEntry
@@ -5265,6 +5317,8 @@ export async function buildCorpus({
       routeFile(pagePath),
       renderChokepointPage({
         chokepoint,
+        relatedCountries: chokepointPageLinks.byChokepointId.get(chokepoint.id).countries,
+        relatedCrises: chokepointPageLinks.byChokepointId.get(chokepoint.id).crises,
         baseUrl,
         lastmod: data.lastmod.chokepoints,
         tradeRoutesById: data.tradeRoutesById,
@@ -5380,6 +5434,7 @@ export async function buildCorpus({
       renderCrisisPage({
         crisis,
         countrySlugByCode,
+        relatedChokepoints: chokepointPageLinks.byCrisisSlug.get(crisis.slug),
         baseUrl,
         lastmod: data.lastmod.crises,
         livePulse: data.livePulse,

--- a/scripts/build-research-reports.mjs
+++ b/scripts/build-research-reports.mjs
@@ -700,7 +700,7 @@ export function renderResearchReportPage({
   tpl,
   baseUrl,
   lastmod,
-  chokepointSlug,
+  chokepointSlugById,
   dataCatalog,
   includedInDataCatalog,
 }) {
@@ -709,11 +709,17 @@ export function renderResearchReportPage({
   if (!SLUG_PATTERN.test(report.slug) || !SLUG_PATTERN.test(report.id)) {
     throw new Error(`Report slug/id must match ${SLUG_PATTERN}: ${report.slug} / ${report.id}`);
   }
-  if (!chokepointSlug) {
-    throw new Error(
-      `Report ${report.id}: focusChokepointId ${report.focusChokepointId} has no entry in the chokepoint registry — refusing to render a /chokepoints/undefined/ handoff link`,
-    );
+  for (const [role, ids] of [
+    ['focusChokepointId', [report.focusChokepointId]],
+    ['contextChokepointId', report.contextChokepointIds],
+  ]) {
+    for (const id of ids) {
+      if (!SLUG_PATTERN.test(chokepointSlugById.get(id) ?? '')) {
+        throw new Error(`Report ${report.id}: ${role} ${id} has no valid route in the chokepoint registry`);
+      }
+    }
   }
+  const chokepointSlug = chokepointSlugById.get(report.focusChokepointId);
   const path = `/research/${report.slug}/`;
   const canonical = absoluteUrl(baseUrl, path);
   const focus = snapshot.chokepoints[report.focusChokepointId];
@@ -747,11 +753,11 @@ ${monthly.map((row) => `          <tr><td>${monthLabel(row.month)}${row.month ==
         </tbody>
       </table></div>`;
 
-  const contextRows = report.contextChokepointIds.map((id) => {
+  const contextRows = [...new Set(report.contextChokepointIds)].map((id) => {
     const chokepoint = snapshot.chokepoints[id];
     const history = chokepoint.history;
     const cell = (start, end) => round1(mean(inRange(history, start, end), 'total')).toFixed(1);
-    return `          <tr><td>${escapeHtml(chokepoint.portwatchName)}</td><td>${cell('2025-01-01', '2025-12-31')}</td><td>${cell('2026-02-01', '2026-02-28')}</td><td>${cell('2026-06-01', '2026-06-30')}</td><td>${cell('2026-07-01', focus.observationEnd)}</td></tr>`;
+    return `          <tr><td><a href="/chokepoints/${escapeHtml(chokepointSlugById.get(id))}/">${escapeHtml(chokepoint.portwatchName)}</a></td><td>${cell('2025-01-01', '2025-12-31')}</td><td>${cell('2026-02-01', '2026-02-28')}</td><td>${cell('2026-06-01', '2026-06-30')}</td><td>${cell('2026-07-01', focus.observationEnd)}</td></tr>`;
   }).join('\n');
   const contextTable = `<div style="overflow-x:auto"><table>
         <caption>Context chokepoints: average daily transits (same snapshot, same units)</caption>
@@ -1026,7 +1032,7 @@ export function writeResearchSection({ data, outDir, baseUrl, tpl, dataCatalog, 
         tpl,
         baseUrl,
         lastmod: data.lastmod.research,
-        chokepointSlug: chokepointSlugById.get(report.focusChokepointId),
+        chokepointSlugById,
         dataCatalog,
         includedInDataCatalog,
       }),

--- a/scripts/chokepoint-page-content.mjs
+++ b/scripts/chokepoint-page-content.mjs
@@ -45,6 +45,8 @@ export const EIA_OIL_TRANSIT_BASELINES = buildEiaOilTransitBaselines();
 
 export const CHOKEPOINT_CONTENT = {
   suez: {
+    countryCodes: ['EG'],
+    crisisSlugs: ['red-sea-security'],
     region: 'Mediterranean ↔ Red Sea',
     glossarySlug: 'suez-canal',
     blurb:
@@ -68,6 +70,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   malacca_strait: {
+    countryCodes: ['MY', 'ID', 'SG'],
     region: 'Indian Ocean ↔ South China Sea',
     glossarySlug: 'strait-of-malacca',
     whyHeading: 'Why is the Strait of Malacca East Asia’s default energy and container gate?',
@@ -92,7 +95,7 @@ export const CHOKEPOINT_CONTENT = {
   },
   hormuz_strait: {
     countryCodes: ['IR', 'OM', 'BH', 'KW', 'QA', 'SA', 'AE'],
-    crisisSlugs: ['hormuz-gulf-security'],
+    crisisSlugs: ['hormuz-gulf-security', 'iran-israel-escalation'],
     editorialLinks: [
       { href: '/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/', label: 'How to monitor energy shocks across chokepoints, fuel, and markets' },
     ],
@@ -119,6 +122,8 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   bab_el_mandeb: {
+    countryCodes: ['YE', 'DJ', 'ER'],
+    crisisSlugs: ['red-sea-security'],
     region: 'Red Sea ↔ Gulf of Aden',
     whyHeading: 'Why do Suez sailings also have to clear Bab el-Mandeb?',
     blurb:
@@ -141,6 +146,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   panama: {
+    countryCodes: ['PA'],
     region: 'Atlantic ↔ Pacific',
     whyHeading: 'Why can drought close the Panama Canal when both oceans are open?',
     blurb:
@@ -163,6 +169,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   taiwan_strait: {
+    countryCodes: ['TW', 'CN'],
     region: 'East China Sea ↔ South China Sea',
     whyHeading: 'Why does military tension in the Taiwan Strait hit containers first?',
     blurb:
@@ -185,6 +192,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   cape_of_good_hope: {
+    countryCodes: ['ZA'],
     region: 'Atlantic ↔ Indian Ocean',
     whyHeading: 'When is the Cape of Good Hope a chokepoint rather than just a longer road?',
     blurb:
@@ -207,6 +215,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   gibraltar: {
+    countryCodes: ['ES', 'MA'],
     region: 'Atlantic ↔ Mediterranean',
     whyHeading: 'Why does every Suez–Europe loop still have to use Gibraltar?',
     blurb:
@@ -229,6 +238,8 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   bosphorus: {
+    countryCodes: ['TR'],
+    crisisSlugs: ['ukraine-war'],
     region: 'Black Sea ↔ Sea of Marmara',
     whyHeading: 'Why can the Montreux Convention close the Bosporus to more than grain?',
     blurb:
@@ -251,6 +262,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   korea_strait: {
+    countryCodes: ['KR', 'JP'],
     region: 'East China Sea ↔ Sea of Japan',
     whyHeading: 'Why watch the Korea Strait if no modelled trade corridor is mapped?',
     blurb:
@@ -273,6 +285,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   dover_strait: {
+    countryCodes: ['GB', 'FR'],
     region: 'English Channel ↔ North Sea',
     whyHeading: 'Why is Dover among the busiest lanes if World Monitor maps no corridor row?',
     blurb:
@@ -295,6 +308,8 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   kerch_strait: {
+    countryCodes: ['UA', 'RU'],
+    crisisSlugs: ['ukraine-war'],
     region: 'Black Sea ↔ Sea of Azov',
     whyHeading: 'Why does control of the Kerch Strait gate Azov-basin trade?',
     blurb:
@@ -317,6 +332,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   lombok_strait: {
+    countryCodes: ['ID'],
     region: 'Indian Ocean ↔ Java Sea',
     whyHeading: 'When do ships choose Lombok instead of Malacca?',
     blurb:

--- a/scripts/chokepoint-page-content.mjs
+++ b/scripts/chokepoint-page-content.mjs
@@ -43,8 +43,14 @@ export const TRADE_ROUTES_OBSERVED_AT = '2026-03-14';
 
 export const EIA_OIL_TRANSIT_BASELINES = buildEiaOilTransitBaselines();
 
+const MARITIME_EXPLAINER = {
+  href: '/blog/posts/what-is-a-maritime-chokepoint/',
+  label: 'How maritime chokepoints are monitored and scored',
+};
+
 export const CHOKEPOINT_CONTENT = {
   suez: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['EG'],
     crisisSlugs: ['red-sea-security'],
     region: 'Mediterranean ↔ Red Sea',
@@ -70,6 +76,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   malacca_strait: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['MY', 'ID', 'SG'],
     region: 'Indian Ocean ↔ South China Sea',
     glossarySlug: 'strait-of-malacca',
@@ -97,6 +104,7 @@ export const CHOKEPOINT_CONTENT = {
     countryCodes: ['IR', 'OM', 'BH', 'KW', 'QA', 'SA', 'AE'],
     crisisSlugs: ['hormuz-gulf-security', 'iran-israel-escalation'],
     editorialLinks: [
+      MARITIME_EXPLAINER,
       { href: '/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/', label: 'How to monitor energy shocks across chokepoints, fuel, and markets' },
     ],
     region: 'Persian Gulf ↔ Gulf of Oman',
@@ -122,6 +130,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   bab_el_mandeb: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['YE', 'DJ', 'ER'],
     crisisSlugs: ['red-sea-security'],
     region: 'Red Sea ↔ Gulf of Aden',
@@ -146,6 +155,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   panama: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['PA'],
     region: 'Atlantic ↔ Pacific',
     whyHeading: 'Why can drought close the Panama Canal when both oceans are open?',
@@ -169,6 +179,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   taiwan_strait: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['TW', 'CN'],
     region: 'East China Sea ↔ South China Sea',
     whyHeading: 'Why does military tension in the Taiwan Strait hit containers first?',
@@ -192,6 +203,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   cape_of_good_hope: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['ZA'],
     region: 'Atlantic ↔ Indian Ocean',
     whyHeading: 'When is the Cape of Good Hope a chokepoint rather than just a longer road?',
@@ -215,6 +227,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   gibraltar: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['ES', 'MA'],
     region: 'Atlantic ↔ Mediterranean',
     whyHeading: 'Why does every Suez–Europe loop still have to use Gibraltar?',
@@ -238,6 +251,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   bosphorus: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['TR'],
     crisisSlugs: ['ukraine-war'],
     region: 'Black Sea ↔ Sea of Marmara',
@@ -262,6 +276,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   korea_strait: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['KR', 'JP'],
     region: 'East China Sea ↔ Sea of Japan',
     whyHeading: 'Why watch the Korea Strait if no modelled trade corridor is mapped?',
@@ -285,6 +300,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   dover_strait: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['GB', 'FR'],
     region: 'English Channel ↔ North Sea',
     whyHeading: 'Why is Dover among the busiest lanes if World Monitor maps no corridor row?',
@@ -308,6 +324,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   kerch_strait: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['UA', 'RU'],
     crisisSlugs: ['ukraine-war'],
     region: 'Black Sea ↔ Sea of Azov',
@@ -332,6 +349,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   lombok_strait: {
+    editorialLinks: [MARITIME_EXPLAINER],
     countryCodes: ['ID'],
     region: 'Indian Ocean ↔ Java Sea',
     whyHeading: 'When do ships choose Lombok instead of Malacca?',

--- a/scripts/chokepoint-page-content.mjs
+++ b/scripts/chokepoint-page-content.mjs
@@ -93,6 +93,9 @@ export const CHOKEPOINT_CONTENT = {
   hormuz_strait: {
     countryCodes: ['IR', 'OM'],
     crisisSlugs: ['hormuz-gulf-security'],
+    editorialLinks: [
+      { href: '/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/', label: 'How to monitor energy shocks across chokepoints, fuel, and markets' },
+    ],
     region: 'Persian Gulf ↔ Gulf of Oman',
     glossarySlug: 'strait-of-hormuz',
     whyHeading: 'Why is the Strait of Hormuz the most watched energy chokepoint?',

--- a/scripts/chokepoint-page-content.mjs
+++ b/scripts/chokepoint-page-content.mjs
@@ -91,6 +91,8 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   hormuz_strait: {
+    countryCodes: ['IR', 'OM'],
+    crisisSlugs: ['hormuz-gulf-security'],
     region: 'Persian Gulf ↔ Gulf of Oman',
     glossarySlug: 'strait-of-hormuz',
     whyHeading: 'Why is the Strait of Hormuz the most watched energy chokepoint?',

--- a/scripts/chokepoint-page-content.mjs
+++ b/scripts/chokepoint-page-content.mjs
@@ -48,9 +48,44 @@ const MARITIME_EXPLAINER = {
   label: 'How maritime chokepoints are monitored and scored',
 };
 
+const TRADE_ROUTE_GUIDE = {
+  href: '/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/',
+  label: 'How to track trade routes and freight costs',
+};
+
+const EARLY_WARNING_TUTORIAL = {
+  href: '/blog/posts/build-supply-chain-early-warning-system-api/',
+  label: 'Build supply-chain alerts with the API',
+};
+
+const SUPPLY_CHAIN_DASHBOARD = {
+  href: '/blog/posts/supply-chain-early-warning-dashboard-worldmonitor-api/',
+  label: 'Design a supply-chain early-warning dashboard',
+};
+
+const SCENARIO_GUIDE = {
+  href: '/blog/posts/stress-test-supply-chain-scenario-engine-worldmonitor/',
+  label: 'Stress-test supply chains with scenarios',
+};
+
+const COMMODITY_GUIDE = {
+  href: '/blog/posts/monitor-global-supply-chains-and-commodity-disruptions/',
+  label: 'Monitor supply chains and commodity disruptions',
+};
+
+const COUNTRY_RISK_WORKFLOW = {
+  href: '/blog/posts/country-risk-monitoring-workflow-for-analysts/',
+  label: 'Apply the country-risk monitoring workflow',
+};
+
+const CONFLICT_GUIDE = {
+  href: '/blog/posts/track-global-conflicts-in-real-time/',
+  label: 'Monitor conflicts across strategic theaters',
+};
+
 export const CHOKEPOINT_CONTENT = {
   suez: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, TRADE_ROUTE_GUIDE, EARLY_WARNING_TUTORIAL, SUPPLY_CHAIN_DASHBOARD, SCENARIO_GUIDE, COMMODITY_GUIDE, COUNTRY_RISK_WORKFLOW],
     countryCodes: ['EG'],
     crisisSlugs: ['red-sea-security'],
     region: 'Mediterranean ↔ Red Sea',
@@ -76,7 +111,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   malacca_strait: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, SUPPLY_CHAIN_DASHBOARD],
     countryCodes: ['MY', 'ID', 'SG'],
     region: 'Indian Ocean ↔ South China Sea',
     glossarySlug: 'strait-of-malacca',
@@ -105,6 +140,11 @@ export const CHOKEPOINT_CONTENT = {
     crisisSlugs: ['hormuz-gulf-security', 'iran-israel-escalation'],
     editorialLinks: [
       MARITIME_EXPLAINER,
+      TRADE_ROUTE_GUIDE,
+      EARLY_WARNING_TUTORIAL,
+      SUPPLY_CHAIN_DASHBOARD,
+      SCENARIO_GUIDE,
+      CONFLICT_GUIDE,
       { href: '/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/', label: 'How to monitor energy shocks across chokepoints, fuel, and markets' },
     ],
     region: 'Persian Gulf ↔ Gulf of Oman',
@@ -130,7 +170,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   bab_el_mandeb: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, TRADE_ROUTE_GUIDE, EARLY_WARNING_TUTORIAL, SUPPLY_CHAIN_DASHBOARD, SCENARIO_GUIDE],
     countryCodes: ['YE', 'DJ', 'ER'],
     crisisSlugs: ['red-sea-security'],
     region: 'Red Sea ↔ Gulf of Aden',
@@ -155,7 +195,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   panama: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, SUPPLY_CHAIN_DASHBOARD, SCENARIO_GUIDE],
     countryCodes: ['PA'],
     region: 'Atlantic ↔ Pacific',
     whyHeading: 'Why can drought close the Panama Canal when both oceans are open?',
@@ -179,7 +219,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   taiwan_strait: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, TRADE_ROUTE_GUIDE, SCENARIO_GUIDE, COUNTRY_RISK_WORKFLOW, CONFLICT_GUIDE],
     countryCodes: ['TW', 'CN'],
     region: 'East China Sea ↔ South China Sea',
     whyHeading: 'Why does military tension in the Taiwan Strait hit containers first?',
@@ -203,7 +243,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   cape_of_good_hope: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, TRADE_ROUTE_GUIDE, EARLY_WARNING_TUTORIAL, COMMODITY_GUIDE],
     countryCodes: ['ZA'],
     region: 'Atlantic ↔ Indian Ocean',
     whyHeading: 'When is the Cape of Good Hope a chokepoint rather than just a longer road?',
@@ -227,7 +267,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   gibraltar: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, TRADE_ROUTE_GUIDE],
     countryCodes: ['ES', 'MA'],
     region: 'Atlantic ↔ Mediterranean',
     whyHeading: 'Why does every Suez–Europe loop still have to use Gibraltar?',
@@ -251,7 +291,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   bosphorus: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, TRADE_ROUTE_GUIDE],
     countryCodes: ['TR'],
     crisisSlugs: ['ukraine-war'],
     region: 'Black Sea ↔ Sea of Marmara',
@@ -300,7 +340,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   dover_strait: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, TRADE_ROUTE_GUIDE],
     countryCodes: ['GB', 'FR'],
     region: 'English Channel ↔ North Sea',
     whyHeading: 'Why is Dover among the busiest lanes if World Monitor maps no corridor row?',
@@ -324,7 +364,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   kerch_strait: {
-    editorialLinks: [MARITIME_EXPLAINER],
+    editorialLinks: [MARITIME_EXPLAINER, TRADE_ROUTE_GUIDE],
     countryCodes: ['UA', 'RU'],
     crisisSlugs: ['ukraine-war'],
     region: 'Black Sea ↔ Sea of Azov',

--- a/scripts/chokepoint-page-content.mjs
+++ b/scripts/chokepoint-page-content.mjs
@@ -91,7 +91,7 @@ export const CHOKEPOINT_CONTENT = {
     ],
   },
   hormuz_strait: {
-    countryCodes: ['IR', 'OM'],
+    countryCodes: ['IR', 'OM', 'BH', 'KW', 'QA', 'SA', 'AE'],
     crisisSlugs: ['hormuz-gulf-security'],
     editorialLinks: [
       { href: '/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/', label: 'How to monitor energy shocks across chokepoints, fuel, and markets' },

--- a/tests/blog-seo-contract.test.mjs
+++ b/tests/blog-seo-contract.test.mjs
@@ -88,6 +88,22 @@ function assertNoUnsupportedVendorPrice(post, vendor) {
 }
 
 describe('blog SEO and GEO corpus contract', () => {
+  it('links all thirteen waterways from the maritime explainer and the existing glossary entries', () => {
+    const article = posts.find((post) => post.file === 'what-is-a-maritime-chokepoint.md');
+    const routes = [
+      'strait-of-hormuz', 'strait-of-malacca', 'suez-canal', 'bab-el-mandeb',
+      'panama-canal', 'taiwan-strait', 'cape-of-good-hope', 'strait-of-gibraltar',
+      'bosporus-strait', 'korea-strait', 'dover-strait', 'kerch-strait', 'lombok-strait',
+    ];
+    for (const route of routes) {
+      const href = `https://www.worldmonitor.app/chokepoints/${route}/`;
+      assert.equal(article.body.split(`](${href})`).length - 1, 1, `maritime explainer links ${route} once`);
+    }
+    for (const slug of ['suez-canal', 'strait-of-malacca']) {
+      const term = GLOSSARY_TERMS.find((entry) => entry.slug === slug);
+      assert.equal(term.learnMore?.filter((link) => link.href === `https://www.worldmonitor.app/chokepoints/${slug}/`).length ?? 0, 1);
+    }
+  });
   it('connects the Hormuz glossary, energy article, and methodology to existing trackers and research', () => {
     const tracker = 'https://www.worldmonitor.app/chokepoints/strait-of-hormuz/';
     const report = RESEARCH_REPORTS.find((entry) => entry.focusChokepointId === 'hormuz_strait');

--- a/tests/blog-seo-contract.test.mjs
+++ b/tests/blog-seo-contract.test.mjs
@@ -88,6 +88,17 @@ function assertNoUnsupportedVendorPrice(post, vendor) {
 }
 
 describe('blog SEO and GEO corpus contract', () => {
+  it('connects the worked editorial examples to their country, crisis, and waterway pages', () => {
+    const expectedLinks = JSON.parse(readFileSync(join(root, 'tests/fixtures/editorial-corpus-links.json'), 'utf8'));
+    for (const [slug, targets] of Object.entries(expectedLinks)) {
+      const article = posts.find((post) => post.file === `${slug}.md`);
+      const prose = article.body.replace(/```[\s\S]*?```/g, '');
+      for (const target of targets) {
+        const href = `https://www.worldmonitor.app${target}`;
+        assert.equal(prose.split(`](${href})`).length - 1, 1, `${slug} links ${target} once outside code examples`);
+      }
+    }
+  });
   it('links all thirteen waterways from the maritime explainer and the existing glossary entries', () => {
     const article = posts.find((post) => post.file === 'what-is-a-maritime-chokepoint.md');
     const routes = [

--- a/tests/blog-seo-contract.test.mjs
+++ b/tests/blog-seo-contract.test.mjs
@@ -5,6 +5,9 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { computeStats, validateCategoryExplainerCopy } from '../scripts/docs-stats.mjs';
+import { GLOSSARY_TERMS } from '../blog-site/src/data/glossary.ts';
+import { CHOKEPOINT_REGISTRY } from '../src/config/chokepoint-registry.ts';
+import { RESEARCH_REPORTS } from '../shared/research-reports/index.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '..');
@@ -85,6 +88,21 @@ function assertNoUnsupportedVendorPrice(post, vendor) {
 }
 
 describe('blog SEO and GEO corpus contract', () => {
+  it('connects the Hormuz glossary, energy article, and methodology to existing trackers and research', () => {
+    const tracker = 'https://www.worldmonitor.app/chokepoints/strait-of-hormuz/';
+    const report = RESEARCH_REPORTS.find((entry) => entry.focusChokepointId === 'hormuz_strait');
+    assert.ok(CHOKEPOINT_REGISTRY.some((entry) => entry.id === report.focusChokepointId));
+    const term = GLOSSARY_TERMS.find((entry) => entry.slug === 'strait-of-hormuz');
+    assert.equal(term.learnMore.filter((link) => link.href === tracker).length, 1);
+    const article = posts.find((post) => post.file === 'energy-shock-monitoring-chokepoints-worldmonitor.md');
+    const reportUrl = `https://www.worldmonitor.app/research/${report.slug}/`;
+    for (const href of [tracker, reportUrl]) {
+      assert.ok(article.body.includes(`](${href})`), `article content links ${href}`);
+    }
+    assert.match(article.body, /historical.*July 2026/i);
+    const methodology = readFileSync(join(root, 'docs/methodology/chokepoints.mdx'), 'utf8');
+    assert.ok(methodology.includes(`](${tracker})`));
+  });
   it('keeps every post complete, unique, current, and answer-first', () => {
     assert.ok(posts.length >= 53, 'expected the complete published blog corpus');
     const titles = new Set();

--- a/tests/chokepoint-page-content.test.mjs
+++ b/tests/chokepoint-page-content.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import * as corpus from '../scripts/build-crawlable-corpus.mjs';
 
 import {
   CHOKEPOINTS,
@@ -30,6 +31,26 @@ const REGISTRY_IDS = [
 ];
 
 describe('chokepoint page content (#7461)', () => {
+  it('resolves authored country and crisis links by ID and derives inverse links once', () => {
+    const chokepoint = { id: 'hormuz_strait', slug: 'stable-route', displayName: 'Renamed waterway' };
+    const country = { code: 'IR', slug: 'stable-country', name: 'Renamed country' };
+    const crisis = { slug: 'gulf-context', title: 'Renamed crisis' };
+    const input = {
+      chokepoints: [chokepoint], countries: [country], crises: [crisis],
+      content: { hormuz_strait: { countryCodes: ['IR', 'IR'], crisisSlugs: ['gulf-context', 'gulf-context'] } },
+    };
+    const links = corpus.buildChokepointPageLinks(input);
+    assert.deepEqual(links.byChokepointId.get('hormuz_strait'), { countries: [country], crises: [crisis] });
+    assert.deepEqual(links.byCountryCode.get('IR'), [chokepoint]);
+    assert.deepEqual(links.byCrisisSlug.get('gulf-context'), [chokepoint]);
+    assert.equal(links.byCountryCode.has('OM'), false);
+    assert.deepEqual(corpus.buildChokepointPageLinks({ ...input, content: {} }).byCountryCode, new Map());
+    for (const [field, value] of [['countryCodes', ['XX']], ['crisisSlugs', ['unknown-crisis']], ['countryCodes', 'IR']]) {
+      assert.throws(() => corpus.buildChokepointPageLinks({
+        ...input, content: { hormuz_strait: { [field]: value } },
+      }), new RegExp(`hormuz_strait.*${field}`));
+    }
+  });
   it('covers every canonical waterway with unique question-shaped copy', () => {
     assert.deepEqual(Object.keys(CHOKEPOINT_CONTENT).sort(), [...REGISTRY_IDS].sort());
     const headings = new Set();

--- a/tests/chokepoint-page-content.test.mjs
+++ b/tests/chokepoint-page-content.test.mjs
@@ -40,7 +40,7 @@ describe('chokepoint page content (#7461)', () => {
       content: { hormuz_strait: { countryCodes: ['IR', 'IR'], crisisSlugs: ['gulf-context', 'gulf-context'] } },
     };
     const links = corpus.buildChokepointPageLinks(input);
-    assert.deepEqual(links.byChokepointId.get('hormuz_strait'), { countries: [country], crises: [crisis] });
+    assert.deepEqual(links.byChokepointId.get('hormuz_strait'), { countries: [country], crises: [crisis], editorial: [] });
     assert.deepEqual(links.byCountryCode.get('IR'), [chokepoint]);
     assert.deepEqual(links.byCrisisSlug.get('gulf-context'), [chokepoint]);
     assert.equal(links.byCountryCode.has('OM'), false);
@@ -49,6 +49,26 @@ describe('chokepoint page content (#7461)', () => {
       assert.throws(() => corpus.buildChokepointPageLinks({
         ...input, content: { hormuz_strait: { [field]: value } },
       }), new RegExp(`hormuz_strait.*${field}`));
+    }
+  });
+  it('accepts canonical blog targets once and rejects missing or noncanonical editorial routes', () => {
+    const href = '/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/';
+    const link = { href, label: 'Energy shock monitoring' };
+    const input = {
+      chokepoints: [{ id: 'hormuz_strait', slug: 'strait-of-hormuz' }],
+      countries: [], crises: [], blogPostPaths: new Set([href]),
+      content: { hormuz_strait: { editorialLinks: [link, link] } },
+    };
+    assert.deepEqual(corpus.buildChokepointPageLinks(input).byChokepointId.get('hormuz_strait').editorial, [link]);
+    for (const invalid of [
+      { href: '/blog/posts/missing/', label: 'Missing article' },
+      { href: `${href}?ref=other`, label: 'Query URL' },
+      { href: `https://other.example${href}`, label: 'External URL' },
+      { href, label: '' },
+    ]) {
+      assert.throws(() => corpus.buildChokepointPageLinks({
+        ...input, content: { hormuz_strait: { editorialLinks: [invalid] } },
+      }), /hormuz_strait.*editorialLinks/);
     }
   });
   it('covers every canonical waterway with unique question-shaped copy', () => {

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -2688,10 +2688,10 @@ describe('crawlable corpus generator', () => {
       const topicWindow = new Window();
       try {
         const requiredPaths = [
-          ['/countries/iran/', '/chokepoints/strait-of-hormuz/'],
-          ['/countries/oman/', '/chokepoints/strait-of-hormuz/'],
-          ['/chokepoints/strait-of-hormuz/', '/countries/iran/'],
-          ['/chokepoints/strait-of-hormuz/', '/countries/oman/'],
+          ...['iran', 'oman', 'bahrain', 'kuwait', 'qatar', 'saudi-arabia', 'united-arab-emirates'].flatMap((slug) => [
+            [`/countries/${slug}/`, '/chokepoints/strait-of-hormuz/'],
+            ['/chokepoints/strait-of-hormuz/', `/countries/${slug}/`],
+          ]),
           ['/chokepoints/strait-of-hormuz/', '/crises/hormuz-gulf-security/'],
           ['/crises/hormuz-gulf-security/', '/chokepoints/strait-of-hormuz/'],
           ['/chokepoints/strait-of-hormuz/', '/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/'],

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -2663,6 +2663,32 @@ describe('crawlable corpus generator', () => {
         }
       }
       assert.deepEqual([...unavailableCoverage], ['PS']);
+      const topicWindow = new Window();
+      try {
+        const requiredPaths = [
+          ['/countries/iran/', '/chokepoints/strait-of-hormuz/'],
+          ['/countries/oman/', '/chokepoints/strait-of-hormuz/'],
+          ['/chokepoints/strait-of-hormuz/', '/countries/iran/'],
+          ['/chokepoints/strait-of-hormuz/', '/countries/oman/'],
+          ['/chokepoints/strait-of-hormuz/', '/crises/hormuz-gulf-security/'],
+          ['/crises/hormuz-gulf-security/', '/chokepoints/strait-of-hormuz/'],
+        ];
+        for (const [source, target] of requiredPaths) {
+          const html = read(outDir, `${source}index.html`);
+          topicWindow.document.body.innerHTML = html;
+          const links = topicWindow.document.querySelectorAll(`main a[href="${target}"]`);
+          assert.equal(links.length, 1, `${source} links ${target} once in content`);
+          assert.ok(existsSync(join(outDir, target, 'index.html')));
+          assert.equal(links[0].hasAttribute('target'), false);
+          assert.equal(links[0].closest('[data-nosnippet]'), null);
+          assert.ok(htmlToMarkdown(html).includes(`](${target})`));
+        }
+        topicWindow.document.body.innerHTML = read(outDir, 'countries/norway/index.html');
+        assert.equal(topicWindow.document.querySelector('main a[href="/chokepoints/strait-of-hormuz/"]'), null);
+        assert.doesNotMatch(topicWindow.document.querySelector('main').textContent, /Related chokepoint trackers/);
+      } finally {
+        topicWindow.close();
+      }
       const microstateCohort = JSON.parse(readFileSync(
         join(repoRoot, 'server/worldmonitor/resilience/v1/cohorts/microstate-territories.json'),
         'utf8',
@@ -4455,7 +4481,7 @@ describe('crawlable corpus generator', () => {
       });
       assert.equal(
         redSeaDataset.dateModified,
-        laterDate(corpus.livePulse.capturedAt, DATASET_SCHEMA_CONTENT_VERSION.crisis),
+        laterDate(corpus.livePulse.crises['red-sea-security'].asOf.slice(0, 10), DATASET_SCHEMA_CONTENT_VERSION.crisis),
         'page links must not advance the crisis Dataset observation clock',
       );
       assert.equal(
@@ -5511,7 +5537,7 @@ describe('live-pulse snapshot injection (#7533)', () => {
   // #7533-allowlist: 2026-08-29 x5 — STORY_CAPTURED_AT synthetic story clock and static snapshot-path fixtures
   // #7533-allowlist: 2026-09-01 x4 — CORPUS_GENERATOR_CONTENT_VERSION and synthetic development fixtures
   // #7533-allowlist: 2026-09-02 x17 — synthetic developments timestamps (incl. the nofollow index-row render fixture, #7748)
-  // #7533-allowlist: 2026-09-03 x15 — genuinely static: research lastmod, DataCatalog and ItemList render fixtures, datasetObservationCoverage fixtures
+  // #7533-allowlist: 2026-09-03 x14. Static DataCatalog and ItemList render fixtures, datasetObservationCoverage fixtures.
   it('rejects undocumented calendar-date literals in this file', () => {
     const source = readFileSync(fileURLToPath(import.meta.url), 'utf8');
     assert.ok(calendarDateAllowances(source).size >= 20, 'the #7533-allowlist comment must stay populated');

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -73,6 +73,7 @@ import {
   MAX_LIVE_SNAPSHOT_AGE_MS,
 } from '../scripts/crawlable-live-tools.mjs';
 import {
+  CHOKEPOINT_CONTENT,
   CHOKEPOINT_SCORE_CONTEXT_ONLY,
   CHOKEPOINT_SCORE_INPUTS,
 } from '../scripts/chokepoint-page-content.mjs';
@@ -1121,6 +1122,20 @@ describe('JSON-LD @context guard', () => {
 });
 
 describe('crawlable corpus generator', () => {
+  it('rejects an invalid authored topic target before replacing generated pages', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'wm-invalid-topic-'));
+    const countryCodes = CHOKEPOINT_CONTENT.hormuz_strait.countryCodes;
+    try {
+      mkdirSync(join(outDir, 'countries'), { recursive: true });
+      writeFileSync(join(outDir, 'countries/index.html'), 'Existing country hub');
+      CHOKEPOINT_CONTENT.hormuz_strait.countryCodes = ['XX'];
+      await assert.rejects(buildCorpus({ rootDir: repoRoot, outDir }), /hormuz_strait.*countryCodes.*XX/);
+      assert.equal(read(outDir, 'countries/index.html'), 'Existing country hub');
+    } finally {
+      CHOKEPOINT_CONTENT.hormuz_strait.countryCodes = countryCodes;
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
   it('keeps decimal values inside one masked sentence', () => {
     assert.deepEqual(
       maskedSentences('Tuvalu reports 12.5% coverage. The inventory is partial.', ['Tuvalu']),
@@ -2657,6 +2672,13 @@ describe('crawlable corpus generator', () => {
             assert.equal(row.querySelector('a')?.getAttribute('href'), href, `${crisis.slug} links ${covered.code} in coverage`);
             assert.ok(existsSync(join(outDir, href, 'index.html')));
             assert.ok(htmlToMarkdown(crisisHtml).includes(`](${href})`));
+            const countryWindow = new Window();
+            try {
+              countryWindow.document.write(read(outDir, `${href}index.html`));
+              assert.ok(countryWindow.document.querySelector(`main a[href="/crises/${crisis.slug}/"]`));
+            } finally {
+              countryWindow.close();
+            }
           }
         } finally {
           window.close();
@@ -2672,16 +2694,24 @@ describe('crawlable corpus generator', () => {
           ['/chokepoints/strait-of-hormuz/', '/countries/oman/'],
           ['/chokepoints/strait-of-hormuz/', '/crises/hormuz-gulf-security/'],
           ['/crises/hormuz-gulf-security/', '/chokepoints/strait-of-hormuz/'],
+          ['/chokepoints/strait-of-hormuz/', '/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/'],
         ];
         for (const [source, target] of requiredPaths) {
           const html = read(outDir, `${source}index.html`);
           topicWindow.document.body.innerHTML = html;
           const links = topicWindow.document.querySelectorAll(`main a[href="${target}"]`);
+          assert.notEqual(source, target);
           assert.equal(links.length, 1, `${source} links ${target} once in content`);
-          assert.ok(existsSync(join(outDir, target, 'index.html')));
+          assert.ok(target.startsWith('/blog/posts/')
+            ? existsSync(join(repoRoot, 'blog-site/src/content/blog', `${target.split('/')[3]}.md`))
+            : existsSync(join(outDir, target, 'index.html')));
           assert.equal(links[0].hasAttribute('target'), false);
+          assert.equal(links[0].relList.contains('nofollow'), false);
           assert.equal(links[0].closest('[data-nosnippet]'), null);
           assert.ok(htmlToMarkdown(html).includes(`](${target})`));
+          topicWindow.document.querySelector('header').append(links[0]);
+          assert.equal(topicWindow.document.querySelector(`main a[href="${target}"]`), null);
+          assert.equal(htmlToMarkdown(topicWindow.document.documentElement.outerHTML).includes(`](${target})`), false);
         }
         topicWindow.document.body.innerHTML = read(outDir, 'countries/norway/index.html');
         assert.equal(topicWindow.document.querySelector('main a[href="/chokepoints/strait-of-hormuz/"]'), null);

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -2688,6 +2688,33 @@ describe('crawlable corpus generator', () => {
       const topicWindow = new Window();
       try {
         const requiredPaths = [
+          ...Object.entries({
+            'suez-canal': ['egypt'],
+            'bab-el-mandeb': ['yemen', 'djibouti', 'eritrea'],
+            'strait-of-malacca': ['malaysia', 'indonesia', 'singapore'],
+            'panama-canal': ['panama'],
+            'taiwan-strait': ['taiwan', 'china'],
+            'strait-of-gibraltar': ['spain', 'morocco'],
+            'bosporus-strait': ['turkey'],
+            'korea-strait': ['south-korea', 'japan'],
+            'dover-strait': ['united-kingdom', 'france'],
+            'kerch-strait': ['ukraine', 'russia'],
+            'lombok-strait': ['indonesia'],
+            'cape-of-good-hope': ['south-africa'],
+          }).flatMap(([waterway, countries]) => countries.flatMap((country) => [
+            [`/chokepoints/${waterway}/`, `/countries/${country}/`],
+            [`/countries/${country}/`, `/chokepoints/${waterway}/`],
+          ])),
+          ...[
+            ['bab-el-mandeb', 'red-sea-security'],
+            ['kerch-strait', 'ukraine-war'],
+            ['suez-canal', 'red-sea-security'],
+            ['bosporus-strait', 'ukraine-war'],
+            ['strait-of-hormuz', 'iran-israel-escalation'],
+          ].flatMap(([waterway, crisis]) => [
+            [`/chokepoints/${waterway}/`, `/crises/${crisis}/`],
+            [`/crises/${crisis}/`, `/chokepoints/${waterway}/`],
+          ]),
           ...['iran', 'oman', 'bahrain', 'kuwait', 'qatar', 'saudi-arabia', 'united-arab-emirates'].flatMap((slug) => [
             [`/countries/${slug}/`, '/chokepoints/strait-of-hormuz/'],
             ['/chokepoints/strait-of-hormuz/', `/countries/${slug}/`],

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -2688,6 +2688,9 @@ describe('crawlable corpus generator', () => {
       const topicWindow = new Window();
       try {
         const requiredPaths = [
+          ...Object.entries(JSON.parse(readFileSync(join(repoRoot, 'tests/fixtures/editorial-corpus-links.json'), 'utf8')))
+            .flatMap(([article, targets]) => targets.filter((target) => target.startsWith('/chokepoints/'))
+              .map((target) => [target, `/blog/posts/${article}/`])),
           ...corpusData.chokepoints.map(({ slug }) => [
             `/chokepoints/${slug}/`, '/blog/posts/what-is-a-maritime-chokepoint/',
           ]),

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -5022,10 +5022,7 @@ describe('crawlable corpus generator', () => {
       laterDate(data.lastmod.countries, CII_COUNTRY_PAGE_CONTENT_VERSION),
       'the CII country clock must derive from the generic country clock',
     );
-    assert.equal(data.lastmod.research, laterDate(
-      ...data.researchReports.map(({ report }) => report.dateModified),
-      RESEARCH_PAGE_CONTENT_VERSION,
-    ));
+    assert.equal(data.lastmod.research, RESEARCH_PAGE_CONTENT_VERSION);
     assert.equal(
       data.lastmod.chokepoints,
       laterDate(

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -2637,6 +2637,32 @@ describe('crawlable corpus generator', () => {
 
       const corpusData = await loadCorpusData({ rootDir: repoRoot });
       const countryByCode = new Map(corpusData.countries.map((country) => [country.code, country]));
+      const unavailableCoverage = new Set();
+      for (const crisis of corpusData.crises) {
+        const window = new Window();
+        try {
+          const crisisHtml = read(outDir, `crises/${crisis.slug}/index.html`);
+          window.document.write(crisisHtml);
+          for (const covered of crisis.coverage) {
+            const row = window.document.querySelector(`main [data-crisis-country][data-country-code="${covered.code}"]`);
+            assert.ok(row, `${crisis.slug} retains coverage for ${covered.code}`);
+            const country = countryByCode.get(covered.code);
+            if (!country) {
+              unavailableCoverage.add(covered.code);
+              assert.equal(row.querySelector('a'), null);
+              assert.ok(row.textContent.includes(covered.name));
+              continue;
+            }
+            const href = `/countries/${country.slug}/`;
+            assert.equal(row.querySelector('a')?.getAttribute('href'), href, `${crisis.slug} links ${covered.code} in coverage`);
+            assert.ok(existsSync(join(outDir, href, 'index.html')));
+            assert.ok(htmlToMarkdown(crisisHtml).includes(`](${href})`));
+          }
+        } finally {
+          window.close();
+        }
+      }
+      assert.deepEqual([...unavailableCoverage], ['PS']);
       const microstateCohort = JSON.parse(readFileSync(
         join(repoRoot, 'server/worldmonitor/resilience/v1/cohorts/microstate-territories.json'),
         'utf8',
@@ -4429,8 +4455,8 @@ describe('crawlable corpus generator', () => {
       });
       assert.equal(
         redSeaDataset.dateModified,
-        laterDate(corpus.lastmod.crises, DATASET_SCHEMA_CONTENT_VERSION.crisis),
-        'changed crisis Dataset schema must advance only the crisis family stamp',
+        laterDate(corpus.livePulse.capturedAt, DATASET_SCHEMA_CONTENT_VERSION.crisis),
+        'page links must not advance the crisis Dataset observation clock',
       );
       assert.equal(
         pageLastmod(redSea),
@@ -4940,7 +4966,10 @@ describe('crawlable corpus generator', () => {
       laterDate(data.lastmod.countries, CII_COUNTRY_PAGE_CONTENT_VERSION),
       'the CII country clock must derive from the generic country clock',
     );
-    assert.equal(data.lastmod.research, '2026-09-03');
+    assert.equal(data.lastmod.research, laterDate(
+      ...data.researchReports.map(({ report }) => report.dateModified),
+      RESEARCH_PAGE_CONTENT_VERSION,
+    ));
     assert.equal(
       data.lastmod.chokepoints,
       laterDate(

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -2688,6 +2688,9 @@ describe('crawlable corpus generator', () => {
       const topicWindow = new Window();
       try {
         const requiredPaths = [
+          ...corpusData.chokepoints.map(({ slug }) => [
+            `/chokepoints/${slug}/`, '/blog/posts/what-is-a-maritime-chokepoint/',
+          ]),
           ...Object.entries({
             'suez-canal': ['egypt'],
             'bab-el-mandeb': ['yemen', 'djibouti', 'eritrea'],

--- a/tests/fixtures/editorial-corpus-links.json
+++ b/tests/fixtures/editorial-corpus-links.json
@@ -1,0 +1,73 @@
+{
+  "tracking-global-trade-routes-chokepoints-freight-costs": [
+    "/chokepoints/strait-of-hormuz/",
+    "/chokepoints/kerch-strait/",
+    "/chokepoints/bab-el-mandeb/",
+    "/chokepoints/suez-canal/",
+    "/chokepoints/bosporus-strait/",
+    "/chokepoints/taiwan-strait/",
+    "/chokepoints/cape-of-good-hope/",
+    "/chokepoints/dover-strait/",
+    "/chokepoints/strait-of-gibraltar/"
+  ],
+  "build-supply-chain-early-warning-system-api": [
+    "/chokepoints/strait-of-hormuz/",
+    "/chokepoints/suez-canal/",
+    "/chokepoints/cape-of-good-hope/",
+    "/chokepoints/bab-el-mandeb/",
+    "/countries/united-arab-emirates/",
+    "/countries/netherlands/",
+    "/countries/egypt/"
+  ],
+  "supply-chain-early-warning-dashboard-worldmonitor-api": [
+    "/chokepoints/strait-of-hormuz/",
+    "/chokepoints/suez-canal/",
+    "/chokepoints/strait-of-malacca/",
+    "/chokepoints/bab-el-mandeb/",
+    "/chokepoints/panama-canal/",
+    "/countries/egypt/",
+    "/countries/singapore/"
+  ],
+  "stress-test-supply-chain-scenario-engine-worldmonitor": [
+    "/chokepoints/taiwan-strait/",
+    "/chokepoints/suez-canal/",
+    "/chokepoints/bab-el-mandeb/",
+    "/chokepoints/panama-canal/",
+    "/chokepoints/strait-of-hormuz/"
+  ],
+  "monitor-global-supply-chains-and-commodity-disruptions": [
+    "/chokepoints/suez-canal/",
+    "/chokepoints/cape-of-good-hope/",
+    "/countries/taiwan/",
+    "/countries/niger/",
+    "/crises/red-sea-security/"
+  ],
+  "country-risk-monitoring-workflow-for-analysts": [
+    "/chokepoints/taiwan-strait/",
+    "/chokepoints/suez-canal/",
+    "/countries/taiwan/",
+    "/countries/mexico/",
+    "/countries/poland/",
+    "/countries/egypt/",
+    "/countries/vietnam/"
+  ],
+  "country-risk-monitoring-due-diligence-worldmonitor": [
+    "/countries/turkey/"
+  ],
+  "track-global-conflicts-in-real-time": [
+    "/chokepoints/strait-of-hormuz/",
+    "/chokepoints/taiwan-strait/",
+    "/countries/iran/",
+    "/countries/ukraine/",
+    "/crises/hormuz-gulf-security/",
+    "/crises/red-sea-security/",
+    "/crises/ukraine-war/"
+  ],
+  "energy-shock-monitoring-chokepoints-worldmonitor": [
+    "/chokepoints/strait-of-hormuz/",
+    "/countries/iran/",
+    "/countries/oman/",
+    "/crises/hormuz-gulf-security/",
+    "/crises/iran-israel-escalation/"
+  ]
+}

--- a/tests/research-report-corpus.test.mjs
+++ b/tests/research-report-corpus.test.mjs
@@ -271,6 +271,29 @@ describe('research report corpus (#5668)', () => {
     }), /contextChokepointId bab_el_mandeb.*chokepoint registry/);
   });
 
+  it('keeps one backlink when a focus waterway also appears as comparison context', async () => {
+    const duplicateOut = mkdtempSync(join(tmpdir(), 'wm-research-duplicate-'));
+    const originalIds = report.contextChokepointIds;
+    try {
+      report.contextChokepointIds = [...originalIds, report.focusChokepointId, ...originalIds];
+      await buildCorpus({ rootDir: repoRoot, outDir: duplicateOut });
+      const window = new Window();
+      try {
+        window.document.write(readFileSync(join(duplicateOut, 'chokepoints/strait-of-hormuz/index.html'), 'utf8'));
+        const links = window.document.querySelectorAll(`main a[href="/research/${report.slug}/"]`);
+        assert.equal(links.length, 1);
+        assert.match(links[0].parentElement.textContent, /Focus in historical research/);
+        window.document.body.innerHTML = readFileSync(join(duplicateOut, 'research', report.slug, 'index.html'), 'utf8');
+        assert.equal(window.document.querySelectorAll('main table a[href="/chokepoints/suez-canal/"]').length, 1);
+      } finally {
+        window.close();
+      }
+    } finally {
+      report.contextChokepointIds = originalIds;
+      rmSync(duplicateOut, { recursive: true, force: true });
+    }
+  });
+
   it('separates evidence layers and states failure modes in plain language', () => {
     for (const label of ['Observed transport data', 'Derived analysis', 'News context', 'Methodology']) {
       assert.ok(html.includes(label), `missing evidence-layer label: ${label}`);

--- a/tests/research-report-corpus.test.mjs
+++ b/tests/research-report-corpus.test.mjs
@@ -9,6 +9,8 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { after, before, describe, it } from 'node:test';
+import { Window } from 'happy-dom';
+import { htmlToMarkdown } from '../api/_md-url-twin.ts';
 
 import { buildCorpus, loadCorpusData } from '../scripts/build-crawlable-corpus.mjs';
 import {
@@ -18,6 +20,7 @@ import {
   formatMetric,
   mean,
   resolveMetricTokens,
+  renderResearchReportPage,
 } from '../scripts/build-research-reports.mjs';
 import {
   enumerateMissingDates,
@@ -234,6 +237,38 @@ describe('research report corpus (#5668)', () => {
       /^World Monitor — real-time global intelligence dashboard/,
       'report OG alt must describe the report, not the generic site card',
     );
+  });
+
+  it('connects historical focus and comparison research in main content and Markdown', () => {
+    const window = new Window();
+    try {
+      for (const [slug, role] of [
+        ['strait-of-hormuz', 'Focus'],
+        ['bab-el-mandeb', 'Comparison'],
+        ['suez-canal', 'Comparison'],
+        ['cape-of-good-hope', 'Comparison'],
+      ]) {
+        window.document.body.innerHTML = html;
+        const href = `/chokepoints/${slug}/`;
+        assert.ok(window.document.querySelector(`main a[href="${href}"]`), `report links ${slug} in content`);
+        assert.ok(htmlToMarkdown(html).includes(`](${href})`));
+        const trackerHtml = readFileSync(join(outDir, 'chokepoints', slug, 'index.html'), 'utf8');
+        window.document.body.innerHTML = trackerHtml;
+        const links = window.document.querySelectorAll(`main a[href="/research/${report.slug}/"]`);
+        assert.equal(links.length, 1, `${slug} has one report return path`);
+        assert.match(links[0].parentElement.textContent, new RegExp(`${role}.*historical research.*${report.datePublished}`, 'i'));
+        assert.ok(htmlToMarkdown(trackerHtml).includes(`](/research/${report.slug}/)`));
+      }
+    } finally {
+      window.close();
+    }
+  });
+
+  it('rejects a declared comparison without a canonical tracker route', () => {
+    assert.throws(() => renderResearchReportPage({
+      report, snapshot, tpl: {},
+      chokepointSlugById: new Map([['hormuz_strait', 'strait-of-hormuz']]),
+    }), /contextChokepointId bab_el_mandeb.*chokepoint registry/);
   });
 
   it('separates evidence layers and states failure modes in plain language', () => {


### PR DESCRIPTION
## Summary

Readers can now follow related countries, crises, chokepoints, historical research, and editorial guides from page content. Crisis coverage names link to their available country profiles. Research comparison names link to trackers, and trackers link back with dated focus/comparison labels.

All 13 waterways have related country profiles. Hormuz includes Iran and all six GCC countries. Suez and Bab el-Mandeb connect with Red Sea context, Kerch and Bosporus with Ukraine context, and Hormuz with Gulf and Iran–Israel context. Crisis coverage remains unchanged.

The maritime explainer links all 13 trackers, and each tracker links back. Suez and Malacca glossary entries now link to their trackers. Nine further trade, supply-chain, country-risk, conflict, and energy articles link their examples to country profiles, crisis pages, and trackers; trackers provide the relevant article return links. The existing declaration and resolver handle the expansion.

## Validation

- 226 focused corpus, research, content, editorial, GEO, and sitemap tests pass. Tests cover main-content links, canonical destinations, Markdown output, both directions, duplicate suppression, invalid targets, and unavailable country pages.
- Blog and corpus builds, `build:llms-full:check`, TypeScript, import boundaries, and `git diff --check` pass. The generated agent text is included.
- The generated-page audit verifies every planned source/target path. The methodology source is checked separately because hosted Mintlify rendering needs post-deployment acceptance.
- Local browser checks followed Suez → Egypt → Suez → Red Sea, inspected all 13 maritime article links at 390px, and checked keyboard focus. Country/crisis pages fit the viewport. The article table links fit; the broader blog page has the same horizontal overflow in a controlled copy with only the new anchors removed.
- Numeric snapshots, scoring, research downloads, and crisis coverage are unchanged. Page revision dates reflect editorial changes. The API tutorial clarifies that the Cape route avoids Suez/Bab el-Mandeb and does not bypass Hormuz.

## Post-Deploy Monitoring & Validation

After deployment and cache refresh, the maintainer should capture the Suez/Egypt/Red Sea loop, the maritime explainer and its tracker return links, Suez/Malacca glossary links, and a country-risk article example. Check successful HTTP responses, canonical targets, links in main content, Markdown preservation, and the hosted methodology link. Review build diagnostics for invalid authored targets. Correct or roll back the affected link change if a required path is absent or wrong. Search indexing and ranking outcomes remain unmeasured.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-Codex-000000)
