### PR TITLE
fix(portwatch): refresh country caches before the expiry cliff

### DIFF
--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -379,9 +379,17 @@ when retained. Coverage diagnostics distinguish `currentCountryCount` from
 `retainedCountryCount` and expose `oldestCountryCacheWrittenAt`. Missing or expired
 countries and unresolved refresh failures still block a healthy publication.
 
+Unchanged upstream dates also enter the refresh queue before cache expiry. With
+174 countries, the lead reserves seven 12-hour runs after allowing two recurring
+critical-country slots, plus one missed run. Thus full refreshes become due at
+three days, while validated retained data remains usable strictly below seven
+days. This can increase activity downloads for unchanged data, within the same
+30-country run cap. An already expired backlog still requires successful bounded
+refreshes before healthy publication resumes.
+
 `portwatchPortActivity` additionally requires per-country **content**
 freshness, which is a different question from transport freshness and country
-cardinality. The seeder reuses a cached country payload whenever upstream
+cardinality. The seeder can reuse a cached country payload when upstream
 `max(date)` has not advanced, so a run can report a fresh heartbeat and a
 complete 174/174 country list while an individual country's observation is
 days old. The producer therefore publishes a `contentFreshness` block, and the

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -19,6 +19,8 @@ import {
   isCriticalContentRefreshDue,
   orderColdFetchQueue,
   PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY,
+  PORTWATCH_CONTENT_FRESHNESS_CADENCE_MINUTES,
+  PORTWATCH_DECISION_CRITICAL_COUNTRIES,
 } from './_portwatch-content-freshness.mjs';
 
 export {
@@ -156,7 +158,8 @@ const BATCH_BACKOFF_MS = 5_000;
 const BATCH_LOG_EVERY = 5;
 const RATE_LIMIT_RETRY_DELAY_MS = 2_000;
 const MAX_RATE_LIMIT_RETRIES = 1;
-// Cache hygiene: force a full refetch if the cached payload is older than 7 days
+// Hard publication expiry: reject cached payloads at seven days. Queue a full
+// refetch earlier so the bounded rotation can finish before this deadline,
 // even when upstream maxDate is unchanged. Protects against window-shift drift
 // (cached aggregates were computed against a window that's now 7+ days offset
 // from today's last30/prev30 cutoffs) and serves as a belt-and-braces refresh
@@ -1251,7 +1254,7 @@ export async function fetchAll(progress, { signal, expectedCountries = [] } = {}
   // `cacheWrittenAt` (ms epoch). We re-use them as-is when both of the
   // following hold:
   //   1. upstream max(date) for the country is unchanged since `asof`
-  //   2. `cacheWrittenAt` is within MAX_CACHE_AGE_MS
+  //   2. `cacheWrittenAt` leaves enough time for a bounded refresh rotation
   // Either check failing → fall through to the expensive paginated fetch.
   //
   // Cold run (no cache / legacy payloads without asof) always falls through.
@@ -1302,6 +1305,14 @@ export async function fetchAll(progress, { signal, expectedCountries = [] } = {}
   let needsFetch = [];
   let cacheHits = 0;
   const now = Date.now();
+  // Reserve a full sweep plus one missed cron before the seven-day expiry.
+  // Critical countries can consume their slots on every run. Without this
+  // lead, unchanged upstream dates keep a synchronized cohort cached until
+  // all countries expire together, when only 30 can recover per run.
+  const rotationSlots = MAX_COLD_FETCH_PER_RUN - PORTWATCH_DECISION_CRITICAL_COUNTRIES.length;
+  const refreshLeadMs = (Math.ceil(eligibleIso3.length / rotationSlots) + 1)
+    * PORTWATCH_CONTENT_FRESHNESS_CADENCE_MINUTES * 60_000;
+  const refreshAgeMs = Math.max(0, MAX_CACHE_AGE_MS - refreshLeadMs);
   for (let i = 0; i < eligibleIso3.length; i++) {
     const iso3 = eligibleIso3[i];
     const iso2 = iso3ToIso2.get(iso3);
@@ -1321,6 +1332,7 @@ export async function fetchAll(progress, { signal, expectedCountries = [] } = {}
         : prev?.asof === null && prev?.zeroActivity === true);
     const cacheFresh = !criticalRefreshDue
       && classifyDeferredPayload(prev, now).status === 'stale'
+      && now - prev.cacheWrittenAt < refreshAgeMs
       && observationMatches;
     if (cacheFresh) {
       const { refreshFailure: _failure, staleAsof: _stale, ...confirmed } = prev;

--- a/tests/portwatch-publication.test.mts
+++ b/tests/portwatch-publication.test.mts
@@ -303,6 +303,58 @@ test('12-hour rolling recovery stays complete across daily advances within the o
   assert.ok(successfulRuns >= 10, 'recover within a rotation and remain complete over multiple rotations');
 });
 
+test('the 120-of-174 crash backlog recovers through persisted bounded batches', () => {
+  let state = fixtures();
+  for (const [index, [, code]] of countries.entries()) {
+    state[`${PREFIX}${code}`].cacheWrittenAt = NOW - (index < 84 ? 8 : 1) * DAY;
+    state[`${PREFIX}${code}`].asof = index >= 84 && index < 148 ? '2026-09-09' : '2026-09-08';
+  }
+  for (const [run, covered] of [120, 150, 174].entries()) {
+    const now = NOW + run * PORTWATCH_CONTENT_FRESHNESS_CADENCE_MINUTES * 60_000;
+    const result = runProducer(state, 'complete', now);
+    assert.equal(result.redis[META].coverage.published, covered);
+    if (covered < 174) {
+      assert.match(result.error, /Incomplete PortWatch coverage/);
+      assert.deepEqual(result.redis[CANONICAL], state[CANONICAL]);
+      assert.equal(result.redis[META].fetchedAt, state[META].fetchedAt);
+    } else {
+      assert.equal(result.error, null);
+      assert.equal(result.redis[META].sourceState, 'ok');
+      assert.equal(result.redis[META].fetchedAt, now);
+    }
+    state = result.redis;
+  }
+});
+
+test('unchanged upstream stays covered across cache expiry without exceeding the refresh cap', () => {
+  let state = fixtures();
+  state[CANONICAL] = countries.map(([, code]) => code);
+  for (const [, code] of countries) {
+    const payload = state[`${PREFIX}${code}`];
+    payload.cacheWrittenAt = NOW;
+    payload.fetchedAt = new Date(NOW).toISOString();
+    payload.asof = '2026-09-09';
+    payload.contentAsOfChangedAt = NOW - 10 * DAY;
+  }
+  const cadenceMs = PORTWATCH_CONTENT_FRESHNESS_CADENCE_MINUTES * 60_000;
+  for (let run = 0; run < 30; run++) {
+    if (run === 9 || run === 22) continue;
+    const now = NOW + run * cadenceMs;
+    const result = runProducer(state, 'complete', now);
+    assert.equal(result.error, null, `run ${run}: ${result.redis[META].coverage.published}/174 covered`);
+    assert.equal(result.redis[META].coverage.published, 174);
+    const activityRequests = result.requests.map((query: string) => new URLSearchParams(query))
+      .filter((query: URLSearchParams) => query.get('where')?.startsWith('ISO3=') && !query.has('outStatistics'));
+    assert.ok(activityRequests.length <= 60, 'retain the 30-country, two-window cap');
+    for (const [, code] of countries) {
+      const payload = result.redis[`${PREFIX}${code}`];
+      assert.ok(now - payload.cacheWrittenAt < 7 * DAY, `${code} expired at run ${run}`);
+      assert.equal(payload.contentAsOfChangedAt, NOW - 10 * DAY, 'refetch must not renew frozen content');
+    }
+    state = result.redis;
+  }
+});
+
 test('a deferred refresh failure cannot be hidden by otherwise complete retained coverage', () => {
   const input = fixtures();
   for (const [, code] of countries) {


### PR DESCRIPTION
## Problem and change

Railway `world-monitor` / `seed-bundle-portwatch-port-activity` exited with code 1 on September 10 at 12:03 UTC. Deployment `8ca0dec2-5ab5-4019-ade5-3b72e60b72fa` completed all 30 attempted country refreshes without errors in 27 seconds, but retained only 120/174 usable countries: 54 deferred caches were older than seven days. The publication safeguard correctly retained the previous canonical list and success clocks.

Unchanged upstream dates could remain cache hits until the hard seven-day expiry, leaving no time for the bounded refresh rotation. Queue these countries earlier. The lead reserves a full sweep with two recurring critical-country slots plus one missed cron. At 174 countries and a 12-hour cadence, refresh becomes due at three days. The seven-day hard expiry, 30-country cap, cadence, original content clocks, and incomplete-publication failure semantics remain unchanged.

This increases downloads for unchanged data within the existing per-run cap. It prevents a synchronized expiry cliff; it does not instantly repair already expired countries or guarantee recovery during upstream failures.

## Verification

- The new real-producer regression failed before the fix at day seven with 30/174 usable countries. It now preserves 174/174 over 15 simulated days, including two missed runs and recurring critical-country refreshes, without renewing frozen content clocks or exceeding the activity request cap.
- A fixture matching the observed backlog recovers 120 → 150 → 174 through persisted bounded batches. Canonical publication and success clocks remain unchanged until recovery completes.
- All 292 focused PortWatch transport, producer, publication, recovery, and health tests passed. HTTP, Redis, and time are controlled in these tests.
- After integrating current main, the affected publication and seed-health tests passed again. Browser and API typechecks passed during pre-push checks.

## Production follow-up

Merge and deployment require separate approval. No production seeder, Redis write, restart, or deployment was run for this fix. After deployment, inspect natural 12-hour runs for full usable coverage and successful publication, while confirming the refresh cap and unchanged source-content timestamps. The existing 54-country backlog requires at least two additional successful capped runs; new expiry or provider failures can extend recovery. Local fixture recovery is not live production acceptance.
