### PR TITLE
fix(railway): refresh main after observing deployments

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -629,9 +629,14 @@ a service has no stable active-deployment baseline.
 The job runs only for the literal `refs/heads/main`. It freezes the event SHA
 against the checkout SHA, uses full Git history with a blobless filter, and
 fails if the exact comparison commit cannot be fetched. It passes that
-immutable commit with `--head`; a local manual
-invocation without `--head` first refreshes the explicit `origin/main`
-tracking ref and then resolves it, never the current feature-branch `HEAD`.
+immutable commit with `--head`. Every invocation refreshes the explicit
+`origin/main` tracking ref again after the Railway fleet read, so lineage is
+judged against current ancestry without moving the comparison head; a merge
+landing mid-read is therefore recognized rather than reported as drift. That
+refresh is skipped when the run deadline has already passed, and a failure to
+refresh degrades to the pre-refresh ref, which can only over-report. A local
+manual invocation without `--head` additionally resolves that refreshed ref as
+the head, never the current feature-branch `HEAD`.
 
 The workflow maps `RAILWAY_PRODUCTION_VIEWER_API_TOKEN` to
 `RAILWAY_API_TOKEN` only on the combined read step. The

--- a/scripts/check-railway-deploy-drift.mjs
+++ b/scripts/check-railway-deploy-drift.mjs
@@ -636,7 +636,7 @@ function normalizeAuthorizedLineage(result, isOnAuthorizedMainLineage) {
   return {
     ...result,
     verdict: 'AHEAD_LINEAGE_UNPROVEN',
-    detail: 'the running descendant is not proven reachable from the authorized main ref',
+    detail: `running ${result.runningSha ?? 'unknown'}; cannot prove this descendant belongs to refreshed origin/main. Verify the deployment source branch and Git fetch access before redeploying.`,
   };
 }
 
@@ -751,9 +751,10 @@ export function resolveOriginMainRelation(headSha, originMainSha, ancestry) {
 export function resolveComparisonHead(argv, {
   git = runGit,
   ancestry = () => 'unknown',
+  refreshMain = false,
 } = {}) {
   const explicit = readArgument(argv, '--head', null);
-  if (explicit === null) {
+  if (explicit === null || refreshMain) {
     git([
       'fetch',
       '--quiet',
@@ -802,7 +803,7 @@ function printReport(results, summary, headSha, graceSha, headContext) {
   console.log(`Railway deploy-drift check: head=${headSha.slice(0, 9)} ${formatComparisonHead(headContext)} grace=${graceSha.slice(0, 9)} services=${results.length} ${JSON.stringify(summary.counts)}`);
 
   if (summary.blocking.length > 0) {
-    console.error(`Railway deploy-drift check found ${summary.blocking.length} service(s) not running the head commit:`);
+    console.error(`Railway deploy-drift check found ${summary.blocking.length} service(s) with deployment or source-verification problems:`);
     for (const problem of summary.blocking) {
       console.error(`- ${problem.service} [${problem.verdict}] ${problem.detail}`);
     }
@@ -855,8 +856,8 @@ async function main() {
   // "cannot prove it keeps the service reported" behaviour.
   const ancestry = createAncestryResolver({ git: runGit });
   const isAncestor = (ancestor, descendant) => ancestry(ancestor, descendant) === 'yes';
-  const headContext = resolveComparisonHead(process.argv, { git: runGit, ancestry });
-  const { headSha, originMainSha: authorizedMainSha } = headContext;
+  let headContext = resolveComparisonHead(process.argv, { git: runGit, ancestry });
+  const { headSha } = headContext;
   // The newest commit that has been available longer than the build grace.
   // On a checkout too shallow to reach back that far, rev-list answers with
   // nothing and this falls back to head — the stricter reading.
@@ -955,6 +956,15 @@ async function main() {
     deadlineAt: deepPassDeadlineAt,
     monotonicNow: () => performance.now(),
   });
+
+  // Main can advance while Railway is read. Fetch after that observation so a
+  // newly deployed main commit has both its object and lineage available.
+  // Keep the original target: refreshing evidence must not move the goalpost.
+  headContext = {
+    ...resolveComparisonHead(['--head', headSha], { git: runGit, ancestry, refreshMain: true }),
+    headSource: headContext.headSource,
+  };
+  const { originMainSha: authorizedMainSha } = headContext;
 
   // One classifier closure for both passes: the shallow fleet read and the
   // deep per-service re-read must judge a history identically, or the deepen

--- a/scripts/check-railway-deploy-drift.mjs
+++ b/scripts/check-railway-deploy-drift.mjs
@@ -766,7 +766,12 @@ export function resolveComparisonHead(argv, {
   try {
     originMainSha = git(['rev-parse', '--verify', '--end-of-options', 'origin/main^{commit}']);
   } catch (error) {
-    if (explicit === null) {
+    // Symmetric with the fetch condition above. A refresh call always passes an
+    // explicit --head, so keying this on `explicit === null` alone would swallow
+    // the failure and hand back originMainSha: null — which reads downstream as
+    // "no commit is on authorized main" and blocks the whole fleet with a detail
+    // string blaming the deployment source rather than this resolution failure.
+    if (explicit === null || refreshMain) {
       throw new Error(
         'cannot resolve origin/main for the deploy-drift comparison; fetch main or pass --head explicitly',
         { cause: error },
@@ -960,10 +965,28 @@ async function main() {
   // Main can advance while Railway is read. Fetch after that observation so a
   // newly deployed main commit has both its object and lineage available.
   // Keep the original target: refreshing evidence must not move the goalpost.
-  headContext = {
-    ...resolveComparisonHead(['--head', headSha], { git: runGit, ancestry, refreshMain: true }),
-    headSource: headContext.headSource,
-  };
+  //
+  // Two guards, both about what sits immediately after this line. The next step
+  // is classifyFleetWithinDeadline, which DISCARDS every history already read
+  // once the deadline has passed — so a refresh that runs past the deadline, or
+  // that spends its 30s git timeout crossing it, converts a fully-read fleet
+  // into a fleet-wide deadline error. That is the same false alarm this refresh
+  // exists to remove. And an unhandled throw here would strand the completed
+  // Railway read with no report at all, which is strictly worse than judging
+  // against a stale ref: a stale authorized main only ever OVER-blocks, so
+  // degrading to the pre-refresh context stays fail-closed.
+  if (performance.now() < deepPassDeadlineAt) {
+    try {
+      headContext = {
+        ...resolveComparisonHead(['--head', headSha], { git: runGit, ancestry, refreshMain: true }),
+        headSource: headContext.headSource,
+      };
+    } catch (error) {
+      console.error(`Could not refresh origin/main after the Railway read; judging lineage against the pre-refresh ref, which can only over-report: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  } else {
+    console.error('Skipped the post-observation origin/main refresh: the run deadline was reached while reading Railway. Lineage is judged against the pre-refresh ref, which can only over-report.');
+  }
   const { originMainSha: authorizedMainSha } = headContext;
 
   // One classifier closure for both passes: the shallow fleet read and the

--- a/scripts/wait-railway-deploy-convergence.mjs
+++ b/scripts/wait-railway-deploy-convergence.mjs
@@ -262,7 +262,16 @@ function runStrictDrift(headSha, environment, timeoutMs, expectedServices) {
   try {
     parsed = JSON.parse(result.stdout);
   } catch (cause) {
-    throw new Error('strict drift returned malformed JSON', { cause });
+    // The subprocess writes its report to stdout and its diagnosis to stderr, so
+    // any crash leaves stdout empty and lands here. Reporting only "malformed
+    // JSON" sends an operator after a contract bug when the real cause — a failed
+    // git fetch, an expired token — was on a stream we discarded. The CLI prints
+    // only { ok, code, disposition }, so this message is the last place the cause
+    // can survive.
+    throw new Error(
+      `strict drift returned malformed JSON (exit ${result.status}): ${String(result.stderr ?? '').trim().slice(0, 500) || '<no stderr>'}`,
+      { cause },
+    );
   }
   if (!parsed?.summary || typeof parsed.summary.ok !== 'boolean') {
     throw new Error('strict drift response has no summary');

--- a/tests/railway-deploy-drift-workflow.test.mjs
+++ b/tests/railway-deploy-drift-workflow.test.mjs
@@ -32,6 +32,14 @@ function stepNamed(job, name) {
   return step;
 }
 
+// Resolved once, before the fixture puts its own `git` on PATH, so the shim can
+// delegate to the real binary by absolute path instead of recursing into itself.
+function realGit() {
+  const result = spawnSync('command', ['-v', 'git'], { encoding: 'utf8', shell: true });
+  assert.equal(result.status, 0, 'git must be on PATH');
+  return result.stdout.trim();
+}
+
 function gitRevision(revision) {
   const result = spawnSync('git', ['rev-parse', revision], {
     cwd: repoRoot,
@@ -192,15 +200,28 @@ function createProbeFixture() {
   const startedAtMs = Date.now();
   const fakeRailway = join(directory, 'railway');
   const fakeDate = join(directory, 'date');
+  const fakeGit = join(directory, 'git');
   const queryLog = join(directory, 'query-log');
+  const gitLog = join(directory, 'git-log');
   writeFileSync(
     fakeRailway,
     `#!/usr/bin/env node\nconst fixture = ${JSON.stringify({ repoRoot, headSha, previousSha, queryLog })};\n(${fakeRailwayCli.toString()})(fixture);\n`,
   );
   writeFileSync(fakeDate, `#!/bin/sh\nprintf '%s\\n' '${startedAtMs}'\n`);
+  // The script fetches origin/main after reading the fleet. Unshimmed, this
+  // probe would perform live network I/O and force-update refs/remotes/origin/main
+  // in the real checkout — a remote-tracking ref every worktree shares — making a
+  // unit test both network-dependent and a mutation of the developer's repository.
+  // Record the fetch and no-op it; everything else must reach real git, because
+  // the classifier depends on genuine merge-base/rev-parse/diff/rev-list answers.
+  writeFileSync(
+    fakeGit,
+    `#!/bin/sh\nif [ "$1" = 'fetch' ]; then\n  printf '%s\\n' "$*" >> '${gitLog}'\n  exit 0\nfi\nexec '${realGit()}' "$@"\n`,
+  );
   chmodSync(fakeRailway, 0o755);
   chmodSync(fakeDate, 0o755);
-  return { directory, headSha, queryLog, startedAtMs };
+  chmodSync(fakeGit, 0o755);
+  return { directory, headSha, queryLog, gitLog, startedAtMs };
 }
 
 function executeWorkflowShell(run, fixture, {
@@ -330,6 +351,16 @@ describe('Railway Native Deploy Health workflow', () => {
         'the config audit must reuse the deployment projection instead of reading 83 services twice',
       );
       assert.equal(queries.filter((query) => query === 'FleetDeployments').length, 1);
+      // The refresh is the whole point of the post-observation fetch: without it
+      // a service running a commit merged during the Railway read is judged
+      // against a stale origin/main and reported as a problem. Drive main() far
+      // enough to prove the fetch actually fires, which unit-testing
+      // resolveComparisonHead in isolation cannot show.
+      assert.match(
+        readFileSync(fixture.gitLog, 'utf8'),
+        /fetch --quiet origin \+refs\/heads\/main:refs\/remotes\/origin\/main/,
+        'main() must refresh origin/main so lineage is judged against current ancestry',
+      );
 
       const projectedConfigDrift = executeWorkflowShell(check.run, fixture, {
         mode: 'config-drift',

--- a/tests/railway-deploy-drift.test.mjs
+++ b/tests/railway-deploy-drift.test.mjs
@@ -836,6 +836,37 @@ describe('strict terminal reconciliation drift', () => {
     assert.equal(formatComparisonHead(result), 'source=--head vs-origin-main=behind');
   });
 
+  it('refreshes main after deployment observation without moving the comparison head', () => {
+    let main = HEAD;
+    const context = resolveComparisonHead(['--head', HEAD], {
+      refreshMain: true,
+      git: (args) => {
+        if (args[0] === 'fetch') { main = NEWER; return ''; }
+        return args.at(-1) === 'origin/main^{commit}' ? main : HEAD;
+      },
+      ancestry: (a, b) => a === HEAD && b === NEWER ? 'yes' : 'no',
+    });
+    assert.equal(context.headSha, HEAD);
+    assert.equal(context.originMainSha, NEWER);
+    assert.equal(context.originMainRelation, 'behind');
+    const result = classify([deployment('SUCCESS', { sha: NEWER })], {
+      isAncestor: (a, b) => a === HEAD && b === NEWER,
+    });
+    assert.equal(summarizeDeployDrift([result], {
+      isOnAuthorizedMainLineage: sha => sha === context.originMainSha,
+    }).ok, true);
+  });
+
+  it('fails closed when the post-observation main refresh fails with a pinned head', () => {
+    assert.throws(() => resolveComparisonHead(['--head', HEAD], {
+      refreshMain: true,
+      git: args => {
+        if (args[0] === 'fetch') throw new Error('main refresh failed');
+        return HEAD;
+      },
+    }), /main refresh failed/);
+  });
+
   it('fails a manual comparison when main cannot be refreshed', () => {
     const calls = [];
     assert.throws(

--- a/tests/railway-deploy-drift.test.mjs
+++ b/tests/railway-deploy-drift.test.mjs
@@ -838,23 +838,74 @@ describe('strict terminal reconciliation drift', () => {
 
   it('refreshes main after deployment observation without moving the comparison head', () => {
     let main = HEAD;
+    // One resolver for the whole test, answering the way git does — including
+    // `--is-ancestor X X`, which exits 0. A stub that only knows HEAD..NEWER
+    // silently answers 'no' to self-ancestry, and then the lineage check below
+    // passes only because it was hand-written to compare SHAs instead of asking
+    // about ancestry at all.
+    const ancestry = (a, b) => (a === b || (a === HEAD && b === NEWER) ? 'yes' : 'no');
     const context = resolveComparisonHead(['--head', HEAD], {
       refreshMain: true,
       git: (args) => {
         if (args[0] === 'fetch') { main = NEWER; return ''; }
         return args.at(-1) === 'origin/main^{commit}' ? main : HEAD;
       },
-      ancestry: (a, b) => a === HEAD && b === NEWER ? 'yes' : 'no',
+      ancestry,
     });
     assert.equal(context.headSha, HEAD);
     assert.equal(context.originMainSha, NEWER);
     assert.equal(context.originMainRelation, 'behind');
     const result = classify([deployment('SUCCESS', { sha: NEWER })], {
-      isAncestor: (a, b) => a === HEAD && b === NEWER,
+      isAncestor: (a, b) => ancestry(a, b) === 'yes',
     });
+    // Built exactly as main() builds it, so a wiring regression between the
+    // refreshed authorized main and the ancestry resolver reaches this assertion.
+    const authorizedMainSha = context.originMainSha;
     assert.equal(summarizeDeployDrift([result], {
-      isOnAuthorizedMainLineage: sha => sha === context.originMainSha,
+      isOnAuthorizedMainLineage: (runningSha) => authorizedMainSha !== null
+        && ancestry(runningSha, authorizedMainSha) === 'yes',
     }).ok, true);
+  });
+
+  it('blocks the fleet when the refreshed authorized main could not be resolved', () => {
+    // The null case main() can reach: a refresh whose fetch succeeded but whose
+    // rev-parse did not. Nothing had exercised the real closure's null guard.
+    const authorizedMainSha = null;
+    const ancestry = (a, b) => (a === b || (a === HEAD && b === NEWER) ? 'yes' : 'no');
+    const result = classify([deployment('SUCCESS', { sha: NEWER })], {
+      isAncestor: (a, b) => ancestry(a, b) === 'yes',
+    });
+    const summary = summarizeDeployDrift([result], {
+      isOnAuthorizedMainLineage: (runningSha) => authorizedMainSha !== null
+        && ancestry(runningSha, authorizedMainSha) === 'yes',
+    });
+    assert.equal(summary.ok, false);
+    assert.equal(summary.blocking[0].verdict, 'AHEAD_LINEAGE_UNPROVEN');
+  });
+
+  // The bug was never in resolveComparisonHead — it was WHERE main() calls it.
+  // main() is not exported, so the two unit tests around it stay green with the
+  // whole refresh block deleted or moved back above the fleet read, which is
+  // exactly the regression. Pin the ordering against the source until main()
+  // grows an injectable seam, using the same read-the-script idiom as
+  // tests/railway-deploy-convergence.test.mjs.
+  it('refreshes authorized main only after the fleet deployment read', () => {
+    const source = readFileSync(new URL('../scripts/check-railway-deploy-drift.mjs', import.meta.url), 'utf8');
+    const fleetRead = source.indexOf('await readDeploymentsForFleet(');
+    const refresh = source.indexOf('refreshMain: true');
+    // The call site, not the export a few hundred lines above it.
+    const classification = source.indexOf('const shallowResults = classifyFleetWithinDeadline(');
+    assert.ok(fleetRead > 0, 'the fleet deployment read must exist');
+    assert.ok(refresh > 0, 'the post-observation refresh must exist');
+    assert.ok(classification > 0, 'the fleet classification pass must exist');
+    assert.ok(
+      refresh > fleetRead,
+      'authorized main must be refreshed AFTER the Railway fleet observation, or a commit merged during that read is judged against a stale ref',
+    );
+    assert.ok(
+      refresh < classification,
+      'the refresh must precede classification, or the fetched lineage is not yet available when verdicts are decided',
+    );
   });
 
   it('fails closed when the post-observation main refresh fails with a pinned head', () => {


### PR DESCRIPTION
Railway Native Deploy Health can falsely reject successful main deployments when a merge lands after its initial Git fetch. The linked run compared `ece017819` with five services deploying `7211204b9`, merged eight seconds after that fetch; all five deployment histories now confirm successful builds of that main commit.

Refresh main after reading fleet history while retaining the immutable comparison head, so new deployments can be verified against current ancestry. Off-main descendants remain blocked, fetch failure remains an error, and unresolved source reports now include the running commit and a concrete diagnostic action.

Related: https://github.com/koala73/worldmonitor/actions/runs/34477562104/job/102871962416

Validation: 177 focused drift, closure, and trigger tests passed; both new regression tests failed before the fix. All pre-push gates passed, including browser and API type checks. The fixed read-only monitor also passed against all 83 production services using the failed job's exact comparison commit, with zero blocking results and zero configuration drift. No production deployments or configuration changes were made.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
