### PR TITLE
fix(tenders): contain verified empty Contracts Finder refresh failures

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -3186,6 +3186,27 @@ function isContainedHealthWarning(entry, evidence, now = Date.now()) {
     && entry.readModelReady !== false;
 }
 
+function isUsableTender(tender) {
+  if (!tender || typeof tender !== 'object' || Array.isArray(tender)) return false;
+  const stringArray = (values) => Array.isArray(values) && values.every((value) => typeof value === 'string');
+  const object = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+  return [tender.id, tender.title, tender.source, tender.sourceNoticeId, tender.officialUrl,
+    tender.status, tender.participationMode].every((value) => typeof value === 'string' && value.trim())
+    && [tender.countryCode, tender.region, tender.buyer, tender.description, tender.noticeType,
+      tender.publishedAt, tender.updatedAt, tender.deadline]
+      .every((value) => value === undefined || typeof value === 'string')
+    && [tender.categoryCodes, tender.sectors, tender.eligibilityRequirements, tender.submissionUrls].every(stringArray)
+    && (tender.money === undefined || (object(tender.money)
+      && (tender.money.amount === undefined || Number.isFinite(tender.money.amount))
+      && (tender.money.currency === undefined || typeof tender.money.currency === 'string')))
+    && (tender.automationFit === undefined || (object(tender.automationFit)
+      && typeof tender.automationFit.level === 'string'
+      && Number.isFinite(tender.automationFit.score)
+      && typeof tender.automationFit.classificationVersion === 'string'
+      && stringArray(tender.automationFit.matchReasons)
+      && stringArray(tender.automationFit.evidence)));
+}
+
 function composeContractsFinderHealth(entry, meta, snapshot, readFailed, now) {
   // Source-status bytes prove a diagnostic exists, not that its tender rows
   // still exist. Replace the generic containment proof with the served data.
@@ -3238,13 +3259,7 @@ function composeContractsFinderHealth(entry, meta, snapshot, readFailed, now) {
     && snapshot.sourceStatuses.filter((status) => status?.source === 'contracts-finder').length === 1
     && snapshot.sourceStatuses.every((status) => status && typeof status.source === 'string' && typeof status.state === 'string')
     && ['available', 'partial', 'empty'].includes(snapshot.availability)
-    && aggregateFresh && snapshot.tenders.every((tender) => tender
-      && [tender.id, tender.title, tender.source].every((value) => typeof value === 'string' && value.trim())
-      && [tender.countryCode, tender.region, tender.status, tender.buyer, tender.description,
-        tender.publishedAt, tender.updatedAt, tender.deadline, tender.money?.currency]
-        .every((value) => value === undefined || typeof value === 'string')
-      && [tender.categoryCodes, tender.sectors].every((values) => Array.isArray(values)
-        && values.every((value) => typeof value === 'string')));
+    && aggregateFresh && snapshot.tenders.every(isUsableTender);
   const aligned = (confirmedEmpty ? source.state === 'error' && meta.sourceState === 'error'
     : source?.state === 'stale' && meta?.sourceState === 'stale')
     && source.lastSuccessfulAt === meta.lastSuccessfulAt && source.fetchedAt === meta.lastAttemptAt

--- a/api/health.js
+++ b/api/health.js
@@ -3178,7 +3178,7 @@ function isContainedHealthWarning(entry, evidence, now = Date.now()) {
   return healthStatusBucket(entry, now) === 'warn'
     && CONTAINMENT_ELIGIBLE_STATUSES.has(entry?.status)
     && Number.isFinite(entry?.records)
-    && entry.records > 0
+    && (entry.records > 0 || (entry.records === 0 && evidence?.confirmedEmpty === true))
     && evidence?.status === entry.status
     && evidence.records === entry.records
     && evidence.usable === true
@@ -3231,17 +3231,34 @@ function composeContractsFinderHealth(entry, meta, snapshot, readFailed, now) {
   const attempt = Date.parse(meta?.lastAttemptAt || '');
   const validEpisode = success > 0 && success <= first && first <= attempt && attempt <= now
     && meta.fetchedAt === success && meta.consecutiveFailures === 1;
-  const aligned = source?.state === 'stale' && meta?.sourceState === 'stale'
+  const aggregateFresh = Number.isFinite(snapshot.fetchedAt) && snapshot.fetchedAt > 0
+    && snapshot.fetchedAt <= now && now < snapshot.fetchedAt + 180 * 60_000;
+  const confirmedEmpty = source?.confirmedEmpty === true && meta?.confirmedEmpty === true
+    && sourceRows.length === 0 && source.recordCount === 0 && meta.recordCount === 0
+    && snapshot.sourceStatuses.filter((status) => status?.source === 'contracts-finder').length === 1
+    && snapshot.sourceStatuses.every((status) => status && typeof status.source === 'string' && typeof status.state === 'string')
+    && ['available', 'partial', 'empty'].includes(snapshot.availability)
+    && aggregateFresh && snapshot.tenders.every((tender) => tender
+      && [tender.id, tender.title, tender.source].every((value) => typeof value === 'string' && value.trim())
+      && [tender.countryCode, tender.region, tender.status, tender.buyer, tender.description,
+        tender.publishedAt, tender.updatedAt, tender.deadline, tender.money?.currency]
+        .every((value) => value === undefined || typeof value === 'string')
+      && [tender.categoryCodes, tender.sectors].every((values) => Array.isArray(values)
+        && values.every((value) => typeof value === 'string')));
+  const aligned = (confirmedEmpty ? source.state === 'error' && meta.sourceState === 'error'
+    : source?.state === 'stale' && meta?.sourceState === 'stale')
     && source.lastSuccessfulAt === meta.lastSuccessfulAt && source.fetchedAt === meta.lastAttemptAt
     && source.firstFailureAt === meta.firstFailureAt && source.consecutiveFailures === meta.consecutiveFailures
     && source.recordCount === records.length && meta.recordCount === records.length
     && sourceRows.length === records.length && new Set(records.map((tender) => tender.id)).size === records.length;
-  const deadline = validEpisode && records.length > 0
+  const deadline = validEpisode && (records.length > 0 || confirmedEmpty)
     ? Math.min(first + 90 * 60_000, success + SEED_META.globalTendersContractsFinder.maxStaleMin * 60_000,
+      ...(confirmedEmpty ? [snapshot.fetchedAt + 180 * 60_000] : []),
       ...records.map((tender) => Date.parse(tender.deadline))) : NaN;
   if (entry.status === 'SEED_ERROR' && aligned && now < deadline) {
     entry.containmentUntil = new Date(deadline).toISOString();
     evidence.usable = true;
+    if (confirmedEmpty) evidence.confirmedEmpty = true;
   }
   evidence.status = entry.status;
   evidence.records = entry.records;

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -80,6 +80,8 @@ Failed refreshes retain only validated open Contracts Finder records less than 1
 
 `globalTendersContractsFinder` keeps `SEED_ERROR`, the warning count, source error, attempt time, success time, and consecutive failure count visible. Availability can contain the first failed refresh only after reading and checking its records in the canonical tender snapshot. `containmentUntil` is the earliest of 90 minutes after the first failure, 180 minutes after source success, or a retained tender's closing time. The second failed refresh, missing or unreadable canonical data, malformed records, inconsistent metadata, or an expired deadline cannot qualify. Full and compact verdict caches expire at the same deadline; this does not change other sources' health policy.
 
+A failed refresh after a verified empty success can also qualify. The producer records `confirmedEmpty` only when the prior canonical envelope has an explicit zero source count, no source rows, and recent source success evidence. Health requires matching canonical and seed metadata, a fresh usable aggregate, and the same first-failure limits. Its deadline also includes aggregate freshness. Zero records without this proof, or records removed by expiry or validation, cannot qualify. The source remains `error` with `SEED_ERROR`; containment does not report a successful refresh.
+
 ### BC active evacuation lists
 
 `canadaAlertsBcSource` uses successful active-list ingestion with a 45-minute freshness budget. BC orders remain active until their status changes or they are removed. Their event modification age is not an expiry rule. See [BC evacuation guidance](https://www2.gov.bc.ca/gov/content/safety/wildfire-status/partners/evacuation).

--- a/scripts/_global-tenders.mjs
+++ b/scripts/_global-tenders.mjs
@@ -265,6 +265,12 @@ export function mergeTenderSourceResults({ settled, sourceNames, previousSnapsho
         string(tender.id) && string(tender.title) && safeOfficialUrl(tender.officialUrl, source)
         && ['active', 'open'].includes(tender.status)
         && [tender.categoryCodes, tender.sectors].every((values) => Array.isArray(values) && values.every((value) => typeof value === 'string'))) : [];
+      const confirmedEmpty = fresh && previousSnapshot?.dataAvailable === true
+        && Array.isArray(previousSnapshot.tenders)
+        && previousSnapshot.tenders.every((tender) => tender && tender.source !== source)
+        && previousSnapshot.sourceStatuses.filter((status) => status?.source === source).length === 1
+        && priorStatus?.recordCount === 0
+        && (priorStatus.state === 'ok' ? priorStatus.fetchedAt === lastSuccessfulAt : priorStatus.confirmedEmpty === true);
       const alreadyFailed = priorStatus && priorStatus.state !== 'ok';
       const previousFailures = Number.isSafeInteger(priorStatus?.consecutiveFailures) && priorStatus.consecutiveFailures >= 1
         ? priorStatus.consecutiveFailures : 1;
@@ -272,6 +278,7 @@ export function mergeTenderSourceResults({ settled, sourceNames, previousSnapsho
       sourceStatuses.push({
         source, state: retained.length ? 'stale' : 'error', recordCount: retained.length,
         fetchedAt: attemptedAt, lastSuccessfulAt, stale: retained.length > 0, error,
+        ...(confirmedEmpty ? { confirmedEmpty: true } : {}),
         consecutiveFailures: alreadyFailed ? Math.min(previousFailures + 1, 100) : 1,
         firstFailureAt: alreadyFailed ? string(priorStatus.firstFailureAt) : attemptedAt,
       });

--- a/scripts/seed-global-tenders.mjs
+++ b/scripts/seed-global-tenders.mjs
@@ -399,6 +399,7 @@ export function sourceHealthMeta(status) {
       lastSuccessfulAt: status.lastSuccessfulAt || '',
       consecutiveFailures: status.consecutiveFailures,
       firstFailureAt: status.firstFailureAt,
+      ...(status.confirmedEmpty === true ? { confirmedEmpty: true } : {}),
       ...(status.error ? { error: status.error } : {}),
     } : {}),
   };

--- a/tests/global-tender-health.test.mjs
+++ b/tests/global-tender-health.test.mjs
@@ -237,6 +237,84 @@ async function classifyContractsFinder(snapshot, now = CF_NOW, readFailed = fals
   return { ...composed, contained: __testing__.isContainedHealthWarning(composed.entry, composed.evidence, now) };
 }
 
+async function failedEmptyContractsFinder(previousSnapshot, siblingRecords = []) {
+  const { fetchGlobalTenders, fetchContractsFinder, sourceStatus } = await import('../scripts/seed-global-tenders.mjs');
+  const success = CF_NOW - 60 * 60_000;
+  previousSnapshot ??= await fetchGlobalTenders({ now: success, adapters: [
+    ['contracts-finder', () => fetchContractsFinder({ now: success, fetchJsonFn: async () => ({ releases: [] }) })],
+  ] });
+  return fetchGlobalTenders({ now: CF_NOW, previousSnapshot, adapters: [
+    ['contracts-finder', async () => { throw new Error('timeout'); }],
+    ['ted', async () => ({ records: siblingRecords, status: sourceStatus('ted', 'ok', siblingRecords, '', CF_NOW) })],
+  ] });
+}
+
+test('verified empty source survives its first failed refresh with truthful producer-to-health evidence', async () => {
+  const snapshot = await failedEmptyContractsFinder();
+  const { entry, contained } = await classifyContractsFinder(snapshot);
+  assert.equal(contained, true);
+  assert.equal(entry.records, 0);
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(entry.lastSuccessAt, new Date(CF_NOW - 60 * 60_000).toISOString());
+  assert.equal(entry.consecutiveSourceFailures, 1);
+  assert.match(entry.error, /timeout/);
+  assert.equal(entry.containmentUntil, new Date(CF_NOW + 90 * 60_000).toISOString());
+  assert.equal((await classifyContractsFinder(snapshot, CF_NOW + 90 * 60_000)).contained, false);
+  assert.equal((await classifyContractsFinder(await failedEmptyContractsFinder(snapshot))).contained, false);
+  const record = { ...(await failedContractsFinder()).tenders[0], source: 'ted' };
+  const populated = await failedEmptyContractsFinder(undefined, [record]);
+  assert.equal(populated.tenders.length, 1);
+  assert.equal((await classifyContractsFinder(populated)).contained, true);
+  populated.tenders[0].countryCode = 123;
+  assert.equal((await classifyContractsFinder(populated)).contained, false, 'reader cannot normalize a numeric country');
+  const { fetchGlobalTenders, fetchContractsFinder } = await import('../scripts/seed-global-tenders.mjs');
+  const recovered = await fetchGlobalTenders({ now: CF_NOW, previousSnapshot: snapshot, adapters: [
+    ['contracts-finder', () => fetchContractsFinder({ now: CF_NOW, fetchJsonFn: async () => ({ releases: [] }) })],
+  ] });
+  assert.equal(recovered.sourceStatuses[0].consecutiveFailures, 0);
+  assert.equal(recovered.sourceStatuses[0].confirmedEmpty, undefined);
+  assert.equal(recovered.sourceStatuses[0].lastSuccessfulAt, new Date(CF_NOW).toISOString());
+  const older = structuredClone(snapshot);
+  older.sourceStatuses[0].lastSuccessfulAt = new Date(CF_NOW - 150 * 60_000).toISOString();
+  assert.equal((await classifyContractsFinder(older)).entry.containmentUntil, new Date(CF_NOW + 30 * 60_000).toISOString());
+  assert.equal((await classifyContractsFinder(older, CF_NOW + 30 * 60_000)).contained, false);
+});
+
+test('zero count alone cannot prove a verified empty source or a usable aggregate', async () => {
+  const fixture = await failedEmptyContractsFinder();
+  for (const [label, mutate] of [
+    ['missing empty proof', s => { delete s.sourceStatuses[0].confirmedEmpty; }],
+    ['missing success', s => { delete s.sourceStatuses[0].lastSuccessfulAt; }],
+    ['missing canonical rows', s => { delete s.tenders; }],
+    ['malformed canonical rows', s => { s.tenders = {}; }],
+    ['unavailable aggregate', s => { s.dataAvailable = false; }],
+    ['unavailable read model', s => { s.availability = 'unavailable'; }],
+    ['duplicate source', s => { s.sourceStatuses.push(s.sourceStatuses[0]); }],
+    ['malformed aggregate status', s => { s.sourceStatuses.push(null); }],
+    ['stale aggregate', s => { s.fetchedAt = CF_NOW - 181 * 60_000; }],
+    ['malformed aggregate row', s => { s.tenders = [null]; }],
+  ]) {
+    const snapshot = structuredClone(fixture);
+    mutate(snapshot);
+    assert.equal((await classifyContractsFinder(snapshot)).contained, false, label);
+  }
+  const nonempty = await failedContractsFinder();
+  nonempty.tenders = [];
+  assert.equal((await classifyContractsFinder(await failedEmptyContractsFinder(nonempty))).contained, false);
+  const { fetchGlobalTenders, fetchContractsFinder } = await import('../scripts/seed-global-tenders.mjs');
+  const good = await fetchGlobalTenders({ now: CF_NOW - 60 * 60_000, adapters: [
+    ['contracts-finder', () => fetchContractsFinder({ now: CF_NOW - 60 * 60_000, fetchJsonFn: async () => ({ releases: [] }) })],
+  ] });
+  for (const mutate of [s => { delete s.tenders; }, s => { s.dataAvailable = false; },
+    s => { s.sourceStatuses.push(s.sourceStatuses[0]); },
+    s => { s.sourceStatuses[0].fetchedAt = new Date(CF_NOW).toISOString(); },
+    s => { s.sourceStatuses[0].recordCount = 1; }]) {
+    const malformed = structuredClone(good);
+    mutate(malformed);
+    assert.equal((await classifyContractsFinder(await failedEmptyContractsFinder(malformed))).contained, false);
+  }
+});
+
 test('Contracts Finder producer-to-health retains every diagnostic during bounded first-failure containment', async () => {
   const snapshot = await failedContractsFinder();
   const { entry, contained } = await classifyContractsFinder(snapshot);
@@ -327,6 +405,13 @@ test('Contracts Finder health checks the canonical payload, not the positive sou
   const read = async () => (await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'))).json();
   const initial = await read();
   assert.equal(initial.problems[CF_NAME].containmentUntil, new Date(CF_NOW + 90 * 60_000).toISOString());
+  canonical = await failedEmptyContractsFinder();
+  Object.assign(meta, seed.sourceHealthMeta(canonical.sourceStatuses[0]));
+  const empty = await read();
+  assert.equal(empty.problems[CF_NAME].records, 0);
+  assert.equal(empty.problems[CF_NAME].status, 'SEED_ERROR');
+  assert.equal(empty.problems[CF_NAME].containmentUntil, initial.problems[CF_NAME].containmentUntil);
+  assert.equal(empty.summary.containedWarn, initial.summary.containedWarn);
   expireDuringWrite = true;
   const slow = await read();
   assert.equal(slow.summary.containedWarn, initial.summary.containedWarn - 1,

--- a/tests/global-tender-health.test.mjs
+++ b/tests/global-tender-health.test.mjs
@@ -315,6 +315,36 @@ test('zero count alone cannot prove a verified empty source or a usable aggregat
   }
 });
 
+test('empty-source containment requires the complete tender reader shape', async () => {
+  const record = { ...(await failedContractsFinder()).tenders[0], source: 'ted' };
+  const fixture = await failedEmptyContractsFinder(undefined, [record]);
+  for (const field of ['sourceNoticeId', 'officialUrl', 'status', 'participationMode',
+    'eligibilityRequirements', 'submissionUrls']) {
+    const snapshot = structuredClone(fixture);
+    delete snapshot.tenders[0][field];
+    assert.equal((await classifyContractsFinder(snapshot)).contained, false, `missing ${field}`);
+  }
+  for (const [label, mutate] of [
+    ['matchReasons string', r => { r.automationFit.matchReasons = 'network'; }],
+    ['evidence object', r => { r.automationFit.evidence = {}; }],
+    ['missing score', r => { delete r.automationFit.score; }],
+    ['invalid level', r => { r.automationFit.level = 1; }],
+    ['missing version', r => { delete r.automationFit.classificationVersion; }],
+    ['null automation', r => { r.automationFit = null; }],
+    ['array money', r => { r.money = []; }],
+    ['string amount', r => { r.money = { amount: '20' }; }],
+    ['null money', r => { r.money = null; }],
+    ['invalid eligibility', r => { r.eligibilityRequirements = [1]; }],
+  ]) {
+    const snapshot = structuredClone(fixture);
+    mutate(snapshot.tenders[0]);
+    assert.equal((await classifyContractsFinder(snapshot)).contained, false, label);
+  }
+  delete fixture.tenders[0].automationFit;
+  delete fixture.tenders[0].money;
+  assert.equal((await classifyContractsFinder(fixture)).contained, true, 'optional nested messages may be absent');
+});
+
 test('Contracts Finder producer-to-health retains every diagnostic during bounded first-failure containment', async () => {
   const snapshot = await failedContractsFinder();
   const { entry, contained } = await classifyContractsFinder(snapshot);


### PR DESCRIPTION
## Summary

A first Contracts Finder timeout after a recent verified empty response could not qualify for containment because health required positive source records. The producer now preserves explicit empty-result proof from the prior canonical envelope. Health checks that proof against seed metadata and the usable aggregate before containing the first failure.

Zero records alone never qualify. Missing or malformed canonical data, inconsistent clocks, a second failure, expired success, and an unusable aggregate remain actionable. Source errors, warning counts, and the original success time remain visible. The existing request, retries, and budgets are unchanged.

The supplied natural-run evidence shows two 45-second timeouts while the aggregate still published 455 records. This change fixes the demonstrated containment contract gap; it does not establish or repair the transport cause.

Related: #7953

## Validation

- New producer-to-health regression failed before the fix and passes afterward.
- 229 focused tender and health tests; 4 reader tests; 474 sidecar tests passed. New assertions cover empty and populated aggregates, recovery, recurrence, source and cache expiry, missing proof, malformed rows, duplicate statuses, and compact health projection.
- Browser and API typechecks, boundary lint, docs check, and diff checks passed.
- Simplification and ce-code-review completed sequentially. Fixed the aggregate reader validation finding; no actionable findings remain. Optional cross-model review returned no usable result.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the maintainer should observe the next two natural hourly `Global-Tenders` runs and `/api/health?compact=1`. A successful response must reset the failure episode. A later first timeout after a verified empty success may have `containmentUntil`, while keeping `SEED_ERROR`, zero source records, the error, and the original success time. A second failure or expired evidence must affect availability. Investigate or revert if containment hides recurrence, outlives its deadline, or accepts unusable canonical data. Do not run an extra seeder to force acceptance.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
