### PR TITLE
fix(oauth): rate limit authorization before Redis writes

### DIFF
--- a/api/oauth/authorize.js
+++ b/api/oauth/authorize.js
@@ -202,6 +202,30 @@ export default async function handler(req) {
     return new Response(null, { status: 204, headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET, POST, OPTIONS', 'Access-Control-Allow-Headers': 'Content-Type' } });
   }
 
+  if (method === 'POST') {
+    // Origin validation: allow any first-party worldmonitor.app host (the consent
+    // page is served host-derived — apex/www/api/variant — so a same-origin JS
+    // fetch or the native form POST to api.worldmonitor.app arrives with any of
+    // those Origins), plus absent origin (server/CLI) and 'null' (WebView with
+    // opaque/sandboxed origin). CSRF nonce provides the actual protection.
+    const origin = req.headers.get('origin');
+    if (origin && origin !== 'null' && !WM_ORIGIN.test(origin)) {
+      return new Response('Forbidden', { status: 403 });
+    }
+  }
+
+  if (method === 'GET' || method === 'POST') {
+    const rl = getRatelimit();
+    if (rl) {
+      try {
+        const { success } = await rl.limit(`ip:${getClientIp(req)}`);
+        if (!success) {
+          return new Response('Too Many Requests', { status: 429 });
+        }
+      } catch { /* graceful degradation */ }
+    }
+  }
+
   if (method === 'GET') {
     const url = new URL(req.url);
     const p = url.searchParams;
@@ -236,9 +260,6 @@ export default async function handler(req) {
       return htmlError('Redirect URI Mismatch', 'The redirect_uri does not match any registered redirect URI for this client.');
     }
 
-    // Reset client TTL (sliding 90-day window)
-    await redisSet(`oauth:client:${client_id}`, { ...client, last_used: Date.now() }, CLIENT_TTL_SECONDS);
-
     const nonce = crypto.randomUUID();
     const nonceStored = await redisSet(`oauth:nonce:${nonce}`, { client_id, redirect_uri, code_challenge, state, created_at: Date.now() }, 600);
     if (!nonceStored) {
@@ -252,26 +273,6 @@ export default async function handler(req) {
   }
 
   if (method === 'POST') {
-    // Origin validation: allow any first-party worldmonitor.app host (the consent
-    // page is served host-derived — apex/www/api/variant — so a same-origin JS
-    // fetch or the native form POST to api.worldmonitor.app arrives with any of
-    // those Origins), plus absent origin (server/CLI) and 'null' (WebView with
-    // opaque/sandboxed origin). CSRF nonce provides the actual protection.
-    const origin = req.headers.get('origin');
-    if (origin && origin !== 'null' && !WM_ORIGIN.test(origin)) {
-      return new Response('Forbidden', { status: 403 });
-    }
-
-    const rl = getRatelimit();
-    if (rl) {
-      try {
-        const { success } = await rl.limit(`ip:${getClientIp(req)}`);
-        if (!success) {
-          return new Response('Too Many Requests', { status: 429 });
-        }
-      } catch { /* graceful degradation */ }
-    }
-
     let params;
     try {
       params = new URLSearchParams(await req.text());

--- a/tests/oauth-authorize-rate-limit.test.mjs
+++ b/tests/oauth-authorize-rate-limit.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, it, mock } from 'node:test';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+const redirectUri = 'https://client.test/callback';
+let handler;
+let commands;
+let counts;
+
+beforeEach(async () => {
+  mock.method(Date, 'now', () => 1_800_000_030_000);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  commands = [];
+  counts = new Map();
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://redis.test/get/')) {
+      commands.push(['GET', decodeURIComponent(url.split('/get/')[1])]);
+      return Response.json({ result: JSON.stringify({ redirect_uris: [redirectUri] }) });
+    }
+    assert.ok(url.startsWith('https://redis.test/'), `Unexpected fetch: ${url}`);
+    const body = JSON.parse(init.body);
+    const pipeline = Array.isArray(body[0]);
+    const results = (pipeline ? body : [body]).map((command) => {
+      commands.push(command);
+      if (['eval', 'evalsha'].includes(command[0].toLowerCase())) {
+        const key = command[3];
+        const count = (counts.get(key) ?? 0) + 1;
+        counts.set(key, count);
+        return { result: [10 - count, 10] };
+      }
+      assert.equal(command[0], 'SET');
+      return { result: 'OK' };
+    });
+    return Response.json(pipeline ? results : results[0]);
+  };
+  ({ default: handler } = await import(`../api/oauth/authorize.js?test=${crypto.randomUUID()}`));
+});
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = originalFetch;
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+});
+
+function request(ip = '192.0.2.1', clientId = 'registered-client') {
+  const params = new URLSearchParams({
+    client_id: clientId, redirect_uri: redirectUri, response_type: 'code',
+    code_challenge: 'a'.repeat(43), code_challenge_method: 'S256',
+  });
+  return new Request(`https://api.worldmonitor.app/oauth/authorize?${params}`, {
+    headers: { 'x-real-ip': ip },
+  });
+}
+
+it('limits GET by trusted IP before client reads or nonce writes, even when client IDs rotate', async () => {
+  for (let i = 0; i < 10; i++) {
+    assert.equal((await handler(request('192.0.2.1', `client-${i}`))).status, 200);
+  }
+  commands.length = 0;
+  assert.equal((await handler(request('192.0.2.1', 'another-client'))).status, 429);
+  assert.ok(commands.every((c) => !['GET', 'SET'].includes(c[0])));
+  assert.equal((await handler(request('192.0.2.2'))).status, 200);
+});
+
+it('renders consent and stores a nonce without renewing the client registration', async () => {
+  const response = await handler(request());
+  assert.equal(response.status, 200);
+  assert.match(await response.text(), /Authorize/);
+  const writes = commands.filter((c) => c[0] === 'SET');
+  assert.equal(writes.length, 1);
+  assert.match(writes[0][1], /^oauth:nonce:/);
+  assert.equal(writes[0][4], 600);
+});
+
+it('OPTIONS and unsupported methods do not consume rate-limit or storage operations', async () => {
+  for (const [method, status] of [['OPTIONS', 204], ['DELETE', 405]]) {
+    assert.equal((await handler(new Request(request().url, { method }))).status, status);
+  }
+  assert.deepEqual(commands, []);
+});
+
+it('POST shares the IP budget and is rejected before nonce consumption', async () => {
+  for (let i = 0; i < 10; i++) await handler(request());
+  commands.length = 0;
+  const response = await handler(new Request(request().url, {
+    method: 'POST', headers: { 'x-real-ip': '192.0.2.1' }, body: '_nonce=test',
+  }));
+  assert.equal(response.status, 429);
+  assert.ok(commands.every((c) => !['GET', 'GETDEL', 'SET'].includes(c[0])));
+});


### PR DESCRIPTION
## Summary

Repeated unauthenticated authorization GETs could write unlimited nonce records and renew a client registration indefinitely. GET and POST now share the existing trusted-IP budget of 10 requests per minute, checked before client reads or nonce writes. Loading consent no longer renews the 90-day client TTL; successful authorization and token exchange retain their renewal behavior.

The existing POST origin validation and limiter outage behavior are preserved. A consent GET and its POST each consume one request, so clients behind a shared IP share this budget.

## Validation

- Regression tests first reproduced request 11 returning 200 and a consent GET writing both client and nonce records; both now pass.
- 34 focused authorization tests pass, including rotating client IDs, independent IPs, shared GET/POST limits, and consent/origin behavior. Tests run the real handler and Upstash limiter against a fake Redis HTTP transport.
- `npm run typecheck:api`, `npm run test:sidecar` (474 tests), focused Biome lint, and `git diff --check` pass.
- Inline diff review completed; no separate review agents were used. Live Redis and deployed edge behavior were not tested.

## Post-Deploy Monitoring & Validation

Owner: deploying maintainer. During the first 30 minutes after deployment, inspect request logs for `/oauth/authorize`, status 429/5xx, and Redis command volume. Expect ordinary consent flows to succeed and excess requests from one trusted IP to return 429 without nonce writes. Investigate sustained legitimate-user 429s or increased authorization failures; revert this PR if normal consent is blocked.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
