### PR TITLE
fix(aviation): retry unavailable China hubs before publication

### DIFF
--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -1451,7 +1451,7 @@ export async function reserveAviationStackBudget(count) {
   }
 }
 
-async function fetchIntl() {
+export async function fetchIntl() {
   const result = await seedIntlDelays();
   if (!result.healthy || result.skipped) {
     const why = result.skipped
@@ -1468,6 +1468,24 @@ async function fetchIntl() {
     const err = new Error(`intl unpublishable: ${why}`);
     err.nonRetryable = true;
     throw err;
+  }
+
+  // A globally healthy sweep can miss required China hubs. Retry only those
+  // hubs once before the publish starts the 55-minute gate, never the full
+  // paid sweep. Reserve the extra calls against the same monthly ceiling.
+  const unavailableHubs = CHINA_AVIATIONSTACK_HUBS.filter((hub) => result.coverage.some(
+    (row) => row.iata === hub.iata && ['failed', 'omitted'].includes(row.status),
+  ));
+  if (unavailableHubs.length > 0 && await reserveAviationStackBudget(unavailableHubs.length)) {
+    const retry = await seedIntlDelays({ airports: unavailableHubs });
+    const recovered = new Map(retry.coverage
+      .filter((row) => row.status === 'normal' || row.status === 'disruption')
+      .map((row) => [row.iata, row]));
+    // Keep the original observations and alerts for every other airport. A
+    // failed retry must not manufacture coverage or refresh old timestamps.
+    result.coverage = result.coverage.map((row) => recovered.get(row.iata) ?? row);
+    result.alerts.push(...retry.alerts);
+    console.log(`[Intl] China hub retry: ${recovered.size}/${unavailableHubs.length} recovered`);
   }
   return result;
 }

--- a/tests/china-aviation-coverage.test.mjs
+++ b/tests/china-aviation-coverage.test.mjs
@@ -1,16 +1,19 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { describe, it } from 'node:test';
+import { afterEach, describe, it, mock } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
   buildDelaysBootstrapPayload,
   CHINA_AVIATIONSTACK_HUBS,
+  fetchIntl,
   publishTransform,
   runChinaAviationStackSmoke,
   seedIntlDelays,
   validate,
 } from '../scripts/seed-aviation.mjs';
+import { CHINA_COVERAGE_ENTRIES } from '../scripts/china-coverage-manifest.mjs';
+import { evaluateChinaCoverage } from '../scripts/china-coverage-health.mjs';
 
 const AGREED_HUBS = ['PEK', 'PVG', 'CAN', 'SZX', 'CTU', 'KMG', 'URC', 'HKG'];
 const airportConfig = readFileSync(fileURLToPath(new URL('../src/config/airports.ts', import.meta.url)), 'utf8');
@@ -21,6 +24,116 @@ function flight({ status = 'scheduled', delay = 0 } = {}) {
     departure: { delay },
   };
 }
+
+describe('China hub recovery before international publication', () => {
+  const envNames = ['AVIATIONSTACK_API', 'UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN', 'AVIATIONSTACK_MONTHLY_BUDGET'];
+  const savedEnv = Object.fromEntries(envNames.map((name) => [name, process.env[name]]));
+  afterEach(() => {
+    mock.restoreAll();
+    for (const [name, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+
+  function fixture({ failures = ['MEX', 'FRA', 'LIS', 'KMG', 'SIN', 'AUH'], recover = true, cap = 100, omitted = false } = {}) {
+    process.env.AVIATIONSTACK_API = 'synthetic-key';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.invalid';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'synthetic-token';
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = String(cap);
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'warn', () => {});
+    const calls = new Map();
+    const initialAt = Date.parse('2026-09-10T07:30:00Z');
+    let now = initialAt;
+    let counter = 56; // main has already reserved the initial sweep.
+    mock.method(Date, 'now', () => now);
+    mock.method(globalThis, 'fetch', async (url, options) => {
+      if (String(url).endsWith('/pipeline')) {
+        return { ok: true, json: async () => JSON.parse(options.body).map(([verb, , count]) => {
+          if (verb === 'INCRBY') counter += count;
+          if (verb === 'DECRBY') counter -= count;
+          return { result: counter };
+        }) };
+      }
+      const iata = new URL(url).searchParams.get('dep_iata');
+      assert.ok(iata, `unexpected request: ${url}`);
+      const attempt = (calls.get(iata) ?? 0) + 1;
+      calls.set(iata, attempt);
+      if (attempt > 1) now = initialAt + 30_000;
+      if (failures.includes(iata) && (attempt === 1 || !recover)) {
+        if (omitted) return { ok: true, json: async () => ({ data: [] }) };
+        throw new Error('synthetic timeout');
+      }
+      return { ok: true, json: async () => ({ data: [flight({ delay: ['KMG', 'CAN'].includes(iata) ? 65 : 0 })] }) };
+    });
+    return { calls, initialAt, counter: () => counter };
+  }
+
+  function health(data, now) {
+    const entry = CHINA_COVERAGE_ENTRIES.find(({ id }) => id === 'aviation.china-hubs');
+    const bootstrap = buildDelaysBootstrapPayload({ faaPayload: null, intlPayload: publishTransform(data), notamPayload: null });
+    return evaluateChinaCoverage({
+      entries: [entry], now,
+      data: { [entry.content.key]: bootstrap },
+      meta: { [entry.transport.key]: { fetchedAt: now, status: 'ok' } },
+    }).entries[0];
+  }
+
+  it('retries only KMG after the reported six timeouts and carries recovery through bootstrap to health', async () => {
+    const state = fixture();
+    const result = await fetchIntl();
+    assert.equal(state.calls.size, 56);
+    assert.deepEqual([...state.calls].filter(([, count]) => count > 1), [['KMG', 2]]);
+    assert.equal(state.counter(), 57);
+    assert.equal(result.coverage.find(({ iata }) => iata === 'KMG').status, 'disruption');
+    assert.equal(result.alerts.filter(({ iata }) => iata === 'KMG').length, 1);
+    assert.equal(result.alerts.find(({ iata }) => iata === 'CAN').updatedAt, state.initialAt);
+    assert.ok(result.coverage.filter(({ iata }) => iata !== 'KMG').every(({ updatedAt }) => updatedAt === state.initialAt));
+    assert.equal(result.coverage.find(({ iata }) => iata === 'KMG').updatedAt, state.initialAt + 30_000);
+    assert.equal(health(result, state.initialAt + 30_000).status, 'healthy');
+  });
+
+  it('keeps repeated failure partial without another retry or invented coverage', async () => {
+    const state = fixture({ recover: false });
+    const result = await fetchIntl();
+    assert.equal(state.calls.get('KMG'), 2);
+    assert.equal(state.counter(), 57);
+    assert.equal(result.healthy, true);
+    assert.equal(health(result, state.initialAt + 30_000).content.status, 'partial');
+    assert.equal(result.coverage.find(({ iata }) => iata === 'KMG').updatedAt, state.initialAt);
+  });
+
+  it('does not retry when the shared budget denies the extra call', async () => {
+    const state = fixture({ cap: 56 });
+    const result = await fetchIntl();
+    assert.equal(state.calls.get('KMG'), 1);
+    assert.equal(state.counter(), 56);
+    assert.equal(health(result, state.initialAt).content.status, 'partial');
+  });
+
+  it('retries provider omission once and recovers all eight hubs within eight extra calls', async () => {
+    const state = fixture({ failures: AGREED_HUBS, omitted: true });
+    const result = await fetchIntl();
+    assert.equal(state.counter(), 64);
+    assert.ok(AGREED_HUBS.every((iata) => state.calls.get(iata) === 2));
+    assert.equal(health(result, state.initialAt + 30_000).status, 'healthy');
+  });
+
+  it('keeps systemic failure nonRetryable so runSeed retains last-good data', async () => {
+    const state = fixture();
+    mock.method(globalThis, 'fetch', async () => { throw new Error('provider down'); });
+    await assert.rejects(fetchIntl(), { nonRetryable: true });
+    assert.equal(state.counter(), 56);
+  });
+
+  it('does not spend extra calls when all required hubs are covered', async () => {
+    const state = fixture({ failures: ['MEX'] });
+    await fetchIntl();
+    assert.equal(state.counter(), 56);
+    assert.ok([...state.calls.values()].every((count) => count === 1));
+  });
+});
 
 describe('China AviationStack hub contract', () => {
   it('covers the agreed provider-backed hub set with exact IATA and ICAO metadata', () => {


### PR DESCRIPTION
## Summary

China hub coverage can remain partial for a full refresh interval after a transient timeout: the reported September 10 sweep covered 50 of 56 airports, which passed the global threshold, then the 55-minute gate skipped the next paid refresh. Retry failed or omitted required China hubs once before publishing an otherwise healthy sweep. In the reported case this costs one extra KMG call, rather than another 56-airport sweep.

The retry reserves its calls against the existing shared monthly ceiling and adds at most eight calls per eligible sweep. Persistent failure or budget denial stays partial; successful observations and their timestamps remain intact. The full-sweep cadence, systemic-failure last-good handling, and three-hour health protection are unchanged.

## Validation

`node --import tsx --test tests/china-aviation-coverage.test.mjs tests/aviation-budget-cap.test.mjs tests/china-coverage-health.test.mjs tests/health-verdict-snapshot.test.mjs` — 98 passed. The regression failed before implementation. Fixtures exercise the actual producer, budget reservation, bootstrap builder and health evaluator, including recovery, repeated failure, budget denial, eight-hub omissions, systemic outage and retained timestamps. `git diff --check` passed. Local ce-code-review completed with no blocking findings using sequential inline passes.

No production seeders ran and no Railway, Redis or Vercel state was changed. Natural-run recovery is not yet verified.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the maintainer should inspect the next two natural paid sweeps and the following three-hour health window. Search seeder logs for `China hub retry`, verify recovery counts and shared AviationStack spend, and check `aviation.china-hubs` for eight covered hubs. Repeated failures must remain `CHINA_COVERAGE_PARTIAL`; the health deadline must not reset. Investigate or roll back if calls exceed the bounded retry batch, timestamps advance for unrecovered observations, or coverage becomes healthy without eight successful hub observations.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
