### PR TITLE
fix: encode story query parameters in outgoing URLs

### DIFF
--- a/api/story.js
+++ b/api/story.js
@@ -29,7 +29,9 @@ export default function handler(req, res) {
   res.setHeader('Vary', 'User-Agent');
 
   const baseUrl = 'https://worldmonitor.app';
-  const spaUrl = `${baseUrl}/?c=${countryCode}&t=${type}${ts ? `&ts=${ts}` : ''}`;
+  const storyParams = new URLSearchParams({ c: countryCode, t: type });
+  if (ts) storyParams.set('ts', ts);
+  const spaUrl = `${baseUrl}/?${storyParams}`;
 
   // Real users → redirect to SPA
   if (!isBot) {
@@ -45,9 +47,11 @@ export default function handler(req, res) {
   const countryName = COUNTRY_NAMES[countryCode] || countryCode || 'Global';
   const title = `${countryName} Intelligence Brief | World Monitor`;
   const description = `Real-time instability analysis for ${countryName}. Country Instability Index, military posture, threat classification, and prediction markets. Free, open-source geopolitical intelligence.`;
-  const imageParams = `c=${countryCode}&t=${type}${score ? `&s=${score}` : ''}${level ? `&l=${level}` : ''}`;
+  const imageParams = new URLSearchParams({ c: countryCode, t: type });
+  if (score) imageParams.set('s', score);
+  if (level) imageParams.set('l', level);
   const imageUrl = `${baseUrl}/api/og-story?${imageParams}`;
-  const storyUrl = `${baseUrl}/api/story?c=${countryCode}&t=${type}${ts ? `&ts=${ts}` : ''}`;
+  const storyUrl = `${baseUrl}/api/story?${storyParams}`;
 
   const html = `<!DOCTYPE html>
 <html lang="en">

--- a/tests/story-user-agent-cache.test.mjs
+++ b/tests/story-user-agent-cache.test.mjs
@@ -2,9 +2,9 @@ import { strict as assert } from 'node:assert';
 import test from 'node:test';
 import handler from '../api/story.js';
 
-function requestStory(userAgent) {
+function requestStory(userAgent, query = 'c=US&t=ciianalysis&ts=2026-08-27T12%3A00%3A00Z') {
   const req = {
-    url: 'https://worldmonitor.app/api/story?c=US&t=ciianalysis&ts=2026-08-27T12%3A00%3A00Z',
+    url: `https://worldmonitor.app/api/story?${query}`,
     headers: { 'user-agent': userAgent },
   };
 
@@ -53,5 +53,31 @@ test('keeps crawler and browser responses cache-distinct for the same URL', () =
   assert.equal(browserResponse.statusCode, 302);
   assert.equal(browserResponse.headers.vary, 'User-Agent');
   assert.equal(browserResponse.headers['cache-control'], 'private, no-store');
-  assert.equal(browserResponse.headers.location, 'https://worldmonitor.app/?c=US&t=ciianalysis&ts=2026-08-27T12:00:00Z');
+  assert.equal(browserResponse.headers.location, 'https://worldmonitor.app/?c=US&t=ciianalysis&ts=2026-08-27T12%3A00%3A00Z');
 });
+
+for (const key of ['c', 't', 'ts', 's', 'l']) {
+  test(`keeps reserved characters in ${key} inside one outgoing parameter`, () => {
+    const values = { c: 'US', t: 'brief', ts: '123', s: '50', l: 'high' };
+    values[key] = 'US&INJECTED=1#fragment+%"<>\r\n';
+    const query = new URLSearchParams(values).toString();
+    const browser = requestStory('Mozilla/5.0', query);
+    const crawler = requestStory('Twitterbot/1.0', query);
+    assert.equal(browser.statusCode, 302);
+    assert.equal(crawler.statusCode, 200);
+    const links = [...crawler.body.matchAll(/(?:content|href)="(https:\/\/worldmonitor\.app[^" ]*)"/g)]
+      .map((match) => match[1].replaceAll('&amp;', '&'));
+    assert.equal(links.length, 5);
+    for (const target of [browser.headers.location, ...links]) {
+      const url = new URL(target);
+      assert.equal(url.origin, 'https://worldmonitor.app');
+      assert.equal(url.hash, '');
+      assert.doesNotMatch(target, /[\r\n"<>]/);
+      const keys = url.pathname === '/api/og-story' ? ['c', 't', 's', 'l'] : ['c', 't', 'ts'];
+      assert.deepEqual([...url.searchParams.keys()], keys);
+      for (const name of keys) {
+        assert.equal(url.searchParams.get(name), name === 'c' ? values[name].toUpperCase() : values[name]);
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Story query values containing `&`, `#`, quotes, or control characters could alter crawler links and browser redirect queries. Encode each value with `URLSearchParams` so it stays in its original parameter, while retaining HTML escaping and existing cache behavior.

## Validation

- Regression tests failed before the fix for all five query parameters and now pass across the redirect and all five crawler URL attributes.
- Focused story and OG tests: 8 passed.
- API typecheck and Convex call audit passed.
- Sidecar suite: 474 passed with local port access (the sandbox initially blocked listeners).
- Sequential local review: no actionable findings. `git diff --check` passed.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the maintainer should check `/api/story` with browser and crawler user agents during the first 15 minutes. Confirm 302/200 responses, encoded parameter round-trips, no added query keys or fragments, and unchanged cache headers. Inspect request logs for `/api/story` errors; unexpected 5xx or broken share links are rollback triggers. Deployment and live validation are not part of this PR's local proof.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
