### PR TITLE
fix(fred): rotate the exit when FRED refuses the one we are on

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1446,6 +1446,30 @@ export function isTransientProxyError(message) {
   return /HTTP 5\d{2}|522|timeout|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|EPIPE|socket (disconnected|hang up)|TLS connection|tls_get_more_records|packet length too long|SSL routines|secure TLS connection/i.test(message || '');
 }
 
+// Whether the ORIGIN refused this particular egress IP — a failure that a
+// different sticky exit can actually fix. FRED rate-limits and blocks by IP,
+// which is the whole reason the proxy leg exists, so a 403/429 served through a
+// healthy tunnel is the most exit-specific failure there is.
+//
+// Deliberately separate from isTransientProxyError rather than folded into it:
+// that predicate is shared by other seeders whose retry budgets are tuned to
+// their own upstreams, and widening it would change their behaviour too. Kept
+// status-based rather than message-based because proxyConnectTunnel and
+// httpsProxyFetchRaw both collapse to `HTTP <status>` text, and only the
+// structured fields tell the two apart.
+//
+// Gateway-layer rejections are excluded: proxyConnectTunnel marks its own
+// failures `proxyConnect: true` for exactly this decision — see its comment in
+// _proxy-utils.cjs, "only the origin case can be helped by a different exit". A
+// 407, or a gateway 403 for a port outside the account's allocation, means the
+// credentials or plan are wrong and no exit fixes that. Other origin 4xx are
+// excluded too: every exit answers a bad series id identically, so rotating on
+// one would just burn the proxy budget before the direct leg gets its turn.
+export function isExitRefusalError(error) {
+  if (!error || error.proxyConnect) return false;
+  return error.status === 403 || error.status === 429;
+}
+
 const FRED_JSON_HEADERS = { Accept: 'application/json', 'User-Agent': CHROME_UA };
 
 // FRED's own edge returns sporadic 5xx on individual series. Observed
@@ -1513,8 +1537,12 @@ export async function fredFetchJson(url, proxyAuth) {
         return await httpsProxyFetchJson(url, proxyAuth, attempt - 1);
       } catch (proxyErr) {
         lastProxyErr = proxyErr;
-        const transient = isTransientProxyError(proxyErr.message);
-        if (attempt < 3 && transient) {
+        // Two different reasons to try the next exit: the hop broke (transient),
+        // or this exit's IP is the thing FRED is refusing (403/429). The second
+        // is what the rotation above is FOR, and it used to break the loop after
+        // one attempt because the transient predicate matches no 4xx.
+        const rotatable = isTransientProxyError(proxyErr.message) || isExitRefusalError(proxyErr);
+        if (attempt < 3 && rotatable) {
           await new Promise((r) => setTimeout(r, 400 * attempt + Math.random() * 300));
           continue;
         }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1447,9 +1447,21 @@ export function isTransientProxyError(message) {
 }
 
 // Whether the ORIGIN refused this particular egress IP — a failure that a
-// different sticky exit can actually fix. FRED rate-limits and blocks by IP,
-// which is the whole reason the proxy leg exists, so a 403/429 served through a
-// healthy tunnel is the most exit-specific failure there is.
+// different sticky exit can actually fix. FRED blocks datacenter IPs, which is
+// why the proxy leg exists at all (#2911), so a 403 served through a healthy
+// tunnel says "this exit is unwelcome" and the next sticky exit may be fine.
+//
+// 403 ONLY, deliberately. 429 was in the first draft and came out under review.
+// Nothing in this repo establishes that FRED's rate limit is scoped to the
+// source IP — #2911 cites direct-fetch TIMEOUTS as the observed motivation, not
+// IP-keyed 429s — and `api_key` travels in the query string (_fred-seeder.mjs),
+// which is how quota is conventionally scoped. If the limit is per-key,
+// rotating exits cannot clear it and merely triples the request count against a
+// quota that is already exhausted, while the Retry-After FRED sends is
+// discarded anyway because httpsProxyFetchRaw drops `result.headers` when it
+// throws. Widen to 429 only with evidence that FRED's 429 is IP-scoped, and
+// plumb Retry-After first — _proxy-utils.cjs already preserves those headers
+// through the tunnel for exactly this reason (#6241).
 //
 // Deliberately separate from isTransientProxyError rather than folded into it:
 // that predicate is shared by other seeders whose retry budgets are tuned to
@@ -1465,9 +1477,14 @@ export function isTransientProxyError(message) {
 // credentials or plan are wrong and no exit fixes that. Other origin 4xx are
 // excluded too: every exit answers a bad series id identically, so rotating on
 // one would just burn the proxy budget before the direct leg gets its turn.
+//
+// Takes the ERROR OBJECT, not a message string — it reads structured fields, so
+// a mistaken isExitRefusalError(err.message) would silently return false
+// forever and quietly disable rotation. The typeof guard makes that loud-ish
+// rather than accidental, and a regression test pins it.
 export function isExitRefusalError(error) {
-  if (!error || error.proxyConnect) return false;
-  return error.status === 403 || error.status === 429;
+  if (!error || typeof error !== 'object' || error.proxyConnect) return false;
+  return error.status === 403;
 }
 
 const FRED_JSON_HEADERS = { Accept: 'application/json', 'User-Agent': CHROME_UA };

--- a/tests/fred-proxy-transient-classify.test.mjs
+++ b/tests/fred-proxy-transient-classify.test.mjs
@@ -80,6 +80,60 @@ test('FRED does not retry a permanent proxy authentication failure', async (t) =
   assert.equal(proxy.mock.calls[0].arguments[1].port, 10001);
 });
 
+// FRED rate-limits and blocks BY IP — that is the entire reason the proxy leg
+// exists. So a 403/429 the origin returns through a healthy tunnel is the most
+// exit-specific failure there is: this exit is unwelcome, and the next sticky
+// exit may well be fine. Before this, rotation was gated solely on
+// isTransientProxyError, which matches no 4xx at all, so the retry loop broke
+// after ONE attempt and fell to the direct leg — from the Railway datacenter IP
+// that FRED blocks hardest. The rotation added in #7963 never fired for it.
+//
+// The gateway case is deliberately excluded. proxyConnectTunnel marks its own
+// rejections `proxyConnect: true` precisely so the two can be told apart; its
+// comment already says "only the origin case can be helped by a different
+// exit". A 407 means our credentials are wrong and no exit fixes that.
+test('FRED rotates to a new exit when the origin refuses this one (403/429)', async (t) => {
+  for (const status of [403, 429]) {
+    const ports = [];
+    const mocked = t.mock.method(proxyUtils, 'proxyFetch', async (_url, config) => {
+      ports.push(config.port);
+      if (config.port === 10001) throw Object.assign(new Error(`HTTP ${status}`), { status });
+      return { ok: true, buffer: Buffer.from('{"observations":[{"value":"7"}]}') };
+    });
+    const direct = t.mock.method(globalThis, 'fetch', async () => { throw new Error('direct must not be needed'); });
+    const result = await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
+    assert.deepEqual(ports, [10001, 10002], `origin ${status} must move to the next exit`);
+    assert.equal(result.observations[0].value, '7');
+    assert.equal(direct.mock.callCount(), 0, `origin ${status} must not reach the direct leg`);
+    mocked.mock.restore();
+    direct.mock.restore();
+  }
+});
+
+test('FRED does not rotate on a gateway rejection — no exit fixes bad credentials', async (t) => {
+  // Same 403 status, but raised by the CONNECT hop rather than by FRED.
+  const proxy = t.mock.method(proxyUtils, 'proxyFetch', async () => {
+    throw Object.assign(new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'), { status: 403, proxyConnect: true });
+  });
+  t.mock.method(globalThis, 'fetch', async () => new Response('{}'));
+  await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
+  assert.equal(proxy.mock.callCount(), 1, 'a gateway rejection must still fail fast');
+});
+
+test('FRED still does not rotate on an origin 4xx that every exit answers alike', async (t) => {
+  // A bad series id is not exit-attributable — 400 and 404 fail identically on
+  // every exit, so rotating just burns the budget before the direct leg.
+  for (const status of [400, 404]) {
+    const proxy = t.mock.method(proxyUtils, 'proxyFetch', async () => {
+      throw Object.assign(new Error(`HTTP ${status}`), { status });
+    });
+    t.mock.method(globalThis, 'fetch', async () => new Response('{}'));
+    await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
+    assert.equal(proxy.mock.callCount(), 1, `origin ${status} must fail fast`);
+    proxy.mock.restore();
+  }
+});
+
 test('the proxy-exhaustion warning names every exit it tried', async (t) => {
   // Rotation can silently no-op: parseProxyConfigForAttempt returns the route
   // untouched for any host outside its sticky map (us.decodo.com, an ISP or

--- a/tests/fred-proxy-transient-classify.test.mjs
+++ b/tests/fred-proxy-transient-classify.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 
-import { CHROME_UA, fredFetchJson, httpsProxyFetchRaw, isTransientProxyError } from '../scripts/_seed-utils.mjs';
+import { CHROME_UA, fredFetchJson, httpsProxyFetchRaw, isExitRefusalError, isTransientProxyError } from '../scripts/_seed-utils.mjs';
 
 // fredFetchJson retries the Decodo proxy only when the error is classified
 // transient; otherwise it breaks to a direct FRED fetch, which a datacenter IP
@@ -80,33 +80,64 @@ test('FRED does not retry a permanent proxy authentication failure', async (t) =
   assert.equal(proxy.mock.calls[0].arguments[1].port, 10001);
 });
 
-// FRED rate-limits and blocks BY IP — that is the entire reason the proxy leg
-// exists. So a 403/429 the origin returns through a healthy tunnel is the most
+// FRED blocks datacenter IPs — that is the entire reason the proxy leg exists
+// (#2911). So a 403 the origin returns through a healthy tunnel is the most
 // exit-specific failure there is: this exit is unwelcome, and the next sticky
 // exit may well be fine. Before this, rotation was gated solely on
 // isTransientProxyError, which matches no 4xx at all, so the retry loop broke
 // after ONE attempt and fell to the direct leg — from the Railway datacenter IP
 // that FRED blocks hardest. The rotation added in #7963 never fired for it.
 //
-// The gateway case is deliberately excluded. proxyConnectTunnel marks its own
-// rejections `proxyConnect: true` precisely so the two can be told apart; its
-// comment already says "only the origin case can be helped by a different
-// exit". A 407 means our credentials are wrong and no exit fixes that.
-test('FRED rotates to a new exit when the origin refuses this one (403/429)', async (t) => {
-  for (const status of [403, 429]) {
-    const ports = [];
-    const mocked = t.mock.method(proxyUtils, 'proxyFetch', async (_url, config) => {
-      ports.push(config.port);
-      if (config.port === 10001) throw Object.assign(new Error(`HTTP ${status}`), { status });
-      return { ok: true, buffer: Buffer.from('{"observations":[{"value":"7"}]}') };
-    });
-    const direct = t.mock.method(globalThis, 'fetch', async () => { throw new Error('direct must not be needed'); });
-    const result = await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
-    assert.deepEqual(ports, [10001, 10002], `origin ${status} must move to the next exit`);
-    assert.equal(result.observations[0].value, '7');
-    assert.equal(direct.mock.callCount(), 0, `origin ${status} must not reach the direct leg`);
-    mocked.mock.restore();
-    direct.mock.restore();
+// The mock RESOLVES `{ ok: false, status }` rather than throwing a pre-tagged
+// error. That matters: `.status` is attached by httpsProxyFetchRaw, and a mock
+// that throws its own tagged error supplies the very field whose production
+// construction this test is supposed to prove — stripping that attachment left
+// the whole suite green. Resolving here routes through the real seam.
+test('FRED rotates to a new exit when the origin refuses this one (403)', async (t) => {
+  const ports = [];
+  t.mock.method(proxyUtils, 'proxyFetch', async (_url, config) => {
+    ports.push(config.port);
+    if (config.port === 10001) return { ok: false, status: 403, buffer: Buffer.from('blocked'), contentType: 'text/plain' };
+    return { ok: true, buffer: Buffer.from('{"observations":[{"value":"7"}]}') };
+  });
+  const direct = t.mock.method(globalThis, 'fetch', async () => { throw new Error('direct must not be needed'); });
+  const result = await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
+  assert.deepEqual(ports, [10001, 10002], 'an origin 403 must move to the next exit');
+  assert.equal(result.observations[0].value, '7');
+  assert.equal(direct.mock.callCount(), 0, 'an origin 403 must not reach the direct leg');
+});
+
+// 429 is NOT rotated on. Nothing establishes that FRED's rate limit is
+// IP-scoped, `api_key` rides in the query string, and rotating would triple the
+// request count against an already-exhausted quota while Retry-After is
+// discarded. If that premise is ever evidenced, this test is the thing to flip.
+test('FRED does not rotate on a 429 — the quota is not known to follow the exit', async (t) => {
+  const ports = [];
+  t.mock.method(proxyUtils, 'proxyFetch', async (_url, config) => {
+    ports.push(config.port);
+    return { ok: false, status: 429, buffer: Buffer.from('slow down'), contentType: 'text/plain' };
+  });
+  const direct = t.mock.method(globalThis, 'fetch', async () => new Response('{"observations":[]}'));
+  await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
+  assert.deepEqual(ports, [10001], 'a 429 must not burn extra exits');
+  assert.equal(direct.mock.callCount(), 1, 'a 429 falls through to the direct leg immediately');
+});
+
+// isExitRefusalError is exported, so pin it directly rather than only through
+// fredFetchJson. The black-box assertions cannot distinguish "this predicate
+// returned false" from "isTransientProxyError already excluded every 4xx".
+test('isExitRefusalError keys on the origin status and ignores gateway rejections', () => {
+  assert.equal(isExitRefusalError(Object.assign(new Error('HTTP 403'), { status: 403 })), true);
+  assert.equal(isExitRefusalError(Object.assign(new Error('HTTP 429'), { status: 429 })), false, '429 is out until the quota is shown to follow the exit');
+  assert.equal(isExitRefusalError(Object.assign(new Error('CONNECT 403'), { status: 403, proxyConnect: true })), false, 'a gateway rejection is not exit-attributable');
+  for (const status of [400, 404, 500, 502, undefined]) {
+    assert.equal(isExitRefusalError(Object.assign(new Error('x'), { status })), false, `status=${String(status)}`);
+  }
+  // The footgun this signature invites: it takes the ERROR, while its neighbour
+  // isTransientProxyError takes the MESSAGE. Passing a string must not silently
+  // read as "not a refusal" by accident of property lookup.
+  for (const notAnError of ['HTTP 403', null, undefined, 403]) {
+    assert.equal(isExitRefusalError(notAnError), false, `non-error input ${String(notAnError)}`);
   }
 });
 
@@ -127,10 +158,13 @@ test('FRED still does not rotate on an origin 4xx that every exit answers alike'
     const proxy = t.mock.method(proxyUtils, 'proxyFetch', async () => {
       throw Object.assign(new Error(`HTTP ${status}`), { status });
     });
-    t.mock.method(globalThis, 'fetch', async () => new Response('{}'));
+    const direct = t.mock.method(globalThis, 'fetch', async () => new Response('{}'));
     await fredFetchJson('https://api.stlouisfed.org/fred/series/observations', 'https://fake:secret@gate.decodo.com:10001');
     assert.equal(proxy.mock.callCount(), 1, `origin ${status} must fail fast`);
+    // Restore BOTH per iteration. Leaving the fetch mock installed stacked a
+    // second mock on the first on the next pass through the loop.
     proxy.mock.restore();
+    direct.mock.restore();
   }
 });
 


### PR DESCRIPTION
> **Stacked on #7971** — base is `fix/fred-rotation-review-gaps`, so this diff shows only the behavioral change. Retarget to `main` once #7971 merges.

> **Updated after self-review.** The first draft rotated on 403 **and** 429. Review found the 429 half rested on an assertion I introduced in that same commit, and it has been removed. See "What changed under review" below.

## Summary

#7963 made FRED retries advance the Decodo sticky port, but gated that rotation on `isTransientProxyError` — a predicate matching 5xx, 522, timeouts and socket/TLS tears, and **no 4xx at all**.

FRED blocks datacenter IPs; that is why the proxy leg exists at all (#2911). So when an exit's IP is the thing being blocked, FRED answers **403**, the predicate returns false, the loop breaks after **one** attempt, and the run falls to the direct leg — from the Railway datacenter IP that FRED blocks hardest. The rotation added in #7963 never fired for the failure it is most suited to.

The same shape has bitten this repo before: #5833/#5839 (SZSE) was a retry predicate that did not cover the code signalling "this egress is blocked."

## What changed under review

**429 is out.** The original commit asserted "FRED rate-limits and blocks BY IP" as though established. It is not: #2911, the commit that adopted the proxy leg, cites direct-fetch *timeouts* as the observed motivation, not IP-keyed 429s, and `api_key` travels in the query string — which is how quota is conventionally scoped. If the limit is per-key, rotating exits cannot clear it and merely **triples the request count against an already-exhausted quota**. Worse, the `Retry-After` FRED sends is discarded regardless, because `httpsProxyFetchRaw` drops `result.headers` when it throws — the exact gap #6241 fixed for OpenSky, never applied at this call site.

403 stays, because a datacenter-IP block genuinely is exit-attributable. The code comment now states only what is evidenced and names what evidence would justify widening to 429.

## Why a separate predicate, and why status-based

`isExitRefusalError` is deliberately **not** a wider `isTransientProxyError`. That predicate is shared by seeders whose retry budgets are tuned to their own upstreams, and widening it would silently change their behavior too.

It reads **structured fields, not the message**, because `proxyConnectTunnel` and `httpsProxyFetchRaw` both collapse to `HTTP <status>` text and only `proxyConnect` tells a gateway rejection from an origin status. `_proxy-utils.cjs` already sets that flag for exactly this decision:

> Marks a gateway-layer rejection (auth, quota, policy) as opposed to a status the target origin returned through the tunnel. The two are indistinguishable once both collapse to `HTTP_<status>`, and **only the origin case can be helped by a different exit**.

`fredFetchJson` simply never read it.

## Deliberately excluded, each with a negative-control test

- **429** — not known to follow the exit (above).
- **Gateway rejections** (`proxyConnect: true`), including a gateway 403 for a port outside the account's allocation — wrong credentials or plan, and no exit fixes that.
- **Every other origin 4xx** — a bad series id answers identically on every exit.

## Validation

The 403 test now **resolves** `{ ok: false, status: 403 }` instead of throwing a pre-tagged error. That matters: the old mock supplied `.status` itself — the very field `httpsProxyFetchRaw` constructs — so it never exercised the production seam. Mutation proved it: stripping `{ status: result.status }` from `_seed-utils.mjs` left all 17 tests green. It now fails.

Every boundary is mutation-pinned by exactly one test:

| Mutation | Test that catches it |
| :--- | :--- |
| strip `{ status: result.status }` from httpsProxyFetchRaw | rotates on origin 403 (**was green before this PR's fix**) |
| put 429 back in the predicate | does not rotate on a 429 + the direct unit test |
| drop `isExitRefusalError` from the gate | rotates on origin 403 |

Also added a direct unit test for `isExitRefusalError` — the black-box assertions could not distinguish "the predicate returned false" from "`isTransientProxyError` already excluded every 4xx" — including a regression pinning that passing a **message string** returns false, since it takes the error object while its neighbour takes the message.

**308/308 pass across 42 suites** over the proxy-adjacent surface. Biome clean. All pre-push gates passed.

## Known gap, not fixed here

`httpsProxyFetchRaw` discards `result.headers` when throwing, so no caller can honor an upstream `Retry-After` — even though `_proxy-utils.cjs` preserves those headers through the tunnel specifically so it could (#6241), and `withRetry` already honors `retryAfterMs` when a caller attaches it. Pre-existing and shared by ~15 callers, so out of scope for this PR; worth its own issue.

Refs #7963

https://claude.ai/code/session_01RJjGjH2SZDA2CR37WGmJjq
