### PR TITLE
fix: bound proxy credentials and public endpoint resource use

### DIFF
--- a/api/ask.ts
+++ b/api/ask.ts
@@ -12,6 +12,8 @@
 // Accept: text/event-stream) emits SSE with the NLWeb event types
 // start → result (one per item) → complete.
 
+import { readBoundedRequestBody, RequestBodyTooLargeError } from './mcp/bounded-body';
+
 import { suggestTools } from './_agent-tool-suggest';
 import { ENDPOINT_RATE_POLICIES, checkScopedRateLimit, getClientIp } from '../server/_shared/rate-limit';
 
@@ -35,6 +37,7 @@ const SITE = 'worldmonitor.app';
 const TOOLS_DOC_URL = 'https://www.worldmonitor.app/docs/mcp-tools-reference';
 const MCP_ENDPOINT = 'https://worldmonitor.app/mcp';
 const MAX_QUERY_CHARS = 2048;
+const MAX_BODY_BYTES = 16 * 1024;
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -116,12 +119,14 @@ async function extractParams(req: Request): Promise<AskParams | null> {
   if (req.method === 'POST') {
     const contentType = req.headers.get('content-type') ?? '';
     try {
+      const text = new TextDecoder().decode(await readBoundedRequestBody(req, MAX_BODY_BYTES));
       if (contentType.includes('application/x-www-form-urlencoded')) {
-        body = Object.fromEntries(new URLSearchParams(await req.text()));
+        body = Object.fromEntries(new URLSearchParams(text));
       } else {
-        body = (await req.json()) as Record<string, unknown>;
+        body = JSON.parse(text) as Record<string, unknown>;
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof RequestBodyTooLargeError) throw error;
       return null; // malformed body
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) return null;
@@ -207,7 +212,16 @@ export default async function handler(req: Request): Promise<Response> {
     );
   }
 
-  const params = await extractParams(req);
+  let params: AskParams | null;
+  try {
+    params = await extractParams(req);
+  } catch (error) {
+    if (!(error instanceof RequestBodyTooLargeError)) throw error;
+    return new Response(
+      JSON.stringify({ _meta: buildMeta('error'), error: 'Request body too large' }),
+      { status: 413, headers: JSON_HEADERS },
+    );
+  }
   if (params === null) {
     return new Response(
       JSON.stringify({ _meta: buildMeta('error'), error: 'Request body must be valid JSON (or form-encoded).' }),

--- a/api/customer-portal.ts
+++ b/api/customer-portal.ts
@@ -16,6 +16,7 @@ import {
   beginStandaloneIdempotency,
   completeStandaloneIdempotency,
   getIdempotencyKey,
+  peekStandaloneIdempotency,
 } from './_idempotency.js';
 // @ts-expect-error — JS module, no declaration file
 import { checkRateLimit } from './_rate-limit.js';
@@ -67,21 +68,27 @@ export default async function handler(
     return json({ error: 'Unauthorized' }, 401, cors);
   }
 
+  const idempotencyKey = getIdempotencyKey(req);
+  const idempotencyOptions = idempotencyKey ? {
+    request: req,
+    pathname: '/api/customer-portal',
+    scope: `user:${session.userId}`,
+    idempotencyKey,
+    corsHeaders: cors,
+  } : null;
+  if (idempotencyOptions) {
+    const existing = await peekStandaloneIdempotency(idempotencyOptions);
+    if (existing.kind !== 'miss' && existing.kind !== 'disabled') return existing.response;
+  }
+
   const limited = await checkRateLimit(req, cors, {
     scope: 'customer-portal', identifier: session.userId, limit: 5, window: '60 s',
     failClosed: true, ctx,
   });
   if (limited) return limited;
 
-  const idempotencyKey = getIdempotencyKey(req);
-  const idempotency = idempotencyKey
-    ? await beginStandaloneIdempotency({
-      request: req,
-      pathname: '/api/customer-portal',
-      scope: `user:${session.userId}`,
-      idempotencyKey,
-      corsHeaders: cors,
-    })
+  const idempotency = idempotencyOptions
+    ? await beginStandaloneIdempotency(idempotencyOptions)
     : null;
   if (
     idempotency &&

--- a/api/customer-portal.ts
+++ b/api/customer-portal.ts
@@ -17,6 +17,8 @@ import {
   completeStandaloneIdempotency,
   getIdempotencyKey,
 } from './_idempotency.js';
+// @ts-expect-error — JS module, no declaration file
+import { checkRateLimit } from './_rate-limit.js';
 import { validateBearerToken } from '../server/auth-session';
 
 const CONVEX_SITE_URL =
@@ -64,6 +66,12 @@ export default async function handler(
   if (!session.valid || !session.userId) {
     return json({ error: 'Unauthorized' }, 401, cors);
   }
+
+  const limited = await checkRateLimit(req, cors, {
+    scope: 'customer-portal', identifier: session.userId, limit: 5, window: '60 s',
+    failClosed: true, ctx,
+  });
+  if (limited) return limited;
 
   const idempotencyKey = getIdempotencyKey(req);
   const idempotency = idempotencyKey

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -328,7 +328,7 @@ async function defaultResolveHostname(hostname) {
 async function assertServerUrlSafe(url) {
   const hostname = url.hostname.toLowerCase();
   if (BLOCKED_HOSTNAMES.has(hostname)) {
-    throw new McpProxySsrfError(`serverUrl hostname is blocked: ${hostname}`);
+    throw new McpProxySsrfError('serverUrl hostname is blocked');
   }
   if (isBlockedResolvedAddress(hostname)) {
     throwBlockedAddress(hostname);
@@ -501,14 +501,14 @@ async function mcpListTools(serverUrl, customHeaders) {
   if (!initResp.ok) throw new McpProxyUpstreamError(`Initialize failed: HTTP ${initResp.status}`);
   const sessionId = initResp.headers.get('Mcp-Session-Id') || initResp.headers.get('mcp-session-id');
   const initData = await parseJsonRpcResponse(initResp);
-  if (initData.error) throw new McpProxyUpstreamError(`Initialize error: ${initData.error.message}`);
+  if (initData.error) throw new McpProxyUpstreamError('Initialize error: MCP server rejected request');
   await sendInitialized(serverUrl, headers, sessionId);
   const listResp = await postJson(serverUrl, {
     jsonrpc: '2.0', id: 2, method: 'tools/list', params: {},
   }, headers, sessionId);
   if (!listResp.ok) throw new McpProxyUpstreamError(`tools/list failed: HTTP ${listResp.status}`);
   const listData = await parseJsonRpcResponse(listResp);
-  if (listData.error) throw new McpProxyUpstreamError(`tools/list error: ${listData.error.message}`);
+  if (listData.error) throw new McpProxyUpstreamError('tools/list error: MCP server rejected request');
   return listData.result?.tools || [];
 }
 
@@ -518,7 +518,7 @@ async function mcpCallTool(serverUrl, toolName, toolArgs, customHeaders) {
   if (!initResp.ok) throw new McpProxyUpstreamError(`Initialize failed: HTTP ${initResp.status}`);
   const sessionId = initResp.headers.get('Mcp-Session-Id') || initResp.headers.get('mcp-session-id');
   const initData = await parseJsonRpcResponse(initResp);
-  if (initData.error) throw new McpProxyUpstreamError(`Initialize error: ${initData.error.message}`);
+  if (initData.error) throw new McpProxyUpstreamError('Initialize error: MCP server rejected request');
   await sendInitialized(serverUrl, headers, sessionId);
   const callResp = await postJson(serverUrl, {
     jsonrpc: '2.0', id: 3, method: 'tools/call',
@@ -526,7 +526,7 @@ async function mcpCallTool(serverUrl, toolName, toolArgs, customHeaders) {
   }, headers, sessionId);
   if (!callResp.ok) throw new McpProxyUpstreamError(`tools/call failed: HTTP ${callResp.status}`);
   const callData = await parseJsonRpcResponse(callResp);
-  if (callData.error) throw new McpProxyUpstreamError(`tools/call error: ${callData.error.message}`);
+  if (callData.error) throw new McpProxyUpstreamError('tools/call error: MCP server rejected request');
   return callData.result;
 }
 
@@ -722,10 +722,10 @@ async function mcpListToolsSse(serverUrl, customHeaders) {
       capabilities: {},
       clientInfo: { name: 'worldmonitor', version: '1.0' },
     });
-    if (initResp.error) throw new McpProxyUpstreamError(`Initialize error: ${initResp.error.message}`);
+    if (initResp.error) throw new McpProxyUpstreamError('Initialize error: MCP server rejected request');
     await session.notify('notifications/initialized', {});
     const listResp = await session.send(2, 'tools/list', {});
-    if (listResp.error) throw new McpProxyUpstreamError(`tools/list error: ${listResp.error.message}`);
+    if (listResp.error) throw new McpProxyUpstreamError('tools/list error: MCP server rejected request');
     return listResp.result?.tools || [];
   } finally {
     session.close();
@@ -742,10 +742,10 @@ async function mcpCallToolSse(serverUrl, toolName, toolArgs, customHeaders) {
       capabilities: {},
       clientInfo: { name: 'worldmonitor', version: '1.0' },
     });
-    if (initResp.error) throw new McpProxyUpstreamError(`Initialize error: ${initResp.error.message}`);
+    if (initResp.error) throw new McpProxyUpstreamError('Initialize error: MCP server rejected request');
     await session.notify('notifications/initialized', {});
     const callResp = await session.send(2, 'tools/call', { name: toolName, arguments: toolArgs || {} });
-    if (callResp.error) throw new McpProxyUpstreamError(`tools/call error: ${callResp.error.message}`);
+    if (callResp.error) throw new McpProxyUpstreamError('tools/call error: MCP server rejected request');
     return callResp.result;
   } finally {
     session.close();
@@ -771,14 +771,13 @@ function captureMeta(serverUrl: URL, customHeaders: unknown, meta: ProxyMeta): v
 async function handleListTools(req: Request, cors: Record<string, string>, meta: ProxyMeta): Promise<Response> {
   const url = new URL(req.url);
   const rawServer = url.searchParams.get('serverUrl');
-  const rawHeaders = url.searchParams.get('headers');
+  if (url.searchParams.has('headers')) {
+    return jsonResponse({ error: 'Use POST tools/list with customHeaders in the JSON body' }, 400, cors);
+  }
   if (!rawServer) return jsonResponse({ error: 'Missing serverUrl' }, 400, cors);
   const serverUrl = await validateServerUrl(rawServer);
   if (!serverUrl) return jsonResponse({ error: 'Invalid serverUrl' }, 400, cors);
-  let customHeaders = {};
-  if (rawHeaders) {
-    try { customHeaders = JSON.parse(rawHeaders); } catch { /* ignore */ }
-  }
+  const customHeaders = {};
   captureMeta(serverUrl, customHeaders, meta);
   const tools = isSseTransport(serverUrl)
     ? await mcpListToolsSse(serverUrl, customHeaders)
@@ -800,12 +799,19 @@ async function handleCallTool(req: Request, cors: Record<string, string>, meta: 
     }
     return jsonResponse({ error: 'Invalid JSON' }, 400, cors);
   }
-  const { serverUrl: rawServer, toolName, toolArgs, customHeaders } = body;
+  const { serverUrl: rawServer, toolName, toolArgs, customHeaders, action } = body;
   if (!rawServer) return jsonResponse({ error: 'Missing serverUrl' }, 400, cors);
-  if (!toolName) return jsonResponse({ error: 'Missing toolName' }, 400, cors);
+  if (action !== undefined && action !== 'tools/list') return jsonResponse({ error: 'Invalid action' }, 400, cors);
+  if (action !== 'tools/list' && !toolName) return jsonResponse({ error: 'Missing toolName' }, 400, cors);
   const serverUrl = await validateServerUrl(rawServer);
   if (!serverUrl) return jsonResponse({ error: 'Invalid serverUrl' }, 400, cors);
   captureMeta(serverUrl, customHeaders, meta);
+  if (action === 'tools/list') {
+    const tools = isSseTransport(serverUrl)
+      ? await mcpListToolsSse(serverUrl, customHeaders || {})
+      : await mcpListTools(serverUrl, customHeaders || {});
+    return jsonResponse({ tools }, 200, cors);
+  }
   const result = isSseTransport(serverUrl)
     ? await mcpCallToolSse(serverUrl, toolName, toolArgs || {}, customHeaders || {})
     : await mcpCallTool(serverUrl, toolName, toolArgs || {}, customHeaders || {});
@@ -923,7 +929,7 @@ export default async function handler(req, ctx) {
     //
     // targetHost is caller-supplied, so it rides in `extra`, never a tag —
     // an attacker-controlled tag value would shred Sentry's tag cardinality.
-    captureSilentError(err, {
+    captureSilentError(new Error(failure.isTimeout ? 'MCP server timed out' : msg), {
       tags: { route: 'api/mcp-proxy', step: 'proxy-dispatch' },
       extra: { target_host: meta.targetHost, target_path: meta.targetPath, method: req.method },
       level: failure.level,

--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -5,11 +5,8 @@
  *
  * Thin Finnhub-search wrapper with a short Upstash cache. Used by every user
  * (the market watchlist is not a PRO feature), so there's no entitlement
- * gate — just CORS + rate limiting + a 10-minute cache on the normalized
- * query. The cache is the real quota guard: Finnhub's free-tier 60/min is
- * per-key (shared across all users), not per-user, so client-side debounce
- * alone wouldn't protect it. The cache is best-effort — any Upstash hiccup
- * falls through to a direct Finnhub call.
+ * gate. Cached results remain available without upstream work; cold queries
+ * require a shared, fail-closed provider budget as well as caller admission.
  */
 
 export const config = { runtime: 'edge' };
@@ -221,6 +218,14 @@ export default async function handler(
   } catch {
     // Cache infrastructure is best-effort; fall through to the real upstream.
   }
+
+  // One distributed admission bucket for every cold query and caller.
+  // Keep half of the 60/min provider allowance for other Finnhub consumers.
+  const quotaResponse = await checkRateLimit(req, cors, {
+    scope: 'symbol-search:finnhub', identifier: 'shared', limit: 30, window: '60 s',
+    failClosed: true, ctx,
+  });
+  if (quotaResponse) return quotaResponse;
 
   try {
     const url = `https://finnhub.io/api/v1/search?q=${encodeURIComponent(q)}&token=${encodeURIComponent(apiKey)}`;

--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -64,6 +64,8 @@ Beyond static discovery documents, several live endpoints exist specifically for
 
 ### `GET|POST /ask` — natural-language routing (NLWeb)
 
+POST bodies are limited to 16 KiB before JSON or form parsing. Oversized bodies return 413, including streamed bodies and bodies with an understated `Content-Length`.
+
 An [NLWeb](https://github.com/microsoft/NLWeb)-style front door: send a question, get back the MCP tools that answer it. Accepts `query` (max 2048 chars) as JSON body, form body, or `?query=`; optional `mode` (default `"list"`), `query_id`, and `streaming` (also triggered by `Accept: text/event-stream`).
 
 ```bash

--- a/docs/api-proxies.mdx
+++ b/docs/api-proxies.mdx
@@ -51,3 +51,12 @@ Scrapes the FwdStart newsletter archive and republishes it as an RSS 2.0 XML fee
 ### `GET|POST /api/mcp-proxy`
 
 Pro-gated outbound MCP proxy: forwards MCP traffic to a caller-supplied third-party MCP server with SSRF protection (private/link-local targets are refused) and its own 30 requests/minute/IP limit. It does **not** forward to WorldMonitor's own [`/api/mcp`](/mcp-overview) — call that directly.
+
+
+Use `GET ?serverUrl=...` for tool discovery without custom headers. Query-string `headers` are rejected with 400. For authenticated upstream discovery, send a JSON POST body:
+
+```json
+{ "action": "tools/list", "serverUrl": "https://mcp.example.com/mcp", "customHeaders": { "Authorization": "Bearer YOUR_UPSTREAM_KEY" } }
+```
+
+The response remains `{ "tools": [...] }`. Existing POST tool calls with `serverUrl`, `toolName`, `toolArgs`, and optional `customHeaders` remain supported. Proxy errors use bounded messages owned by WorldMonitor; raw upstream error text is not returned.

--- a/docs/usage-rate-limits.mdx
+++ b/docs/usage-rate-limits.mdx
@@ -126,7 +126,7 @@ Uncached `/api/symbol-search` requests also require admission to one shared 30 r
 
 | Endpoint | Limit | Window | Scope |
 |----------|-------|--------|-------|
-| `POST /api/customer-portal` | 5 | 60 s | Per authenticated user; fail-closed |
+| `POST /api/customer-portal` | 5 | 60 s | Per authenticated user; completed idempotent replays excluded; fail-closed |
 | `POST /api/scenario/v1/run-scenario` | 10 | 60 s | Per IP |
 | `POST /api/scenario/v1/run-scenario` (queue depth) | 100 in-flight | — | Global |
 | `POST /api/leads/v1/register-interest` | 5 | 60 min | Per IP + Turnstile (desktop sources require signed HMAC bypass) |

--- a/docs/usage-rate-limits.mdx
+++ b/docs/usage-rate-limits.mdx
@@ -120,16 +120,19 @@ Routes that fetch a third-party host on our behalf carry their own per-IP budget
 
 The two edge handlers (`/api/skills/fetch-agentskills`, `/api/youtube/live`) enforce their budgets in-handler via `checkScopedRateLimit`/`checkRateLimit`; `/api/reverse-geocode` mirrors its per-IP budget as a literal constant per `api/*.js` constraints. `/api/infrastructure/v1/reverse-geocode` is a gateway RPC, so the gateway enforces its per-IP budget through `checkEndpointRateLimit` (fail-closed on Redis outage). After a shared-cache miss, both reverse-geocode handlers also use one fail-closed provider-wide Redis bucket capped at 1 request per second before they call Nominatim; cache hits do not consume that aggregate budget.
 
+Uncached `/api/symbol-search` requests also require admission to one shared 30 requests/minute Finnhub bucket, independent of query and caller. Cached results do not spend this budget. Exhaustion returns 429 with `Retry-After`; unavailable admission storage returns 503 before Finnhub is called.
+
 ## Write endpoints
 
 | Endpoint | Limit | Window | Scope |
 |----------|-------|--------|-------|
+| `POST /api/customer-portal` | 5 | 60 s | Per authenticated user; fail-closed |
 | `POST /api/scenario/v1/run-scenario` | 10 | 60 s | Per IP |
 | `POST /api/scenario/v1/run-scenario` (queue depth) | 100 in-flight | — | Global |
 | `POST /api/leads/v1/register-interest` | 5 | 60 min | Per IP + Turnstile (desktop sources require signed HMAC bypass) |
 | `POST /api/leads/v1/submit-contact` | 3 | 60 min | Per IP + Turnstile |
 
-Other write endpoints (`/api/brief/share-url`, `/api/notification-channels`, `/api/create-checkout`, `/api/customer-portal`, etc.) fall back to the default per-IP limit above.
+Other write endpoints (`/api/brief/share-url`, `/api/notification-channels`, `/api/create-checkout`, etc.) fall back to the default per-IP limit above.
 
 ## Bootstrap / health / version
 

--- a/src/components/McpConnectModal.ts
+++ b/src/components/McpConnectModal.ts
@@ -404,13 +404,14 @@ export function openMcpConnectModal(options: McpConnectOptions): void {
     connectBtn.disabled = true;
     try {
       const headers = getEffectiveHeaders();
-      const qs = new URLSearchParams({ serverUrl });
-      if (Object.keys(headers).length) qs.set('headers', JSON.stringify(headers));
       // premiumFetch attaches the Clerk Pro Bearer for normal web Pro
       // users. /api/mcp-proxy is in PREMIUM_RPC_PATHS so the path gate
       // fires; the server-side isCallerPremium check accepts Bearer,
       // wm_ user keys, and enterprise keys (PR #3768).
-      const resp = await premiumFetch(`${proxyUrl('/api/mcp-proxy')}?${qs}`, {
+      const resp = await premiumFetch(proxyUrl('/api/mcp-proxy'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'tools/list', serverUrl, customHeaders: headers }),
         signal: AbortSignal.timeout(20_000),
       });
       const data = await resp.json() as { tools?: McpToolDef[]; error?: string };

--- a/tests/customer-portal-limits.test.mts
+++ b/tests/customer-portal-limits.test.mts
@@ -18,8 +18,8 @@ it('limits portal sessions per authenticated user before the relay, across token
   const buckets = new Map<string, number>();
   globalThis.fetch = async (input, init) => {
     const url = String(input);
-    if (url.startsWith('https://clerk.portal.test')) return Response.json({ keys: [jwk] });
-    if (url.startsWith('https://portal-redis.test')) {
+    if (new URL(url).origin === 'https://clerk.portal.test') return Response.json({ keys: [jwk] });
+    if (new URL(url).origin === 'https://portal-redis.test') {
       const commands = JSON.parse(String(init?.body));
       return Response.json(commands.map((command: unknown[]) => {
         const key = String(command[3]);
@@ -45,7 +45,7 @@ it('limits portal sessions per authenticated user before the relay, across token
   assert.equal(relayCalls, 5);
   const healthyFetch = globalThis.fetch;
   globalThis.fetch = async (input, init) => {
-    if (String(input).startsWith('https://portal-redis.test')) throw new Error('Redis unavailable');
+    if (new URL(String(input)).origin === 'https://portal-redis.test') throw new Error('Redis unavailable');
     return healthyFetch(input, init);
   };
   const token = await new SignJWT({ sub: 'other_user', plan: 'pro' })

--- a/tests/customer-portal-limits.test.mts
+++ b/tests/customer-portal-limits.test.mts
@@ -16,12 +16,22 @@ it('limits portal sessions per authenticated user before the relay, across token
   const jwk = { ...await exportJWK(publicKey), kid: 'portal-test', alg: 'RS256' };
   let relayCalls = 0;
   const buckets = new Map<string, number>();
+  const stored = new Map<string, string>();
+  let replayToken = '';
   globalThis.fetch = async (input, init) => {
     const url = String(input);
     if (new URL(url).origin === 'https://clerk.portal.test') return Response.json({ keys: [jwk] });
     if (new URL(url).origin === 'https://portal-redis.test') {
       const commands = JSON.parse(String(init?.body));
       return Response.json(commands.map((command: unknown[]) => {
+        const operation = String(command[0]).toUpperCase();
+        const storageKey = String(command[1]);
+        if (operation === 'GET') return { result: stored.get(storageKey) ?? null };
+        if (operation === 'SET') {
+          if (command.includes('NX') && stored.has(storageKey)) return { result: null };
+          stored.set(storageKey, String(command[2]));
+          return { result: 'OK' };
+        }
         const key = String(command[3]);
         const count = (buckets.get(key) ?? 0) + 1;
         buckets.set(key, count);
@@ -36,16 +46,30 @@ it('limits portal sessions per authenticated user before the relay, across token
     const token = await new SignJWT({ sub: 'user_portal', plan: 'pro', jti: String(i) })
       .setProtectedHeader({ alg: 'RS256', kid: 'portal-test' })
       .setIssuer('https://clerk.portal.test').setIssuedAt().setExpirationTime('5m').sign(privateKey);
+    replayToken = token;
     const res = await handler(new Request('https://worldmonitor.app/api/customer-portal', {
-      method: 'POST', headers: { Authorization: `Bearer ${token}`, 'x-real-ip': `192.0.2.${i + 1}` },
+      method: 'POST', headers: { Authorization: `Bearer ${token}`, 'x-real-ip': `192.0.2.${i + 1}`, ...(i === 0 ? { 'Idempotency-Key': 'completed-portal' } : {}) },
     }));
     assert.equal(res.status, i < 5 ? 200 : 429);
     if (i >= 5) assert.ok(res.headers.get('Retry-After'));
   }
   assert.equal(relayCalls, 5);
+  const replayRequest = () => new Request('https://worldmonitor.app/api/customer-portal', {
+    method: 'POST', headers: { Authorization: `Bearer ${replayToken}`, 'Idempotency-Key': 'completed-portal' },
+  });
+  const replay = await handler(replayRequest());
+  assert.equal(replay.status, 200);
+  assert.equal(replay.headers.get('Idempotent-Replayed'), 'true');
+  assert.deepEqual(await replay.json(), { url: 'https://billing.test/session' });
+  assert.equal(relayCalls, 5);
+  const missedReplay = await handler(new Request('https://worldmonitor.app/api/customer-portal', {
+    method: 'POST', headers: { Authorization: `Bearer ${replayToken}`, 'Idempotency-Key': 'new-portal' },
+  }));
+  assert.equal(missedReplay.status, 429);
+  assert.equal(stored.size, 1, 'rejected misses must not create idempotency reservations');
   const healthyFetch = globalThis.fetch;
   globalThis.fetch = async (input, init) => {
-    if (new URL(String(input)).origin === 'https://portal-redis.test') throw new Error('Redis unavailable');
+    if (new URL(String(input)).origin === 'https://portal-redis.test' && /eval/i.test(String(init?.body))) throw new Error('Redis unavailable');
     return healthyFetch(input, init);
   };
   const token = await new SignJWT({ sub: 'other_user', plan: 'pro' })
@@ -54,6 +78,9 @@ it('limits portal sessions per authenticated user before the relay, across token
   const unavailable = await handler(new Request('https://worldmonitor.app/api/customer-portal', {
     method: 'POST', headers: { Authorization: `Bearer ${token}` },
   }));
+  const replayDuringLimiterOutage = await handler(replayRequest());
+  assert.equal(replayDuringLimiterOutage.status, 200);
+  assert.equal(replayDuringLimiterOutage.headers.get('Idempotent-Replayed'), 'true');
   // The limiter caches its configured client; an unavailable Redis still fails closed.
   assert.equal(relayCalls, 5);
   assert.ok([429, 503].includes(unavailable.status));

--- a/tests/customer-portal-limits.test.mts
+++ b/tests/customer-portal-limits.test.mts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { after, it } from 'node:test';
+import { generateKeyPair, exportJWK, SignJWT } from 'jose';
+
+process.env.CLERK_JWT_ISSUER_DOMAIN = 'https://clerk.portal.test';
+process.env.CONVEX_SITE_URL = 'https://portal.convex.site';
+process.env.RELAY_SHARED_SECRET = 'synthetic-relay-secret';
+process.env.UPSTASH_REDIS_REST_URL = 'https://portal-redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'synthetic-redis-token';
+const { default: handler } = await import('../api/customer-portal.ts');
+const originalFetch = globalThis.fetch;
+after(() => { globalThis.fetch = originalFetch; });
+
+it('limits portal sessions per authenticated user before the relay, across tokens and IPs', async () => {
+  const { publicKey, privateKey } = await generateKeyPair('RS256');
+  const jwk = { ...await exportJWK(publicKey), kid: 'portal-test', alg: 'RS256' };
+  let relayCalls = 0;
+  const buckets = new Map<string, number>();
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://clerk.portal.test')) return Response.json({ keys: [jwk] });
+    if (url.startsWith('https://portal-redis.test')) {
+      const commands = JSON.parse(String(init?.body));
+      return Response.json(commands.map((command: unknown[]) => {
+        const key = String(command[3]);
+        const count = (buckets.get(key) ?? 0) + 1;
+        buckets.set(key, count);
+        return { result: [5 - count, 5] };
+      }));
+    }
+    assert.equal(url, 'https://portal.convex.site/relay/customer-portal');
+    relayCalls++;
+    return Response.json({ url: 'https://billing.test/session' });
+  };
+  for (let i = 0; i < 7; i++) {
+    const token = await new SignJWT({ sub: 'user_portal', plan: 'pro', jti: String(i) })
+      .setProtectedHeader({ alg: 'RS256', kid: 'portal-test' })
+      .setIssuer('https://clerk.portal.test').setIssuedAt().setExpirationTime('5m').sign(privateKey);
+    const res = await handler(new Request('https://worldmonitor.app/api/customer-portal', {
+      method: 'POST', headers: { Authorization: `Bearer ${token}`, 'x-real-ip': `192.0.2.${i + 1}` },
+    }));
+    assert.equal(res.status, i < 5 ? 200 : 429);
+    if (i >= 5) assert.ok(res.headers.get('Retry-After'));
+  }
+  assert.equal(relayCalls, 5);
+  const healthyFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    if (String(input).startsWith('https://portal-redis.test')) throw new Error('Redis unavailable');
+    return healthyFetch(input, init);
+  };
+  const token = await new SignJWT({ sub: 'other_user', plan: 'pro' })
+    .setProtectedHeader({ alg: 'RS256', kid: 'portal-test' })
+    .setIssuer('https://clerk.portal.test').setIssuedAt().setExpirationTime('5m').sign(privateKey);
+  const unavailable = await handler(new Request('https://worldmonitor.app/api/customer-portal', {
+    method: 'POST', headers: { Authorization: `Bearer ${token}` },
+  }));
+  // The limiter caches its configured client; an unavailable Redis still fails closed.
+  assert.equal(relayCalls, 5);
+  assert.ok([429, 503].includes(unavailable.status));
+});

--- a/tests/helpers/symbol-search-budget.mts
+++ b/tests/helpers/symbol-search-budget.mts
@@ -1,0 +1,14 @@
+// Supply Redis admission for tests whose subject is Finnhub response handling.
+export function allowSymbolSearchBudget(upstream: typeof fetch): typeof fetch {
+  process.env.UPSTASH_REDIS_REST_URL ||= 'https://symbol-budget.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN ||= 'synthetic-token';
+  return async (input, init) => {
+    if (String(input).startsWith('https://symbol-budget.test')) {
+      const commands = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+      return Response.json(commands
+        ? commands.map(() => ({ result: [100, 600] }))
+        : { result: null });
+    }
+    return upstream(input, init);
+  };
+}

--- a/tests/helpers/symbol-search-budget.mts
+++ b/tests/helpers/symbol-search-budget.mts
@@ -3,7 +3,7 @@ export function allowSymbolSearchBudget(upstream: typeof fetch): typeof fetch {
   process.env.UPSTASH_REDIS_REST_URL ||= 'https://symbol-budget.test';
   process.env.UPSTASH_REDIS_REST_TOKEN ||= 'synthetic-token';
   return async (input, init) => {
-    if (String(input).startsWith('https://symbol-budget.test')) {
+    if (new URL(String(input)).origin === 'https://symbol-budget.test') {
       const commands = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
       return Response.json(commands
         ? commands.map(() => ({ result: [100, 600] }))

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -160,6 +160,27 @@ describe('api/mcp-proxy', () => {
     globalThis.fetch = originalFetch;
   });
 
+  it('rejects query credentials before resolving or calling an upstream', async () => {
+    let calls = 0;
+    setResolveHostnameForTest(async () => { calls++; return [PUBLIC_TEST_ADDRESS]; });
+    globalThis.fetch = async () => { calls++; throw new Error('unexpected fetch'); };
+    for (const headers of ['', JSON.stringify({ Authorization: 'Bearer synthetic-secret' })]) {
+      const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp', headers }));
+      assert.equal(res.status, 400);
+      assert.doesNotMatch(await res.text(), /synthetic-secret/);
+    }
+    assert.equal(calls, 0);
+  });
+
+  it('bounds and redacts upstream JSON-RPC error messages', async () => {
+    globalThis.fetch = async () => Response.json({ error: { message: 'synthetic-secret'.repeat(20000) } });
+    const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }));
+    assert.equal(res.status, 422);
+    const text = await res.text();
+    assert.ok(text.length < 200);
+    assert.doesNotMatch(text, /synthetic-secret/);
+  });
+
   // ── Auth gate (issue #3723) ───────────────────────────────────────────────
 
   for (const [name, makeResponse, expected] of [
@@ -316,15 +337,15 @@ describe('api/mcp-proxy', () => {
 
     it('drops Metadata-Flavor / X-aws-ec2-metadata-token but forwards legit headers', async () => {
       const captured = captureForwardedHeaders();
-      const res = await handler(makeGetRequest({
+      const res = await handler(makePostRequest({ action: 'tools/list',
         serverUrl: 'https://mcp.example.com/mcp',
-        headers: JSON.stringify({
+        customHeaders: {
           'Metadata-Flavor': 'Google',
           'metadata': 'true',
           'X-aws-ec2-metadata-token': 'stolen-token',
           'X-aws-ec2-metadata-token-ttl-seconds': '21600',
           'Authorization': 'Bearer legit-mcp-token',
-        }),
+        },
       }));
       assert.equal(res.status, 200);
       assert.ok(captured.headers, 'target fetch must have been called');
@@ -640,7 +661,7 @@ describe('api/mcp-proxy', () => {
       const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }));
       assert.equal(res.status, 422);
       const data = await res.json();
-      assert.match(data.error, /Method not found/i);
+      assert.match(data.error, /MCP server rejected request/i);
     });
 
     it('returns 504 on fetch timeout', async () => {
@@ -655,14 +676,14 @@ describe('api/mcp-proxy', () => {
       assert.match(data.error, /timed out/i);
     });
 
-    it('ignores invalid JSON in headers param', async () => {
+    it('rejects invalid JSON in the removed query-header channel', async () => {
       globalThis.fetch = makeMcpFetch({ tools: [] });
       const url = new URL('https://worldmonitor.app/api/mcp-proxy');
       url.searchParams.set('serverUrl', 'https://mcp.example.com/mcp');
       url.searchParams.set('headers', 'not json');
       const req = new Request(url.toString(), { method: 'GET', headers: { origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': ENTERPRISE_KEY } });
       const res = await handler(req);
-      assert.equal(res.status, 200);
+      assert.equal(res.status, 400);
     });
 
     it('passes custom headers to upstream', async () => {
@@ -671,9 +692,9 @@ describe('api/mcp-proxy', () => {
         capturedHeaders = Object.fromEntries(Object.entries(opts?.headers || {}));
         return makeMcpFetch({ tools: [] })(url, opts);
       };
-      const res = await handler(makeGetRequest({
+      const res = await handler(makePostRequest({ action: 'tools/list',
         serverUrl: 'https://mcp.example.com/mcp',
-        headers: JSON.stringify({ Authorization: 'Bearer test-key' }),
+        customHeaders: { Authorization: 'Bearer test-key' },
       }));
       assert.equal(res.status, 200);
       assert.equal(capturedHeaders['Authorization'], 'Bearer test-key');
@@ -685,9 +706,9 @@ describe('api/mcp-proxy', () => {
         capturedHeaders = Object.fromEntries(Object.entries(opts?.headers || {}));
         return makeMcpFetch({ tools: [] })(url, opts);
       };
-      const res = await handler(makeGetRequest({
+      const res = await handler(makePostRequest({ action: 'tools/list',
         serverUrl: 'https://mcp.example.com/mcp',
-        headers: JSON.stringify({ 'X-Evil\r\nInjected': 'bad' }),
+        customHeaders: { 'X-Evil\r\nInjected': 'bad' },
       }));
       assert.equal(res.status, 200);
       for (const k of Object.keys(capturedHeaders)) {
@@ -941,7 +962,7 @@ describe('api/mcp-proxy', () => {
       }));
       assert.equal(res.status, 422);
       const data = await res.json();
-      assert.match(data.error, /Unknown tool/i);
+      assert.match(data.error, /MCP server rejected request/i);
     });
 
     it('returns 504 on a native fetch TimeoutError during tool call', async () => {
@@ -1454,10 +1475,11 @@ describe('api/mcp-proxy', () => {
 
     it('audit log contains header NAMES but never header VALUES (no secret leakage)', async () => {
       globalThis.fetch = makeMcpFetch({ tools: [] });
-      const res = await handler(makeGetRequest(
+      const res = await handler(makePostRequest(
         {
+          action: 'tools/list',
           serverUrl: 'https://mcp.example.com/mcp',
-          headers: JSON.stringify({ Authorization: 'Bearer super-secret-token-XYZ', 'X-Api-Key': 'k_abc123' }),
+          customHeaders: { Authorization: 'Bearer super-secret-token-XYZ', 'X-Api-Key': 'k_abc123' },
         },
         'https://worldmonitor.app',
         { extra: { 'cf-connecting-ip': uniqueCallerIp() } },
@@ -1762,7 +1784,7 @@ describe('api/mcp-proxy — observability', () => {
     assert.ok(catchAt > 0, 'the top-level catch still classifies failures');
     const tail = src.slice(catchAt, src.indexOf('logProxyCall({', catchAt));
 
-    assert.match(tail, /captureSilentError\(err,/, 'a swallowed handler fault must not be silent');
+    assert.match(tail, /captureSilentError\(new Error\(/, 'a swallowed handler fault must not be silent');
     assert.match(tail, /step:\s*'proxy-dispatch'/);
     assert.match(
       tail,

--- a/tests/nlweb-ask.test.mjs
+++ b/tests/nlweb-ask.test.mjs
@@ -31,6 +31,27 @@ describe('nlweb: /ask endpoint', () => {
     );
   }
 
+  for (const contentType of ['application/json', 'application/x-www-form-urlencoded']) {
+    for (const length of [undefined, '1', '20000']) {
+      it(`rejects oversized ${contentType} streams with length ${length}`, async () => {
+        let cancelled = false;
+        const headers = { 'Content-Type': contentType };
+        if (length) headers['Content-Length'] = length;
+        const req = new Request('https://worldmonitor.app/ask', {
+          method: 'POST', headers, duplex: 'half',
+          body: new ReadableStream({
+            pull(controller) { controller.enqueue(new TextEncoder().encode('x'.repeat(17000))); },
+            cancel() { cancelled = true; },
+          }),
+        });
+        const res = await handler(req);
+        assert.equal(res.status, 413);
+        assert.equal((await res.json())._meta.response_type, 'error');
+        assert.equal(cancelled, true);
+      });
+    }
+  }
+
   it('POST {query} returns NLWeb JSON with the _meta envelope', async () => {
     const res = await post({ query: 'live shipping chokepoint status' });
     assert.equal(res.status, 200);

--- a/tests/symbol-search-quota.test.mts
+++ b/tests/symbol-search-quota.test.mts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { after, it } from 'node:test';
+import handler from '../api/symbol-search.ts';
+
+process.env.WORLDMONITOR_VALID_KEYS = 'synthetic-search-key';
+process.env.FINNHUB_API_KEY = 'synthetic-finnhub-key';
+const originalFetch = globalThis.fetch;
+after(() => { globalThis.fetch = originalFetch; });
+
+function request(query: string, ip = '192.0.2.1') {
+  return new Request(`https://worldmonitor.app/api/symbol-search?q=${query}`, {
+    headers: { 'X-WorldMonitor-Key': 'synthetic-search-key', 'x-real-ip': ip },
+  });
+}
+
+it('fails closed without distributed admission', async () => {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  let calls = 0;
+  globalThis.fetch = async () => { calls++; return Response.json({ result: [] }); };
+  assert.equal((await handler(request('missing-budget'))).status, 503);
+  assert.equal(calls, 0);
+});
+
+it('shares the cold-query budget across unique queries and callers, with cache hits still available', async () => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://quota-redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'synthetic-token';
+  let admitted = 0;
+  let providerCalls = 0;
+  const identifiers = new Set<string>();
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://quota-redis.test')) {
+      if (!init?.body) return Response.json({ result: url.includes('cached') ? JSON.stringify({ results: [] }) : null });
+      const commands = JSON.parse(String(init.body));
+      return Response.json(commands.map((command: unknown[]) => {
+        if (JSON.stringify(command).includes('rl:symbol-search:finnhub')) {
+          identifiers.add(String(command[3]));
+          return { result: [30 - ++admitted, 30] };
+        }
+        return { result: [500, 600] };
+      }));
+    }
+    assert.ok(url.startsWith('https://finnhub.io/'));
+    providerCalls++;
+    return Response.json({ result: [] });
+  };
+  const results = await Promise.all(Array.from({ length: 35 }, (_, i) => handler(request(`unique-${i}`, `192.0.2.${i + 1}`))));
+  assert.equal(results.filter(r => r.status === 200).length, 30);
+  assert.equal(results.filter(r => r.status === 429).length, 5);
+  assert.equal(providerCalls, 30);
+  assert.equal(identifiers.size, 1, 'all callers must reserve the same bucket');
+  assert.equal((await handler(request('cached'))).status, 200);
+  assert.equal(providerCalls, 30);
+});

--- a/tests/symbol-search-quota.test.mts
+++ b/tests/symbol-search-quota.test.mts
@@ -30,7 +30,7 @@ it('shares the cold-query budget across unique queries and callers, with cache h
   const identifiers = new Set<string>();
   globalThis.fetch = async (input, init) => {
     const url = String(input);
-    if (url.startsWith('https://quota-redis.test')) {
+    if (new URL(url).origin === 'https://quota-redis.test') {
       if (!init?.body) return Response.json({ result: url.includes('cached') ? JSON.stringify({ results: [] }) : null });
       const commands = JSON.parse(String(init.body));
       return Response.json(commands.map((command: unknown[]) => {

--- a/tests/symbol-search-sentry-capture.test.mts
+++ b/tests/symbol-search-sentry-capture.test.mts
@@ -1,3 +1,4 @@
+import { allowSymbolSearchBudget } from './helpers/symbol-search-budget.mts';
 import assert from 'node:assert/strict';
 import { after, describe, it } from 'node:test';
 
@@ -32,9 +33,8 @@ delete process.env.NODE_TEST_CONTEXT;
 process.env.VITE_SENTRY_DSN = 'https://testpublickey@sentry.test/12345';
 process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
 process.env.FINNHUB_API_KEY = 'test-key';
-// Leave UPSTASH_* unset: both the cache helpers and the rate limiter guard on
-// those vars and return early WITHOUT fetching, so Finnhub + the Sentry
-// envelope are the only two URLs the handler ever hits.
+// allowSymbolSearchBudget supplies mocked Redis admission and cache misses;
+// this file isolates Finnhub status classification and Sentry delivery.
 
 // parseDsn() derives `${protocol}//${host}/api/${projectId}/envelope/` from the
 // DSN above → this prefix.
@@ -64,7 +64,7 @@ function makeReq(q = 'nvidia'): Request {
  */
 async function runWithFinnhubStatus(finnhubStatus: number): Promise<{ envelopeHits: number; status: number }> {
   let envelopeHits = 0;
-  globalThis.fetch = (async (input: RequestInfo | URL) => {
+  globalThis.fetch = allowSymbolSearchBudget((async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     if (url.startsWith(ENVELOPE_URL_PREFIX)) {
       envelopeHits++;
@@ -72,7 +72,7 @@ async function runWithFinnhubStatus(finnhubStatus: number): Promise<{ envelopeHi
     }
     if (url.includes('finnhub.io')) return new Response('upstream', { status: finnhubStatus });
     throw new Error(`unexpected fetch: ${url}`);
-  }) as typeof fetch;
+  }) as typeof fetch);
 
   const tasks: Array<Promise<unknown>> = [];
   const res = await handler(makeReq(), { waitUntil: (p: Promise<unknown>) => { tasks.push(p); } });

--- a/tests/symbol-search.test.mts
+++ b/tests/symbol-search.test.mts
@@ -1,3 +1,4 @@
+import { allowSymbolSearchBudget } from './helpers/symbol-search-budget.mts';
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
@@ -82,7 +83,7 @@ describe('symbol-search handler', () => {
     process.env.FINNHUB_API_KEY = 'test-key';
     let requestedUrl = '';
     let requestedUA: string | null = null;
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    globalThis.fetch = allowSymbolSearchBudget((async (input: RequestInfo | URL, init?: RequestInit) => {
       requestedUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       const h = new Headers(init?.headers ?? {});
       requestedUA = h.get('User-Agent');
@@ -90,7 +91,7 @@ describe('symbol-search handler', () => {
         JSON.stringify({ count: 1, result: [{ symbol: 'NVDA', displaySymbol: 'NVDA', description: 'NVIDIA CORP', type: 'Common Stock' }] }),
         { status: 200 },
       );
-    }) as typeof fetch;
+    }) as typeof fetch);
 
     const res = await handler(makeReq('nvidia'));
     assert.equal(res.status, 200);
@@ -105,7 +106,7 @@ describe('symbol-search handler', () => {
   it('returns empty results for a blank query without calling Finnhub', async () => {
     process.env.FINNHUB_API_KEY = 'test-key';
     let called = false;
-    globalThis.fetch = (async () => { called = true; return new Response('{}'); }) as typeof fetch;
+    globalThis.fetch = allowSymbolSearchBudget((async () => { called = true; return new Response('{}'); }) as typeof fetch);
 
     const res = await handler(makeReq('   '));
     assert.equal(res.status, 200);
@@ -120,7 +121,7 @@ describe('symbol-search handler', () => {
 
   it('maps a Finnhub 429 to 503 so the client backs off instead of failing hard', async () => {
     process.env.FINNHUB_API_KEY = 'test-key';
-    globalThis.fetch = (async () => new Response('rate limited', { status: 429 })) as typeof fetch;
+    globalThis.fetch = allowSymbolSearchBudget((async () => new Response('rate limited', { status: 429 })) as typeof fetch);
     const res = await handler(makeReq('nvidia'));
     assert.equal(res.status, 503);
   });
@@ -133,7 +134,7 @@ describe('symbol-search handler', () => {
     let finnhubCalls = 0;
     let cooldownSetBody: string | null = null;
 
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    globalThis.fetch = allowSymbolSearchBudget((async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.startsWith('https://upstash.test/get/symsearch')) {
         return new Response(JSON.stringify({ result: null }), { status: 200 });
@@ -148,7 +149,7 @@ describe('symbol-search handler', () => {
       }
       if (url.startsWith('https://upstash.test')) return permissiveUpstashCatchAll();
       throw new Error(`unexpected fetch: ${url}`);
-    }) as typeof fetch;
+    }) as typeof fetch);
 
     const writePromises: Array<Promise<unknown>> = [];
     const res = await handler(makeReq('nvidia'), { waitUntil: (p) => writePromises.push(p) });
@@ -182,7 +183,7 @@ describe('symbol-search handler', () => {
       expiresAt: now + 12_100,
     };
 
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
+    globalThis.fetch = allowSymbolSearchBudget((async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.startsWith('https://upstash.test/get/')) {
         const key = decodeURIComponent(url.slice('https://upstash.test/get/'.length));
@@ -199,7 +200,7 @@ describe('symbol-search handler', () => {
       }
       if (url.startsWith('https://upstash.test')) return permissiveUpstashCatchAll();
       throw new Error(`unexpected fetch: ${url}`);
-    }) as typeof fetch;
+    }) as typeof fetch);
 
     const res = await handler(makeReq('nvidia'));
     assert.equal(res.status, 503);
@@ -210,7 +211,7 @@ describe('symbol-search handler', () => {
 
   it('returns 500 when the upstream fetch throws', async () => {
     process.env.FINNHUB_API_KEY = 'test-key';
-    globalThis.fetch = (async () => { throw new Error('network down'); }) as typeof fetch;
+    globalThis.fetch = allowSymbolSearchBudget((async () => { throw new Error('network down'); }) as typeof fetch);
     const res = await handler(makeReq('nvidia'));
     assert.equal(res.status, 500);
   });
@@ -247,7 +248,7 @@ describe('symbol-search handler', () => {
     const cachedPayload = { results: [{ symbol: 'GLW', name: 'Corning Inc', display: 'GLW' }] };
     let finnhubCalls = 0;
 
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
+    globalThis.fetch = allowSymbolSearchBudget((async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.startsWith('https://upstash.test/get/symsearch')) {
         // Upstash returns the JSON-stringified value under `.result`.
@@ -259,7 +260,7 @@ describe('symbol-search handler', () => {
       }
       if (url.startsWith('https://upstash.test')) return permissiveUpstashCatchAll();
       throw new Error(`unexpected fetch: ${url}`);
-    }) as typeof fetch;
+    }) as typeof fetch);
 
     const res = await handler(makeReq('glw'));
     assert.equal(res.status, 200);
@@ -277,7 +278,7 @@ describe('symbol-search handler', () => {
     let setBody: string | null = null;
     let getKey: string | null = null;
 
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    globalThis.fetch = allowSymbolSearchBudget((async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.startsWith('https://upstash.test/get/symsearch')) {
         const key = decodeURIComponent(url.slice('https://upstash.test/get/'.length));
@@ -300,7 +301,7 @@ describe('symbol-search handler', () => {
       }
       if (url.startsWith('https://upstash.test')) return permissiveUpstashCatchAll();
       throw new Error(`unexpected fetch: ${url}`);
-    }) as typeof fetch;
+    }) as typeof fetch);
 
     // Pass a stub ctx so the cache-write runs synchronously enough to assert.
     const writePromises: Array<Promise<unknown>> = [];


### PR DESCRIPTION
MCP tool discovery previously put upstream credentials in GET query parameters, and JSON-RPC failures exposed raw upstream messages. Discovery now supports a bounded POST body with `action: "tools/list"`; the Connect dialog uses it, query headers return 400, and header-free GET discovery and existing POST tool calls remain supported. Public errors contain proxy-owned text, and diagnostics retain failure classification without raw exception causes.

The public resource paths now reject oversized `/ask` bodies at 16 KiB before JSON/form parsing, cap new customer-portal attempts at 5/minute per authenticated user, replaying completed idempotent requests before admission, and reserve a shared 30/minute budget before uncached symbol-search calls. Portal and Finnhub admission fail closed when Redis is unavailable. Cached symbol results remain available without spending provider budget.

Validation at final head `8e1e9071c` (browser screenshots at `a5981a73b`; browser code is unchanged):

- All 143 focused tests pass. MCP, NLWeb, portal, symbol-search and Sentry regression suites pass with synthetic inputs and mocked providers. Coverage includes misleading Content-Length and streamed overflow cancellation, query-header rejection before DNS/fetch, bounded upstream error text, portal rejection before relay work, completed-response replay after quota exhaustion or limiter outage, rejection without new idempotency reservations, and 35 concurrent unique queries across callers admitting only 30 Finnhub calls.
- `npm run typecheck:api`, `npm run typecheck`, `npm run lint:boundaries`, `npm run test:sidecar` (474 tests), the idempotency docs check, and all pre-push gates pass.
- Browser: clicked Connect MCP, entered a synthetic upstream credential, verified POST JSON with no query string, and observed the returned synthetic tool. API responses were mocked and other external requests blocked. Screenshots below show the committed head; unrelated dashboard data errors from empty fixtures do not establish full-dashboard acceptance.

No live provider, payment, production mutation, or deployment acceptance was attempted. The symbol budget bounds this endpoint's consumption; other Finnhub consumers can still use the remaining shared allowance. Legacy clients that put custom headers in GET URLs must migrate to POST.

![Connect dialog with synthetic credentials at a5981a73b](https://github.com/user-attachments/assets/9a79eedb-e05a-4eed-aebd-db94c6c595bd)

![Successful POST discovery and synthetic tool at a5981a73b](https://github.com/user-attachments/assets/0be97bd5-b895-4578-ae06-010bd769ffa2)

