### PR TITLE
fix(mnd): retry transport failures before response headers

### DIFF
--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2222,8 +2222,10 @@ function errorCode(error) {
 }
 
 function isMndTransportFailure(code, diagnostic) {
+  // The proxy buffers bodies before returning, so its generic failures have no known stage.
   return code === 'TIMEOUT'
-    || (code === 'SOURCE_ERROR' && diagnostic.stage === 'response_headers'
+    || (code === 'SOURCE_ERROR' && diagnostic.transport !== 'proxy'
+      && diagnostic.stage === 'response_headers'
       && diagnostic.httpStatus === null);
 }
 

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2221,6 +2221,12 @@ function errorCode(error) {
   return 'SOURCE_ERROR';
 }
 
+function isMndTransportFailure(code, diagnostic) {
+  return code === 'TIMEOUT'
+    || (code === 'SOURCE_ERROR' && diagnostic.stage === 'response_headers'
+      && diagnostic.httpStatus === null);
+}
+
 function boundedDiagnosticString(value, maxChars = PROXY_DIAGNOSTIC_MAX_CHARS) {
   if (typeof value !== 'string') return null;
   const normalized = value
@@ -2620,7 +2626,7 @@ export async function fetchCrossStraitActivitySnapshot({
     ? (input, init) => fetchMndViaProxy(input, init, mndProxyConfig, proxyRequestFn)
     : null;
   let mndPreferredFetchFn = fetchFn;
-  const mndTimeoutRetryFetchFn = () => mndProxyFetchFn && mndPreferredFetchFn === fetchFn
+  const mndTransportRetryFetchFn = () => mndProxyFetchFn && mndPreferredFetchFn === fetchFn
     ? mndProxyFetchFn
     : fetchFn;
   const resolvedJapanProxyFetchFn = proxyUrl
@@ -2673,7 +2679,7 @@ export async function fetchCrossStraitActivitySnapshot({
           path: new URL(url).pathname, purpose: 'list', attempt: attempt + 1,
           stage: 'response_headers', httpStatus: null,
         };
-        const requestFetchFn = attempt > 0 ? mndTimeoutRetryFetchFn() : mndPreferredFetchFn;
+        const requestFetchFn = attempt > 0 ? mndTransportRetryFetchFn() : mndPreferredFetchFn;
         if (requestFetchFn === mndProxyFetchFn) diagnostic.transport = 'proxy';
         try {
           const html = await fetchBoundedText(requestFetchFn, url, mndContract, diagnostic);
@@ -2696,7 +2702,7 @@ export async function fetchCrossStraitActivitySnapshot({
           mndRequestDiagnostics.push({
             ...diagnostic, errorCode: errorCode(error), elapsedMs: Math.round(monotonicNow() - startedAt),
           });
-          if (errorCode(error) !== 'TIMEOUT' || attempt === 1
+          if (!isMndTransportFailure(errorCode(error), diagnostic) || attempt === 1
             || listRequestCount >= MND_MAX_LIST_PAGES_PER_BACKFILL_RUN
             || !hasMndOutboundBudget({ runStartedAt, nowFn, cadenceMs: REQUEST_CADENCE_MS })) {
             throw error;
@@ -2798,8 +2804,8 @@ export async function fetchCrossStraitActivitySnapshot({
         purpose: isRefresh ? 'refresh' : 'detail', attempt: retryErrorCode ? 2 : 1,
         stage: 'response_headers', httpStatus: null,
       };
-      const requestFetchFn = retryErrorCode === 'TIMEOUT'
-        ? mndTimeoutRetryFetchFn()
+      const requestFetchFn = retryErrorCode === 'TIMEOUT' || retryErrorCode === 'SOURCE_ERROR'
+        ? mndTransportRetryFetchFn()
         : mndPreferredFetchFn;
       if (requestFetchFn === mndProxyFetchFn) diagnostic.transport = 'proxy';
       let startedAt;
@@ -2830,7 +2836,7 @@ export async function fetchCrossStraitActivitySnapshot({
           ...diagnostic, errorCode: code, elapsedMs: Math.round(monotonicNow() - startedAt),
         });
         if (
-          (code === 'MND_PUBLICATION_METADATA_MISSING' || code === 'TIMEOUT')
+          (code === 'MND_PUBLICATION_METADATA_MISSING' || isMndTransportFailure(code, diagnostic))
           && !retryErrorCode
           && detailRequestCount < detailAttemptLimit
         ) {

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -2992,8 +2992,9 @@ describe('quantified cross-Strait activity (#5575)', () => {
     );
   });
 
+  for (const failureMessage of ['request timeout', 'fetch failed']) {
   for (const failure of ['none', 'list', 'detail'] as const) {
-    it(`uses MND proxy only after a timeout (${failure}) and resets the route each run`, async () => {
+    it(`uses MND proxy after ${failureMessage} (${failure}) and resets the route each run`, async () => {
       const direct: string[] = [];
       const proxied: string[] = [];
       const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
@@ -3006,7 +3007,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
           if (url.includes('mod.go.jp')) return new Response(usableJapanEnglishIndex);
           direct.push(url);
           if (failure === 'list' || (failure === 'detail' && !url.includes('plaactlist'))) {
-            throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+            throw new TypeError(failureMessage);
           }
           return new Response(url.includes('plaactlist') ? list : fixture('mnd-detail.html'));
         },
@@ -3038,6 +3039,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
       }
     });
   }
+  }
 
   it('uses direct retry when a preferred proxy later times out on an MND list page', async () => {
     const transports: string[] = [];
@@ -3049,7 +3051,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
         if (url.includes('mod.go.jp')) return new Response(usableJapanEnglishIndex);
         transports.push(`direct:${new URL(url).pathname}`);
         if (url === CROSS_STRAIT_SOURCE_CONTRACTS.taiwanMnd.listUrl) {
-          throw new Error('request timeout');
+          throw new TypeError('fetch failed');
         }
         if (url.endsWith('/plaactlist/2')) return new Response(mndListWithCount(1, 90_100));
         return new Response(fixture('mnd-detail.html'));
@@ -3338,7 +3340,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(clock, 20_000);
   });
 
-  it('publishes recovered MND proxy data and retains the true success clock when both routes later fail', async () => {
+  it('recovers MND header failures and keeps repeated unusable coverage actionable', async () => {
     const stored = new Map();
     const writer = async (key, value) => { stored.set(key, value); };
     const reader = async key => stored.get(key) ?? null;
@@ -3355,7 +3357,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
         sleepFn: async () => {},
         fetchFn: async (input: string | URL | Request) => {
           if (String(input).includes('mod.go.jp')) return new Response(usableJapanEnglishIndex);
-          throw new Error('request timeout');
+          throw new TypeError('fetch failed');
         },
         proxyRequestFn: async (url: string) => {
           if (!recovers) throw new Error('proxy timeout');
@@ -3367,6 +3369,8 @@ describe('quantified cross-Strait activity (#5575)', () => {
       const meta = stored.get(metaKey);
       assert.equal(meta.fetchedAt, recovers ? now : Date.parse(retrievedAt));
       assert.equal(meta.consecutiveSourceFailures, recovers ? 0 : attempt);
+      assert.equal(snapshot.sources.find(source => source.id === 'taiwan-mnd')
+        .requestDiagnostics[0].errorCode, 'SOURCE_ERROR');
       assert.ok(snapshot.observations.some(row => row.sourceId === 'taiwan-mnd'));
       const entry = classifyKey(name, dataKey, { allowOnDemand: true }, {
         keyStrens: new Map([[dataKey, Buffer.byteLength(JSON.stringify(stored.get(dataKey)))]]),
@@ -3378,6 +3382,32 @@ describe('quantified cross-Strait activity (#5575)', () => {
       previousSnapshot = snapshot;
     }
   });
+
+  for (const response of ['http-error', 'body-error', 'empty-list'] as const) {
+    it(`does not retry an MND ${response} as a header transport failure`, async () => {
+      let directCalls = 0;
+      let proxyCalls = 0;
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        now: Date.parse(retrievedAt), proxyUrl: '', mndProxyUrl: 'https://proxy.test',
+        sleepFn: async () => {},
+        fetchFn: async (input: string | URL | Request) => {
+          if (String(input).includes('mod.go.jp')) return new Response(usableJapanEnglishIndex);
+          directCalls += 1;
+          if (response === 'http-error') return new Response('unavailable', { status: 503 });
+          if (response === 'body-error') return new Response(new ReadableStream({
+            start(controller) { controller.error(new TypeError('terminated')); },
+          }));
+          return new Response('<html></html>');
+        },
+        proxyRequestFn: async () => { proxyCalls += 1; throw new Error('must not proxy'); },
+      });
+      const mnd = snapshot.sources.find(source => source.id === 'taiwan-mnd');
+      assert.equal(directCalls, response === 'empty-list' ? MND_MAX_LIST_PAGES_PER_BACKFILL_RUN : 1);
+      assert.equal(proxyCalls, 0);
+      assert.equal(mnd.transportStatus, 'error');
+      assert.equal(mnd.lastSuccessAt, null);
+    });
+  }
 
   for (const failure of ['metadata', 'timeout'] as const) it(`retries transient MND detail ${failure} within the detail request cap`, async () => {
     const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -3340,6 +3340,46 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(clock, 20_000);
   });
 
+  it('does not retry a buffered MND proxy body failure as a direct header failure', async () => {
+    const direct: string[] = [];
+    const proxied: string[] = [];
+    const list = mndListWithCount(MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      now: Date.parse(retrievedAt), proxyUrl: '', mndProxyUrl: 'https://proxy.test',
+      sleepFn: async () => {},
+      fetchFn: async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('mod.go.jp')) return new Response(usableJapanEnglishIndex);
+        direct.push(url);
+        throw new TypeError('fetch failed');
+      },
+      proxyRequestFn: (url, config, options) => {
+        proxied.push(url);
+        return proxyFetch(url, config, {
+          ...options,
+          connectTunnel: async () => ({ socket: {}, destroy: () => {} }),
+          requestFn: (_options, onResponse) => Object.assign(new EventEmitter(), {
+            end() {
+              const body = Object.assign(new PassThrough(), { headers: {}, statusCode: 200 });
+              onResponse(body);
+              if (url.includes('plaactlist')) body.end(list);
+              else body.destroy(new Error('response stream reset'));
+            },
+          }),
+        });
+      },
+    });
+    const mnd = snapshot.sources.find(source => source.id === 'taiwan-mnd');
+    assert.deepEqual(direct, [CROSS_STRAIT_SOURCE_CONTRACTS.taiwanMnd.listUrl]);
+    assert.equal(proxied.length, 1 + MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    assert.equal(new Set(proxied).size, proxied.length);
+    assert.equal(mnd.transportStatus, 'error');
+    assert.equal(mnd.lastSuccessAt, null);
+    assert.deepEqual(mnd.errorCodes, ['SOURCE_ERROR']);
+    assert.equal(mnd.requestDiagnostics.filter(row => row.purpose === 'detail').length,
+      MND_MAX_DETAIL_REQUESTS_PER_RUN);
+  });
+
   it('recovers MND header failures and keeps repeated unusable coverage actionable', async () => {
     const stored = new Map();
     const writer = async (key, value) => { stored.set(key, value); };

--- a/tests/source-proxy-fallback.test.mjs
+++ b/tests/source-proxy-fallback.test.mjs
@@ -38,14 +38,14 @@ afterEach(() => {
 
 // Each adapter resolves its proxy URL in a default parameter, parses it with
 // parseProxyConfig, and hands the result to the transport as
-// proxyRequestFn(url, {host, port, auth, tls}, opts). Recording that host is the
-// most direct observation of which environment variable won.
+// proxyRequestFn(url, {host, port, auth, tls}, opts). Record the destination too:
+// cross-strait collection can proxy MND and Japan requests in either order.
 function recordingProxyFetch() {
-  const hosts = [];
+  const routes = [];
   return {
-    hosts,
-    proxyRequestFn: (_url, proxyConfig) => {
-      hosts.push(proxyConfig?.host ?? null);
+    routes,
+    proxyRequestFn: (url, proxyConfig) => {
+      routes.push({ target: new URL(url).hostname, proxy: proxyConfig?.host ?? null });
       throw new Error('proxy transport short-circuited for test');
     },
   };
@@ -55,52 +55,60 @@ describe('source-specific proxy resolution', () => {
   describe('SZSE / china corporate disclosures', () => {
     it('prefers SZSE_PROXY_URL when both are set', async () => {
       setProxyEnv({ PROXY_URL: 'http://shared:1', SZSE_PROXY_URL: 'http://szse:2' });
-      const { hosts, proxyRequestFn } = recordingProxyFetch();
+      const { routes, proxyRequestFn } = recordingProxyFetch();
       await fetchChinaCorporateDisclosureSnapshot({
         fetchFn: async () => { throw new Error('direct blocked'); },
         proxyRequestFn,
         onDecision: () => {},
       }).catch(() => {});
-      assert.ok(hosts.length > 0, 'proxy transport must be reached');
-      assert.equal(hosts[0], 'szse');
+      assert.ok(routes.length > 0, 'proxy transport must be reached');
+      assert.equal(routes[0].proxy, 'szse');
     });
 
     it('falls back to PROXY_URL when the source-specific var is unset', async () => {
       setProxyEnv({ PROXY_URL: 'http://shared:1' });
-      const { hosts, proxyRequestFn } = recordingProxyFetch();
+      const { routes, proxyRequestFn } = recordingProxyFetch();
       await fetchChinaCorporateDisclosureSnapshot({
         fetchFn: async () => { throw new Error('direct blocked'); },
         proxyRequestFn,
         onDecision: () => {},
       }).catch(() => {});
-      assert.ok(hosts.length > 0, 'proxy transport must be reached');
-      assert.equal(hosts[0], 'shared');
+      assert.ok(routes.length > 0, 'proxy transport must be reached');
+      assert.equal(routes[0].proxy, 'shared');
     });
   });
 
   describe('Japan MOD / cross-strait activity', () => {
     it('prefers JAPAN_MOD_PROXY_URL when both are set', async () => {
       setProxyEnv({ PROXY_URL: 'http://shared:1', JAPAN_MOD_PROXY_URL: 'http://japan:2' });
-      const { hosts, proxyRequestFn } = recordingProxyFetch();
+      const { routes, proxyRequestFn } = recordingProxyFetch();
       await fetchCrossStraitActivitySnapshot({
         fetchFn: async () => { throw new Error('direct blocked'); },
         proxyRequestFn,
         sleepFn: async () => {},
       }).catch(() => {});
-      assert.ok(hosts.length > 0, 'proxy transport must be reached');
-      assert.equal(hosts[0], 'japan');
+      assert.deepEqual(routes.filter(route => route.target === 'www.mod.go.jp'), [
+        { target: 'www.mod.go.jp', proxy: 'japan' },
+      ]);
+      assert.deepEqual(routes.filter(route => route.target === 'www.mnd.gov.tw'), [
+        { target: 'www.mnd.gov.tw', proxy: 'shared' },
+      ]);
     });
 
     it('falls back to PROXY_URL when the source-specific var is unset', async () => {
       setProxyEnv({ PROXY_URL: 'http://shared:1' });
-      const { hosts, proxyRequestFn } = recordingProxyFetch();
+      const { routes, proxyRequestFn } = recordingProxyFetch();
       await fetchCrossStraitActivitySnapshot({
         fetchFn: async () => { throw new Error('direct blocked'); },
         proxyRequestFn,
         sleepFn: async () => {},
       }).catch(() => {});
-      assert.ok(hosts.length > 0, 'proxy transport must be reached');
-      assert.equal(hosts[0], 'shared');
+      assert.deepEqual(routes.filter(route => route.target === 'www.mod.go.jp'), [
+        { target: 'www.mod.go.jp', proxy: 'shared' },
+      ]);
+      assert.deepEqual(routes.filter(route => route.target === 'www.mnd.gov.tw'), [
+        { target: 'www.mnd.gov.tw', proxy: 'shared' },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Why

MND source health can enter failure while an alternate route has never been tried. A list request that throws `TypeError('fetch failed')` before response headers becomes `SOURCE_ERROR` and is abandoned immediately. MND failover handled only `TIMEOUT`, so an available proxy could not recover this failure.

Allow one bounded alternate-route attempt for direct `SOURCE_ERROR` before response headers, for both lists and details. Generic proxy errors remain non-retryable because proxy buffering does not expose their failure stage; existing timeout retries remain available. A response must still pass validation to select the route or advance source success. Last-good data, failure diagnostics, request/time limits, and health thresholds retain their contracts. This repairs skipped failover; simultaneous direct and proxy outages remain visible failures.

Related: #7850, #7874, #7834

## Verification

- Three new regression cases failed before the fix. All 199 adapter, shipping, production-registration, and source-proxy fallback tests now pass.
- CI exposed an order-dependent proxy test. It now verifies the route per destination, so MND uses the shared proxy and Japan uses its configured proxy regardless of request order.
- A real proxy-buffering regression proves that a post-header stream failure cannot consume direct retry slots for required reports.
- Producer-to-health fixtures preserve the last success clock on failure, warn after repeated unusable coverage, and clear after valid recovery. HTTP responses, generic body errors, and empty lists do not qualify for the new header-failure retry.
- Contract and application typechecks, lint, and diff checks pass. Lint reports existing warnings. Sequential ce-code-review found no actionable findings; the separate Claude process returned no usable review.
- A read-only local request to the exact MND list returned HTTP 200 and parsed current records. This is not Railway recovery evidence.

## Post-Deploy Monitoring & Validation

After separately authorized deployment, the PR owner should observe two consecutive natural Cross-Strait runs and at least one header-failure episode within 24 hours. Check `[cross-strait] MND request failures`, `requestDiagnostics`, `lastSuccessAt`, and `crossStraitActivityTaiwanMnd`. A header failure should receive its bounded retry; only validated coverage should advance success. Repeated unusable coverage must warn while retained data remains available. Treat false fresh health or exceeded request/time caps as rollback triggers. Production acceptance is pending; no production seeder or deployment was run for this PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
