### PR TITLE
fix(webmcp): support legacy navigator registration

### DIFF
--- a/docs/webmcp-maintenance.mdx
+++ b/docs/webmcp-maintenance.mdx
@@ -111,7 +111,7 @@ Treat the deployment SHA, response headers, inventory, UI behavior, and terminal
 
 ## Compatibility and removal policy
 
-WorldMonitor targets `document.modelContext.registerTool()` and feature-detects it. It does not ship `navigator.modelContext`, `provideContext`, or a draft compatibility shim.
+WorldMonitor prefers `document.modelContext.registerTool()`. A legacy-only host falls back to `navigator.modelContext.registerTool()`, then `provideContext({ tools })`. This supports older hosts and scanners such as isitagentready.com that still probe `navigator`. The WebMCP maintainer owns removal after those consumers support current document-based discovery. The fallback creates no globals and does not register on both providers.
 
 If a future browser transition requires a temporary fallback:
 

--- a/docs/webmcp.mdx
+++ b/docs/webmcp.mdx
@@ -98,7 +98,7 @@ Chrome 149–151 exposes `registerTool()` but invokes the registered callback wi
 The cancellation-required tools persist browser state, can navigate away, or can consume server-side allowance. The gate prevents those effects from starting when the host cannot cancel them. The view-state tools remain available. `set_map_view`, `set_time_range`, and `focus_country` also update the address bar through `history.replaceState`, which creates the same reloadable share state as the dashboard controls.
 
 <Note>
-Browsers without the current API, including the Tauri desktop webview when it does not expose WebMCP, safely do nothing. WorldMonitor does not install a browser polyfill and does not fall back to an older draft API.
+Browsers without either supported registration API safely do nothing. WorldMonitor does not install a browser polyfill. Legacy-only hosts use the fallback described below.
 </Note>
 
 ## Tool inventory
@@ -290,7 +290,7 @@ WebMCP is designed primarily for a local browser workflow with a person in the l
 
 ## Debug with the browser API
 
-Use the current API on `document`. The older `navigator.modelContext` surface is deprecated in Chrome 150, and the removed `provideContext` draft API is not supported.
+WorldMonitor prefers `document.modelContext.registerTool()`. When that API is absent, the homepage and dashboard try legacy `navigator.modelContext.registerTool()`, then `navigator.modelContext.provideContext({ tools })`. Each page registers through one provider only. No browser globals are created. Legacy hosts keep the same tool checks, including cancellation requirements.
 
 ```js
 const modelContext = document.modelContext;

--- a/docs/zh/webmcp-maintenance.mdx
+++ b/docs/zh/webmcp-maintenance.mdx
@@ -111,7 +111,7 @@ npm run test:e2e:webmcp:production
 
 ## 兼容与移除策略
 
-WorldMonitor 以 `document.modelContext.registerTool()` 为目标并进行特性检测。它不提供 `navigator.modelContext`、`provideContext` 或草案兼容 shim。
+WorldMonitor 优先使用 `document.modelContext.registerTool()`。仅支持旧版 API 的宿主依次回退到 `navigator.modelContext.registerTool()` 和 `provideContext({ tools })`。此路径支持仍检测 `navigator` 的旧版宿主和 isitagentready.com 等扫描器。当这些使用者支持当前基于 document 的发现方式后，由 WebMCP 维护者负责移除此回退。回退不创建全局对象，也不会在两个提供者上重复注册。
 
 如果未来浏览器迁移需要临时 fallback：
 

--- a/docs/zh/webmcp.mdx
+++ b/docs/zh/webmcp.mdx
@@ -98,7 +98,7 @@ Chrome 149–151 虽已暴露 `registerTool()`，但调用已注册回调时只�
 需要取消能力的工具会持久化浏览器状态、离开当前页面，或消耗服务器端额度。宿主无法取消时，门禁会阻止这些效果开始。视图状态工具仍可用。`set_map_view`、`set_time_range` 与 `focus_country` 还会通过 `history.replaceState` 更新地址栏，生成与仪表板控件相同、刷新后可恢复的分享状态。
 
 <Note>
-如果浏览器没有当前 API，包括未暴露 WebMCP 的 Tauri 桌面 WebView，WorldMonitor 会安全地不执行任何操作。它不会安装浏览器 polyfill，也不会退回旧草案 API。
+如果浏览器没有任何受支持的注册 API，WorldMonitor 会安全地不执行任何操作。它不会安装浏览器 polyfill。仅支持旧版 API 的宿主使用下文所述的回退路径。
 </Note>
 
 ## 工具清单
@@ -290,7 +290,7 @@ WebMCP 主要面向本地、有人参与的浏览器工作流。即使某些浏�
 
 ## 使用浏览器 API 调试
 
-使用 `document` 上的当前 API。旧的 `navigator.modelContext` 从 Chrome 150 起已弃用，已移除的 `provideContext` 草案 API 不受支持。
+WorldMonitor 优先使用 `document.modelContext.registerTool()`。当该 API 不存在时，首页和仪表盘依次尝试旧版 `navigator.modelContext.registerTool()` 和 `navigator.modelContext.provideContext({ tools })`。每个页面只通过一个提供者注册，不创建浏览器全局对象。旧版宿主保留相同的工具检查，包括取消要求。
 
 ```js
 const modelContext = document.modelContext;

--- a/e2e/webmcp.spec.ts
+++ b/e2e/webmcp.spec.ts
@@ -2078,3 +2078,34 @@ test.describe('top-level WebMCP dashboard contract', () => {
     }
   });
 });
+
+for (const api of ['registerTool', 'provideContext'] as const) {
+  test(`discovers homepage and dashboard tools with legacy ${api}`, async ({ page }) => {
+    test.skip(productionSmoke, 'Legacy provider fixtures run only against the local build.');
+    await page.addInitScript((method) => {
+      Object.defineProperty(document, 'modelContext', { value: undefined, configurable: true });
+      const tools: WebMCP.ModelContextTool[] = [];
+      Object.defineProperty(navigator, 'modelContext', {
+        configurable: true,
+        value: {
+          [method]: method === 'registerTool'
+            ? (tool: WebMCP.ModelContextTool) => { tools.push(tool); }
+            : (context: { tools: WebMCP.ModelContextTool[] }) => { tools.push(...context.tools); },
+          getTools: () => tools,
+        },
+      });
+    }, api);
+    for (const [route, expected] of [
+      ['/pro/welcome.html', HOMEPAGE_TOOL_NAMES],
+      ['/dashboard', DASHBOARD_TOOL_NAMES],
+    ] as const) {
+      await page.goto(route);
+      await expect.poll(() => page.evaluate(() => {
+        const provider = (navigator as Navigator & {
+          modelContext: { getTools(): WebMCP.ModelContextTool[] };
+        }).modelContext;
+        return provider.getTools().map(tool => tool.name).sort();
+      })).toEqual([...expected].sort());
+    }
+  });
+}

--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -14,7 +14,7 @@
          parse time when the provider is already present (native WebMCP), and
          retries once on DOMContentLoaded/load for a provider installed later
          (e.g. a scanner polyfill); the registration guard keeps it idempotent, and
-         it is a no-op in browsers without document.modelContext. The MCP server is
+         it is a no-op in browsers without a supported WebMCP provider. The MCP server is
          the remote HTTP (Streamable HTTP) transport at https://worldmonitor.app/mcp
          — getWorldMonitorMcpEndpoint hands agents that endpoint. The nonce is added
          by Vite (html.cspNonce) at build time, so this inline script needs no CSP
@@ -91,7 +91,27 @@
           } catch (e) {
             return;
           }
-          if (!provider || typeof provider.registerTool !== 'function') return;
+          if (!provider || typeof provider.registerTool !== 'function') {
+            try {
+              provider = typeof navigator !== 'undefined' ? navigator.modelContext : null;
+            } catch (e) {
+              return;
+            }
+          }
+          if (!provider) return;
+          if (typeof provider.registerTool !== 'function') {
+            if (typeof provider.provideContext !== 'function') return;
+            registrationStarted = true;
+            try {
+              Promise.resolve(provider.provideContext({ tools: tools })).then(
+                function () { registered = true; },
+                function () { registered = false; }
+              );
+            } catch (e) {
+              registered = false;
+            }
+            return;
+          }
           registrationStarted = true;
           var registrations = [];
           for (var i = 0; i < tools.length; i++) {

--- a/src/services/webmcp.ts
+++ b/src/services/webmcp.ts
@@ -471,8 +471,16 @@ type DashboardWebMcpTool = Omit<WebMCP.ModelContextTool, 'execute'> & {
   ) => Promise<unknown> | unknown;
 };
 
+interface LegacyWebMcpProvider {
+  registerTool?: (tool: DashboardWebMcpTool) => void | Promise<void>;
+  unregisterTool?: (name: string) => void;
+  provideContext?: (context: { tools: DashboardWebMcpTool[] }) => void | Promise<void>;
+  clearContext?: () => void;
+}
+
 interface WebMcpRegistrationRuntime {
   document?: Pick<Document, 'modelContext' | 'addEventListener'>;
+  navigator?: { modelContext?: LegacyWebMcpProvider };
   window?: Pick<Window, 'addEventListener'>;
   track?: WebMcpAnalytics;
 }
@@ -3063,7 +3071,7 @@ function registrationFailureReason(error: unknown): RegistrationFailureReason | 
 }
 
 function observeRegistration(
-  provider: WebMCP.ModelContext,
+  provider: Pick<WebMCP.ModelContext, 'registerTool'>,
   tool: DashboardWebMcpTool,
   controller: AbortController,
   trackEvent: WebMcpAnalytics,
@@ -3091,10 +3099,11 @@ function observeRegistration(
 }
 
 function startRegistration(
-  provider: WebMCP.ModelContext,
+  provider: Pick<WebMCP.ModelContext, 'registerTool'>,
   tools: DashboardWebMcpTool[],
   controller: AbortController,
   trackEvent: WebMcpAnalytics,
+  api = 'document-current',
 ): void {
   const registrations = tools.map((tool) => (
     observeRegistration(provider, tool, controller, trackEvent)
@@ -3119,7 +3128,7 @@ function startRegistration(
     reportWebMcpEvent(trackEvent, 'webmcp-registered', {
       toolCount,
       pageSurface: 'dashboard',
-      api: 'document-current',
+      api,
     });
   });
 }
@@ -3152,9 +3161,55 @@ export function registerWebMcpTools(
     } catch {
       return false;
     }
-    if (!provider || typeof provider.registerTool !== 'function') return false;
+    if (provider && typeof provider.registerTool === 'function') {
+      registrationStarted = true;
+      startRegistration(provider, tools, controller, trackEvent);
+      return true;
+    }
+    let legacy: LegacyWebMcpProvider | undefined;
+    try {
+      const runtimeNavigator = runtime.navigator
+        ?? (typeof navigator === 'undefined' ? undefined : navigator as Navigator & { modelContext?: LegacyWebMcpProvider });
+      legacy = runtimeNavigator?.modelContext;
+    } catch {
+      return false;
+    }
+    if (!legacy || (typeof legacy.registerTool !== 'function' && typeof legacy.provideContext !== 'function')) return false;
     registrationStarted = true;
-    startRegistration(provider, tools, controller, trackEvent);
+    const legacyTools = tools.map((tool) => ({
+      ...tool,
+      execute: (input: Record<string, unknown>, context?: WebMcpToolExecutionContext) => {
+        throwIfWebMcpAborted(controller.signal);
+        return tool.execute(input, context);
+      },
+    }));
+    const batch = typeof legacy.registerTool !== 'function';
+    const cleanup = (): void => {
+      try {
+        if (batch) legacy.clearContext?.();
+        else for (const tool of legacyTools) legacy.unregisterTool?.(tool.name);
+      } catch {
+        // Old hosts may have no usable unregister API. Callbacks still reject after teardown.
+      }
+    };
+    controller.signal.addEventListener('abort', cleanup, { once: true });
+    let batchRegistration: Promise<void> | undefined;
+    const adapter = {
+      registerTool(tool: DashboardWebMcpTool): Promise<void> {
+        throwIfWebMcpAborted(controller.signal);
+        if (batch) {
+          batchRegistration ??= new Promise<void>((resolve) => resolve(legacy.provideContext!({ tools: legacyTools })))
+            .then(() => { if (controller.signal.aborted) cleanup(); });
+          return batchRegistration;
+        }
+        return Promise.resolve(legacy.registerTool!(tool)).then(() => {
+          if (controller.signal.aborted) {
+            try { legacy.unregisterTool?.(tool.name); } catch { /* The callback remains disabled. */ }
+          }
+        });
+      },
+    };
+    startRegistration(adapter, legacyTools, controller, trackEvent, batch ? 'navigator-batch' : 'navigator-register');
     return true;
   };
 

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -295,10 +295,8 @@ function createRegistrationRuntime(provider) {
 }
 
 describe('webmcp.ts: current API contract', () => {
-  it('uses document.modelContext and removes both navigator and provideContext paths', () => {
+  it('keeps the current document API as the preferred registration path', () => {
     assert.match(src, /runtimeDocument\.modelContext/);
-    assert.doesNotMatch(src, /navigator\.modelContext/);
-    assert.doesNotMatch(src, /provideContext/);
   });
 
   it('keeps every registration same-origin and never delegates tools to an iframe', () => {
@@ -2683,10 +2681,10 @@ const homepageSourceScript = findHomepageWebMcpScript(homepageSrc);
 const homepageIife = homepageSourceScript?.body
   .match(/\(function \(\) \{[\s\S]*?\}\)\(\);/)?.[0];
 const runHomepageInline = homepageIife
-  ? new Function('window', 'document', homepageIife)
+  ? new Function('window', 'document', 'navigator', homepageIife)
   : null;
 
-function runHomepage(providerFactory) {
+function runHomepage(providerFactory, navigator = {}) {
   const registered = [];
   const documentListeners = new Map();
   const windowListeners = new Map();
@@ -2699,7 +2697,7 @@ function runHomepage(providerFactory) {
     location: { assign: (url) => { navigatedTo = url; } },
     addEventListener: (event, listener) => windowListeners.set(event, listener),
   };
-  runHomepageInline(window, document);
+  runHomepageInline(window, document, navigator);
   return {
     registered,
     document,
@@ -2718,9 +2716,8 @@ const collectingHomepageProvider = (registered) => ({
 
 describe('homepage WebMCP source registration', () => {
 
-  it('uses only the current document API and observes registerTool promises', () => {
+  it('observes registerTool promises', () => {
     assert.ok(homepageSourceScript);
-    assert.doesNotMatch(homepageSourceScript.body, /navigator\.modelContext|provideContext/);
     assert.match(homepageSourceScript.body, /Promise\.resolve\(provider\.registerTool\(tools\[i\]\)\)/);
     assert.match(homepageSourceScript.body, /function \(\) \{ return false; \}/);
   });
@@ -2800,7 +2797,7 @@ describe('homepage WebMCP built CSP copy', { skip: shouldSkipProBuiltOutput() },
     const builtScript = findHomepageWebMcpScript(welcomeBuilt);
     assert.ok(builtScript);
     assert.match(builtScript.attrs, /\bnonce="wm-static-bootstrap"/);
-    assert.doesNotMatch(builtScript.body, /navigator\.modelContext|provideContext/);
+    assert.match(builtScript.body, /navigator\.modelContext/);
   });
 });
 
@@ -3344,5 +3341,107 @@ describe('webmcp App.ts binding invariants', () => {
     const dashboardSrc = readFileSync(resolve(ROOT, 'src/app/webmcp-dashboard.ts'), 'utf-8');
     assert.doesNotMatch(appSrc, /from '@\/app\/agent-bus-applier'/);
     assert.match(dashboardSrc, /await import\('\.\/agent-bus-applier'\)/);
+  });
+});
+
+describe('legacy WebMCP compatibility', () => {
+  for (const batch of [false, true]) {
+    it(`registers dashboard tools once through legacy ${batch ? 'provideContext' : 'registerTool'} and disables them on teardown`, async () => {
+      const registered = [];
+      const removed = [];
+      let calls = 0;
+      const provider = batch ? {
+        provideContext({ tools }) { calls++; registered.push(...tools); },
+        clearContext() { removed.push('all'); },
+      } : {
+        registerTool(tool) { calls++; registered.push(tool); },
+        unregisterTool(name) { removed.push(name); },
+      };
+      const harness = createRegistrationRuntime(undefined);
+      harness.runtime.navigator = {};
+      const controller = registerWebMcpTools(createBindings(), harness.runtime);
+      harness.runtime.navigator.modelContext = provider;
+      harness.listeners.get('DOMContentLoaded')();
+      harness.windowListeners.get('load')();
+      assert.deepEqual(registered.map(tool => tool.name), DASHBOARD_TOOL_NAMES);
+      assert.equal(calls, batch ? 1 : DASHBOARD_TOOL_NAMES.length);
+      await settlePromises();
+      const read = registered.find(tool => tool.name === 'get_dashboard_context');
+      assert.equal((await read.execute({})).variant, 'full');
+      assert.equal(harness.events.find(({ event }) => event === 'webmcp-registered').data.api,
+        batch ? 'navigator-batch' : 'navigator-register');
+      controller.abort();
+      assert.deepEqual(removed, batch ? ['all'] : DASHBOARD_TOOL_NAMES);
+      assert.throws(() => read.execute({}), { name: 'AbortError' });
+    });
+
+    it(`registers the homepage once through legacy ${batch ? 'provideContext' : 'registerTool'}`, async () => {
+      const registered = [];
+      let calls = 0;
+      const navigator = {};
+      const result = runHomepage(undefined, navigator);
+      navigator.modelContext = batch ? {
+        provideContext({ tools }) { calls++; registered.push(...tools); },
+      } : {
+        registerTool(tool) { calls++; registered.push(tool); },
+      };
+      result.documentListeners.get('DOMContentLoaded')();
+      result.windowListeners.get('load')();
+      assert.deepEqual(registered.map(tool => tool.name), WEBMCP_HOMEPAGE_TOOL_NAMES);
+      assert.equal(calls, batch ? 1 : 2);
+      assert.equal(registered[1].execute({}).endpoint, 'https://worldmonitor.app/mcp');
+      await settlePromises();
+    });
+  }
+
+  it('does not read the legacy provider when the current API is available', () => {
+    const navigator = { get modelContext() { throw new Error('legacy provider accessed'); } };
+    const registered = [];
+    const harness = createRegistrationRuntime({ registerTool(tool) { registered.push(tool); } });
+    harness.runtime.navigator = navigator;
+    registerWebMcpTools(createBindings(), harness.runtime);
+    assert.deepEqual(registered.map(tool => tool.name), DASHBOARD_TOOL_NAMES);
+    assert.equal(runHomepage(collectingHomepageProvider, navigator).registered.length, 2);
+  });
+
+  it('contains rejected legacy batch registrations on both pages', async () => {
+    const navigator = { modelContext: { provideContext() { return Promise.reject(new Error('unavailable')); } } };
+    const harness = createRegistrationRuntime(undefined);
+    harness.runtime.navigator = navigator;
+    registerWebMcpTools(createBindings(), harness.runtime);
+    runHomepage(undefined, navigator);
+    await settlePromises();
+    assert.equal(harness.events.some(({ event }) => event === 'webmcp-registered'), false);
+    assert.equal(harness.events.filter(({ event }) => event === 'webmcp-registration-failed').length, DASHBOARD_TOOL_NAMES.length);
+  });
+
+  it('cleans up a batch that resolves after dashboard teardown', async () => {
+    let resolveRegistration;
+    let clears = 0;
+    const harness = createRegistrationRuntime(undefined);
+    harness.runtime.navigator = { modelContext: {
+      provideContext() { return new Promise(resolve => { resolveRegistration = resolve; }); },
+      clearContext() { clears++; },
+    } };
+    const controller = registerWebMcpTools(createBindings(), harness.runtime);
+    controller.abort();
+    assert.equal(clears, 1);
+    resolveRegistration();
+    await settlePromises();
+    assert.equal(clears, 2);
+    assert.equal(harness.events.some(({ event }) => event === 'webmcp-registered'), false);
+  });
+
+  it('prefers legacy registerTool over provideContext on both pages', () => {
+    const registered = [];
+    const navigator = { modelContext: {
+      registerTool(tool) { registered.push(tool.name); },
+      provideContext() { assert.fail('batch registration must not run'); },
+    } };
+    const harness = createRegistrationRuntime(undefined);
+    harness.runtime.navigator = navigator;
+    registerWebMcpTools(createBindings(), harness.runtime);
+    runHomepage(undefined, navigator);
+    assert.deepEqual(registered, [...DASHBOARD_TOOL_NAMES, ...WEBMCP_HOMEPAGE_TOOL_NAMES]);
   });
 });


### PR DESCRIPTION
## Why

Older browser hosts and readiness scanners can expose only `navigator.modelContext`, so WorldMonitor registers no tools there. Keep `document.modelContext.registerTool()` first, then try legacy `registerTool()` and finally `provideContext({ tools })` on the homepage and dashboard.

Each page selects one provider. The fallback reuses the existing tools and their access and cancellation checks. Dashboard teardown disables legacy callbacks and uses the host's cleanup methods when available. No dependencies, new modules, or browser globals are added.

## Verification

- 403 focused WebMCP and documentation assertions passed, including registration order, duplicate prevention, rejection handling, invocation, and teardown.
- 973 DOM tests passed.
- The exact-commit browser suite passed 17 tests. Four production or target-cancellation checks were skipped. Controlled provider fixtures verify both legacy APIs on the built homepage and dashboard.
- Type checking, import-boundary lint, documentation checks, and the homepage build passed.

The scanner itself has not been rescanned against this change. Production acceptance requires deployment and a fresh scan.
