### PR TITLE
fix(tenders): widen World Bank retry spacing

### DIFF
--- a/scripts/seed-global-tenders.mjs
+++ b/scripts/seed-global-tenders.mjs
@@ -85,7 +85,7 @@ function samIpv4ResponseTransport(httpsGetFn = httpsGet) {
 // Callers with a long per-attempt timeout must lower maxRetries accordingly.
 // Sources run in parallel, so the section pays the slowest source, not the sum.
 async function fetchResponse(url, options = {}, transport = fetchResponseTransport) {
-  const { timeoutMs = 20_000, maxRetries = 2, retry429 = true, ...fetchOptions } = options;
+  const { timeoutMs = 20_000, maxRetries = 2, retryDelayMs = 1000, retry429 = true, ...fetchOptions } = options;
   return withRetry(async () => {
     const response = await transport(url, {
       ...fetchOptions,
@@ -103,7 +103,7 @@ async function fetchResponse(url, options = {}, transport = fetchResponseTranspo
       throw error;
     }
     return response;
-  }, maxRetries, 1000);
+  }, maxRetries, retryDelayMs);
 }
 
 async function fetchJson(url, options = {}) {
@@ -325,7 +325,7 @@ export async function fetchWorldBank({ now = Date.now(), fetchJsonFn = fetchJson
   url.searchParams.set('srce', 'both');
   url.searchParams.set('notice_type_exact', 'Invitation for Bids^Invitation for Prequalification^Request for Expression of Interest');
   url.searchParams.set('deadline_strdate', new Date(now).toISOString().slice(0, 10));
-  const payload = await fetchJsonFn(url);
+  const payload = await fetchJsonFn(url, { retryDelayMs: 5000 });
   const rawNotices = payload?.procnotices;
   if (!rawNotices || (typeof rawNotices !== 'object' && !Array.isArray(rawNotices))) {
     throw new Error('World Bank response is missing procnotices');

--- a/tests/global-tenders-world-bank-retry.test.mjs
+++ b/tests/global-tenders-world-bank-retry.test.mjs
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchGlobalTenders, fetchTed, fetchWorldBank, sourceHealthMeta } from '../scripts/seed-global-tenders.mjs';
+
+const NOW = Date.parse('2026-09-10T10:00:00Z');
+const PAYLOAD = { procnotices: [{
+  id: 'OP1', notice_type: 'Invitation for Bids', bid_description: 'Network services',
+  project_ctry_code: 'IN', submission_deadline_date: '2026-10-01T00:00:00Z',
+}] };
+
+function provider(t, respond) {
+  const calls = [];
+  const waits = [];
+  const timeouts = [];
+  let elapsed = 0;
+  t.mock.method(AbortSignal, 'timeout', (ms) => {
+    timeouts.push(ms);
+    return new AbortController().signal;
+  });
+  t.mock.method(globalThis, 'setTimeout', (callback, ms) => {
+    waits.push(ms);
+    elapsed += ms;
+    queueMicrotask(callback);
+    return 0;
+  });
+  t.mock.method(globalThis, 'fetch', async (url, options) => {
+    calls.push({ url: String(url), options });
+    return respond({ elapsed, attempt: calls.length });
+  });
+  return { calls, waits, timeouts };
+}
+
+test('World Bank can recover after the former three-second retry window', async (t) => {
+  const { calls, waits, timeouts } = provider(t, ({ elapsed }) => elapsed < 10_000
+    ? new Response('upstream failure', { status: 500 })
+    : Response.json(PAYLOAD));
+  const result = await fetchWorldBank({ now: NOW });
+  assert.deepEqual(waits, [5000, 10_000]);
+  assert.equal(calls.length, 3);
+  assert.deepEqual(timeouts, [20_000, 20_000, 20_000]);
+  assert.equal(calls[0].options.retryDelayMs, undefined);
+  assert.equal(new Set(calls.map((call) => call.url)).size, 1);
+  assert.equal(new URL(calls[0].url).pathname, '/api/v2/procnotices');
+  assert.equal(result.status.state, 'ok');
+  assert.equal(result.records[0].id, 'world-bank:OP1');
+});
+
+test('other tender sources keep their existing retry interval', async (t) => {
+  const { waits } = provider(t, ({ attempt }) => attempt < 3
+    ? new Response('upstream failure', { status: 500 })
+    : Response.json({ notices: [] }));
+  const result = await fetchTed({ now: NOW });
+  assert.equal(result.status.state, 'ok');
+  assert.deepEqual(waits, [1000, 2000]);
+});
+
+test('exhausted World Bank retries retain data without advancing source success', async (t) => {
+  const { calls, waits } = provider(t, () => new Response('upstream failure', { status: 500 }));
+  const successfulAt = NOW - 60 * 60_000;
+  const success = await fetchWorldBank({ now: successfulAt, fetchJsonFn: async () => PAYLOAD });
+  let previousSnapshot = { tenders: success.records, sourceStatuses: [success.status], fetchedAt: successfulAt };
+  for (const now of [NOW, NOW + 60 * 60_000]) {
+    const snapshot = await fetchGlobalTenders({ now, previousSnapshot, adapters: [['world-bank', fetchWorldBank]] });
+    assert.equal(snapshot.tenders.length, 1);
+    assert.equal(snapshot.sourceStatuses[0].state, 'stale');
+    assert.equal(snapshot.sourceStatuses[0].error, 'HTTP 500');
+    assert.equal(snapshot.sourceStatuses[0].lastSuccessfulAt, new Date(successfulAt).toISOString());
+    assert.equal(sourceHealthMeta(snapshot.sourceStatuses[0]).fetchedAt, successfulAt);
+    assert.equal(sourceHealthMeta(snapshot.sourceStatuses[0]).sourceState, 'stale');
+    previousSnapshot = snapshot;
+  }
+  assert.equal(calls.length, 6);
+  assert.deepEqual(waits, [5000, 10_000, 5000, 10_000]);
+});
+
+test('World Bank permanent errors fail immediately', async (t) => {
+  const { calls, waits } = provider(t, () => new Response('forbidden', { status: 403 }));
+  await assert.rejects(fetchWorldBank({ now: NOW }), /HTTP 403/);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(waits, []);
+});
+
+test('World Bank distinguishes a valid empty response from malformed data', async (t) => {
+  const { calls } = provider(t, ({ attempt }) => Response.json(attempt === 1 ? { procnotices: [] } : { error: 'unavailable' }));
+  const result = await fetchWorldBank({ now: NOW });
+  assert.deepEqual(result.records, []);
+  assert.equal(result.status.state, 'ok');
+  await assert.rejects(fetchWorldBank({ now: NOW }), /missing procnotices/);
+  assert.equal(calls.length, 2);
+});


### PR DESCRIPTION
## Summary

The World Bank procurement adapter currently exhausts its three attempts with retry delays of only 1 and 2 seconds. A short upstream HTTP 500 outage can outlast that retry window and leave the source serving last-good records.

Use 5- and 10-second delays for World Bank through the existing retry helper. Keep three attempts, the 20-second attempt timeout, permanent-error rejection, and last-good/error semantics. Other tender sources retain their current delays. Without a longer provider `Retry-After` hint, the attempt and delay budget is 75 seconds within the 180-second bundle section. Existing `Retry-After` handling is unchanged.

The request is `GET https://search.worldbank.org/api/v2/procnotices` with the existing open-opportunity filters. PR #7953 addressed Contracts Finder, not this source. Current main includes that PR.

## Validation

- A controlled HTTP 500 outage extending beyond the former three-second retry window fails before the change and succeeds afterward.
- 63 focused tender tests pass, including retry exhaustion across two runs, unchanged source-success clocks, permanent errors, valid empty versus malformed responses, other-source retry spacing, and the unchanged World Bank timeout.
- ce-code-review completed sequentially in the main task under repository instructions. Added timeout and other-source checks during review; no actionable findings remain.
- Browser and API typechecks and all pre-push gates passed.

This is a bounded resilience change. The controlled recovery test does not establish the recovery time of a real upstream outage. No production seed, Redis write, merge, or deployment was performed.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the maintainer should observe two natural hourly runs in Railway `seed-bundle-relay-backup`, filtering logs for `Global-Tenders`, `Retry`, and `HTTP 500`, and inspect `/api/health?compact=1` for `globalTendersWorldBank`. Retries should show 5000/10000 ms waits. A real successful response should refresh source data and clear the source error. Exhausted runs must still retain last-good data with the original success clock and report `SEED_ERROR`. Repeated failures require upstream investigation; this change does not claim to repair the provider. Revert if the added wait prevents the bundle from completing within its section budget.
