### PR TITLE
fix(forecasts): bound recovery after malformed market synthesis

### DIFF
--- a/docs/solutions/reliability/market-implications-bounded-recovery.md
+++ b/docs/solutions/reliability/market-implications-bounded-recovery.md
@@ -1,0 +1,41 @@
+# Bounded recovery for malformed market synthesis
+
+An unparseable market-implications completion previously ended synthesis until
+the next scheduled job. The panel retained usable cards, but those cards could
+cross the freshness threshold while waiting for another attempt. A successful
+parent forecast job does not establish market-implications synthesis success.
+
+After a parse miss, recovery requires a positive integer completion count and at
+least 512 unused tokens from the original 2,500-token allowance. It makes one
+additional call to the responding provider, without transport retries or a
+fallback-chain restart. The prompt requests one or two concise cards using the
+same world-state context and validation rules. The existing validator rejects
+invalid tickers and card fields before publication.
+
+Admission reserves that provider's full timeout plus the existing five-second
+guard. Both the original 120-second stage deadline and 200-second run deadline
+still apply. Unknown usage, inadequate tokens or inadequate time means no recovery
+request. Repeated malformed output or a recovery transport failure retains the
+parse-failure classification and last-good cards. A parseable but invalid recovery
+records the existing validation failure. One failed synthesis increments the
+failure streak once, not once per internal call.
+
+Completion allocation stays at 2,500 tokens across the returned malformed
+completion and recovery request. An admitted recovery adds one input-prompt
+charge; total spend is not unchanged. There is no additional normal-path request,
+model upgrade or new provider. No freshness threshold or schedule changes.
+
+Fixtures cover bounded recovery, repeated parse failure, transport failure,
+invalid cards, missing/invalid/exhausted usage, stage and run deadlines, valid
+initial responses and fallback suppression. They use synthetic responses, not
+production payloads. Existing checks cover market health, cache, budget,
+provider routing, telemetry, generic transport and reader registration.
+
+After an authorized deployment, the service owner should observe the next two
+natural scheduled runs and a natural parse miss. Search for `llm_market_implications`
+with `parseFailure` and `recoveryAdmitted`, then publication or retained failure.
+Check actual `generatedAt` and `lastSuccessAt`, validation, failure streaks,
+completion allocation, input usage and job duration. A normal successful run does
+not prove the recovery branch. If bounds are exceeded or a success clock advances
+without validated cards, stop acceptance and revert through the normal authorized
+release procedure. Local fixture proof is separate from production acceptance.

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -17146,10 +17146,11 @@ const ALL_ALLOWED_TICKERS = new Set([
   ...ALLOWED_INSTRUMENTS.rates,
 ]);
 
-const MARKET_IMPLICATIONS_SYSTEM_PROMPT = `You are a senior macro strategist generating structured trade-implication cards from live world intelligence.
+function buildMarketImplicationsSystemPrompt(cardCount) {
+  return `You are a senior macro strategist generating structured trade-implication cards from live world intelligence.
 
 RULES:
-- Generate 3 to 5 trade-implication cards based ONLY on the provided world-state context.
+- Generate ${cardCount} trade-implication cards based ONLY on the provided world-state context.
 - Each card must reference a specific ticker from the ALLOWED TICKERS list.
 - direction must be exactly one of: LONG, SHORT, HEDGE
 - timeframe must be one of: 1W, 2W, 1M, 3M
@@ -17172,6 +17173,7 @@ RULES:
 
 Respond with ONLY a JSON array:
 [{"ticker":"","name":"","direction":"","timeframe":"","confidence":"","title":"","narrative":"","risk_caveat":"","driver":"","transmission_chain":[{"node":"","impact_type":"","logic":""}]},...]`;
+}
 
 function buildMarketImplicationsContext(inputs) {
   const parts = [];
@@ -17681,7 +17683,7 @@ async function buildAndSeedMarketImplications(inputs) {
     // straight through to the fallback instead of retrying it (#5003 review).
     maxRetries: 0,
   };
-  let result = await callForecastLLM(MARKET_IMPLICATIONS_SYSTEM_PROMPT, userPrompt, callOptions);
+  let result = await callForecastLLM(buildMarketImplicationsSystemPrompt('3 to 5'), userPrompt, callOptions);
 
   if (!result?.text) {
     // A budget-exhausted result is the same benign starve as the pre-call guard.
@@ -17713,7 +17715,7 @@ async function buildAndSeedMarketImplications(inputs) {
     console.log(JSON.stringify({ event: 'llm_market_implications', parseFailure: true,
       recoveryAdmitted, remainingTokens, parseStage: parsed.diagnostics.stage }));
     if (recoveryAdmitted) {
-      const recovered = await callForecastLLM(MARKET_IMPLICATIONS_SYSTEM_PROMPT,
+      const recovered = await callForecastLLM(buildMarketImplicationsSystemPrompt('1 or 2 concise'),
         `${userPrompt}\n\nThe previous response could not be parsed. Return ONLY a valid JSON array with one or two concise cards. Keep every required field.`,
         recoveryOptions);
       if (recovered?.text) {

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -15622,7 +15622,9 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
         const model = json.model || provider.model;
         console.log(`  [LLM:${stage}] ${provider.name} success model=${model}`);
         recordLlmAttempt(provider.name, model, true, attemptT0, tokensExtra);
-        return { text, model, provider: provider.name };
+        return { text, model, provider: provider.name,
+          ...(stage === 'market_implications' ? { completionTokens: json.usage?.completion_tokens } : {}),
+        };
       } catch (err) {
         // All real attempts were recorded inside the retry callback; budget
         // pre-emptions never sent the prompt, so nothing to record here.
@@ -17667,7 +17669,8 @@ async function buildAndSeedMarketImplications(inputs) {
 
   const userPrompt = `World state as of ${new Date().toISOString()}:\n\n${context}\n\nAllowed tickers: ${[...ALL_ALLOWED_TICKERS].join(', ')}`;
 
-  const result = await callForecastLLM(MARKET_IMPLICATIONS_SYSTEM_PROMPT, userPrompt, {
+  const synthesisStartedAt = Date.now();
+  const callOptions = {
     ...llmOptions,
     stage: 'market_implications',
     maxTokens: 2500,
@@ -17677,7 +17680,8 @@ async function buildAndSeedMarketImplications(inputs) {
     // providers) would exceed the entire run budget, so a slow primary must fall
     // straight through to the fallback instead of retrying it (#5003 review).
     maxRetries: 0,
-  });
+  };
+  let result = await callForecastLLM(MARKET_IMPLICATIONS_SYSTEM_PROMPT, userPrompt, callOptions);
 
   if (!result?.text) {
     // A budget-exhausted result is the same benign starve as the pre-call guard.
@@ -17693,7 +17697,31 @@ async function buildAndSeedMarketImplications(inputs) {
     return;
   }
 
-  const parsed = extractStructuredLlmPayload(result.text);
+  let parsed = extractStructuredLlmPayload(result.text);
+  if (!Array.isArray(parsed.items) || parsed.items.length === 0) {
+    // A malformed completion otherwise waits for the next hourly job. Allow
+    // one smaller generation, only with measured unused completion tokens and
+    // enough time for the responding provider under the original stage deadline.
+    const usedTokens = result.completionTokens;
+    const remainingTokens = Number.isInteger(usedTokens) && usedTokens > 0
+      ? callOptions.maxTokens - usedTokens : 0;
+    const remainingStageMs = getForecastLlmStageBudgetMs(callOptions) - (Date.now() - synthesisStartedAt);
+    const recoveryOptions = { ...callOptions, providerOrder: [result.provider],
+      maxTokens: remainingTokens, stageBudgetMs: remainingStageMs };
+    const recoveryAdmitted = remainingTokens >= 512
+      && Math.min(remainingStageMs, getRemainingForecastLlmRunBudgetMs()) >= getMarketImplicationsMinRunBudgetMs(recoveryOptions);
+    console.log(JSON.stringify({ event: 'llm_market_implications', parseFailure: true,
+      recoveryAdmitted, remainingTokens, parseStage: parsed.diagnostics.stage }));
+    if (recoveryAdmitted) {
+      const recovered = await callForecastLLM(MARKET_IMPLICATIONS_SYSTEM_PROMPT,
+        `${userPrompt}\n\nThe previous response could not be parsed. Return ONLY a valid JSON array with one or two concise cards. Keep every required field.`,
+        recoveryOptions);
+      if (recovered?.text) {
+        result = recovered;
+        parsed = extractStructuredLlmPayload(result.text);
+      }
+    }
+  }
   const rawCards = parsed.items;
 
   if (!Array.isArray(rawCards) || rawCards.length === 0) {

--- a/tests/market-implications-recovery.test.mjs
+++ b/tests/market-implications-recovery.test.mjs
@@ -54,6 +54,9 @@ test('unparseable synthesis recovers in one bounded attempt and publishes actual
   assert.equal(requests.length, 2);
   assert.equal(requests[0].max_tokens, 2500);
   assert.equal(requests[1].max_tokens, 1000, 'remaining completion allowance only');
+  assert.match(requests[0].messages[0].content, /Generate 3 to 5 trade-implication cards/);
+  assert.match(requests[1].messages[0].content, /Generate 1 or 2 concise trade-implication cards/);
+  assert.doesNotMatch(requests[1].messages[0].content, /Generate 3 to 5/);
   assert.equal(store[key].model, 'fixture-model');
   assert.notEqual(store[key].generatedAt, oldTime);
   assert.equal(store[metaKey].consecutiveFailures, 0);

--- a/tests/market-implications-recovery.test.mjs
+++ b/tests/market-implications-recovery.test.mjs
@@ -1,0 +1,134 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildAndSeedMarketImplications, __setRedisStoreForTests,
+  __setForecastLlmTransportForTests, __setForecastLlmRunDeadlineForTests,
+} from '../scripts/seed-forecasts.mjs';
+
+const originalEnv = { ...process.env };
+const realFetch = global.fetch;
+const realNow = Date.now;
+afterEach(() => {
+  Date.now = realNow;
+  process.env = { ...originalEnv };
+  global.fetch = realFetch;
+  __setRedisStoreForTests(null);
+  __setForecastLlmTransportForTests(null);
+  __setForecastLlmRunDeadlineForTests(null);
+});
+const key = 'intelligence:market-implications:v1';
+const metaKey = 'seed-meta:intelligence:market-implications';
+const oldTime = '2020-01-01T00:00:00.000Z';
+const card = { ticker: 'USO', name: 'United States Oil Fund', direction: 'LONG',
+  timeframe: '1W', confidence: 'HIGH', title: 'Oil supply risk',
+  narrative: 'Shipping disruption increases the risk of reduced oil supply.',
+  risk_caveat: 'Shipping can recover.', driver: 'Shipping disruption', transmission_chain: [] };
+// Synthetic malformed JSON with a missing comma between card fields.
+const malformed = '[{"ticker":"USO" "name":"United States Oil Fund"}]';
+function setup(responses) {
+  process.env.OPENROUTER_API_KEY = 'fixture-key';
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
+  const store = { [key]: { cards: [card], generatedAt: oldTime, model: 'old' },
+    [metaKey]: { fetchedAt: Date.parse(oldTime), lastSuccessAt: Date.parse(oldTime), status: 'ok', recordCount: 1 } };
+  __setRedisStoreForTests(store);
+  __setForecastLlmRunDeadlineForTests(Date.now() + 120_000);
+  global.fetch = async () => ({ ok: true, json: async () => ({ result: 1 }) });
+  const requests = [];
+  __setForecastLlmTransportForTests({ fetch: async (_url, init) => {
+    requests.push(JSON.parse(init.body));
+    assert.ok(requests.length <= responses.length, 'no unbounded retries');
+    const response = responses[requests.length - 1];
+    response.beforeReturn?.();
+    return { ok: response.status === undefined, status: response.status,
+      headers: new Headers(), json: async () => ({ model: 'fixture-model',
+      choices: [{ message: { content: response.text }, finish_reason: 'stop' }],
+      usage: response.tokens === undefined ? undefined : { completion_tokens: response.tokens } }) };
+  } });
+  return { store, requests };
+}
+
+test('unparseable synthesis recovers in one bounded attempt and publishes actual new cards', async () => {
+  const { store, requests } = setup([{ text: malformed, tokens: 1500 },
+    { text: JSON.stringify([card]), tokens: 200 }]);
+  await buildAndSeedMarketImplications({});
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].max_tokens, 2500);
+  assert.equal(requests[1].max_tokens, 1000, 'remaining completion allowance only');
+  assert.equal(store[key].model, 'fixture-model');
+  assert.notEqual(store[key].generatedAt, oldTime);
+  assert.equal(store[metaKey].consecutiveFailures, 0);
+  assert.equal(store[metaKey].lastSynthesisFailureCode, null);
+});
+
+test('an exhausted stage budget cannot be reset by recovery even when run time remains', async () => {
+  const { store, requests } = setup([{ text: malformed, tokens: 1500,
+    beforeReturn: () => {
+      const later = realNow() + 90_000;
+      Date.now = () => later;
+      __setForecastLlmRunDeadlineForTests(later + 200_000);
+    } }]);
+  await buildAndSeedMarketImplications({});
+  assert.equal(requests.length, 1);
+  assert.equal(store[metaKey].consecutiveFailures, 1);
+});
+
+test('recovery transport failure does not erase the initial parse failure or retry transport', async () => {
+  const { store, requests } = setup([{ text: malformed, tokens: 1500 }, { status: 503 }]);
+  await buildAndSeedMarketImplications({});
+  assert.equal(requests.length, 2);
+  assert.equal(store[key].generatedAt, oldTime);
+  assert.equal(store[metaKey].lastSynthesisFailureCode, 'MARKET_IMPLICATIONS_NO_PARSEABLE_CARDS');
+});
+
+test('recovery cards still pass ticker validation before publication', async () => {
+  const { store, requests } = setup([{ text: malformed, tokens: 1500 },
+    { text: JSON.stringify([{ ...card, ticker: '^INVALID' }]), tokens: 200 }]);
+  await buildAndSeedMarketImplications({});
+  assert.equal(requests.length, 2);
+  assert.equal(store[key].generatedAt, oldTime);
+  assert.equal(store[metaKey].lastSynthesisFailureCode, 'MARKET_IMPLICATIONS_VALIDATION');
+});
+
+test('valid initial synthesis makes no recovery request', async () => {
+  const { store, requests } = setup([{ text: JSON.stringify([card]), tokens: 1500 }]);
+  await buildAndSeedMarketImplications({});
+  assert.equal(requests.length, 1);
+  assert.equal(store[key].model, 'fixture-model');
+});
+
+test('two malformed responses retain content and success clocks and count one failed synthesis', async () => {
+  const { store, requests } = setup([{ text: malformed, tokens: 1500 }, { text: malformed, tokens: 200 }]);
+  await buildAndSeedMarketImplications({});
+  assert.equal(requests.length, 2);
+  assert.equal(store[key].generatedAt, oldTime);
+  assert.equal(store[metaKey].lastSuccessAt, Date.parse(oldTime));
+  assert.equal(store[metaKey].consecutiveFailures, 1);
+  assert.equal(store[metaKey].lastSynthesisFailureCode, 'MARKET_IMPLICATIONS_NO_PARSEABLE_CARDS');
+  assert.ok(!Object.keys(store).some(k => k.startsWith('forecast:llm-market-implications:')));
+});
+
+for (const tokens of [undefined, 0, -1, 2000, 2500, 3000]) {
+  test(`no recovery without a usable remaining token allowance (${tokens})`, async () => {
+    const { store, requests } = setup([{ text: malformed, tokens }]);
+    await buildAndSeedMarketImplications({});
+    assert.equal(requests.length, 1);
+    assert.equal(store[metaKey].consecutiveFailures, 1);
+    assert.equal(store[key].generatedAt, oldTime);
+  });
+}
+test('run deadline cannot admit recovery: preserve the real parse failure, not a budget skip', async () => {
+  const { store, requests } = setup([{ text: malformed, tokens: 1500,
+    beforeReturn: () => __setForecastLlmRunDeadlineForTests(Date.now() + 10_000) }]);
+  await buildAndSeedMarketImplications({});
+  assert.equal(requests.length, 1);
+  assert.equal(store[metaKey].lastSynthesisFailureCode, 'MARKET_IMPLICATIONS_NO_PARSEABLE_CARDS');
+});
+
+test('recovery cannot restart the fallback chain after the original provider fails', async () => {
+  const { store, requests } = setup([{ text: malformed, tokens: 1500 }, { status: 503 }]);
+  process.env.GROQ_API_KEY = 'fixture-key';
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter,groq';
+  await buildAndSeedMarketImplications({});
+  assert.equal(requests.length, 2);
+  assert.equal(store[metaKey].consecutiveFailures, 1);
+});


### PR DESCRIPTION
An unparseable market-implications completion previously ended synthesis until the next scheduled job. Add one smaller recovery generation before that wait, while preserving usable cards and truthful success/failure clocks if recovery cannot run or fails.

Recovery uses only the measured remainder of the 2,500 completion-token allowance, reserves the responding provider's full timeout, and stays within the original stage/run deadlines. It cannot restart a fallback chain. Existing card validation and freshness thresholds remain in force. An admitted recovery adds one input-prompt charge; there is no additional normal-path request.

Validation: 89 focused tests pass across recovery, market health/cache/budget, provider routing/telemetry/generic transport and reader registration. `npm run typecheck:api`, syntax checking and `git diff --check` pass. The new recovery fixture failed before implementation. Local sequential ce-code-review found and fixed a fallback-chain restart; no actionable findings remain. All fixtures use synthetic data.

See the [recovery contract](docs/solutions/reliability/market-implications-bounded-recovery.md) for limits and acceptance steps.

## Post-Deploy Monitoring & Validation

After separately authorized merge/deployment, the service owner should verify the deployed commit, inspect the next two natural scheduled runs, and keep recovery acceptance open until a natural parse miss occurs. Search logs for `llm_market_implications`, `parseFailure`, `recoveryAdmitted` and publication. Compare completion/input usage with `generatedAt`, `lastSuccessAt`, failure streak and code. Expect at most one recovery request and validated publication, or preserved last-good state when recovery fails or lacks budget. Stop acceptance and revert through the authorized release procedure if a limit is exceeded or success advances without validated cards.

No live synthesis probe, production seeder invocation, configuration change or deployment was performed. Local fixture proof does not establish natural recovery with the change.
