### PR TITLE
fix(sentry): carry Chromium's second Java-bridge reason to the marketing surface

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -149,24 +149,36 @@ export const MARKETING_IGNORE_ERRORS: RegExp[] = [
   // postMessage` entry above covers the same bridge from the other direction
   // (WORLDMONITOR-10W, whose dashboard-side copy is added in the same pass).
   /\bWKWebView_[A-Za-z]\w*/,
-  // Android WebView's Java-bridge teardown error. Chromium's `android_webview`
-  // emits this exact sentence — `Error invoking <method>: Java object is gone` —
-  // when injected JS calls a `@JavascriptInterface` method whose Java object has
-  // already been garbage-collected or detached, which is what happens when an
-  // in-app browser's own chrome script runs during `beforeunload`. The observed
-  // event is Instagram 415 on Android 13 calling its own
-  // `enableButtonsClickedMetaDataLogging` bridge; neither that method name nor
-  // the phrase appears anywhere in this bundle, and a pure-web bundle has no
-  // `@JavascriptInterface` object to lose, so it can never be ours. Already
-  // suppressed on the dashboard since #4005 (`/Java object is gone/` in
-  // `src/bootstrap/sentry-init.ts`); the two surfaces run separate Sentry
-  // clients, so the missing marketing copy is what let WORLDMONITOR-117 through
-  // with three infra-only frames (the `/pro/assets/sentry-*.js` chunk plus two
-  // `<anonymous>`), which `marketingBeforeSend`'s frame gates cannot act on.
+  // Android WebView's Java-bridge errors. Chromium's `android_webview` wraps a
+  // failed `@JavascriptInterface` call as `Error invoking <method>: <reason>`,
+  // where the reason is a `GinJavaBridgeError` member. Two have been observed
+  // in production, and both are enumerated here:
+  //   WORLDMONITOR-117  `Error invoking enableButtonsClickedMetaDataLogging: Java object is gone`
+  //   WORLDMONITOR-126  `Error invoking log: Java bridge method invocation error`
+  // The first is an in-app browser's chrome script calling a bridge whose Java
+  // object was already collected or detached, typically during `beforeunload`
+  // (Instagram 415 on Android 13). The second is an injected `scanForForms`
+  // autofill scan on Chrome Mobile 153 / Android 10, reaching Sentry through
+  // the SDK's `setTimeout` instrumentation. Neither method name nor either
+  // sentence appears anywhere in this bundle, and a pure-web bundle owns no
+  // `@JavascriptInterface` object at all, so neither can ever be ours.
   //
-  // Anchored to the whole sentence, unlike the dashboard's bare
-  // `/Java object is gone/`. `ignoreErrors` is frame-blind, so an unanchored
-  // substring also drops any first-party message that happens to CONTAIN the
+  // Already suppressed on the dashboard (`src/bootstrap/sentry-init.ts`, which
+  // enumerates both reasons); the two surfaces run separate Sentry clients, so
+  // a missing marketing copy is what lets these through with infra-only frames
+  // (the `/pro/assets/sentry-*.js` chunk plus `<anonymous>`), which
+  // `marketingBeforeSend`'s frame gates cannot act on. That gap produced
+  // WORLDMONITOR-117, and again WORLDMONITOR-126 after #7356 copied only the
+  // first reason across.
+  //
+  // The reasons stay ENUMERATED rather than matched by a slot: a Chromium
+  // reason we have not seen should surface as a new issue and be added
+  // deliberately, which is the safe failure direction — under-suppression
+  // announces itself, over-suppression does not.
+  //
+  // Anchored to the whole sentence, as the dashboard entry has been since
+  // #7357. `ignoreErrors` is frame-blind, so an unanchored substring also
+  // drops any first-party message that happens to CONTAIN the
   // phrase (`Our Java object is gone`) even when its stack points straight at
   // `/pro/assets/*.js` — the observability blind spot this array exists to
   // avoid. Only the complete Chromium shape is third-party by construction, so
@@ -179,10 +191,10 @@ export const MARKETING_IGNORE_ERRORS: RegExp[] = [
   // obtenirDonnées()` is legal, and Chromium emits the same sentence for it)
   // while JavaScript's `\w` is, so an ASCII slot silently misses them. Widening
   // it cannot loosen the rule — the envelope is anchored at both ends and the
-  // reason is fixed, so this matches only if our own bundle emits the whole
-  // Chromium sentence. Java method names hold no colon, so excluding one keeps
-  // the slot off the reason separator (PR #7356 review).
-  /^Error invoking [^\s:]+: Java object is gone$/,
+  // reasons are enumerated, so this matches only if our own bundle emits a
+  // whole Chromium sentence. Java method names hold no colon, so excluding
+  // one keeps the slot off the reason separator (PR #7356 review).
+  /^Error invoking [^\s:]+: (?:Java object is gone|Java bridge method invocation error)$/,
   // iOS in-app WebView native bridge. The host app injects `sendDataToNative` /
   // `sendPageHideMessage` into the document and they dereference
   // `window.webkit.messageHandlers`, which only exists when a WKWebView host

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -438,6 +438,62 @@ describe('marketing ignoreErrors — in-app-browser injected globals (2026-08-27
     assert.equal(isIgnored('Error', 'Java object is missing'), false);
     assert.equal(isIgnored('Error', 'Our Java gateway is gone'), false);
   });
+
+  it("drops the Java bridge's other Chromium reason (WORLDMONITOR-126)", () => {
+    // Verbatim production value: Chrome Mobile 153 on Android 10 at `/`, fired
+    // through Sentry's `setTimeout` instrumentation from an injected
+    // `scanForForms` autofill scan, with only the `/pro/assets/sentry-*.js`
+    // chunk and one `<anonymous>` on the stack.
+    //
+    // `GinJavaBridgeError` has more than one member, and the dashboard array
+    // enumerates two of them (`src/bootstrap/sentry-init.ts`). #7356 copied
+    // only `Java object is gone` to this surface, so the second reason fell
+    // through to a separate issue on the marketing client. The reasons stay
+    // ENUMERATED rather than slotted: a Chromium reason we have not seen should
+    // surface as a new issue and be added deliberately, because
+    // under-suppression announces itself and over-suppression does not.
+    assert.equal(
+      isIgnored('Error', 'Error invoking log: Java bridge method invocation error'),
+      true,
+    );
+    // The method slot is shape-matched here too, per the entry above.
+    assert.equal(
+      isIgnored('Error', 'Error invoking 获取设备信息: Java bridge method invocation error'),
+      true,
+    );
+  });
+
+  it('keeps a first-party message that merely CONTAINS the second reason', () => {
+    // Same control as the `Java object is gone` half: `ignoreErrors` is
+    // frame-blind, so only the complete anchored Chromium sentence may match.
+    assert.equal(isIgnored('Error', 'Java bridge method invocation error'), false);
+    assert.equal(
+      isIgnored('Error', 'Relay failed: Java bridge method invocation error'),
+      false,
+    );
+    assert.equal(
+      isIgnored('Error', 'Error invoking log: Java bridge method invocation error (retrying)'),
+      false,
+    );
+  });
+
+  it('keeps an unenumerated Chromium reason so it surfaces as a new issue', () => {
+    // The safe failure direction the entry documents: a reason we have never
+    // observed must still report rather than be swallowed by a widened slot.
+    assert.equal(isIgnored('Error', 'Error invoking log: Java exception was raised'), false);
+  });
+
+  it('pins the marketing surface as `Error invoking`-free, which is what licenses the rule', () => {
+    // What licenses matching the envelope at all: a pure-web bundle owns no
+    // `@JavascriptInterface` object, so it can never emit Chromium's sentence.
+    // The dashboard test pins the same scan for its own copy.
+    const offenders = marketingFirstPartySources()
+      .filter((f) => !f.rel.includes('sentry-filter-policy'))
+      .filter((f) => /Error invoking/.test(f.code))
+      .map((f) => f.rel);
+    assert.deepEqual(offenders, [],
+      'the marketing surface now emits `Error invoking` — re-derive the WORLDMONITOR-117/-126 rule');
+  });
 });
 
 describe('marketingBeforeSend — Safari-masked injected script (WORLDMONITOR-110)', () => {


### PR DESCRIPTION
Found while triaging the Sentry board.

## What broke

Chromium's `android_webview` wraps a failed `@JavascriptInterface` call as
`Error invoking <method>: <GinJavaBridgeError>`. The dashboard array in
`src/bootstrap/sentry-init.ts` enumerates two reasons. PR #7356 copied only the
first one (`Java object is gone`) to the marketing array, so the second reason
fell through to its own issue on the marketing client:

```
Error invoking log: Java bridge method invocation error
```

The two surfaces run separate Sentry clients, which is the same lockstep gap
that produced WORLDMONITOR-117, -15, -102, -108, -10N and -10T.

## Evidence

The event is Chrome Mobile 153 on Android 10 at `/`, reaching Sentry through the
SDK's `setTimeout` instrumentation from an injected `scanForForms` autofill scan.
Its stack carries only `/pro/assets/sentry-DIK_0LP0.js` and one `<anonymous>`
frame, so `marketingBeforeSend`'s frame gates have nothing to act on and the
suppression has to be message-level.

I confirmed the root page serves that exact chunk, so the marketing client is the
reporter and this array is the gate with the hole:

```
$ curl -s -A '<browser UA>' https://www.worldmonitor.app/ | grep -o '/pro/assets/[^"]*\.js'
/pro/assets/sentry-DIK_0LP0.js
/pro/assets/welcome-BshM4pn6.js
```

## Design

The reasons stay **enumerated** rather than matched by a slot. A Chromium reason
we have not seen should surface as a new issue and be added deliberately, because
under-suppression announces itself and over-suppression does not. This keeps the
marketing entry identical in shape to the dashboard's.

Two comment claims had gone stale and are corrected in the same pass: the
dashboard entry is no longer a bare `/Java object is gone/`, having been anchored
in #7357, and the reason is no longer singular.

## Tests

Following the shape the neighbouring entries already use:

- the suppression, with the verbatim production value plus a non-ASCII bridge
  method name, since Java identifiers are not ASCII-only
- three preservation controls: the bare phrase, a first-party message that merely
  contains it, and a trailing-suffix near-miss
- an unenumerated-reason control, pinning the safe failure direction
- a source scan pinning the marketing surface as `Error invoking`-free, which is
  what licenses matching the envelope at all

The suppression test is the only one that was red before the fix. The four
controls were already green, so they bound the blast radius rather than prove the
change.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| biome | clean |
| `tests/pro-sentry-filter-policy.test.mts` | 95/95 |
| `tests/sentry-beforesend.test.mjs` | 307/307 |
| `tests/csp-filter.test.mjs` | 134/134 |
| `tests/sentry-allow-urls.test.mts` | 9/9 |

## Note on resolve-on-commit

This carries no resolve marker on purpose. The Sentry GitHub integration turns
one into an `inRelease` pin rather than a plain resolve, which is the mute the
project's resolve policy forbids. That is tracked in #7838. The issue is left for
a plain resolve once this deploys.

https://claude.ai/code/session_01FQB5maSGLhjTGeXycSXPWM
