### PR TITLE
fix(fred): rotate sticky proxy exits on retry

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1418,14 +1418,14 @@ export function curlFetch(
 //                  "http://user:pass@host:port"  (explicit plain TCP)
 // Bare/undeclared-scheme proxies always use TLS (Decodo gate.decodo.com requires it).
 // Explicit http:// proxies use plain TCP to avoid breaking non-TLS setups.
-async function httpsProxyFetchJson(url, proxyAuth) {
-  const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, { accept: 'application/json' });
+async function httpsProxyFetchJson(url, proxyAuth, proxyAttempt = 0) {
+  const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, { accept: 'application/json', proxyAttempt });
   return JSON.parse(buffer.toString('utf8'));
 }
 
-export async function httpsProxyFetchRaw(url, proxyAuth, { accept = '*/*', timeoutMs = 20_000, signal } = {}) {
-  const { proxyFetch, parseProxyConfig } = createRequire(import.meta.url)('./_proxy-utils.cjs');
-  const proxyConfig = parseProxyConfig(proxyAuth);
+export async function httpsProxyFetchRaw(url, proxyAuth, { accept = '*/*', timeoutMs = 20_000, signal, proxyAttempt = 0 } = {}) {
+  const { proxyFetch, parseProxyConfigForAttempt } = createRequire(import.meta.url)('./_proxy-utils.cjs');
+  const proxyConfig = parseProxyConfigForAttempt(proxyAuth, proxyAttempt);
   if (!proxyConfig) throw new Error('Invalid proxy auth string');
   const result = await proxyFetch(url, proxyConfig, { accept, timeoutMs, signal, headers: { 'User-Agent': CHROME_UA } });
   if (!result.ok) throw Object.assign(new Error(`HTTP ${result.status}`), { status: result.status });
@@ -1489,12 +1489,13 @@ async function fredDirectFetchJson(url) {
 // so try proxy first to avoid 20s timeout on every direct attempt.
 export async function fredFetchJson(url, proxyAuth) {
   if (proxyAuth) {
-    // Retry the proxy (rotates exit IP per attempt) before falling back direct.
+    // Advance Decodo sticky ports before falling back direct. Reusing port
+    // 10001 kept all retries on the failed exit during the 2026-09-10 outage.
     // isTransientProxyError covers TLS-handshake tears — see its doc comment.
     let lastProxyErr;
     for (let attempt = 1; attempt <= 3; attempt++) {
       try {
-        return await httpsProxyFetchJson(url, proxyAuth);
+        return await httpsProxyFetchJson(url, proxyAuth, attempt - 1);
       } catch (proxyErr) {
         lastProxyErr = proxyErr;
         const transient = isTransientProxyError(proxyErr.message);

--- a/tests/fred-proxy-transient-classify.test.mjs
+++ b/tests/fred-proxy-transient-classify.test.mjs
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
 
 import { CHROME_UA, fredFetchJson, isTransientProxyError } from '../scripts/_seed-utils.mjs';
 
@@ -13,6 +14,56 @@ import { CHROME_UA, fredFetchJson, isTransientProxyError } from '../scripts/_see
 // Run: node --test tests/fred-proxy-transient-classify.test.mjs
 
 const originalFetch = globalThis.fetch;
+const proxyUtils = createRequire(import.meta.url)('../scripts/_proxy-utils.cjs');
+
+test('FRED retries a failed sticky exit on a different port before falling back direct', async (t) => {
+  const routes = [];
+  t.mock.method(proxyUtils, 'proxyFetch', async (_url, config) => {
+    routes.push(config);
+    if (config.port === 10001) throw new Error('Proxy CONNECT: HTTP/1.1 522 Server Error');
+    return { ok: true, buffer: Buffer.from('{"observations":[{"value":"1"}]}') };
+  });
+  t.mock.method(globalThis, 'fetch', async () => { throw new Error('direct must not be needed'); });
+  const result = await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
+  assert.deepEqual(routes.map((route) => route.port), [10001, 10002]);
+  assert.ok(routes.every((route) => route.host === 'gate.decodo.com' && route.tls && route.auth === 'fake:secret'));
+  assert.equal(result.observations[0].value, '1');
+});
+
+test('FRED exhausts three distinct sticky exits then retains the direct fallback', async (t) => {
+  const ports = [];
+  t.mock.method(proxyUtils, 'proxyFetch', async (_url, config) => {
+    ports.push(config.port);
+    throw new Error('Proxy CONNECT: HTTP/1.1 522 Server Error');
+  });
+  const direct = t.mock.method(globalThis, 'fetch', async () => new Response('{"observations":[]}'));
+  await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:49999');
+  assert.deepEqual(ports, [49999, 10001, 10002]);
+  assert.equal(direct.mock.callCount(), 1);
+});
+
+test('FRED leaves non-sticky and other-provider routes unchanged on retry', async (t) => {
+  for (const proxy of ['http://fake:secret@gate.decodo.com:7000', 'http://fake:secret@proxy.test:10001']) {
+    const routes = [];
+    const mocked = t.mock.method(proxyUtils, 'proxyFetch', async (_url, config) => {
+      routes.push(config);
+      if (routes.length === 1) throw new Error('HTTP 503');
+      return { ok: true, buffer: Buffer.from('{}') };
+    });
+    await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', proxy);
+    assert.equal(routes.length, 2);
+    assert.deepEqual(routes[1], routes[0]);
+    assert.equal(routes[0].tls, false);
+    mocked.mock.restore();
+  }
+});
+
+test('FRED does not rotate or retry a permanent proxy authentication failure', async (t) => {
+  const proxy = t.mock.method(proxyUtils, 'proxyFetch', async () => { throw new Error('HTTP 407'); });
+  t.mock.method(globalThis, 'fetch', async () => new Response('{}'));
+  await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
+  assert.equal(proxy.mock.callCount(), 1);
+});
 
 // The direct leg is the LAST leg — when it drops a series, that series is gone
 // for the whole cycle. On 2026-08-26 FRED returned `direct: HTTP 502` for


### PR DESCRIPTION
## Summary

FRED proxy retries reuse the same configured sticky exit. When that exit fails, all three attempts can fail together before the direct fallback also fails.

Advance the existing Decodo sticky-port selector on each FRED retry. Other providers, rotating ports, retry limits, TLS, direct fallback, and publication rules remain unchanged.

## Validation

- The new sticky-exit regression failed before the fix and passed afterward.
- 72 focused FRED, publication, metadata-cache, concurrency, proxy and seed-helper tests passed.
- Tests cover exit rotation, port wraparound, exhausted retries and direct fallback, permanent authentication failure, and unchanged other-provider/non-sticky routes.
- Browser and API typechecks and all pre-push gates passed.

## Post-deploy validation

After deployment, verify a natural scheduled FRED run completes and publishes all expected series. A provider-wide outage must still preserve last-good data and remain visible as a failed refresh. Deployment and production acceptance remain pending.
