### PR TITLE
fix(docker): require Redis REST authentication at startup

### DIFF
--- a/docker/redis-rest-proxy.mjs
+++ b/docker/redis-rest-proxy.mjs
@@ -11,7 +11,7 @@
  *
  * Env:
  *   REDIS_URL           - Redis connection string (default: redis://redis:6379)
- *   SRH_TOKEN           - Bearer token for auth (default: none)
+ *   SRH_TOKEN           - Required bearer token (nonempty visible ASCII, no spaces)
  *   PORT                - Listen port (default: 80)
  *   SRH_MAX_BODY_BYTES  - Max request body size (default: 16777216 / 16 MB)
  */
@@ -23,6 +23,11 @@ import { createClient } from 'redis';
 const REDIS_URL = process.env.SRH_CONNECTION_STRING || process.env.REDIS_URL || 'redis://redis:6379';
 const TOKEN = process.env.SRH_TOKEN || '';
 const PORT = parseInt(process.env.PORT || '80', 10);
+
+// Reject unusable HTTP credentials before creating a Redis client or listener.
+if (!/^[\x21-\x7e]+$/.test(TOKEN)) {
+  throw new Error('SRH_TOKEN must contain only visible ASCII characters without spaces');
+}
 
 // Redact userinfo before a connection string ever reaches stdout — REDIS_URL
 // carries the Redis password (SRH_CONNECTION_STRING: redis://:<password>@host:port)
@@ -51,7 +56,7 @@ console.log(`Connected to Redis at ${maskRedisUrl(REDIS_URL)}`);
 // handler's try block, so it became an unhandled rejection and Node exited:
 // one unauthenticated request killed the container. Verified on node 24.
 function checkAuth(req) {
-  if (!TOKEN) return true;
+  if (!TOKEN) return false;
   const auth = req.headers.authorization || '';
   const prefix = 'Bearer ';
   if (!auth.startsWith(prefix)) return false;

--- a/tests/redis-rest-proxy-auth.test.mjs
+++ b/tests/redis-rest-proxy-auth.test.mjs
@@ -1,0 +1,70 @@
+import { it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import crypto from 'node:crypto';
+
+// Execute the full startup and request handler with only external I/O mocked.
+const source = readFileSync(new URL('../docker/redis-rest-proxy.mjs', import.meta.url), 'utf8')
+  .replace(/^#!.*\n/, '')
+  .replace(/^import .*;\n/gm, '');
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const run = new AsyncFunction('process', 'http', 'crypto', 'createClient', 'console', source);
+
+async function boot(token) {
+  const calls = [];
+  let handler;
+  const env = token === undefined ? {} : { SRH_TOKEN: token };
+  const client = {
+    on() {},
+    async connect() { calls.push('connect'); },
+    async sendCommand(command) { calls.push(command); return 'PONG'; },
+    multi() {
+      return { sendCommand: client.sendCommand, async exec() { calls.push('exec'); return []; } };
+    },
+  };
+  const started = run({ env }, {
+    createServer(callback) {
+      handler = callback;
+      return { listen(port, host) { calls.push(['listen', port, host]); } };
+    },
+  }, crypto, () => { calls.push('createClient'); return client; }, { log() {}, error() {}, warn() {} });
+  return { calls, started, request: async (url, authorization) => {
+    const response = { status: 200, setHeader() {}, writeHead(status) { this.status = status; }, end(body) { this.body = body; } };
+    await handler({ method: 'GET', url, headers: { authorization } }, response);
+    return response;
+  } };
+}
+
+for (const token of [undefined, '', ' ', '\t', ' token', 'token ', 'to ken', 'token\n', 'token\r', 'token\x7f', '秘密']) {
+  it(`rejects unusable configuration ${JSON.stringify(token)} before external I/O`, async () => {
+    const app = await boot(token);
+    await assert.rejects(app.started, /SRH_TOKEN must contain only visible ASCII/);
+    assert.deepEqual(app.calls, []);
+  });
+}
+
+it('requires authentication for welcome and health requests and keeps container binding', async () => {
+  const token = 'a'.repeat(64);
+  const app = await boot(token);
+  await app.started;
+  assert.deepEqual(app.calls, ['createClient', 'connect', ['listen', 80, '0.0.0.0']]);
+  for (const path of ['/', '/ping']) {
+    for (const header of [undefined, '', 'Basic abc', 'Bearer wrong', `Bearer ${'a'.repeat(63)}ÿ`]) {
+      assert.equal((await app.request(path, header)).status, 401);
+    }
+    assert.equal((await app.request(path, `Bearer ${token}`)).status, 200);
+  }
+  assert.deepEqual(app.calls.filter(Array.isArray).slice(1), [['PING']]);
+  for (const path of ['/FLUSHALL', '/CONFIG/GET/*', '/EVAL/return%201/0', '/EVALSHA/abc/0']) {
+    assert.match((await app.request(path, `Bearer ${token}`)).body, /Command not allowed/);
+  }
+  assert.deepEqual(app.calls.filter(Array.isArray).slice(1), [['PING']]);
+});
+
+it('ships a required token and loopback-only host exposure', () => {
+  const compose = readFileSync(new URL('../docker-compose.yml', import.meta.url), 'utf8');
+  const service = compose.slice(compose.indexOf('\n  redis-rest:\n'));
+  assert.match(service, /SRH_TOKEN: "\$\{REDIS_TOKEN:\?/);
+  assert.match(service, /ports:\s*\n\s*- "127\.0\.0\.1:8079:80"/);
+  assert.match(compose, /UPSTASH_REDIS_REST_URL: "http:\/\/redis-rest:80"/);
+});

--- a/tests/redis-rest-proxy-body-limit.test.mjs
+++ b/tests/redis-rest-proxy-body-limit.test.mjs
@@ -422,8 +422,8 @@ describe('redis-rest proxy body limit (#7099)', () => {
       assert.equal(withToken(undefined), false, 'absent header');
     });
 
-    it('stays open when no token is configured', () => {
-      assert.equal(buildHelpers({}).checkAuth({ headers: {} }), true);
+    it('rejects requests when no token is configured', () => {
+      assert.equal(buildHelpers({}).checkAuth({ headers: {} }), false);
     });
   });
 


### PR DESCRIPTION
## Problem and change

Starting the Redis REST proxy without `SRH_TOKEN` previously enabled unauthenticated Redis access. Reject missing, empty, whitespace, control-character, and non-ASCII token configuration before creating the Redis client or HTTP listener. Keep the container's `0.0.0.0` binding and authenticated requests, including `/ping`, intact.

Compose already requires `REDIS_TOKEN` and publishes the REST port only on `127.0.0.1`; no Compose change is needed. Command and pinned-script allowlists are unchanged.

## Verification

- Node 24 repair preflight passed on current `origin/main`.
- 67 Redis proxy tests passed: startup with mocked external I/O, bearer authentication, byte-length crash regression, blocked commands/scripts, body limits with local HTTP sockets, and URL masking.
- 12 Docker credential/configuration tests passed.
- `git diff --check` passed.

Tests use synthetic credentials and a mocked Redis client. No production requests or live Redis/container deployment were used.
