### PR TITLE
fix(oauth): bind token abuse limits to trusted client IP

### DIFF
--- a/api/oauth/token.ts
+++ b/api/oauth/token.ts
@@ -875,8 +875,6 @@ async function checkClientExists(deps: TokenHandlerDeps, clientId: string): Prom
 async function applyRateLimit(
   req: Request,
   grantType: string | null,
-  clientSecret: string | null,
-  clientId: string | null,
   ctx: WaitUntilCtx | undefined,
 ): Promise<TokenRateLimitDecision> {
   const rl = getRatelimit();
@@ -890,15 +888,8 @@ async function applyRateLimit(
     return { kind: 'degraded' };
   }
   try {
-    let rlKey: string;
-    if (grantType === 'client_credentials' && clientSecret) {
-      rlKey = `cred:${(await sha256Hex(clientSecret)).slice(0, 8)}`;
-    } else if (clientId) {
-      rlKey = `cid:${clientId}`;
-    } else {
-      rlKey = `ip:${getClientIp(req)}`;
-    }
-    const result = await rl.limit(rlKey);
+    // Unvalidated credentials and client IDs must not select their own abuse budget.
+    const result = await rl.limit(`ip:${getClientIp(req)}`);
     // @upstash/ratelimit v2 races Redis against an internal timeout and
     // RESOLVES `{ success: true, reason: 'timeout' }` rather than rejecting,
     // so a slow Redis is indistinguishable from a genuine allow unless we
@@ -944,7 +935,7 @@ export async function tokenHandler(req: Request, deps: TokenHandlerDeps): Promis
   const clientSecret = params.get('client_secret');
   const clientId = params.get('client_id');
 
-  const rateLimit = await applyRateLimit(req, grantType, clientSecret, clientId, deps.ctx);
+  const rateLimit = await applyRateLimit(req, grantType, deps.ctx);
   if (rateLimit.kind === 'limited') {
     emitOAuthTokenUsage(deps.ctx, req, rateLimit.response, startedAt, 'rate_limit_429');
     return rateLimit.response;

--- a/tests/oauth-token.test.mjs
+++ b/tests/oauth-token.test.mjs
@@ -1763,6 +1763,84 @@ describe('U6 tokenHandler — client_credentials (regression guard)', () => {
 // Rate-limit degradation observability (#7270)
 // ---------------------------------------------------------------------------
 
+describe('oauth/token trusted-IP abuse budget', () => {
+  for (const grantType of ['client_credentials', 'authorization_code', 'refresh_token']) {
+    it(`${grantType}: rotating identifiers cannot bypass the IP limit`, async () => {
+      const { Ratelimit } = await import('@upstash/ratelimit');
+      const { Redis } = await import('@upstash/redis');
+      const originalFetch = globalThis.fetch;
+      const counts = new Map();
+      globalThis.fetch = async (input, init) => {
+        assert.ok(String(input).startsWith('https://redis.test/'));
+        const body = JSON.parse(init.body);
+        const pipeline = Array.isArray(body[0]);
+        const results = (pipeline ? body : [body]).map((command) => {
+          assert.ok(['eval', 'evalsha'].includes(command[0].toLowerCase()));
+          // Ignore the sliding-window suffix so the fixture is stable across a minute boundary.
+          const key = command[3].replace(/:[0-9]+$/, '');
+          const count = (counts.get(key) ?? 0) + 1;
+          counts.set(key, count);
+          return { result: [10 - count, 10] };
+        });
+        return Response.json(pipeline ? results : results[0]);
+      };
+      try {
+        __setOAuthTokenRatelimitForTest(new Ratelimit({
+          redis: new Redis({ url: 'https://redis.test', token: 'test-token' }),
+          limiter: Ratelimit.slidingWindow(10, '60 s'),
+          prefix: 'rl:oauth-token', analytics: false,
+        }));
+        const { deps, redis } = makeDeps();
+        const request = (i, ip = '192.0.2.1') => {
+          const req = makeReq(grantType, {
+            client_secret: `invalid-secret-${i}`, client_id: `client-${i}`,
+            code: `missing-code-${i}`, code_verifier: CODE_VERIFIER,
+            redirect_uri: REDIRECT_URI, refresh_token: `missing-refresh-${i}`,
+          });
+          req.headers.set('x-real-ip', ip);
+          req.headers.set('x-forwarded-for', `198.51.100.${i}`);
+          req.headers.set('cf-connecting-ip', `198.51.100.${i}`);
+          return req;
+        };
+        const invalidStatus = grantType === 'client_credentials' ? 401 : 400;
+        for (let i = 0; i < 10; i++) {
+          assert.equal((await tokenHandler(request(i), deps)).status, invalidStatus);
+        }
+        const previousOps = redis.ops.length;
+        const blocked = await tokenHandler(request(10), deps);
+        assert.equal(blocked.status, 429);
+        assert.equal((await blocked.json()).error, 'rate_limit_exceeded');
+        assert.equal(redis.ops.length, previousOps, 'blocked request must not process the grant');
+        assert.equal((await tokenHandler(request(10, '192.0.2.2'), deps)).status, invalidStatus);
+        assert.deepEqual([...counts.keys()].sort(), [
+          'rl:oauth-token:ip:192.0.2.1', 'rl:oauth-token:ip:192.0.2.2',
+        ]);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  }
+
+  it('grant switching and missing trusted IP use one stable fallback bucket', async () => {
+    const keys = [];
+    __setOAuthTokenRatelimitForTest({
+      limit: async (key) => {
+        keys.push(key);
+        return { success: false };
+      },
+    });
+    const { deps, redis } = makeDeps();
+    for (const grantType of ['client_credentials', 'authorization_code', 'refresh_token', 'unsupported']) {
+      const req = makeReq(grantType, { client_id: grantType, client_secret: grantType });
+      req.headers.set('x-forwarded-for', '198.51.100.1');
+      req.headers.set('cf-connecting-ip', '198.51.100.2');
+      assert.equal((await tokenHandler(req, deps)).status, 429);
+    }
+    assert.deepEqual(keys, Array(4).fill('ip:unknown'));
+    assert.deepEqual(redis.ops, []);
+  });
+});
+
 describe('oauth/token rate-limit degradation (#7270)', () => {
   const originalEnv = { ...process.env };
   const originalConsoleError = console.error;


### PR DESCRIPTION
## Summary

An unauthenticated caller could avoid token throttling by changing `client_secret` or `client_id` on each request. All token grants now share a trusted-IP budget of 10 requests per minute before grant processing, so rotating credentials, identifiers, or grant types cannot select a fresh bucket. Requests without a trusted IP share the existing `unknown` fallback.

The existing limiter outage behavior and sanitized telemetry are preserved. Clients behind one IP now share this budget instead of receiving separate credential/client buckets.

## Validation

- Four new regression cases failed before implementation: all three grants bypassed the limit, and changing grants selected different attacker-controlled keys.
- All 57 token tests pass. New tests exercise the real handler, trusted-IP helper, and Upstash limiter against a fake Redis HTTP transport; request 11 returns 429 before grant storage operations, while a different IP retains its own budget.
- Existing successful exchanges, refresh recovery, and limiter degradation/telemetry tests pass.
- API typecheck, focused Biome lint, and `git diff --check` pass. Inline diff review completed; no separate review agents were used. Live Redis and deployed edge behavior were not tested.

## Post-Deploy Monitoring & Validation

Owner: deploying maintainer. During the first 30 minutes after deployment, inspect `/oauth/token` request logs, `rate_limit_429`, `rate_limit_degraded`, and token success/5xx rates. Expect excess requests from one trusted IP to receive 429 while normal grant exchanges succeed. Investigate sustained legitimate-client 429s behind shared IPs or increased handshake failures; revert this PR if normal token exchange is blocked.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
