### PR TITLE
fix(supply-chain): withhold unverified corridor routing prose

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -597,6 +597,12 @@ export default async function handler(req, ctx) {
       }
       if (names[i] === 'wildfires') responseValue = compactWildfireBootstrapPayload(responseValue);
       if (names[i] === 'naturalEvents') responseValue = compactNaturalEventsDashboardPayload(responseValue);
+      if (names[i] === 'chokepoints' && Array.isArray(val?.chokepoints)) {
+        responseValue = { ...val, chokepoints: val.chokepoints.map(cp => cp?.transitSummary ? {
+          ...cp,
+          transitSummary: { ...cp.transitSummary, riskSummary: '', riskReportAction: '' },
+        } : cp) };
+      }
       data[names[i]] = responseValue;
     } else {
       missing.push(names[i]);

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -2598,6 +2598,14 @@ export const CACHE_TOOLS: ToolDef[] = [
           }
         }
       }
+      mapNested(data, 'transit-summaries', 'summaries', (summaries) => {
+        if (!summaries || typeof summaries !== 'object' || Array.isArray(summaries)) return summaries;
+        return Object.fromEntries(Object.entries(summaries).map(([id, entry]) => [id,
+          entry && typeof entry === 'object'
+            ? { ...entry, riskSummary: '', riskReportAction: '' }
+            : entry,
+        ]));
+      });
       const cp = argStr(params.chokepoint);
       if (cp) {
         mapNested(data, 'transit-summaries', 'summaries', (m) => pickMapKeysLike(m, cp));

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -2612,7 +2612,7 @@ export const CACHE_TOOLS: ToolDef[] = [
         mapNested(data, 'transit-summaries', 'summaries', (m) => pickMapKeysLike(m, cp));
         mapNested(data, 'chokepoint_transits', 'transits', (m) => pickMapKeysLike(m, cp));
         data['chokepoint-flows'] = pickMapKeysLike(data['chokepoint-flows'], cp);
-        narrowNested(data, 'chokepoint-baselines', 'chokepoints', (c) => ciIncludes(c.id, cp) || ciIncludes(c.relayId, cp) || ciIncludes(c.name, cp));
+        narrowNested(data, 'chokepoint-baselines', 'chokepoints', (c) => ciIncludes(c?.id, cp) || ciIncludes(c?.relayId, cp) || ciIncludes(c?.name, cp));
       }
       const limit = argNum(params.limit) ?? DEFAULT_LIST_LIMIT;
       capNested(data, 'chokepoint-baselines', 'chokepoints', limit);

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -2499,7 +2499,8 @@ export const CACHE_TOOLS: ToolDef[] = [
             todayCargo: { type: ['number', 'null'] }, todayOther: { type: ['number', 'null'] },
             wowChangePct: { type: ['number', 'null'] }, riskLevel: { type: 'string' },
             incidentCount7d: { type: ['number', 'null'] }, disruptionPct: { type: ['number', 'null'] },
-            riskSummary: { type: 'string' }, riskReportAction: { type: 'string' },
+            riskSummary: { type: 'string', description: 'Generated prose is withheld as an empty string. This does not indicate low risk.' },
+            riskReportAction: { type: 'string', description: 'Operational advice is withheld as an empty string because it has no verified routing basis.' },
             anomaly: { type: 'object' }, dataAvailable: { type: 'boolean' },
             // null todayTotal means the relay's 24h AIS window was empty --
             // unsupplied, not a measured zero (#7457). dataAvailable is

--- a/api/mcp/resources/index.ts
+++ b/api/mcp/resources/index.ts
@@ -315,7 +315,7 @@ export const TEMPLATE_RESOURCE_REGISTRY: TemplateResourceDef[] = [
   {
     uriTemplate: 'worldmonitor://chokepoints/{slug}/status',
     name: 'Chokepoint Status',
-    description: 'Maritime chokepoint transit summary: today total / tanker / cargo counts, week-over-week change, risk level, incident count, disruption percentage, and risk narrative. URI param {slug} is one of the hand-curated kebab-case identifiers (suez, strait-of-malacca, strait-of-hormuz, bab-el-mandeb, panama-canal, taiwan-strait, cape-of-good-hope, strait-of-gibraltar, bosphorus, korea-strait, dover-strait, kerch-strait, lombok-strait).',
+    description: 'Maritime chokepoint transit summary: today total / tanker / cargo counts, week-over-week change, risk level, incident count, and disruption percentage. Generated riskSummary and riskReportAction prose is withheld as empty strings; this does not indicate low risk. URI param {slug} is one of the hand-curated kebab-case identifiers (suez, strait-of-malacca, strait-of-hormuz, bab-el-mandeb, panama-canal, taiwan-strait, cape-of-good-hope, strait-of-gibraltar, bosphorus, korea-strait, dover-strait, kerch-strait, lombok-strait).',
     mimeType: 'application/json',
     tool: 'get_chokepoint_status',
     paramExtractor: (uri: string) => {

--- a/docs/mcp-jmespath.mdx
+++ b/docs/mcp-jmespath.mdx
@@ -412,6 +412,8 @@ This is the workhorse shape for "give me the top-N by some metric". The same sha
 
 **Intent.** From `get_chokepoint_status`, get the risk level + 7-day incident count for the Strait of Hormuz only.
 
+Generated `riskSummary` and `riskReportAction` prose is withheld as empty strings. Missing prose does not mean low risk. Use the structured risk fields and check measurement availability before interpreting counts.
+
 **Tool call:**
 
 ```json
@@ -429,8 +431,8 @@ This is the workhorse shape for "give me the top-N by some metric". The same sha
 {
   "transit-summaries": {
     "summaries": {
-      "suez":          { "riskLevel": "critical", "incidentCount7d": 28,  "wowChangePct":   4.5, "riskSummary": "..." },
-      "hormuz_strait": { "riskLevel": "critical", "incidentCount7d": 627, "wowChangePct": -72.5, "riskSummary": "..." },
+      "suez":          { "riskLevel": "critical", "incidentCount7d": 28,  "wowChangePct":   4.5, "riskSummary": "" },
+      "hormuz_strait": { "riskLevel": "critical", "incidentCount7d": 627, "wowChangePct": -72.5, "riskSummary": "" },
       "panama":        { "riskLevel": "",         "incidentCount7d": 0,   "wowChangePct":   0.4, "riskSummary": "" }
     }
   }

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -7015,8 +7015,9 @@ async function seedCorridorRisk() {
         eventCount7d: Number(corridor.event_count_7d ?? 0),
         disruptionPct: Number(corridor.disruption_pct ?? 0),
         vesselCount: Number(corridor.vessel_count ?? 0),
-        riskSummary: String(corridor.risk_summary || '').slice(0, 200),
-        riskReportAction: String((corridor.risk_report?.action) || '').slice(0, 500),
+        // Generated prose has no verified routing or cost basis.
+        riskSummary: '',
+        riskReportAction: '',
       };
     }
     if (Object.keys(result).length === 0) {
@@ -7033,7 +7034,7 @@ async function seedCorridorRisk() {
       const label = corridorId.replace(/_/g, ' ').replace(/\b\w/g, ch => ch.toUpperCase());
       publishNotificationEvent({
         eventType: 'corridor_risk',
-        payload: { title: `${label}: risk score ${c.riskScore}${c.riskSummary ? ' — ' + c.riskSummary.slice(0, 80) : ''}`, source: 'Corridor Risk' },
+        payload: { title: `${label}: risk score ${c.riskScore}`, source: 'Corridor Risk' },
         severity: c.riskScore >= 70 ? 'critical' : 'high',
         variant: undefined,
         dedupTtl: 3600,
@@ -9782,8 +9783,9 @@ async function seedTransitSummaries() {
       riskLevel: cr?.riskLevel ?? '',
       incidentCount7d: cr?.incidentCount7d ?? 0,
       disruptionPct: cr?.disruptionPct ?? 0,
-      riskSummary: cr?.riskSummary ?? '',
-      riskReportAction: cr?.riskReportAction ?? '',
+      // Persisted corridor data can predate prose suppression.
+      riskSummary: '',
+      riskReportAction: '',
       anomaly,
       dataAvailable: Boolean(cpData),
     };

--- a/scripts/publish-bootstrap-tiers.mjs
+++ b/scripts/publish-bootstrap-tiers.mjs
@@ -188,6 +188,12 @@ export async function assembleBootstrapTierPayload(registry, options = {}) {
     // every client downloads. Compact at publish time; the canonical Redis
     // value stays intact for RPC / MCP (#7288).
     if (names[index] === 'naturalEvents') value = compactNaturalEventsDashboardPayload(value);
+    if (names[index] === 'chokepoints' && Array.isArray(value?.chokepoints)) {
+      value = { ...value, chokepoints: value.chokepoints.map(cp => cp?.transitSummary ? {
+        ...cp,
+        transitSummary: { ...cp.transitSummary, riskSummary: '', riskReportAction: '' },
+      } : cp) };
+    }
     data[names[index]] = value;
   }
 

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -393,6 +393,9 @@ function narrowServedSources(response: GetChokepointStatusResponse): GetChokepoi
     ...response,
     chokepoints: response.chokepoints.map((cp) => ({
       ...cp,
+      ...(cp.transitSummary ? {
+        transitSummary: { ...cp.transitSummary, riskSummary: '', riskReportAction: '' },
+      } : {}),
       navigationalWarningsAvailable: cp.navigationalWarningsAvailable === true,
       aisSnapshotAvailable: cp.aisSnapshotAvailable === true,
       ...(cp.flowEstimate
@@ -506,8 +509,8 @@ async function fetchChokepointData(): Promise<ChokepointFetchResult> {
         riskLevel: ts.riskLevel,
         incidentCount7d: ts.incidentCount7d,
         disruptionPct: ts.disruptionPct,
-        riskSummary: ts.riskSummary,
-        riskReportAction: ts.riskReportAction,
+        riskSummary: '',
+        riskReportAction: '',
         // Default true for pre-fix writers (absence = covered). New writers
         // explicitly emit false for canonical zero-state fills.
         dataAvailable: transitMovementAvailable,

--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -419,9 +419,6 @@ export class SupplyChainPanel extends Panel {
           : (ts?.riskLevel === 'elevated' || ts?.riskLevel === 'moderate') ? 'sc-disrupt-yellow' : 'sc-disrupt-green';
 
         const expanded = this.expandedChokepoint === cp.name;
-        const actionRow = expanded && ts?.riskReportAction
-          ? `<div class="sc-routing-advisory">${escapeHtml(ts.riskReportAction)}</div>`
-          : '';
         // Render the chart placeholder only when expanded AND upstream reported
         // data available for this chokepoint. If dataAvailable === false, the
         // per-id history key would also be zero (we skip the lazy-fetch).
@@ -543,7 +540,6 @@ export class SupplyChainPanel extends Panel {
               </div>` : ''}
             ${cp.description ? `<div class="trade-description">${escapeHtml(cp.description)}</div>` : ''}
             <div class="trade-affected">${cp.affectedRoutes.slice(0, 3).map(r => escapeHtml(r)).join(', ')}</div>
-            ${actionRow}
             ${chartPlaceholder}
             ${bypassSection}
             ${scenarioSection}

--- a/tests/chokepoint-bootstrap-publication.test.mjs
+++ b/tests/chokepoint-bootstrap-publication.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import handler from '../api/bootstrap.js';
+import { assembleBootstrapTierPayload } from '../scripts/publish-bootstrap-tiers.mjs';
+
+const capture = JSON.parse(readFileSync(new URL('./fixtures/chokepoints-routing-advice-2026-09-10.json', import.meta.url), 'utf8'));
+
+test('bootstrap origin and tier publisher withhold legacy advice without changing risk observations', async () => {
+  const originalFetch = globalThis.fetch;
+  const keys = ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN'];
+  const originalEnv = keys.map(key => process.env[key]);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'synthetic';
+  const fetchFn = async (input, init) => {
+    assert.equal(String(input), 'https://redis.test/pipeline');
+    const commands = JSON.parse(init.body);
+    return Response.json(commands.map(([command, key]) => {
+      assert.equal(command, 'GET');
+      return { result: key === 'supply_chain:chokepoints:v4' ? JSON.stringify(capture.body) : null };
+    }));
+  };
+  globalThis.fetch = fetchFn;
+  try {
+    const response = await handler(new Request('https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1'));
+    assert.equal(response.status, 200);
+    const origin = await response.json();
+    const published = await assembleBootstrapTierPayload({ chokepoints: 'supply_chain:chokepoints:v4' }, { fetchFn });
+    const expected = structuredClone(capture.body);
+    for (const cp of expected.chokepoints) Object.assign(cp.transitSummary, { riskSummary: '', riskReportAction: '' });
+    assert.deepEqual(origin.data.chokepoints, expected);
+    assert.deepEqual(published.data.chokepoints, expected);
+  } finally {
+    globalThis.fetch = originalFetch;
+    keys.forEach((key, index) => {
+      if (originalEnv[index] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[index];
+    });
+  }
+});

--- a/tests/chokepoint-source-availability.test.mts
+++ b/tests/chokepoint-source-availability.test.mts
@@ -68,6 +68,56 @@ afterEach(() => {
 });
 
 describe('chokepoint source availability', () => {
+  it('withholds legacy generated prose while preserving the captured risk observations', async () => {
+    const capture = JSON.parse(await readFile('tests/fixtures/chokepoints-routing-advice-2026-09-10.json', 'utf8'));
+    const harness = redisHarness(async (url) => { throw new Error(`unexpected fetch: ${url}`); });
+    harness.values.set('supply_chain:chokepoints:v4', JSON.stringify(capture.body));
+    globalThis.fetch = harness.fetchImpl as typeof fetch;
+
+    const response = await getChokepointStatus({} as never, {});
+    const expected = structuredClone(capture.body);
+    for (const cp of expected.chokepoints) {
+      cp.transitSummary.riskSummary = '';
+      cp.transitSummary.riskReportAction = '';
+    }
+    assert.deepEqual(response, expected);
+    assert.doesNotMatch(JSON.stringify(response), /REROUTE|50-80K|Salalah/);
+  });
+
+  it('withholds generated prose from old transit summaries before caching a fresh response', async () => {
+    const capture = JSON.parse(await readFile('tests/fixtures/chokepoints-routing-advice-2026-09-10.json', 'utf8'));
+    const original = capture.body.chokepoints.find((cp: { id: string }) => cp.id === 'hormuz_strait');
+    const harness = redisHarness(async (url) => {
+      if (url.includes('msi.nga.mil')) return Response.json([]);
+      if (url.startsWith('https://relay.test/ais/snapshot')) return Response.json({
+        density: [], disruptions: [], snapshotAt: Date.now(), status: { connected: true, vessels: 10, messages: 20 },
+      });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const summaries = completeTransitSummaries();
+    const cases = [original.transitSummary.riskReportAction, undefined, null, { route: 'Suez', cost: '$50-80K' }];
+    for (const [index, advice] of cases.entries()) {
+      Object.assign(summaries[CHOKEPOINTS[index]!.id]!, {
+        riskSummary: advice, riskReportAction: advice, riskLevel: 'critical', incidentCount7d: 628,
+        todayTotal: null, todayTanker: null, todayCargo: null, todayOther: null,
+      });
+    }
+    harness.values.set('supply_chain:transit-summaries:v1', JSON.stringify({ summaries, fetchedAt: capture.retrievedAt }));
+    globalThis.fetch = harness.fetchImpl as typeof fetch;
+
+    const response = await getChokepointStatus({} as never, {});
+    assert.equal(response.upstreamUnavailable, false);
+    for (const cp of response.chokepoints.slice(0, cases.length)) {
+      assert.equal(cp.transitSummary?.riskReportAction, '');
+      assert.equal(cp.transitSummary?.riskSummary, '');
+      assert.equal(cp.transitSummary?.riskLevel, 'critical');
+      assert.equal(cp.transitSummary?.incidentCount7d, 628);
+      assert.equal(cp.transitSummary?.todayCountsAvailable, false);
+      assert.equal(cp.transitSummary?.dataAvailable, true);
+    }
+    assert.doesNotMatch(harness.values.get('supply_chain:chokepoints:v4') || '', /REROUTE|50-80K|Salalah/);
+  });
+
   it('uses append-only proto fields and the private NGA v2 cache key', async () => {
     const maritimeProto = await readFile('proto/worldmonitor/maritime/v1/list_navigational_warnings.proto', 'utf8');
     const supplyChainProto = await readFile('proto/worldmonitor/supply_chain/v1/supply_chain_data.proto', 'utf8');

--- a/tests/chokepoint-source-availability.test.mts
+++ b/tests/chokepoint-source-availability.test.mts
@@ -68,56 +68,6 @@ afterEach(() => {
 });
 
 describe('chokepoint source availability', () => {
-  it('withholds legacy generated prose while preserving the captured risk observations', async () => {
-    const capture = JSON.parse(await readFile('tests/fixtures/chokepoints-routing-advice-2026-09-10.json', 'utf8'));
-    const harness = redisHarness(async (url) => { throw new Error(`unexpected fetch: ${url}`); });
-    harness.values.set('supply_chain:chokepoints:v4', JSON.stringify(capture.body));
-    globalThis.fetch = harness.fetchImpl as typeof fetch;
-
-    const response = await getChokepointStatus({} as never, {});
-    const expected = structuredClone(capture.body);
-    for (const cp of expected.chokepoints) {
-      cp.transitSummary.riskSummary = '';
-      cp.transitSummary.riskReportAction = '';
-    }
-    assert.deepEqual(response, expected);
-    assert.doesNotMatch(JSON.stringify(response), /REROUTE|50-80K|Salalah/);
-  });
-
-  it('withholds generated prose from old transit summaries before caching a fresh response', async () => {
-    const capture = JSON.parse(await readFile('tests/fixtures/chokepoints-routing-advice-2026-09-10.json', 'utf8'));
-    const original = capture.body.chokepoints.find((cp: { id: string }) => cp.id === 'hormuz_strait');
-    const harness = redisHarness(async (url) => {
-      if (url.includes('msi.nga.mil')) return Response.json([]);
-      if (url.startsWith('https://relay.test/ais/snapshot')) return Response.json({
-        density: [], disruptions: [], snapshotAt: Date.now(), status: { connected: true, vessels: 10, messages: 20 },
-      });
-      throw new Error(`unexpected fetch: ${url}`);
-    });
-    const summaries = completeTransitSummaries();
-    const cases = [original.transitSummary.riskReportAction, undefined, null, { route: 'Suez', cost: '$50-80K' }];
-    for (const [index, advice] of cases.entries()) {
-      Object.assign(summaries[CHOKEPOINTS[index]!.id]!, {
-        riskSummary: advice, riskReportAction: advice, riskLevel: 'critical', incidentCount7d: 628,
-        todayTotal: null, todayTanker: null, todayCargo: null, todayOther: null,
-      });
-    }
-    harness.values.set('supply_chain:transit-summaries:v1', JSON.stringify({ summaries, fetchedAt: capture.retrievedAt }));
-    globalThis.fetch = harness.fetchImpl as typeof fetch;
-
-    const response = await getChokepointStatus({} as never, {});
-    assert.equal(response.upstreamUnavailable, false);
-    for (const cp of response.chokepoints.slice(0, cases.length)) {
-      assert.equal(cp.transitSummary?.riskReportAction, '');
-      assert.equal(cp.transitSummary?.riskSummary, '');
-      assert.equal(cp.transitSummary?.riskLevel, 'critical');
-      assert.equal(cp.transitSummary?.incidentCount7d, 628);
-      assert.equal(cp.transitSummary?.todayCountsAvailable, false);
-      assert.equal(cp.transitSummary?.dataAvailable, true);
-    }
-    assert.doesNotMatch(harness.values.get('supply_chain:chokepoints:v4') || '', /REROUTE|50-80K|Salalah/);
-  });
-
   it('uses append-only proto fields and the private NGA v2 cache key', async () => {
     const maritimeProto = await readFile('proto/worldmonitor/maritime/v1/list_navigational_warnings.proto', 'utf8');
     const supplyChainProto = await readFile('proto/worldmonitor/supply_chain/v1/supply_chain_data.proto', 'utf8');
@@ -404,4 +354,56 @@ describe('chokepoint source availability', () => {
       /source coverage incomplete/,
     );
   });
+  it('withholds legacy generated prose while preserving the captured risk observations', async () => {
+    const capture = JSON.parse(await readFile('tests/fixtures/chokepoints-routing-advice-2026-09-10.json', 'utf8'));
+    const harness = redisHarness(async (url) => { throw new Error(`unexpected fetch: ${url}`); });
+    harness.values.set('supply_chain:chokepoints:v4', JSON.stringify(capture.body));
+    globalThis.fetch = harness.fetchImpl as typeof fetch;
+
+    const response = await getChokepointStatus({} as never, {});
+    const expected = structuredClone(capture.body);
+    for (const cp of expected.chokepoints) {
+      cp.transitSummary.riskSummary = '';
+      cp.transitSummary.riskReportAction = '';
+    }
+    assert.deepEqual(response, expected);
+    assert.doesNotMatch(JSON.stringify(response), /REROUTE|50-80K|Salalah/);
+  });
+
+  it('withholds generated prose from old transit summaries before caching a fresh response', async () => {
+    const capture = JSON.parse(await readFile('tests/fixtures/chokepoints-routing-advice-2026-09-10.json', 'utf8'));
+    const original = capture.body.chokepoints.find((cp: { id: string }) => cp.id === 'hormuz_strait');
+    const harness = redisHarness(async (url) => {
+      if (url.includes('msi.nga.mil')) return Response.json([]);
+      if (url.startsWith('https://relay.test/ais/snapshot')) return Response.json({
+        density: [], disruptions: [], snapshotAt: Date.now(), status: { connected: true, vessels: 10, messages: 20 },
+      });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const summaries = completeTransitSummaries();
+    const cases = [original.transitSummary.riskReportAction, undefined, null, { route: 'Suez', cost: '$50-80K' }];
+    for (const [index, advice] of cases.entries()) {
+      Object.assign(summaries[CHOKEPOINTS[index]!.id]!, {
+        riskSummary: advice, riskReportAction: advice, riskLevel: 'critical', incidentCount7d: 628,
+        todayTotal: null, todayTanker: null, todayCargo: null, todayOther: null,
+      });
+    }
+    harness.values.set('supply_chain:transit-summaries:v1', JSON.stringify({ summaries, fetchedAt: capture.retrievedAt }));
+    globalThis.fetch = harness.fetchImpl as typeof fetch;
+
+    const response = await getChokepointStatus({} as never, {});
+    assert.equal(response.upstreamUnavailable, false);
+    for (const cp of response.chokepoints.slice(0, cases.length)) {
+      assert.equal(cp.transitSummary?.riskReportAction, '');
+      assert.equal(cp.transitSummary?.riskSummary, '');
+      assert.equal(cp.transitSummary?.riskLevel, 'critical');
+      assert.equal(cp.transitSummary?.incidentCount7d, 628);
+      assert.equal(cp.transitSummary?.todayCountsAvailable, false);
+      assert.equal(cp.transitSummary?.dataAvailable, true);
+    }
+    const cached = harness.values.get('supply_chain:chokepoints:v4');
+    assert.ok(cached, 'the fresh response must be written to the shared cache');
+    assert.doesNotMatch(cached, /REROUTE|50-80K|Salalah/);
+  });
+
 });

--- a/tests/dom/chokepoint-partial-coverage.test.mts
+++ b/tests/dom/chokepoint-partial-coverage.test.mts
@@ -4,6 +4,8 @@ import type { GetChokepointStatusResponse } from '@/generated/client/worldmonito
 import { ChokepointStripPanel } from '@/components/ChokepointStripPanel';
 import { SupplyChainPanel } from '@/components/SupplyChainPanel';
 import { mountEmbedChokepointStrip } from '@/embed/panels/chokepoint-strip';
+import { getChokepointStatus } from '../../server/worldmonitor/supply-chain/v1/get-chokepoint-status';
+import capture from '../fixtures/chokepoints-routing-advice-2026-09-10.json';
 import { initTestI18n } from './helpers/i18n.mts';
 
 const partialResponse = {
@@ -40,6 +42,36 @@ afterEach(() => {
 });
 
 describe('chokepoint partial coverage', () => {
+  it('renders critical Hormuz status without advice or an observed zero after a legacy cache read', async () => {
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://redis.test');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'synthetic');
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
+      const url = String(input);
+      if (url.startsWith('https://redis.test/get/')) return Response.json({ result: JSON.stringify(capture.body) });
+      return Response.json({});
+    });
+    try {
+      const response = await getChokepointStatus({} as never, {});
+      for (const data of [capture.body as unknown as GetChokepointStatusResponse, response]) {
+        const panel = new SupplyChainPanel();
+        panel.updateChokepointStatus(data);
+        await vi.advanceTimersByTimeAsync(151);
+        panel.getElement().querySelector<HTMLElement>('[data-cp-id="Strait of Hormuz"] .trade-restriction-header')!.click();
+        await vi.advanceTimersByTimeAsync(151);
+        const card = panel.getElement().querySelector('[data-cp-id="Strait of Hormuz"]')!;
+        expect(card.querySelector('.trade-restriction-header')?.getAttribute('aria-expanded')).toBe('true');
+        expect(card.textContent).toContain('critical');
+        expect(card.textContent).toContain('628');
+        expect(card.textContent).toContain('red');
+        expect(card.textContent).not.toMatch(/REROUTE|50-80K|Salalah|0 vessels/);
+        expect(card.querySelector('.sc-routing-advisory')).toBeNull();
+        panel.destroy();
+      }
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('shows the warning in the full supply-chain panel when rows remain available', async () => {
     const panel = new SupplyChainPanel();
     panel.updateChokepointStatus(partialResponse);

--- a/tests/fixtures/chokepoints-routing-advice-2026-09-10.json
+++ b/tests/fixtures/chokepoints-routing-advice-2026-09-10.json
@@ -1,0 +1,595 @@
+{
+  "retrievedAt": "2026-09-10T06:53:31.871Z",
+  "url": "https://www.worldmonitor.app/api/supply-chain/v1/get-chokepoint-status",
+  "status": 200,
+  "body": {
+    "chokepoints": [
+      {
+        "id": "suez",
+        "name": "Suez Canal",
+        "lat": 30.45,
+        "lon": 32.35,
+        "disruptionScore": 35,
+        "status": "yellow",
+        "activeWarnings": 1,
+        "aisDisruptions": 0,
+        "congestionLevel": "normal",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "China-Europe (Suez)",
+          "Gulf-Europe Oil",
+          "Qatar LNG-Europe"
+        ],
+        "description": "JWC Listed Area — adjacent to active Red Sea conflict and Iran-Israel war spillover; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": -3.3,
+          "history": [],
+          "riskLevel": "critical",
+          "incidentCount7d": 8,
+          "disruptionPct": 100,
+          "riskSummary": "The Suez Canal approach has deteriorated sharply in the past 7 days with 17 material conflict events (63% of all activity). Armed confrontations and coercive military pressure are concentrated at Port",
+          "riskReportAction": "Reroute non-urgent cargo via Cape of Good Hope immediately. Additional transit time: 10-12 days. Additional cost: 18-22% for fuel and insurance. For time-sensitive shipments, transit Suez only if cargo value justifies 35-40% insurance premium increase and 2-4 day delay risk. Confirm with Egyptian Port Authority that your vessel is cleared before entering approach zone. Do not anchor in northern Red Sea until clearance is confirmed.",
+          "dataAvailable": true
+        },
+        "flowEstimate": {
+          "currentMbd": 7.5,
+          "baselineMbd": 7.6,
+          "flowRatio": 0.983,
+          "disrupted": false,
+          "source": "portwatch-dwt",
+          "hazardAlertLevel": "",
+          "hazardAlertName": ""
+        },
+        "warRiskTier": "WAR_RISK_TIER_HIGH"
+      },
+      {
+        "id": "malacca_strait",
+        "name": "Strait of Malacca",
+        "lat": 2.5,
+        "lon": 101.5,
+        "disruptionScore": 15,
+        "status": "green",
+        "activeWarnings": 1,
+        "aisDisruptions": 1,
+        "congestionLevel": "elevated",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "China-Middle East Oil",
+          "China-Europe (via Suez)",
+          "Japan-Middle East Oil"
+        ],
+        "description": "No active disruptions; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": 1.3,
+          "history": [],
+          "riskLevel": "",
+          "incidentCount7d": 0,
+          "disruptionPct": 0,
+          "riskSummary": "",
+          "riskReportAction": "",
+          "dataAvailable": true
+        },
+        "flowEstimate": {
+          "currentMbd": 13.8,
+          "baselineMbd": 17.2,
+          "flowRatio": 0.804,
+          "disrupted": false,
+          "source": "portwatch-dwt",
+          "hazardAlertLevel": "",
+          "hazardAlertName": ""
+        },
+        "warRiskTier": "WAR_RISK_TIER_NORMAL"
+      },
+      {
+        "id": "hormuz_strait",
+        "name": "Strait of Hormuz",
+        "lat": 26.56,
+        "lon": 56.25,
+        "disruptionScore": 70,
+        "status": "red",
+        "activeWarnings": 0,
+        "aisDisruptions": 0,
+        "congestionLevel": "normal",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "Gulf Oil Exports",
+          "Qatar LNG",
+          "Iran Exports"
+        ],
+        "description": "Active conflict — Iran-Israel war; Iranian naval blockade risk and mines reported in Persian Gulf; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "eastbound",
+          "westbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": -26.7,
+          "history": [],
+          "riskLevel": "critical",
+          "incidentCount7d": 628,
+          "disruptionPct": 100,
+          "riskSummary": "Persian Gulf shipping corridor is under acute stress with 737 material conflict events recorded in 7 days (48% of all activity). Concentrated clashes near Bandar Abbas, Bahrain, and the UAE indicate s",
+          "riskReportAction": "REROUTE all non-essential cargo via Suez Canal immediately. Direct Hormuz transit should be limited to essential supplies with full war-risk insurance (costs +$50-80K per tanker transit). For time-sensitive freight, use Salalah (Oman) as transshipment hub instead of UAE ports — adds 3-4 days but avoids active conflict zones near Dubai/Jebel Ali. Restart Bandar Abbas operations only after 5+ consecutive days without material conflict events (Goldstein >-3.0). Bahrain port access is viable for non",
+          "dataAvailable": true
+        },
+        "flowEstimate": {
+          "currentMbd": 2.6,
+          "baselineMbd": 21,
+          "flowRatio": 0.122,
+          "disrupted": true,
+          "source": "portwatch-dwt",
+          "hazardAlertLevel": "RED",
+          "hazardAlertName": "HORMUZ-26"
+        },
+        "warRiskTier": "WAR_RISK_TIER_WAR_ZONE"
+      },
+      {
+        "id": "bab_el_mandeb",
+        "name": "Bab el-Mandeb",
+        "lat": 12.58,
+        "lon": 43.33,
+        "disruptionScore": 40,
+        "status": "yellow",
+        "activeWarnings": 0,
+        "aisDisruptions": 0,
+        "congestionLevel": "normal",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "Suez-Indian Ocean",
+          "Gulf-Europe Oil",
+          "Red Sea Transit"
+        ],
+        "description": "JWC Listed Area — active Houthi attacks on commercial shipping; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": -3.3,
+          "history": [],
+          "riskLevel": "critical",
+          "incidentCount7d": 276,
+          "disruptionPct": 100,
+          "riskSummary": "Sustained armed conflict across Yemen's interior and coastal regions has intensified in the past 48 hours, with 10 material conflict events recorded. Multiple armed confrontations near Shabwa and Mari",
+          "riskReportAction": "Maintain RED SEA CORRIDOR USE with enhanced protocols. Route container vessels via direct Bab-el-Mandeb passage during daylight hours only; night transits add 8-12 hours buffer. Alternative: Cape of Good Hope reroute adds 10-12 days transit time and 18-24% fuel cost premium—deploy only for ultra-high-value cargo or if specific maritime incidents occur near Bab-el-Mandeb. Recommend Djibouti port for bunker/inspection (lower risk than Aden). Carriers should carry premium insurance surcharge of 0.1",
+          "dataAvailable": true
+        },
+        "flowEstimate": {
+          "currentMbd": 3.5,
+          "baselineMbd": 6.2,
+          "flowRatio": 0.572,
+          "disrupted": true,
+          "source": "portwatch-dwt",
+          "hazardAlertLevel": "",
+          "hazardAlertName": ""
+        },
+        "warRiskTier": "WAR_RISK_TIER_CRITICAL"
+      },
+      {
+        "id": "panama",
+        "name": "Panama Canal",
+        "lat": 9.08,
+        "lon": -79.68,
+        "disruptionScore": 0,
+        "status": "green",
+        "activeWarnings": 0,
+        "aisDisruptions": 0,
+        "congestionLevel": "normal",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "US East Coast-Asia",
+          "US East Coast-South America",
+          "Atlantic-Pacific Bulk"
+        ],
+        "description": "No active disruptions; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": 2.9,
+          "history": [],
+          "riskLevel": "",
+          "incidentCount7d": 0,
+          "disruptionPct": 0,
+          "riskSummary": "",
+          "riskReportAction": "",
+          "dataAvailable": true
+        },
+        "flowEstimate": {
+          "currentMbd": 1,
+          "baselineMbd": 0.9,
+          "flowRatio": 1.096,
+          "disrupted": false,
+          "source": "portwatch-dwt",
+          "hazardAlertLevel": "",
+          "hazardAlertName": ""
+        },
+        "warRiskTier": "WAR_RISK_TIER_NORMAL"
+      },
+      {
+        "id": "taiwan_strait",
+        "name": "Taiwan Strait",
+        "lat": 24,
+        "lon": 119.5,
+        "disruptionScore": 20,
+        "status": "yellow",
+        "activeWarnings": 0,
+        "aisDisruptions": 1,
+        "congestionLevel": "low",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "China-Japan Trade",
+          "Korea-Southeast Asia",
+          "Pacific Semiconductor"
+        ],
+        "description": "Cross-strait military tensions and PLA exercises; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 4,
+          "todayTanker": 0,
+          "todayCargo": 3,
+          "todayOther": 1,
+          "todayCountsAvailable": true,
+          "wowChangePct": 17.8,
+          "history": [],
+          "riskLevel": "critical",
+          "incidentCount7d": 617,
+          "disruptionPct": 100,
+          "riskSummary": "South China Sea corridor experiencing rapid escalation with 1,643 events in 7 days, 47% classified as material conflict. Armed clashes between Philippine and Chinese forces intensified May 2-3 near Be",
+          "riskReportAction": "REROUTE all non-essential container/break-bulk traffic away from Philippine archipelago and northern South China Sea. Recommended corridor: Singapore → Sunda/Lombok Strait → Indian Ocean → alternative Pacific routing (adds 3-5 days, +$150K-250K per 20ft container). Maintain Manila port operations for essential medical/food aid only. Tanker traffic: Use Malacca Strait with heightened piracy protocols. For urgent Manila-bound cargo: accept 6-8 day delay pending military de-escalation or authorize ",
+          "dataAvailable": true
+        },
+        "warRiskTier": "WAR_RISK_TIER_ELEVATED"
+      },
+      {
+        "id": "cape_of_good_hope",
+        "name": "Cape of Good Hope",
+        "lat": -34.36,
+        "lon": 18.49,
+        "disruptionScore": 15,
+        "status": "green",
+        "activeWarnings": 0,
+        "aisDisruptions": 1,
+        "congestionLevel": "high",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "Asia-Europe (Cape Route)",
+          "Gulf-Americas Oil",
+          "Suez Bypass"
+        ],
+        "description": "No active disruptions; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "eastbound",
+          "westbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": -14.5,
+          "history": [],
+          "riskLevel": "",
+          "incidentCount7d": 0,
+          "disruptionPct": 0,
+          "riskSummary": "",
+          "riskReportAction": "",
+          "dataAvailable": true
+        },
+        "warRiskTier": "WAR_RISK_TIER_NORMAL"
+      },
+      {
+        "id": "gibraltar",
+        "name": "Strait of Gibraltar",
+        "lat": 35.96,
+        "lon": -5.35,
+        "disruptionScore": 15,
+        "status": "green",
+        "activeWarnings": 0,
+        "aisDisruptions": 1,
+        "congestionLevel": "high",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "Atlantic-Mediterranean",
+          "Gulf-Europe Oil (final leg)",
+          "India-Europe"
+        ],
+        "description": "No active disruptions; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "eastbound",
+          "westbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 1,
+          "todayTanker": 0,
+          "todayCargo": 1,
+          "todayOther": 0,
+          "todayCountsAvailable": true,
+          "wowChangePct": 10,
+          "history": [],
+          "riskLevel": "",
+          "incidentCount7d": 0,
+          "disruptionPct": 0,
+          "riskSummary": "",
+          "riskReportAction": "",
+          "dataAvailable": true
+        },
+        "warRiskTier": "WAR_RISK_TIER_NORMAL"
+      },
+      {
+        "id": "bosphorus",
+        "name": "Bosporus Strait",
+        "lat": 41.12,
+        "lon": 29.05,
+        "disruptionScore": 30,
+        "status": "yellow",
+        "activeWarnings": 0,
+        "aisDisruptions": 1,
+        "congestionLevel": "high",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "Russia Black Sea Exports",
+          "Ukraine Grain",
+          "Caspian Oil Transit",
+          "Aegean-Marmara Transit"
+        ],
+        "description": "Montreux Convention restrictions; elevated due to Russia-Ukraine war and periodic Turkish traffic controls; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 1,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 1,
+          "todayCountsAvailable": true,
+          "wowChangePct": -11.2,
+          "history": [],
+          "riskLevel": "critical",
+          "incidentCount7d": 329,
+          "disruptionPct": 100,
+          "riskSummary": "The Black Sea corridor is experiencing acute escalation with 752 material conflict events recorded in the past 7 days (69% of total activity). Armed clashes dominate the region: May 3 dawn attacks str",
+          "riskReportAction": "REROUTE immediately: divert all Black Sea cargo via Suez Canal (Red Sea–Mediterranean). Expected additional transit time: +8–10 days (Cape routing adds 14–16 days; Suez adds 8–10). Cost impact: +$45,000–$80,000 per TEU containerized cargo; +20–25% on bulk/tanker rates due to insurance. For urgent non-hazardous breakbulk: consider extreme risk premium routing via Georgian ports (Batumi) only if force majeure exemption acceptable—Tuapse engagement on May 3 makes Russian Black Sea ports unusable fo",
+          "dataAvailable": true
+        },
+        "flowEstimate": {
+          "currentMbd": 2.5,
+          "baselineMbd": 2.9,
+          "flowRatio": 0.85,
+          "disrupted": false,
+          "source": "portwatch-dwt",
+          "hazardAlertLevel": "",
+          "hazardAlertName": ""
+        },
+        "warRiskTier": "WAR_RISK_TIER_ELEVATED"
+      },
+      {
+        "id": "korea_strait",
+        "name": "Korea Strait",
+        "lat": 34,
+        "lon": 129,
+        "disruptionScore": 0,
+        "status": "green",
+        "activeWarnings": 0,
+        "aisDisruptions": 0,
+        "congestionLevel": "normal",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "Japan-Korea Trade",
+          "China-Japan (alternate)",
+          "Pacific-East Asia"
+        ],
+        "description": "No active disruptions; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": -10.6,
+          "history": [],
+          "riskLevel": "",
+          "incidentCount7d": 0,
+          "disruptionPct": 0,
+          "riskSummary": "",
+          "riskReportAction": "",
+          "dataAvailable": true
+        },
+        "warRiskTier": "WAR_RISK_TIER_NORMAL"
+      },
+      {
+        "id": "dover_strait",
+        "name": "Dover Strait",
+        "lat": 51.05,
+        "lon": 1.45,
+        "disruptionScore": 30,
+        "status": "yellow",
+        "activeWarnings": 7,
+        "aisDisruptions": 1,
+        "congestionLevel": "high",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "North Sea-Atlantic",
+          "Europe Intra-Trade",
+          "UK-Continental Europe"
+        ],
+        "description": "No active disruptions; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 7,
+          "todayTanker": 3,
+          "todayCargo": 0,
+          "todayOther": 4,
+          "todayCountsAvailable": true,
+          "wowChangePct": 2,
+          "history": [],
+          "riskLevel": "",
+          "incidentCount7d": 0,
+          "disruptionPct": 0,
+          "riskSummary": "",
+          "riskReportAction": "",
+          "dataAvailable": true
+        },
+        "flowEstimate": {
+          "currentMbd": 2.9,
+          "baselineMbd": 3,
+          "flowRatio": 0.97,
+          "disrupted": false,
+          "source": "portwatch-dwt",
+          "hazardAlertLevel": "",
+          "hazardAlertName": ""
+        },
+        "warRiskTier": "WAR_RISK_TIER_NORMAL"
+      },
+      {
+        "id": "kerch_strait",
+        "name": "Kerch Strait",
+        "lat": 45.33,
+        "lon": 36.6,
+        "disruptionScore": 70,
+        "status": "red",
+        "activeWarnings": 0,
+        "aisDisruptions": 0,
+        "congestionLevel": "normal",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "Ukraine Grain (Azov)",
+          "Russia Azov Ports",
+          "Crimea Supply"
+        ],
+        "description": "Active conflict zone; Russia controls Kerch Bridge; Ukraine grain exports via Azov severely restricted; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": 0,
+          "history": [],
+          "riskLevel": "",
+          "incidentCount7d": 0,
+          "disruptionPct": 0,
+          "riskSummary": "",
+          "riskReportAction": "",
+          "dataAvailable": true
+        },
+        "warRiskTier": "WAR_RISK_TIER_WAR_ZONE"
+      },
+      {
+        "id": "lombok_strait",
+        "name": "Lombok Strait",
+        "lat": -8.47,
+        "lon": 115.72,
+        "disruptionScore": 0,
+        "status": "green",
+        "activeWarnings": 0,
+        "aisDisruptions": 0,
+        "congestionLevel": "normal",
+        "navigationalWarningsAvailable": true,
+        "aisSnapshotAvailable": true,
+        "affectedRoutes": [
+          "Malacca Bypass (VLCCs)",
+          "Australia-Asia",
+          "Indian Ocean-Pacific"
+        ],
+        "description": "No active disruptions; Threat baseline last reviewed > 120 days ago — review recommended",
+        "directions": [
+          "northbound",
+          "southbound"
+        ],
+        "directionalDwt": [],
+        "transitSummary": {
+          "todayTotal": 0,
+          "todayTanker": 0,
+          "todayCargo": 0,
+          "todayOther": 0,
+          "todayCountsAvailable": false,
+          "wowChangePct": -6.9,
+          "history": [],
+          "riskLevel": "",
+          "incidentCount7d": 0,
+          "disruptionPct": 0,
+          "riskSummary": "",
+          "riskReportAction": "",
+          "dataAvailable": true
+        },
+        "warRiskTier": "WAR_RISK_TIER_NORMAL"
+      }
+    ],
+    "fetchedAt": "2026-09-10T06:50:30.970Z",
+    "upstreamUnavailable": false
+  }
+}

--- a/tests/mcp-flow-source-taxonomy.test.mts
+++ b/tests/mcp-flow-source-taxonomy.test.mts
@@ -251,19 +251,7 @@ describe('get_chokepoint_status narrows source end-to-end through tools/call (#6
     }
   });
 
-  // KNOWN LIMIT, pinned rather than claimed away. api/mcp/dispatch.ts wraps
-  // `_postFilter` in a try/catch that falls back to the RAW, un-narrowed `data`
-  // on any non-stored-contract throw, so the closed-enum guarantee holds only
-  // while the WHOLE filter body avoids throwing — not just the narrowing loop,
-  // which is total over any JSON shape. The reachable trigger today is
-  // pre-existing and downstream of the narrowing: narrowNested dereferences
-  // `c.id` on every chokepoint-baselines row, so a null row throws once a
-  // `chokepoint` argument is supplied.
-  //
-  // This asserts what the code ACTUALLY does, so the day someone makes the
-  // enum fail closed (or the fallback stops discarding the narrowed clone),
-  // this test goes red and the decision is deliberate instead of accidental.
-  it('fails OPEN: a throw later in the filter serves the raw un-narrowed source', async () => {
+  it('keeps the source enum narrowed when a baseline row is null', async () => {
     globalThis.fetch = async (url, init) => {
       const u = url.toString();
       if (u.endsWith('/pipeline')) {
@@ -273,8 +261,6 @@ describe('get_chokepoint_status narrows source end-to-end through tools/call (#6
       if (u.includes(`/get/${encodeURIComponent('energy:chokepoint-flows:v1')}`)) {
         return Response.json({ result: JSON.stringify(FLOWS) });
       }
-      // A null row makes narrowNested's `c.id` deref throw — but only once the
-      // `chokepoint` argument below sends the filter down that branch.
       if (u.includes(`/get/${encodeURIComponent('energy:chokepoint-baselines:v1')}`)) {
         return Response.json({ result: JSON.stringify({ chokepoints: [null] }) });
       }
@@ -291,18 +277,13 @@ describe('get_chokepoint_status narrows source end-to-end through tools/call (#6
       }),
     }));
 
-    assert.equal(res.status, 200, 'the fail-open path must still answer 200, not surface the filter bug');
+    assert.equal(res.status, 200);
     const body = await res.json();
-    assert.ok(body.result?.content, 'tools/call must return content on the fail-open path');
+    assert.ok(body.result?.content, 'tools/call must return content');
     const served = JSON.parse(body.result.content[0].text).data['chokepoint-flows'];
 
-    assert.equal(
-      served.suez.source, 'satellite-blend',
-      'CURRENT behaviour: the fallback discards the narrowed clone, so an undeclared basis reaches the client verbatim despite the outputSchema advertising a closed enum. Change this assertion only alongside a deliberate decision to make the enum fail closed.',
-    );
-    assert.ok(
-      !WIRE_TAXONOMY.includes(served.suez.source),
-      'and that served value is outside the declared enum — this is the gap, stated plainly',
-    );
+    assert.equal(served.suez.source, 'FLOW_SOURCE_UNSPECIFIED');
+    assert.deepEqual(Object.keys(served), ['suez']);
+    assert.deepEqual(JSON.parse(body.result.content[0].text).data['chokepoint-baselines'].chokepoints, []);
   });
 });

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -1157,19 +1157,22 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     assert.equal(payload.stale, true, 'preview risk data must use the preview freshness verdict');
   });
 
-  it('withholds cached corridor prose through tools and resource reads', async () => {
-    const capture = JSON.parse(readFileSync(resolve(__dirname, 'fixtures/chokepoints-routing-advice-2026-09-10.json'), 'utf8'));
-    const captured = capture.body.chokepoints.find(cp => cp.id === 'hormuz_strait').transitSummary;
-    for (const advice of [captured.riskReportAction, undefined, null, { route: 'Suez', cost: '$50-80K' }]) {
-      const summary = { ...captured, todayTotal: null, riskSummary: advice, riskReportAction: advice };
-      installMockFetch({ keyOverrides: {
-        'supply_chain:transit-summaries:v1': { summaries: { hormuz_strait: summary }, fetchedAt: capture.retrievedAt },
-      } });
-      for (const request of [
-        callBody('get_chokepoint_status', { chokepoint: 'hormuz_strait' }),
-        readBody('worldmonitor://chokepoints/strait-of-hormuz/status'),
-      ]) {
+  for (const method of ['tools/call', 'resources/read']) {
+    it(`withholds cached corridor prose with a null baseline row through ${method}`, async () => {
+      const capture = JSON.parse(readFileSync(resolve(__dirname, 'fixtures/chokepoints-routing-advice-2026-09-10.json'), 'utf8'));
+      const captured = capture.body.chokepoints.find(cp => cp.id === 'hormuz_strait').transitSummary;
+      const baseline = { id: 'hormuz_strait', name: 'Strait of Hormuz' };
+      for (const advice of [captured.riskReportAction, undefined, null, { route: 'Suez', cost: '$50-80K' }]) {
+        const summary = { ...captured, todayTotal: null, riskSummary: advice, riskReportAction: advice };
+        installMockFetch({ keyOverrides: {
+          'supply_chain:transit-summaries:v1': { summaries: { hormuz_strait: summary }, fetchedAt: capture.retrievedAt },
+          'energy:chokepoint-baselines:v1': { chokepoints: [null, baseline, { id: 'suez' }] },
+        } });
+        const request = method === 'tools/call'
+          ? callBody('get_chokepoint_status', { chokepoint: 'hormuz' })
+          : readBody('worldmonitor://chokepoints/strait-of-hormuz/status');
         const response = await handler(envKeyReq(request));
+        assert.equal(response.status, 200);
         const body = await response.json();
         assert.equal(body.error, undefined);
         const text = body.result.contents?.[0]?.text ?? body.result.content?.[0]?.text;
@@ -1177,10 +1180,11 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
         const served = payload.data['transit-summaries'].summaries.hormuz_strait;
         assert.deepEqual(served, { ...summary, riskSummary: '', riskReportAction: '' });
         assert.equal(payload.data['transit-summaries'].fetchedAt, capture.retrievedAt);
+        assert.deepEqual(payload.data['chokepoint-baselines'].chokepoints, [baseline]);
         assert.doesNotMatch(text, /REROUTE|50-80K|Salalah/);
       }
-    }
-  });
+    });
+  }
 
   it('resources/read worldmonitor://chokepoints/suez/status returns the transit-summary envelope with cached_at + stale', async () => {
     const res = await handler(envKeyReq(readBody('worldmonitor://chokepoints/suez/status')));

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -1157,6 +1157,31 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     assert.equal(payload.stale, true, 'preview risk data must use the preview freshness verdict');
   });
 
+  it('withholds cached corridor prose through tools and resource reads', async () => {
+    const capture = JSON.parse(readFileSync(resolve(__dirname, 'fixtures/chokepoints-routing-advice-2026-09-10.json'), 'utf8'));
+    const captured = capture.body.chokepoints.find(cp => cp.id === 'hormuz_strait').transitSummary;
+    for (const advice of [captured.riskReportAction, undefined, null, { route: 'Suez', cost: '$50-80K' }]) {
+      const summary = { ...captured, todayTotal: null, riskSummary: advice, riskReportAction: advice };
+      installMockFetch({ keyOverrides: {
+        'supply_chain:transit-summaries:v1': { summaries: { hormuz_strait: summary }, fetchedAt: capture.retrievedAt },
+      } });
+      for (const request of [
+        callBody('get_chokepoint_status', { chokepoint: 'hormuz_strait' }),
+        readBody('worldmonitor://chokepoints/strait-of-hormuz/status'),
+      ]) {
+        const response = await handler(envKeyReq(request));
+        const body = await response.json();
+        assert.equal(body.error, undefined);
+        const text = body.result.contents?.[0]?.text ?? body.result.content?.[0]?.text;
+        const payload = JSON.parse(text);
+        const served = payload.data['transit-summaries'].summaries.hormuz_strait;
+        assert.deepEqual(served, { ...summary, riskSummary: '', riskReportAction: '' });
+        assert.equal(payload.data['transit-summaries'].fetchedAt, capture.retrievedAt);
+        assert.doesNotMatch(text, /REROUTE|50-80K|Salalah/);
+      }
+    }
+  });
+
   it('resources/read worldmonitor://chokepoints/suez/status returns the transit-summary envelope with cached_at + stale', async () => {
     const res = await handler(envKeyReq(readBody('worldmonitor://chokepoints/suez/status')));
     assert.equal(res.status, 200);

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -395,6 +395,27 @@ describe('seedTransitSummaries (relay)', () => {
     assert.ok(checked >= 13, `expected every canonical chokepoint compared, got ${checked}`);
   });
 
+  it('withholds legacy corridor prose on restart while retaining structured risk and absent counts', async () => {
+    const capture = JSON.parse(readFileSync(resolve(root, 'tests/fixtures/chokepoints-routing-advice-2026-09-10.json'), 'utf8'));
+    const risk = capture.body.chokepoints.find(cp => cp.id === 'hormuz_strait').transitSummary;
+    const writes = [];
+    const seed = buildSeedTransitSummaries({
+      envelopeRead: async key => key === 'supply_chain:portwatch:v1'
+        ? { hormuz_strait: { history: [], wowChangePct: -26.7 } }
+        : { hormuz_strait: risk },
+      envelopeWrite: async (key, data) => { writes.push({ key, data }); return true; },
+      upstashSet: async () => {},
+    });
+    await seed();
+    const summary = writes.find(w => w.key === 'supply_chain:transit-summaries:v1').data.summaries.hormuz_strait;
+    assert.equal(summary.riskReportAction, '');
+    assert.equal(summary.riskSummary, '');
+    assert.equal(summary.riskLevel, 'critical');
+    assert.equal(summary.incidentCount7d, 628);
+    assert.equal(summary.todayTotal, null);
+    assert.equal(summary.dataAvailable, true);
+  });
+
   it('still publishes a real Panama disruptionPct of 0 from corridor risk', async () => {
     const fakePortwatch = {
       panama: { history: makeDays(40, 30, 0), wowChangePct: -10.1 },

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -395,6 +395,56 @@ describe('seedTransitSummaries (relay)', () => {
     assert.ok(checked >= 13, `expected every canonical chokepoint compared, got ${checked}`);
   });
 
+  it('ingests generated prose without publishing it in corridor, transit or notification payloads', async () => {
+    const capture = JSON.parse(readFileSync(resolve(root, 'tests/fixtures/chokepoints-routing-advice-2026-09-10.json'), 'utf8'));
+    const captured = capture.body.chokepoints.find(cp => cp.id === 'hormuz_strait').transitSummary;
+    const corridorBody = relaySrc.match(/async function seedCorridorRisk\(\)\s*\{([\s\S]*?)\n\}/)?.[1];
+    assert.ok(corridorBody);
+    const source = [
+      extractConstLine('CORRIDOR_RISK_BASE_URL'),
+      extractConstLine('CORRIDOR_RISK_TTL'),
+      'let corridorRiskSeedInFlight = false;',
+      `async function seedCorridorRisk() {${corridorBody}\n}`,
+      seedHarnessSrc.replace('return seedTransitSummaries;', 'return { seedCorridorRisk, seedTransitSummaries };'),
+    ].join('\n');
+    for (const advice of [captured.riskReportAction, undefined, null, { route: 'Suez', cost: '$50-80K' }]) {
+      const writes = new Map();
+      const notifications = [];
+      const seed = new Function(
+        'fetch', 'envelopeRead', 'envelopeWrite', 'upstashSet', 'console', 'UPSTASH_ENABLED',
+        'chokepointCrossings', 'detectTrafficAnomaly', 'CHOKEPOINT_THREAT_LEVELS',
+        'CORRIDOR_RISK_NAME_MAP', 'deriveCorridorRiskLevel', 'CHROME_UA', 'publishNotificationEvent',
+        source,
+      )(
+        async () => Response.json([{ name: 'Strait of Hormuz', score: 80, incident_count_7d: 628,
+          disruption_pct: 100, risk_summary: advice, risk_report: { action: advice } }]),
+        async key => key === 'supply_chain:portwatch:v1'
+          ? Object.fromEntries(ALL_CANONICAL_IDS.map(id => [id, { history: [], wowChangePct: -26.7 }]))
+          : null,
+        async (key, data) => { writes.set(key, data); return true; },
+        async () => {}, { log() {}, warn(message) { assert.fail(message); } }, true,
+        new Map(), detectTrafficAnomaly, CHOKEPOINT_THREAT_LEVELS,
+        CORRIDOR_RISK_NAME_MAP, deriveCorridorRiskLevel, 'test-agent',
+        async event => { notifications.push(event); },
+      );
+      await seed.seedCorridorRisk();
+      await seed.seedTransitSummaries();
+      const corridor = writes.get('supply_chain:corridorrisk:v1').hormuz_strait;
+      const summary = writes.get('supply_chain:transit-summaries:v1').summaries.hormuz_strait;
+      for (const entry of [corridor, summary]) {
+        assert.equal(entry.riskSummary, '');
+        assert.equal(entry.riskReportAction, '');
+        assert.equal(entry.riskLevel, 'critical');
+        assert.equal(entry.incidentCount7d, 628);
+        assert.equal(entry.disruptionPct, 100);
+      }
+      assert.equal(summary.todayTotal, null);
+      assert.equal(summary.dataAvailable, true);
+      assert.equal(notifications.length, 1);
+      assert.doesNotMatch(JSON.stringify([...writes.values(), notifications]), /REROUTE|50-80K|Salalah/);
+    }
+  });
+
   it('withholds legacy corridor prose on restart while retaining structured risk and absent counts', async () => {
     const capture = JSON.parse(readFileSync(resolve(root, 'tests/fixtures/chokepoints-routing-advice-2026-09-10.json'), 'utf8'));
     const risk = capture.body.chokepoints.find(cp => cp.id === 'hormuz_strait').transitSummary;


### PR DESCRIPTION
## Summary

The Hormuz response recommended an impossible Suez bypass and supplied unsupported shipping cost and timing estimates. CorridorRisk generated prose passed through the relay and caches into API, MCP and dashboard output.

Withhold `riskSummary` and `riskReportAction` at ingestion and publication boundaries, including old corridor data, transit summaries, REST caches, bootstrap responses and published bootstrap tiers. Both fields remain empty strings for API compatibility. Remove the obsolete dashboard advice row so a pre-fix response in its persisted browser cache cannot restore the advice. Structured risk, flow, observation dates and availability flags remain intact. No replacement shipping plan or route engine is added.

Fixes #7958.

## Verification

The exact production GET capture from 10 September 2026 is a regression fixture. The failing tests were committed before the fix. They reproduced the Suez recommendation in relay hydration and the real REST handler.

Checks cover fresh relay ingestion and notification payloads, legacy cache hydration, cold and cached REST responses, MCP tools and resource reads, bootstrap origin/publisher parity, and the expanded Supply Chain card. Malformed and absent prose and advice inserted into the summary field are suppressed. Critical risk, 628 incidents, source dates and unavailable today counts are retained.

Validation passed 189 focused relay/REST/MCP/bootstrap regressions, 4 DOM checks, 474 sidecar tests, frontend/API/DOM type checks and import-boundary lint.

Chromium rendered the real panel with the raw legacy response and actual bootstrap output at 1440px and 390px. Both preserved critical risk and 628 incidents and withheld the advice row and false observed zero. The isolated renderer check had no console errors. Full-dashboard fixture navigation did not activate its lazy Supply Chain loader, so full dashboard acceptance remains a deployment check.

Local review used `ce-code-review` sequentially under the repository tool mapping. No actionable findings remain. No independent model review was run.

## Post-Deploy Monitoring & Validation

The repository owner should check fresh REST, fast bootstrap, `get_chokepoint_status` and the Hormuz MCP resource after the web deployment. Confirm both prose fields are empty while critical status and availability flags match the source records. Expand Hormuz in the dashboard and confirm no generated route advice or false observed zero appears.

After the authorized relay and bootstrap publisher deployments, observe one natural hourly CorridorRisk run and the next transit-summary and bootstrap publication cycles. Search logs for `[CorridorRisk] Seeded`, `[TransitSummary]` and bootstrap publisher failures. Inspect the new payloads and preserve observation timestamps.

Acceptance remains open until browser/CDN/KV objects have refreshed or expired. Failure signals are returning route/cost prose, lost structured observations, changed availability, or publisher/relay failures. If these occur, retain web-reader suppression and investigate the affected writer; reverting all readers would re-expose legacy advice. No deployment or production seeder was run for this PR.
