### PR TITLE
fix: prevent active content in RSS proxy responses

### DIFF
--- a/api/og-story.test.mjs
+++ b/api/og-story.test.mjs
@@ -46,3 +46,21 @@ test('uses a known level when it is allowlisted', () => {
   assert.match(response.body, /#ef4444/);
 });
 
+test('escapes hostile country text in both SVG text fields', () => {
+  const country = '</text><script>alert("x")</script><text>&';
+  const response = renderOgStory(new URLSearchParams({ c: country, s: '50', t: country }).toString());
+  const escaped = '&lt;/TEXT&gt;&lt;SCRIPT&gt;ALERT(&quot;X&quot;)&lt;/SCRIPT&gt;&lt;TEXT&gt;&amp;';
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.split(escaped).length - 1, 2);
+  assert.doesNotMatch(response.body, /<script/i);
+});
+
+test('retains known country names and finite score geometry for hostile inputs', () => {
+  for (const score of ['<script/>', '9'.repeat(400), '-50', '150']) {
+    const response = renderOgStory(new URLSearchParams({ c: 'us', s: score, l: '__proto__' }).toString());
+    assert.match(response.body, />UNITED STATES<\/text>/);
+    assert.match(response.body, />US<\/text>/);
+    assert.doesNotMatch(response.body, /NaN|Infinity|<script/i);
+    assert.equal(response.headers['content-type'], 'image/svg+xml');
+  }
+});

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -233,7 +233,11 @@ export default async function handler(req, ctx) {
     return new Response(data, {
       status: response.status,
       headers: {
-        'Content-Type': response.headers.get('content-type') || 'application/xml',
+        // Consumers parse response.text() as feed XML. Never let an upstream
+        // MIME type or active XML turn this same-origin URL into a document.
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+        'Content-Security-Policy': "sandbox; default-src 'none'",
         // validateApiKey() gates every GET. Shared caches do not key on the
         // credential header, so this must not be public / s-maxage / CDN-cached.
         // `private` keeps CDNs out; max-age lets the SPA feedCache persist.

--- a/api/rss-proxy.test.mjs
+++ b/api/rss-proxy.test.mjs
@@ -158,7 +158,7 @@ test('allows legitimate apex to www RSS canonical redirects', async () => {
   const res = await handler(makeRequest('https://techcrunch.com/feed'));
 
   assert.equal(res.status, 200);
-  assert.equal(res.headers.get('content-type'), 'application/rss+xml');
+  assert.equal(res.headers.get('content-type'), 'text/plain; charset=utf-8');
   assert.match(await res.text(), /<rss>/);
   assert.deepEqual(calls.map((call) => call.url), [
     'https://techcrunch.com/feed',
@@ -732,7 +732,7 @@ test('retries through the relay when the direct fetch returns a non-2xx status',
   ]);
 });
 
-test('falls back to application/xml when upstream sends no content-type', async () => {
+test('uses inert text when upstream sends no content-type', async () => {
   const calls = spyFetch(() => {
     const res = new Response('<rss><channel/></rss>', { status: 200 });
     res.headers.delete('content-type');
@@ -742,7 +742,7 @@ test('falls back to application/xml when upstream sends no content-type', async 
   const res = await handler(makeRequest('https://techcrunch.com/feed'));
 
   assert.equal(res.status, 200);
-  assert.equal(res.headers.get('Content-Type'), 'application/xml');
+  assert.equal(res.headers.get('Content-Type'), 'text/plain; charset=utf-8');
   assert.equal(calls.length, 1);
 });
 
@@ -924,4 +924,40 @@ test('does not treat an upstream CBC 403 as a cacheable success (#6624)', async 
   assert.equal(res.headers.get('cache-control'), 'private, max-age=180');
   assert.equal(res.headers.get('cdn-cache-control'), null);
   assert.equal(calls[0].headers['User-Agent'], RSS_BROWSER_UA);
+});
+
+for (const relay of [false, true]) {
+  for (const mime of ['text/html', 'application/xhtml+xml', 'image/svg+xml', 'application/xml', 'application/rss+xml']) {
+    test(`serves hostile ${mime} as inert text through ${relay ? 'relay' : 'direct'} fetch`, async () => {
+      if (relay) process.env.WS_RELAY_URL = 'wss://relay.example.com';
+      const body = '<?xml-stylesheet href="https://attacker.invalid/style.xsl"?><html xmlns="http://www.w3.org/1999/xhtml"><script>alert(1)</script></html>';
+      const calls = spyFetch(() => new Response(body, { headers: {
+        'Content-Type': mime,
+        'X-Cache': 'STALE',
+        'X-Relay-Stale': '1',
+      } }));
+      const response = await handler(makeRequest(relay ? 'https://www.cisa.gov/feed' : 'https://techcrunch.com/feed'));
+      assert.equal(response.status, 200);
+      assert.equal(await response.text(), body);
+      assert.equal(response.headers.get('Content-Type'), 'text/plain; charset=utf-8');
+      assert.equal(response.headers.get('X-Content-Type-Options'), 'nosniff');
+      assert.equal(response.headers.get('Content-Security-Policy'), "sandbox; default-src 'none'");
+      assert.equal(response.headers.get('Cache-Control'), 'private, max-age=180');
+      assert.equal(response.headers.get('X-Relay-Stale'), relay ? '1' : null);
+      assert.equal(response.headers.get('X-Cache'), relay ? 'STALE' : null);
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].url.includes('relay.example.com'), relay);
+    });
+  }
+}
+
+test('keeps upstream HTML errors inert while preserving their status', async () => {
+  const body = '<html><script>alert(1)</script></html>';
+  spyFetch(() => new Response(body, { status: 403, headers: { 'Content-Type': 'text/html' } }));
+  const response = await handler(makeRequest('https://techcrunch.com/feed'));
+  assert.equal(response.status, 403);
+  assert.equal(await response.text(), body);
+  assert.equal(response.headers.get('Content-Type'), 'text/plain; charset=utf-8');
+  assert.equal(response.headers.get('X-Content-Type-Options'), 'nosniff');
+  assert.equal(response.headers.get('Content-Security-Policy'), "sandbox; default-src 'none'");
 });

--- a/api/rss-proxy.test.mjs
+++ b/api/rss-proxy.test.mjs
@@ -946,7 +946,7 @@ for (const relay of [false, true]) {
       assert.equal(response.headers.get('X-Relay-Stale'), relay ? '1' : null);
       assert.equal(response.headers.get('X-Cache'), relay ? 'STALE' : null);
       assert.equal(calls.length, 1);
-      assert.equal(calls[0].url.includes('relay.example.com'), relay);
+      assert.equal(new URL(calls[0].url).hostname, relay ? 'relay.example.com' : 'techcrunch.com');
     });
   }
 }


### PR DESCRIPTION
## Summary

An allowlisted upstream could make `/api/rss-proxy` return HTML, XHTML, or SVG with an executable MIME type on our origin. Return all upstream bodies as UTF-8 plain text with `nosniff` and a sandbox CSP. Preserve body text, upstream status, private caching, CORS, and relay stale markers. The dashboard already reads `response.text()` before parsing feed XML.

The reported `/api/og-story` country injection is already prevented on current main: both country text fields use XML escaping. Regression tests now cover hostile country/type values, unsupported levels, and non-finite score input. No SVG source or visual layout change is needed.

## Validation

- Trusted repair preflight passed on Node 24; branch based on refreshed main.
- New RSS assertions reproduced upstream MIME reflection before the fix; OG hostile-query assertions passed unchanged.
- 58 focused endpoint tests passed using synthetic inputs and mocked fetches, including direct/relay active MIME types, stale headers, missing MIME, legitimate RSS, and HTML error bodies.
- API typecheck and Convex call audit passed; sidecar suite passed 486 tests after granting local listener access (initial sandbox run failed with EPERM). The final added HTML-error test passed in the focused run.
- Manual scoped security and simplicity review and `git diff --check` passed. Dedicated agent review was skipped because this task explicitly prohibits subagents.
- No live exploitation, production mutation, deployment, or browser execution test was performed. External consumers that require an XML MIME type will now receive plain text; feed body parsing remains their responsibility.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the maintainer should inspect `/api/rss-proxy` response headers and normal feed loading for 15 minutes. Watch RSS proxy errors and feed parse failures. Expected: inert response headers, unchanged private caching, and normal feed updates. A sustained feed-loading regression is the rollback trigger. Deployment and production acceptance remain unverified.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
