### PR TITLE
fix(billing): restrict checkout to current self-serve products

### DIFF
--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -192,6 +192,12 @@ export default async function handler(
 
     const data = await resp.json();
     if (!resp.ok) {
+      if (resp.status === 400 && data?.error === 'INVALID_CHECKOUT_PRODUCT') {
+        return completeStandaloneIdempotency(
+          idempotency,
+          json({ error: 'INVALID_CHECKOUT_PRODUCT' }, 400, cors),
+        );
+      }
       if (resp.status === 429) {
         const retryAfter = resp.headers.get('retry-after');
         return completeStandaloneIdempotency(

--- a/convex/__tests__/checkoutLoginEmailMetadata.test.ts
+++ b/convex/__tests__/checkoutLoginEmailMetadata.test.ts
@@ -1,3 +1,4 @@
+import { PRODUCT_CATALOG } from "../config/productCatalog";
 /**
  * #6335 — the checkout stamps the authenticated login email into signed
  * metadata, so the activation webhook does not have to trust `users.email`
@@ -27,7 +28,7 @@ vi.mock("../lib/dodo", () => ({
 
 const modules = import.meta.glob("../**/*.ts");
 const SIGNING_SECRET = "checkout-login-email-test-signing-secret";
-const PRODUCT_ID = "pdt_login_email_metadata";
+const PRODUCT_ID = PRODUCT_CATALOG.pro_monthly.dodoProductId!;
 const CLERK_USER = {
   subject: "user_login_email_metadata",
   tokenIdentifier: "clerk|user_login_email_metadata",

--- a/convex/__tests__/checkoutProductAdmission.test.ts
+++ b/convex/__tests__/checkoutProductAdmission.test.ts
@@ -1,6 +1,6 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 import { LEGACY_PRODUCT_ALIASES, PRODUCT_CATALOG } from "../config/productCatalog";
 import { createDodoCheckoutSession } from "../lib/dodo";
 import schema from "../schema";
@@ -13,15 +13,6 @@ vi.mock("../lib/dodo", () => ({
 
 const modules = import.meta.glob("../**/*.ts");
 const buyer = { subject: "user_product_admission", tokenIdentifier: "clerk|user_product_admission" };
-const products: Array<[string, string | null]> = [
-  ...Object.values(PRODUCT_CATALOG)
-    .filter((plan) => plan.dodoProductId)
-    .map((plan): [string, string] => [plan.dodoProductId!, plan.planKey]),
-  ...Object.entries(LEGACY_PRODUCT_ALIASES),
-  ["pdt_unmapped_investigation", null],
-  ["not-a-product-id", null],
-];
-
 beforeEach(() => {
   vi.stubEnv("DODO_IDENTITY_SIGNING_SECRET", "synthetic-product-admission-secret");
 });
@@ -31,29 +22,65 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-test.each(products)("checkout forwards %s with plan metadata %s but grants no entitlement", async (productId, planKey) => {
+const allowed = Object.values(PRODUCT_CATALOG).filter((p) => p.dodoProductId && p.currentForCheckout && p.selfServe);
+const rejected = [
+  ...Object.values(PRODUCT_CATALOG).filter((p) => p.dodoProductId && (!p.currentForCheckout || !p.selfServe)).map((p) => p.dodoProductId!),
+  ...Object.keys(LEGACY_PRODUCT_ALIASES),
+  "pdt_unmapped_investigation", "not-a-product-id", "", "constructor", "__proto__",
+];
+
+for (const entryPoint of ["public", "internal"] as const) {
+  const invoke = (t: ReturnType<typeof convexTest>, productId: string, bypassPendingGuard = false) =>
+    entryPoint === "public"
+      ? t.withIdentity(buyer).action(api.payments.checkout.createCheckout, { productId, bypassPendingGuard })
+      : t.action(internal.payments.checkout.internalCreateCheckout, { userId: buyer.subject, productId, bypassPendingGuard });
+
+  test.each(allowed)(`${entryPoint} admits $planKey`, async (plan) => {
+    const t = convexTest(schema, modules);
+    vi.mocked(createDodoCheckoutSession).mockResolvedValue({ checkout_url: "https://checkout.example/session" });
+    await expect(invoke(t, plan.dodoProductId!)).resolves.toEqual({ checkout_url: "https://checkout.example/session" });
+    expect(createDodoCheckoutSession).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(createDodoCheckoutSession).mock.calls[0][0];
+    expect(payload.product_cart).toEqual([{ product_id: plan.dodoProductId, quantity: 1 }]);
+    expect(payload.metadata?.wm_plan_key).toBe(plan.planKey);
+  });
+
+  test.each(rejected)(`${entryPoint} rejects %s before provider or storage effects`, async (productId) => {
+    const t = convexTest(schema, modules);
+    for (const bypass of [false, true]) {
+      await expect(invoke(t, productId, bypass)).rejects.toThrow("INVALID_CHECKOUT_PRODUCT");
+    }
+    expect(createDodoCheckoutSession).not.toHaveBeenCalled();
+    for (const table of ["entitlements", "subscriptions", "users"] as const) {
+      expect(await t.run((ctx) => ctx.db.query(table).collect())).toEqual([]);
+    }
+  });
+}
+
+test("relay returns a non-retryable product rejection", async () => {
+  vi.stubEnv("RELAY_SHARED_SECRET", "synthetic-relay-secret");
   const t = convexTest(schema, modules);
-  vi.mocked(createDodoCheckoutSession).mockResolvedValue({ checkout_url: "https://checkout.example/session" });
-  const result = await t.withIdentity(buyer).action(api.payments.checkout.createCheckout, { productId });
-  expect(result).toEqual({ checkout_url: "https://checkout.example/session" });
-  expect(createDodoCheckoutSession).toHaveBeenCalledTimes(1);
-  const payload = vi.mocked(createDodoCheckoutSession).mock.calls[0][0];
-  expect(payload.product_cart).toEqual([{ product_id: productId, quantity: 1 }]);
-  if (planKey) expect(payload.metadata?.wm_plan_key).toBe(planKey);
-  else expect(payload.metadata).not.toHaveProperty("wm_plan_key");
-  expect(await t.run((ctx) => ctx.db.query("entitlements").collect())).toEqual([]);
-  expect(await t.run((ctx) => ctx.db.query("subscriptions").collect())).toEqual([]);
+  const response = await t.fetch("/relay/create-checkout", {
+    method: "POST",
+    headers: { Authorization: "Bearer synthetic-relay-secret", "Content-Type": "application/json" },
+    body: JSON.stringify({ userId: buyer.subject, productId: Object.keys(LEGACY_PRODUCT_ALIASES)[0] }),
+  });
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({ error: "INVALID_CHECKOUT_PRODUCT" });
+  expect(createDodoCheckoutSession).not.toHaveBeenCalled();
 });
 
-test.each(["pdt_unmapped_investigation", "not-a-product-id"])(
-  "provider rejection of %s creates no subscription or entitlement",
-  async (productId) => {
+test.each(["currentForCheckout", "selfServe"] as const)("requires %s independently", async (flag) => {
+  const plan = PRODUCT_CATALOG.pro_monthly;
+  const original = plan[flag];
+  plan[flag] = false;
+  try {
     const t = convexTest(schema, modules);
-    vi.mocked(createDodoCheckoutSession).mockRejectedValue(new Error("synthetic provider product rejection"));
-    await expect(t.withIdentity(buyer).action(api.payments.checkout.createCheckout, { productId }))
-      .rejects.toThrow("synthetic provider product rejection");
-    expect(createDodoCheckoutSession).toHaveBeenCalledTimes(1);
-    expect(await t.run((ctx) => ctx.db.query("entitlements").collect())).toEqual([]);
-    expect(await t.run((ctx) => ctx.db.query("subscriptions").collect())).toEqual([]);
-  },
-);
+    await expect(t.withIdentity(buyer).action(api.payments.checkout.createCheckout, {
+      productId: plan.dodoProductId!,
+    })).rejects.toThrow("INVALID_CHECKOUT_PRODUCT");
+    expect(createDodoCheckoutSession).not.toHaveBeenCalled();
+  } finally {
+    plan[flag] = original;
+  }
+});

--- a/convex/__tests__/checkoutRateLimit.test.ts
+++ b/convex/__tests__/checkoutRateLimit.test.ts
@@ -1,3 +1,4 @@
+import { PRODUCT_CATALOG } from "../config/productCatalog";
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -283,7 +284,7 @@ describe("relay and public action contracts", () => {
       },
       body: JSON.stringify({
         userId: TEST_USER.subject,
-        productId: "prod_rate_limited",
+        productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
       }),
     });
 
@@ -319,7 +320,7 @@ describe("relay and public action contracts", () => {
       },
       body: JSON.stringify({
         userId: ANON_USER_ID,
-        productId: "prod_rate_limited",
+        productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
       }),
     });
 
@@ -347,7 +348,7 @@ describe("relay and public action contracts", () => {
       },
       body: JSON.stringify({
         userId: TEST_USER.subject,
-        productId: "prod_rate_limited",
+        productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
       }),
     });
 
@@ -385,7 +386,7 @@ describe("relay and public action contracts", () => {
       },
       body: JSON.stringify({
         userId: TEST_USER.subject,
-        productId: "prod_provider_timeout",
+        productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
       }),
     });
 
@@ -406,7 +407,7 @@ describe("relay and public action contracts", () => {
     const request = t.withIdentity(TEST_USER).action(
       api.payments.checkout.createCheckout,
       {
-        productId: "prod_rate_limited",
+        productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
       },
     );
     await expect(request).rejects.toBeInstanceOf(Error);
@@ -670,7 +671,7 @@ describe("provider client retry contract", () => {
 // ---------------------------------------------------------------------------
 describe("terminal rate-limit alarm", () => {
   const ALARM_USER = "user_alarm_probe";
-  const ALARM_PRODUCT = "prod_alarm_probe";
+  const ALARM_PRODUCT = PRODUCT_CATALOG.pro_monthly.dodoProductId!;
 
   async function readAlarmRows(t: ReturnType<typeof convexTest>) {
     return t.run(async (ctx) =>

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1721,6 +1721,9 @@ http.route({
         headers: { "Content-Type": "application/json" },
       });
     } catch (err) {
+      if (extractConvexErrorCode(err) === "INVALID_CHECKOUT_PRODUCT") {
+        return Response.json({ error: "INVALID_CHECKOUT_PRODUCT" }, { status: 400 });
+      }
       const msg = err instanceof Error ? err.message : "Checkout creation failed";
       return new Response(JSON.stringify({ error: msg }), {
         status: 500,

--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -24,7 +24,7 @@ import {
   signCheckoutLoginEmail,
   signUserId,
 } from "../lib/identitySigning";
-import { resolveProductToPlan } from "../config/productCatalog";
+import { PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
 import { isTrustedReturnUrlOrigin } from "./returnUrlOrigin";
 import {
   CHECKOUT_RATE_LIMITED,
@@ -44,6 +44,18 @@ import { normalizeCheckoutAttributionSource as normalizeAttributionSource } from
 
 const ACTIVE_SUBSCRIPTION_EXISTS = "ACTIVE_SUBSCRIPTION_EXISTS";
 const PAYMENT_IN_PROGRESS = "PAYMENT_IN_PROGRESS";
+
+function requireCheckoutProduct(productId: string): void {
+  const allowed = Object.values(PRODUCT_CATALOG).some(
+    (entry) => entry.dodoProductId === productId && entry.currentForCheckout && entry.selfServe,
+  );
+  if (!allowed) {
+    throw new ConvexError({
+      code: "INVALID_CHECKOUT_PRODUCT",
+      message: "This product is not available for checkout.",
+    });
+  }
+}
 
 // RFC 5321 maximum forward-path length. A value beyond it is not an address we
 // could deliver to anyway, and it keeps the stamped metadata value small.
@@ -411,6 +423,7 @@ export const createCheckout = action({
   },
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
+    requireCheckoutProduct(args.productId);
     const identity = await resolveUserIdentity(ctx);
     if (args.bypassPendingGuard) {
       // Audit trail: the user confirmed "start a new checkout anyway" past a
@@ -480,6 +493,7 @@ export const internalCreateCheckout = internalAction({
     if (!args.userId) {
       throw new ConvexError("userId is required");
     }
+    requireCheckoutProduct(args.productId);
     if (args.bypassPendingGuard) {
       // See createCheckout — audit the pending-guard bypass (#4438 review).
       console.info(`[checkout] pending-payment guard bypassed user=${args.userId} product=${args.productId}`);

--- a/docs/solutions/security-unmapped-payment-products.md
+++ b/docs/solutions/security-unmapped-payment-products.md
@@ -1,5 +1,18 @@
 # Unmapped payment product investigation (#7900)
 
+## Checkout admission follow-up (2026-09-10)
+
+New checkouts now require an exact catalog product ID with both
+`currentForCheckout` and `selfServe` enabled. Both public and internal actions
+reject legacy aliases, Enterprise, unknown and malformed IDs before billing
+queries, Terms writes, signing or provider calls. The pending-payment bypass
+cannot skip this check. The relay and edge return `INVALID_CHECKOUT_PRODUCT`
+with HTTP 400.
+
+Legacy resolution and subscription processing are unchanged. The investigation
+below records the behavior before this admission fix; merchant reachability and
+the existing unknown-product webhook fallback remain separate questions.
+
 ## Result and evidence boundary
 
 **Fallback confirmed; buyer reachability blocked on merchant evidence.** This is

--- a/e2e/country-brief.spec.ts
+++ b/e2e/country-brief.spec.ts
@@ -118,6 +118,9 @@ test('US brief keeps late evidence, metric design and report data connected', as
   await expect(panel.locator('.cdp-country-name')).toHaveText('United States');
   await expect(panel.locator('#cdp-section-factors')).toHaveAttribute('aria-busy', 'true');
   await topic('Economy & trade').click();
+  // Release while the real request is still live; unrelated metric checks can exceed its deadline on CI.
+  data.releaseFactors();
+  await expect(panel.locator('#cdp-section-factors').getByRole('tab', { includeHidden: true })).toHaveCount(5);
   const housing = panel.locator('#cdp-section-housing');
   await expect(housing.locator('.cdp-metric-hero')).toHaveText(['156.4', '186.6', '8.0']);
   await expect(housing).toContainText('-2.1% · ↓ Falling');
@@ -125,7 +128,6 @@ test('US brief keeps late evidence, metric design and report data connected', as
   await expect(panel.locator('#cdp-section-debt .cdp-metric-hero')).toHaveText('128.6%');
   await expect(panel.locator('#cdp-section-debt')).toContainText('source value needs review');
   await expect(panel.locator('#cdp-section-tariffs')).toContainText('→ Unchanged');
-  data.releaseFactors();
   await expect(panel.locator('#cdp-section-factors')).toHaveAttribute('aria-busy', 'false');
   await expect(topic('Economy & trade')).toHaveAttribute('aria-current', 'page');
   await housing.scrollIntoViewIfNeeded();

--- a/tests/create-checkout-active-subscription.test.mts
+++ b/tests/create-checkout-active-subscription.test.mts
@@ -207,3 +207,16 @@ describe('/api/create-checkout ACTIVE_SUBSCRIPTION_EXISTS relay handling', () =>
     assert.equal(consoleError.mock.calls.length, 0);
   });
 });
+
+it('forwards invalid checkout product as HTTP 400 without a transport retry signal', async () => {
+  const mod = await importFreshCreateCheckout();
+  const relayFetch = mock.fn(async () => Response.json({ error: 'INVALID_CHECKOUT_PRODUCT' }, { status: 400 }));
+  mod.__setCreateCheckoutDepsForTests({
+    validateBearerToken: async () => ({ valid: true, userId: 'user_product_admission' }),
+    fetch: relayFetch,
+  });
+  const response = await mod.default(makeCheckoutRequest());
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: 'INVALID_CHECKOUT_PRODUCT' });
+  assert.equal(relayFetch.mock.calls.length, 1);
+});


### PR DESCRIPTION
## Summary

Checkout previously forwarded legacy, Enterprise, and unknown product IDs to Dodo even though they were not current self-serve offers. New requests now require an exact catalog ID with both checkout flags enabled; invalid products return `INVALID_CHECKOUT_PRODUCT` (HTTP 400 through the relay and edge) before billing queries, Terms writes, signing, or provider calls.

Existing subscription and legacy webhook resolution remain unchanged. Previously issued hosted checkout links are not revoked, and merchant acceptance of arbitrary products was not tested.

Related: #7900

## Validation

- Observed 26 admission failures before the fix; current self-serve products already passed.
- Full Convex suite: 1,941 passed, including both checkout actions, pending-guard bypass, each catalog flag independently, relay rejection, and existing subscription/webhook behavior. Only provider transport is mocked for admission tests.
- Edge and browser transport tests: 23 passed; product rejection stays HTTP 400 rather than a retryable gateway failure.
- Sidecar suite: 474 passed. API typecheck and `git diff --check` passed.
- CI repair: release the intentionally delayed scorecard response before unrelated metric assertions consume its 12-second production deadline. A temporary 13-second delay reproduced the exact missing-tab failure before the change and passed afterward; that delay was removed. All 17 country-brief browser tests pass with retries disabled, and all 45 checkout admission tests pass after integrating current main.
- Sequential local code review completed with no actionable findings. No live payment or deployment performed.

## Post-Deploy Monitoring & Validation

Owner: repository maintainer, during the first 24 hours after an approved Convex and Edge deployment. Check checkout responses and logs for `INVALID_CHECKOUT_PRODUCT` and `[checkout] createCheckout failed`; current self-serve IDs should still create sessions, while excluded IDs should return 400 without provider calls. Investigate a rise in checkout failures or rejection of a current offer before further rollout; pause rollout and correct the catalog/guard mismatch if that occurs. Existing hosted links and the unknown-product webhook fallback require separate assessment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)

