### PR TITLE
fix(oauth): accept dashboard keys through MCP consent

### DIFF
--- a/api/_oauth-token.js
+++ b/api/_oauth-token.js
@@ -2,13 +2,14 @@
 import { keyFingerprint, sha256Hex } from './_crypto.js';
 // @ts-expect-error — JS module, no declaration file
 import { getRedisCredentials } from './_upstash-json.js';
+import { validateUserApiKeyHash } from './_user-api-key.js';
 
 /**
  * Bearer-to-context resolver for the OAuth + MCP edge.
  *
  * U6 of plan 2026-05-10-001 (`feat-pro-mcp-clerk-auth-quota-plan`) introduced
  * the discriminated `McpAuthContext` union — the same `oauth:token:<uuid>`
- * Redis namespace now stores TWO disjoint shapes:
+ * Redis namespace stores three disjoint shapes:
  *
  *   Legacy (env-key issued, written by `storeNewTokens` / `storeLegacyToken`
  *   in `api/oauth/token.js`): a bare JSON-string holding either a 64-hex
@@ -21,7 +22,11 @@ import { getRedisCredentials } from './_upstash-json.js';
  *   object carrying the Convex `mcpProTokens` row id and the user id.
  *     stored = { kind: 'pro', userId: 'user_abc', mcpTokenId: 'k57...' }
  *
- * Both shapes coexist forever — there is no migration. Resolver dispatches
+ *   Dashboard key: { kind: 'user_key', api_key_hash: '<sha256>' }.
+ *   Resolve its current owner through the shared key validator on each use;
+ *   MCP applies the same entitlement and quota checks as header-based keys.
+ *
+ * The shapes coexist without a migration. Resolver dispatches
  * on `typeof raw` then on `raw.kind`. Authorization-code / refresh-token
  * issued access tokens also get `oauth:tokenfam:<uuid>`; when
  * `oauth:famrev:<family_id>` exists, the resolver rejects that bearer so
@@ -99,6 +104,7 @@ export async function resolveApiKeyFromHash(fullHash) {
  *
  *   { kind: 'env_key', apiKey: string }
  *   | { kind: 'pro',   userId: string, mcpTokenId: string }
+ *   | { kind: 'user_key', userId: string }
  *   | null
  *
  * Branch logic:
@@ -136,6 +142,12 @@ export async function resolveBearerToContext(token) {
     if (raw.length === 64) apiKey = await resolveApiKeyFromHash(raw);
     else if (raw.length === 16) apiKey = await resolveApiKeyFromFingerprint(raw);
     return apiKey ? { kind: 'env_key', apiKey } : null;
+  }
+
+  if (raw && typeof raw === 'object' && raw.kind === 'user_key') {
+    const result = await validateUserApiKeyHash(raw.api_key_hash);
+    if (!result.ok && result.status === 503) throw new Error('API key validation unavailable');
+    return result.ok ? { kind: 'user_key', userId: result.userId } : null;
   }
 
   // New Pro object shape — defensive shape-check before trusting.

--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -245,6 +245,14 @@ export async function validateBootstrapUserApiKey(key) {
   }
 
   const keyHash = await sha256Hex(key);
+  return validateUserApiKeyHash(keyHash);
+}
+
+// OAuth stores only the key hash. Reuse the same revocation and scope checks.
+export async function validateUserApiKeyHash(keyHash) {
+  if (typeof keyHash !== 'string' || !/^[a-f0-9]{64}$/.test(keyHash)) {
+    return { ok: false, status: 401, error: 'Invalid API key', reason: 'malformed' };
+  }
   return coalesce(userKeyInFlight, keyHash, () => validateBootstrapUserApiKeyHash(keyHash));
 }
 

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -22,7 +22,8 @@ export type McpAuthContext =
   // way env_key does). Downstream `_execute` fetches sign as this userId via
   // the same internal HMAC as the OAuth door, so the gateway does not
   // increment the shared daily account meter a second time.
-  | { kind: 'user_key'; apiKey: string; userId: string }
+  // OAuth resolves the stored hash without recovering the plaintext key.
+  | { kind: 'user_key'; apiKey?: string; userId: string }
   // U7 (R7): an uncredentialed caller admitted to the always-free tool subset.
   // Carries NO identity by construction — it is the absence of a principal,
   // modelled as its own kind rather than a synthesised `env_key`/`pro` so every

--- a/api/oauth/authorize.js
+++ b/api/oauth/authorize.js
@@ -4,6 +4,7 @@ import { getClientIp } from '../_rate-limit.js';
 import { timingSafeIncludes, sha256Hex } from '../_crypto.js';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
+import { checkBootstrapUserApiKeyRateLimit, validateBootstrapUserApiKey } from '../_user-api-key.js';
 
 export const config = { runtime: 'edge' };
 
@@ -322,7 +323,17 @@ export default async function handler(req) {
 
     // Validate API key
     const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-    if (!await timingSafeIncludes(api_key, validKeys)) {
+    const enterpriseKey = await timingSafeIncludes(api_key, validKeys);
+    let userKey = null;
+    if (!enterpriseKey && api_key.startsWith('wm_')) {
+      const guard = await checkBootstrapUserApiKeyRateLimit(req);
+      if (!guard.ok) return new Response(guard.error, { status: guard.status, headers: guard.headers });
+      userKey = await validateBootstrapUserApiKey(api_key);
+      if (!userKey.ok && userKey.status === 503) {
+        return new Response(userKey.error, { status: 503, headers: userKey.headers });
+      }
+    }
+    if (!enterpriseKey && !userKey?.ok) {
       // Generate and store a fresh nonce; fail closed if storage is unavailable
       const retryNonce = crypto.randomUUID();
       const retryNonceStored = await redisSet(`oauth:nonce:${retryNonce}`, { client_id, redirect_uri, code_challenge, state, created_at: Date.now() }, 600);
@@ -344,6 +355,7 @@ export default async function handler(req) {
     // Issue authorization code — all fields sourced from nonceData
     const code = crypto.randomUUID();
     const codeData = {
+      ...(!enterpriseKey ? { kind: 'user_key' } : {}),
       client_id,
       redirect_uri,
       code_challenge,

--- a/api/oauth/authorize.js
+++ b/api/oauth/authorize.js
@@ -192,8 +192,24 @@ button:disabled{opacity:.5;cursor:default}
 </form>
 </div>
 <p class="footer"><a href="https://www.worldmonitor.app" target="_blank" rel="noopener">worldmonitor.app</a> &middot; <a href="https://www.worldmonitor.app/pro" target="_blank" rel="noopener">Get an API key &#x2192;</a></p>
-<script>(function(){function showForm(){var f=document.getElementById('cf');if(f)f.style.display='';var d=document.getElementById('dt');if(d)d.style.display='none';var k=document.getElementById('api_key');if(k){k.required=true;try{k.focus();}catch(e){}}}var em=document.getElementById('ke');if(em&&em.textContent&&em.textContent.length>0){showForm();}if(window.location.hash==='#api-key'){showForm();}var tk=document.getElementById('tk');if(tk){tk.addEventListener('click',function(e){e.preventDefault();showForm();});tk.addEventListener('keydown',function(e){if(e.key==='Enter'||e.key===' '){e.preventDefault();showForm();}});}var cf=document.getElementById('cf');if(cf){cf.addEventListener('submit',function(e){e.preventDefault();var jf=document.getElementById('jf');if(jf)jf.value='1';var b=document.getElementById('ab');b.disabled=true;b.textContent='Authorizing…';var d=new URLSearchParams(new FormData(e.target));fetch('/oauth/authorize',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:d}).then(function(r){var c=r.headers.get('Content-Type')||'';if(c.indexOf('json')>=0)return r.json().then(function(j){if(j.location){window.location.replace(j.location);return;}if(j.error==='invalid_key'){var n=document.getElementById('nn');if(n)n.value=j.nonce||'';var em2=document.getElementById('ke');if(em2){em2.textContent='Invalid API key. Please check and try again.';em2.style.display='';}showForm();}b.disabled=false;b.textContent='Authorize';});return r.text().then(function(h){document.open();document.write(h);document.close();});}).catch(function(){b.disabled=false;b.textContent='Authorize';});});}})();</script>
+<script>(function(){function showForm(){var f=document.getElementById('cf');if(f)f.style.display='';var d=document.getElementById('dt');if(d)d.style.display='none';var k=document.getElementById('api_key');if(k){k.required=true;try{k.focus();}catch(e){}}}var em=document.getElementById('ke');if(em&&em.textContent&&em.textContent.length>0){showForm();}if(window.location.hash==='#api-key'){showForm();}var tk=document.getElementById('tk');if(tk){tk.addEventListener('click',function(e){e.preventDefault();showForm();});tk.addEventListener('keydown',function(e){if(e.key==='Enter'||e.key===' '){e.preventDefault();showForm();}});}var cf=document.getElementById('cf');if(cf){cf.addEventListener('submit',function(e){e.preventDefault();var jf=document.getElementById('jf');if(jf)jf.value='1';var b=document.getElementById('ab');b.disabled=true;b.textContent='Authorizing…';var d=new URLSearchParams(new FormData(e.target));fetch('/oauth/authorize',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:d}).then(function(r){var c=r.headers.get('Content-Type')||'';if(c.indexOf('json')>=0)return r.json().then(function(j){if(j.location){window.location.replace(j.location);return;}if(j.error==='invalid_key'||j.error==='temporarily_unavailable'){var n=document.getElementById('nn');if(n)n.value=j.nonce||'';var em2=document.getElementById('ke');if(em2){em2.textContent=j.message||'Invalid API key. Please check and try again.';em2.style.display='';}showForm();}b.disabled=false;b.textContent='Authorize';});return r.text().then(function(h){document.open();document.write(h);document.close();});}).catch(function(){b.disabled=false;b.textContent='Authorize';});});}})();</script>
 </body></html>`, { status: 200, headers: PAGE_HEADERS });
+}
+
+async function retryConsent(nonceData, client, isXHR, failure) {
+  const retryNonce = crypto.randomUUID();
+  // A consumed nonce stays consumed. Only server-held request values are copied.
+  const stored = await redisSet(`oauth:nonce:${retryNonce}`, { ...nonceData, created_at: Date.now() }, 600);
+  if (!stored) return htmlError('Service Unavailable', 'Authorization service is temporarily unavailable. Please start over shortly.');
+  const headers = { ...PAGE_HEADERS, ...failure.headers };
+  if (isXHR) {
+    return new Response(JSON.stringify({ error: failure.error, message: failure.message, nonce: retryNonce }), {
+      status: failure.status,
+      headers: { ...headers, 'Content-Type': 'application/json' },
+    });
+  }
+  const page = consentPage({ ...nonceData, client_name: client.client_name ?? 'Unknown Client' }, retryNonce, failure.message);
+  return new Response(page.body, { status: failure.status === 400 ? 200 : failure.status, headers });
 }
 
 export default async function handler(req) {
@@ -327,29 +343,20 @@ export default async function handler(req) {
     let userKey = null;
     if (!enterpriseKey && api_key.startsWith('wm_')) {
       const guard = await checkBootstrapUserApiKeyRateLimit(req);
-      if (!guard.ok) return new Response(guard.error, { status: guard.status, headers: guard.headers });
+      if (!guard.ok) return retryConsent(nonceData, client, isXHR, {
+        error: 'temporarily_unavailable', message: guard.error, status: guard.status, headers: guard.headers,
+      });
       userKey = await validateBootstrapUserApiKey(api_key);
       if (!userKey.ok && userKey.status === 503) {
-        return new Response(userKey.error, { status: 503, headers: userKey.headers });
+        return retryConsent(nonceData, client, isXHR, {
+          error: 'temporarily_unavailable', message: userKey.error, status: 503, headers: userKey.headers,
+        });
       }
     }
     if (!enterpriseKey && !userKey?.ok) {
-      // Generate and store a fresh nonce; fail closed if storage is unavailable
-      const retryNonce = crypto.randomUUID();
-      const retryNonceStored = await redisSet(`oauth:nonce:${retryNonce}`, { client_id, redirect_uri, code_challenge, state, created_at: Date.now() }, 600);
-      if (!retryNonceStored) {
-        return htmlError('Service Unavailable', 'Authorization service is temporarily unavailable. Please try again shortly.');
-      }
-      if (isXHR) {
-        return new Response(JSON.stringify({ error: 'invalid_key', nonce: retryNonce }), {
-          status: 400,
-          headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
-        });
-      }
-      return consentPage({
-        client_name: client.client_name ?? 'Unknown Client',
-        redirect_uri, client_id, response_type: 'code', code_challenge, code_challenge_method: 'S256', state,
-      }, retryNonce, 'Invalid API key. Please check and try again.');
+      return retryConsent(nonceData, client, isXHR, {
+        error: 'invalid_key', message: 'Invalid API key. Please check and try again.', status: 400,
+      });
     }
 
     // Issue authorization code — all fields sourced from nonceData

--- a/api/oauth/token.ts
+++ b/api/oauth/token.ts
@@ -313,14 +313,15 @@ async function storeNewTokens(
   clientId: string,
   scope: string,
   familyId: string,
+  kind?: 'user_key',
 ): Promise<boolean> {
   const results = await pipeline([
-    ['SET', `oauth:token:${accessUuid}`, JSON.stringify(apiKeyHash), 'EX', TOKEN_TTL_SECONDS],
+    ['SET', `oauth:token:${accessUuid}`, JSON.stringify(kind === 'user_key' ? { kind, api_key_hash: apiKeyHash } : apiKeyHash), 'EX', TOKEN_TTL_SECONDS],
     ['SET', accessTokenFamilyKey(accessUuid), JSON.stringify(familyId), 'EX', TOKEN_TTL_SECONDS],
     [
       'SET',
       `oauth:refresh:${refreshUuid}`,
-      JSON.stringify({ client_id: clientId, api_key_hash: apiKeyHash, scope, family_id: familyId }),
+      JSON.stringify({ kind, client_id: clientId, api_key_hash: apiKeyHash, scope, family_id: familyId }),
       'EX',
       REFRESH_TTL_SECONDS,
     ],
@@ -426,7 +427,7 @@ interface CodeDataLegacy {
   code_challenge: string;
   scope?: string;
   api_key_hash: string;
-  kind?: undefined;
+  kind?: 'user_key';
 }
 
 interface RefreshDataPro {
@@ -443,7 +444,7 @@ interface RefreshDataLegacy {
   api_key_hash: string;
   scope: string;
   family_id: string;
-  kind?: undefined;
+  kind?: 'user_key';
 }
 
 // ---------------------------------------------------------------------------
@@ -528,8 +529,7 @@ async function handleAuthorizationCode(
   const refreshUuid = deps.randomUuid();
   const familyId = deps.randomUuid();
 
-  // Branch by code-record kind. Pro records carry `userId` + `mcpTokenId`;
-  // legacy records carry the `api_key_hash` SHA-256.
+  // Pro records carry `userId` + `mcpTokenId`; API-key records carry a hash.
   if (codeData.kind === 'pro') {
     const scope = codeData.scope ?? 'mcp_pro';
     const stored = await storeProTokens(
@@ -554,7 +554,7 @@ async function handleAuthorizationCode(
     });
   }
 
-  // Legacy env-key path — unchanged
+  // Preserve dashboard-key identity; only operator keys use the legacy shape.
   const scope = codeData.scope ?? 'mcp';
   const stored = await storeNewTokens(
     deps.redisPipeline,
@@ -564,6 +564,7 @@ async function handleAuthorizationCode(
     clientId,
     scope,
     familyId,
+    codeData.kind,
   );
   if (!stored) {
     return jsonResp({ error: 'server_error', error_description: 'Token storage failed' }, 500);
@@ -770,7 +771,7 @@ async function handleRefreshToken(
     });
   }
 
-  // Legacy env-key path — unchanged
+  // Preserve dashboard-key identity across refresh rotation.
   const scope = refreshData.scope ?? 'mcp';
   const stored = await storeNewTokens(
     deps.redisPipeline,
@@ -780,6 +781,7 @@ async function handleRefreshToken(
     clientId,
     scope,
     refreshData.family_id,
+    refreshData.kind,
   );
   if (!stored) {
     await restoreRefreshAttempt(

--- a/docs/api-oauth.mdx
+++ b/docs/api-oauth.mdx
@@ -74,6 +74,8 @@ Starts the OAuth flow. Renders a consent page that redirects to Clerk for sign-i
 
 **Code TTL**: 10 minutes. Single-use (atomic `GETDEL` on exchange).
 
+The **Use API key instead** option accepts dashboard-issued `wm_` keys and enterprise keys. Dashboard-key OAuth tokens retain the key owner's identity and use the same MCP entitlement and quota checks as `X-WorldMonitor-Key` requests. Only the key hash is stored; bearer use revalidates the key through the shared validator, whose revocation cache lasts up to 60 seconds. API-key creation requires `apiAccess`; MCP calls follow `mcpAccess` and the applicable account allowance. Pro users can use sign-in without creating an API key. Company Monitoring keys with restricted scopes are not accepted by this generic MCP flow.
+
 ### `POST /api/oauth/token`
 
 Exchanges an authorization code for an access token, or refreshes an existing token.

--- a/tests/mcp-user-key-auth.test.mjs
+++ b/tests/mcp-user-key-auth.test.mjs
@@ -83,6 +83,26 @@ describe('api/mcp — user API keys on /mcp (#4859) + pre-check hardening (#4860
 
   // ── #4859 — user keys accepted, entitlement-gated ──
 
+  it('dashboard OAuth bearer without a plaintext key uses the user quota', async () => {
+    const { deps, pipe } = makeUserKeyDeps({
+      resolveBearerToContext: async () => ({ kind: 'user_key', userId: USER_KEY_USER_ID }),
+      pipelineOpts: { initialCount: 50 },
+    });
+    const res = await mcpHandler(proReq('POST', callBody('get_market_data')), deps);
+    assert.equal(res.status, 429);
+    assert.equal((await res.json()).error?.code, -32029);
+    assert.equal(pipe.count, 50);
+  });
+
+  it('dashboard OAuth bearer cannot bypass entitlement verification', async () => {
+    const { deps } = makeUserKeyDeps({
+      resolveBearerToContext: async () => ({ kind: 'user_key', userId: USER_KEY_USER_ID }),
+      getEntitlements: async () => { throw new Error('unavailable'); },
+    });
+    const res = await mcpHandler(proReq('POST', callBody('get_market_data')), deps);
+    assert.equal(res.status, 503);
+  });
+
   it('happy: valid user key + mcpAccess entitlement → describe_tool 200', async () => {
     const { deps, pipe } = makeUserKeyDeps();
     const res = await mcpHandler(userKeyReq(callBody('describe_tool', { tool_name: 'get_market_data' })), deps);

--- a/tests/oauth-dashboard-key.test.mjs
+++ b/tests/oauth-dashboard-key.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, it } from 'node:test';
+import handler from '../api/oauth/authorize.js';
+import tokenEndpoint from '../api/oauth/token.ts';
+import { resolveBearerToContext } from '../api/_oauth-token.js';
+import { sha256Hex } from '../api/_crypto.js';
+
+const key = `wm_${'b'.repeat(40)}`;
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+let store;
+let validation;
+let convexCalls;
+beforeEach(() => {
+  store = new Map();
+  validation = { userId: 'user_dashboard' };
+  convexCalls = 0;
+  Object.assign(process.env, {
+    UPSTASH_REDIS_REST_URL: 'https://redis.test', UPSTASH_REDIS_REST_TOKEN: 'fake',
+    CONVEX_SITE_URL: 'https://convex.test', CONVEX_SERVER_SHARED_SECRET: 'fake',
+    WORLDMONITOR_VALID_KEYS: 'enterprise-test-key',
+  });
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://convex.test')) {
+      convexCalls++;
+      assert.equal(JSON.parse(init.body).keyHash, await sha256Hex(key));
+      return Response.json(validation, { status: validation === 'unavailable' ? 503 : 200 });
+    }
+    assert.ok(url.startsWith('https://redis.test'), url);
+    const command = (cmd) => {
+      const [op, name, value] = cmd;
+      if (op.toUpperCase() === 'GET') return { result: store.get(name) ?? null };
+      if (op.toUpperCase() === 'SET') { store.set(name, value); return { result: 'OK' }; }
+      if (['INCR', 'EXPIRE'].includes(op.toUpperCase())) return { result: 1 };
+      if (op.toUpperCase() === 'TTL') return { result: 60 };
+      // Upstash rate-limit scripts are outside this auth integration test.
+      return { result: [1, 60000, 0] };
+    };
+    if (url.endsWith('/pipeline')) return Response.json(JSON.parse(init.body).map(command));
+    const match = new URL(url).pathname.match(/^\/(get|getdel)\/(.+)$/);
+    if (match) {
+      const name = decodeURIComponent(match[2]);
+      const value = store.get(name) ?? null;
+      if (match[1] === 'getdel') store.delete(name);
+      return Response.json({ result: value });
+    }
+    return Response.json(command(JSON.parse(init.body)));
+  };
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const name of Object.keys(process.env)) if (!(name in originalEnv)) delete process.env[name];
+  Object.assign(process.env, originalEnv);
+});
+
+async function consent(apiKey = key) {
+  const challenge = Buffer.from(await sha256Hex('a'.repeat(64)), 'hex').toString('base64url');
+  store.set('oauth:nonce:test', JSON.stringify({ client_id: 'client', redirect_uri: 'https://client.test/callback', code_challenge: challenge, state: 'state' }));
+  store.set('oauth:client:client', JSON.stringify({ redirect_uris: ['https://client.test/callback'] }));
+  return handler(new Request('https://api.worldmonitor.app/oauth/authorize', {
+    method: 'POST', body: new URLSearchParams({ _nonce: 'test', _js: '1', api_key: apiKey }),
+  }));
+}
+
+it('consents a dashboard key and resolves its bearer as a metered user', async () => {
+  const response = await consent();
+  assert.equal(response.status, 200);
+  const code = new URL((await response.json()).location).searchParams.get('code');
+  const record = JSON.parse(store.get(`oauth:code:${code}`));
+  assert.equal(record.kind, 'user_key');
+  assert.equal(record.api_key_hash, await sha256Hex(key));
+  assert.ok(!JSON.stringify([...store]).includes(key));
+  const exchange = await tokenEndpoint(new Request('https://api.worldmonitor.app/oauth/token', {
+    method: 'POST', body: new URLSearchParams({
+      grant_type: 'authorization_code', code, code_verifier: 'a'.repeat(64),
+      client_id: 'client', redirect_uri: 'https://client.test/callback',
+    }),
+  }));
+  assert.equal(exchange.status, 200);
+  const tokens = await exchange.json();
+  assert.deepEqual(await resolveBearerToContext(tokens.access_token), { kind: 'user_key', userId: 'user_dashboard' });
+  assert.ok(!JSON.stringify([...store]).includes(key));
+});
+
+it('keeps enterprise consent on the legacy path', async () => {
+  const response = await consent('enterprise-test-key');
+  assert.equal(response.status, 200);
+  const code = new URL((await response.json()).location).searchParams.get('code');
+  assert.equal(JSON.parse(store.get(`oauth:code:${code}`)).kind, undefined);
+  assert.equal(convexCalls, 0);
+});
+
+it('rejects revoked dashboard keys', async () => {
+  validation = null;
+  assert.equal((await consent()).status, 400);
+});
+
+it('reports validation failure as retryable', async () => {
+  validation = 'unavailable';
+  assert.equal((await consent()).status, 503);
+});
+
+it('rejects scoped company keys on the generic consent path', async () => {
+  validation = { userId: 'user_dashboard', scopes: ['company_monitoring:read'], companyMonitoringAccountId: 'account' };
+  assert.equal((await consent()).status, 400);
+});
+
+it('revalidates bearer key revocation and preserves backend failures', async () => {
+  store.set('oauth:token:bearer', JSON.stringify({ kind: 'user_key', api_key_hash: await sha256Hex(key) }));
+  validation = 'unavailable';
+  await assert.rejects(resolveBearerToContext('bearer'));
+  validation = null;
+  assert.equal(await resolveBearerToContext('bearer'), null);
+});
+
+it('rejects malformed bearer hashes without reaching Convex', async () => {
+  for (const hash of [null, '', 'a'.repeat(63), 'A'.repeat(64), {}]) {
+    store.set('oauth:token:bearer', JSON.stringify({ kind: 'user_key', api_key_hash: hash }));
+    assert.equal(await resolveBearerToContext('bearer'), null);
+  }
+  assert.equal(convexCalls, 0);
+});
+
+it('rejects a dashboard bearer from a revoked refresh family before key validation', async () => {
+  store.set('oauth:token:bearer', JSON.stringify({ kind: 'user_key', api_key_hash: await sha256Hex(key) }));
+  store.set('oauth:tokenfam:bearer', JSON.stringify('family'));
+  store.set('oauth:famrev:family', JSON.stringify(true));
+  assert.equal(await resolveBearerToContext('bearer'), null);
+  assert.equal(convexCalls, 0);
+});

--- a/tests/oauth-dashboard-key.test.mjs
+++ b/tests/oauth-dashboard-key.test.mjs
@@ -11,10 +11,12 @@ const originalEnv = { ...process.env };
 let store;
 let validation;
 let convexCalls;
+let rateCount;
 beforeEach(() => {
   store = new Map();
   validation = { userId: 'user_dashboard' };
   convexCalls = 0;
+  rateCount = 1;
   Object.assign(process.env, {
     UPSTASH_REDIS_REST_URL: 'https://redis.test', UPSTASH_REDIS_REST_TOKEN: 'fake',
     CONVEX_SITE_URL: 'https://convex.test', CONVEX_SERVER_SHARED_SECRET: 'fake',
@@ -33,7 +35,8 @@ beforeEach(() => {
       const [op, name, value] = cmd;
       if (op.toUpperCase() === 'GET') return { result: store.get(name) ?? null };
       if (op.toUpperCase() === 'SET') { store.set(name, value); return { result: 'OK' }; }
-      if (['INCR', 'EXPIRE'].includes(op.toUpperCase())) return { result: 1 };
+      if (op.toUpperCase() === 'INCR') return { result: rateCount };
+      if (op.toUpperCase() === 'EXPIRE') return { result: 1 };
       if (op.toUpperCase() === 'TTL') return { result: 60 };
       // Upstash rate-limit scripts are outside this auth integration test.
       return { result: [1, 60000, 0] };
@@ -55,12 +58,12 @@ afterEach(() => {
   Object.assign(process.env, originalEnv);
 });
 
-async function consent(apiKey = key) {
+async function consent(apiKey = key, xhr = true) {
   const challenge = Buffer.from(await sha256Hex('a'.repeat(64)), 'hex').toString('base64url');
   store.set('oauth:nonce:test', JSON.stringify({ client_id: 'client', redirect_uri: 'https://client.test/callback', code_challenge: challenge, state: 'state' }));
   store.set('oauth:client:client', JSON.stringify({ redirect_uris: ['https://client.test/callback'] }));
   return handler(new Request('https://api.worldmonitor.app/oauth/authorize', {
-    method: 'POST', body: new URLSearchParams({ _nonce: 'test', _js: '1', api_key: apiKey }),
+    method: 'POST', body: new URLSearchParams({ _nonce: 'test', _js: xhr ? '1' : '', api_key: apiKey }),
   }));
 }
 
@@ -99,7 +102,42 @@ it('rejects revoked dashboard keys', async () => {
 
 it('reports validation failure as retryable', async () => {
   validation = 'unavailable';
-  assert.equal((await consent()).status, 503);
+  const response = await consent();
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get('Retry-After'), '5');
+  const retry = await response.json();
+  assert.equal(retry.error, 'temporarily_unavailable');
+  assert.ok(retry.nonce);
+  assert.equal(store.has('oauth:nonce:test'), false);
+  validation = { userId: 'user_dashboard' };
+  const recovered = await handler(new Request('https://api.worldmonitor.app/oauth/authorize', {
+    method: 'POST', body: new URLSearchParams({ _nonce: retry.nonce, _js: '1', api_key: key }),
+  }));
+  assert.equal(recovered.status, 200);
+  assert.equal(new URL((await recovered.json()).location).hostname, 'client.test');
+});
+
+it('renders a usable native consent form after transient validation failure', async () => {
+  validation = 'unavailable';
+  const response = await consent(key, false);
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get('Retry-After'), '5');
+  const html = await response.text();
+  const nonce = html.match(/id="nn" value="([^"]+)"/)?.[1];
+  assert.ok(nonce);
+  assert.notEqual(nonce, 'test');
+  assert.ok(store.has(`oauth:nonce:${nonce}`));
+});
+
+it('returns a fresh nonce when dashboard validation is rate limited', async () => {
+  rateCount = 601;
+  const response = await consent();
+  assert.equal(response.status, 429);
+  assert.equal(response.headers.get('Retry-After'), '60');
+  const retry = await response.json();
+  assert.equal(retry.error, 'temporarily_unavailable');
+  assert.ok(store.has(`oauth:nonce:${retry.nonce}`));
+  assert.equal(convexCalls, 0);
 });
 
 it('rejects scoped company keys on the generic consent path', async () => {

--- a/tests/oauth-dashboard-key.test.mjs
+++ b/tests/oauth-dashboard-key.test.mjs
@@ -22,12 +22,13 @@ beforeEach(() => {
   });
   globalThis.fetch = async (input, init) => {
     const url = String(input);
-    if (url.startsWith('https://convex.test')) {
+    const origin = new URL(url).origin;
+    if (origin === 'https://convex.test') {
       convexCalls++;
       assert.equal(JSON.parse(init.body).keyHash, await sha256Hex(key));
       return Response.json(validation, { status: validation === 'unavailable' ? 503 : 200 });
     }
-    assert.ok(url.startsWith('https://redis.test'), url);
+    assert.equal(origin, 'https://redis.test');
     const command = (cmd) => {
       const [op, name, value] = cmd;
       if (op.toUpperCase() === 'GET') return { result: store.get(name) ?? null };

--- a/tests/oauth-token.test.mjs
+++ b/tests/oauth-token.test.mjs
@@ -286,6 +286,36 @@ function makeReq(grantType, params) {
   });
 }
 
+it('preserves dashboard key identity through code exchange and refresh', async () => {
+  const { redis, deps } = makeDeps();
+  const keyHash = await sha256Hex(`wm_${'a'.repeat(40)}`);
+  redis.store.set('oauth:code:dashboard', {
+    kind: 'user_key', api_key_hash: keyHash, client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI, code_challenge: CODE_CHALLENGE, scope: 'mcp',
+  });
+  redis.store.set(`oauth:client:${CLIENT_ID}`, CLIENT_RECORD);
+  const response = await tokenHandler(makeReq('authorization_code', {
+    code: 'dashboard', code_verifier: CODE_VERIFIER,
+    client_id: CLIENT_ID, redirect_uri: REDIRECT_URI,
+  }), deps);
+  assert.equal(response.status, 200);
+  const tokens = await response.json();
+  assert.deepEqual(JSON.parse(redis.store.get(`oauth:token:${tokens.access_token}`)), {
+    kind: 'user_key', api_key_hash: keyHash,
+  });
+  const refresh = JSON.parse(redis.store.get(`oauth:refresh:${tokens.refresh_token}`));
+  assert.equal(refresh.kind, 'user_key');
+  const rotated = await tokenHandler(makeReq('refresh_token', {
+    refresh_token: tokens.refresh_token, client_id: CLIENT_ID,
+  }), deps);
+  assert.equal(rotated.status, 200);
+  const next = await rotated.json();
+  assert.deepEqual(JSON.parse(redis.store.get(`oauth:token:${next.access_token}`)), {
+    kind: 'user_key', api_key_hash: keyHash,
+  });
+  assert.equal(JSON.parse(redis.store.get(`oauth:refresh:${next.refresh_token}`)).family_id, refresh.family_id);
+});
+
 describe('OAuth Redis refresh-attempt production contract', () => {
   it('atomically consumes a refresh token and creates a short-lived attempt', async () => {
     const realFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

Dashboard-issued `wm_` keys currently fail the MCP OAuth consent form because it accepts only enterprise environment keys. This lets dashboard users complete consent and token exchange, with refresh tokens preserving their user identity. Bearer use revalidates the stored key hash and follows the existing MCP entitlement and quota checks; plaintext dashboard keys are never stored in OAuth records.

API-key creation still requires `apiAccess`. MCP calls retain their existing `mcpAccess` and account-allowance rules. Enterprise OAuth behavior is preserved.

## Validation

- 208 focused OAuth/MCP tests pass, including real consent → token endpoint → bearer resolution with fixture Redis/Convex, refresh identity, revoked/scoped keys, retryable failures, family revocation, and user quota enforcement.
- Required sidecar suite, API/browser typechecks, lint, and diff checks pass.
- Independent review found and fixed a consent-retry dead end after transient validation failure. Desktop/mobile browser checks prove the form remains usable and the replacement nonce completes authorization. No live account or production mutation was used. Revocation retains the existing up-to-60-second key cache window.

## Post-Deploy Monitoring & Validation

Owner: PR author, during the first 30 minutes after an authorized deployment. With an authorized test account, complete dashboard-key consent, exchange and refresh, then verify a metered MCP call and revocation after the cache window. Check OAuth 400/503 rates and `[bootstrap-user-api-key] validation unavailable` logs. Healthy behavior is successful consent and user-metered calls; enterprise calls must stay unchanged. Roll back if valid keys are rejected persistently, revoked keys remain usable beyond the cache window, or user quota/entitlement checks are bypassed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)

![Desktop consent after a simulated validation outage at dcdfd645d; test key and fresh nonce; retry verified](https://github.com/user-attachments/assets/4e23a8a6-fc75-44f1-afab-f50bc9be451b)

![Mobile consent after a simulated validation outage at dcdfd645d; test key and fresh nonce; retry verified](https://github.com/user-attachments/assets/6a4c2556-8d9b-44db-8ee4-299050dc68b8)