### PR TITLE
fix(portwatch): distinguish usable coverage from publication

### DIFF
--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -381,6 +381,23 @@ when retained. Coverage diagnostics distinguish `currentCountryCount` from
 `retainedCountryCount` and expose `oldestCountryCacheWrittenAt`. Missing or expired
 countries and unresolved refresh failures still block a healthy publication.
 
+Run logs separate **usable country payloads** from **canonical-list membership**.
+Batch progress describes data assembled in memory; persistence is still pending.
+Only after the Redis transaction is confirmed does the seeder report saved state
+and whether the canonical list advanced or was retained. For example:
+
+```text
+Recovery state saved; canonical list retained at 60 countries; usable coverage 150/174; full publication blocked; 0 unresolved refresh failures
+```
+
+Canonical membership is not a current API-availability count: the country reader
+also checks payload presence and age. The legacy `coverage.published` field means
+usable coverage from the run, including retained payloads; it does not mean the
+canonical list advanced. `recordCount` and success clocks remain unchanged on an
+incomplete run, which continues to exit nonzero. A merge or deployment alone does
+not prove recovery. A failed or ambiguous transaction response does not confirm
+that recovery state was saved or that publication advanced.
+
 Unchanged upstream dates also enter the refresh queue before cache expiry. With
 174 countries, the lead reserves seven 12-hour runs after allowing two recurring
 critical-country slots, plus one missed run. Thus full refreshes become due at

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -384,7 +384,9 @@ countries and unresolved refresh failures still block a healthy publication.
 Run logs separate **usable country payloads** from **canonical-list membership**.
 Batch progress describes data assembled in memory; persistence is still pending.
 Only after the Redis transaction is confirmed does the seeder report saved state
-and whether the canonical list advanced or was retained. For example:
+and whether the canonical list advanced or its TTL extension confirmed retention.
+If retention cannot be confirmed, the log labels the starting count as historical
+and reports `canonical retention unconfirmed`. For example:
 
 ```text
 Recovery state saved; canonical list retained at 60 countries; usable coverage 150/174; full publication blocked; 0 unresolved refresh failures

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -7,6 +7,7 @@ import {
   acquireLockSafely,
   releaseLock,
   extendExistingTtl,
+  extendExistingTtlDetailed,
   logSeedResult,
   readSeedSnapshot,
   resolveProxyForConnect,
@@ -1773,8 +1774,10 @@ export async function main() {
       ? { ...buildPortActivityMetaPayload({ countryData, coverage: { ...coverage, status: 'complete', completionRatio: 1 } }), sourceState: 'ok' }
       : buildPortActivityFailureMeta(previousMeta, { coverage });
 
+    let canonicalTtlExtended = false;
     if (!canonicalAdvances) {
-      await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL);
+      const retention = await extendExistingTtlDetailed([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL);
+      canonicalTtlExtended = retention.extendedKeys.includes(CANONICAL_KEY);
       console.error(
         `  INCOMPLETE RUN: ${countryData.size}/${coverage.target} usable countries; ` +
         `${freshFetchedCount} fetched, ${cacheHitCount} cache-fresh, ${servedStaleCount} stale-served, ` +
@@ -1792,11 +1795,14 @@ export async function main() {
       canonicalAdvances,
     });
     failureRecorded = !canonicalAdvances;
-    const canonicalState = canonicalAdvances
-      ? `canonical list advanced to ${countries.length} countries`
-      : prevIso2List === null
-        ? 'no prior canonical list'
-        : `canonical list retained at ${prevIso2List.length} countries`;
+    let canonicalState = 'no prior canonical list';
+    if (canonicalAdvances) {
+      canonicalState = `canonical list advanced to ${countries.length} countries`;
+    } else if (prevIso2List !== null) {
+      canonicalState = canonicalTtlExtended
+        ? `canonical list retained at ${prevIso2List.length} countries`
+        : `canonical retention unconfirmed (${prevIso2List.length} countries at run start)`;
+    }
     console.log(
       `  ${canonicalAdvances ? 'State saved' : 'Recovery state saved'}; ${canonicalState}; ` +
       `usable coverage ${countryData.size}/${coverage.target}; ` +

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -1409,8 +1409,8 @@ export async function fetchAll(progress, { signal, expectedCountries = [] } = {}
     const originalMisses = MAX_COLD_FETCH_PER_RUN + servedStale + droppedTooOld + droppedNoCache;
     console.warn(
       `  [port-activity] Cold-fetch capped at ${MAX_COLD_FETCH_PER_RUN}/run — ` +
-      `refreshing ${MAX_COLD_FETCH_PER_RUN} now, serving ${servedStale} on stale cache (asof behind), ` +
-      `${droppedTooOld} dropped (cache > ${MAX_CACHE_AGE_MS / 86_400_000}d old), ${droppedNoCache} dropped (no prior payload). ` +
+      `refreshing ${MAX_COLD_FETCH_PER_RUN} now, retaining ${servedStale} usable cached payloads (refresh deferred), ` +
+      `${droppedTooOld} dropped (cache >= ${MAX_CACHE_AGE_MS / 86_400_000}d old), ${droppedNoCache} dropped (no prior payload). ` +
       `Rotation: ~${Math.ceil(originalMisses / MAX_COLD_FETCH_PER_RUN)} runs to fully refresh.`,
     );
   }
@@ -1538,7 +1538,7 @@ export async function fetchAll(progress, { signal, expectedCountries = [] } = {}
     if (progress) progress.seeded = countryData.size;
     if (batchIdx === 1 || batchIdx % BATCH_LOG_EVERY === 0 || batchIdx === batches) {
       const elapsed = ((Date.now() - activityStart) / 1000).toFixed(1);
-      console.log(`  [port-activity]   batch ${batchIdx}/${batches}: ${countryData.size} countries published, ${errors.length} errors (${elapsed}s)`);
+      console.log(`  [port-activity]   batch ${batchIdx}/${batches}: ${countryData.size} usable country payloads assembled; ${errors.length} refresh errors; persistence pending (${elapsed}s)`);
     }
 
     // Circuit-breaker: if batch 1 is ≥80% rejected with the SAME class of
@@ -1621,8 +1621,8 @@ export async function fetchAll(progress, { signal, expectedCountries = [] } = {}
       ? ` Refresh failures: ${coverage.refreshFailures.map(({ iso2, code }) => `${iso2}:${code}`).join(', ')}.`
       : '';
     console.error(
-      `  [port-activity] COVERAGE GAPS: ${coverage.published}/${coverage.target}; ` +
-      `unpublished countries: ${coverage.missingCountries.join(', ') || 'none'}; ` +
+      `  [port-activity] COVERAGE GAPS: ${coverage.published}/${coverage.target} usable; ` +
+      `countries without usable payloads: ${coverage.missingCountries.join(', ') || 'none'}; ` +
       `unidentified shortfall: ${coverage.unidentifiedMissingCount}.${failureCodes}`,
     );
   }
@@ -1761,7 +1761,7 @@ export async function main() {
       expectedCountries: Array.isArray(prevIso2List) ? prevIso2List : [],
     });
 
-    console.log(`  Fetched ${countryData.size} countries`);
+    console.log(`  Assembled ${countryData.size} usable country payloads; persistence pending`);
 
     const canonicalAdvances = !shutdownController.signal.aborted && shouldAdvanceCanonicalForRun({
       countryCount: countryData.size,
@@ -1779,10 +1779,11 @@ export async function main() {
         `  INCOMPLETE RUN: ${countryData.size}/${coverage.target} usable countries; ` +
         `${freshFetchedCount} fetched, ${cacheHitCount} cache-fresh, ${servedStaleCount} stale-served, ` +
         `${droppedTooOldCount} expired, ${droppedNoCacheCount} missing. ` +
-        'Preserving canonical and success clocks; persisting recovery state and failure metadata.',
+        'Full publication blocked; recovery-state and failure-metadata writes pending.',
       );
     }
 
+    console.log(`  Persistence pending: usable coverage ${countryData.size}/${coverage.target}; ${coverage.refreshFailures.length} unresolved refresh failures`);
     await publishPortActivitySnapshot({
       countryData,
       retryState,
@@ -1791,6 +1792,17 @@ export async function main() {
       canonicalAdvances,
     });
     failureRecorded = !canonicalAdvances;
+    const canonicalState = canonicalAdvances
+      ? `canonical list advanced to ${countries.length} countries`
+      : prevIso2List === null
+        ? 'no prior canonical list'
+        : `canonical list retained at ${prevIso2List.length} countries`;
+    console.log(
+      `  ${canonicalAdvances ? 'State saved' : 'Recovery state saved'}; ${canonicalState}; ` +
+      `usable coverage ${countryData.size}/${coverage.target}; ` +
+      `${canonicalAdvances ? '' : 'full publication blocked; '}` +
+      `${coverage.refreshFailures.length} unresolved refresh failures`,
+    );
     if (!canonicalAdvances) throw new Error('Incomplete PortWatch coverage; canonical retained');
 
     logSeedResult('supply_chain', countryData.size, Date.now() - startedAt, { source: 'portwatch-ports' });

--- a/tests/portwatch-publication.test.mts
+++ b/tests/portwatch-publication.test.mts
@@ -70,6 +70,17 @@ function runProducer(input: Record<string, any>, mode = 'complete', now = NOW, c
             : mode === 'cache-read-type' ? { result: 42 } : { error: 'ERR read failed' };
           return Response.json(replies);
         }
+        if (mode === 'canonical-expired' && u.pathname === '/pipeline'
+          && JSON.parse(init.body).some(([verb]) => verb === 'EXPIRE')) {
+          state.redis.delete('${CANONICAL}');
+        }
+        if (mode === 'canonical-unconfirmed' && u.pathname === '/pipeline'
+          && JSON.parse(init.body).some(([verb]) => verb === 'EXPIRE')) {
+          const response = await state.fetchImpl(url, init);
+          const results = await response.json();
+          results[0] = {};
+          return Response.json(results);
+        }
         if (u.pathname === '/multi-exec') {
           if (mode === 'transaction-rejected') return Response.json({ error: 'write rejected' }, { status: 503 });
           const response = await state.fetchImpl(url, init);
@@ -472,5 +483,17 @@ for (const mode of ['transaction-rejected', 'transaction-ambiguous']) {
     assert.match(result.logs, /Persistence pending/);
     if (mode === 'transaction-rejected') assert.deepEqual(result.redis[CANONICAL], input[CANONICAL]);
     else assert.equal(result.redis[CANONICAL].length, 174, 'write can commit despite an unconfirmed response');
+  });
+}
+
+for (const mode of ['canonical-expired', 'canonical-unconfirmed']) {
+  test(`${mode} during a partial run is not reported as retained publication`, () => {
+    const input = fixtures();
+    const result = runProducer(input, mode);
+    assert.match(result.error, /Incomplete PortWatch coverage/);
+    if (mode === 'canonical-expired') assert.equal(result.redis[CANONICAL], undefined);
+    else assert.deepEqual(result.redis[CANONICAL], input[CANONICAL]);
+    assert.match(result.logs, /Recovery state saved; canonical retention unconfirmed \(168 countries at run start\); usable coverage 60\/174; full publication blocked/);
+    assert.doesNotMatch(result.logs, /canonical list retained at/);
   });
 }

--- a/tests/portwatch-publication.test.mts
+++ b/tests/portwatch-publication.test.mts
@@ -70,6 +70,13 @@ function runProducer(input: Record<string, any>, mode = 'complete', now = NOW, c
             : mode === 'cache-read-type' ? { result: 42 } : { error: 'ERR read failed' };
           return Response.json(replies);
         }
+        if (u.pathname === '/multi-exec') {
+          if (mode === 'transaction-rejected') return Response.json({ error: 'write rejected' }, { status: 503 });
+          const response = await state.fetchImpl(url, init);
+          if (mode === 'transaction-ambiguous') return Response.json({});
+          console.log('TEST transaction confirmed');
+          return response;
+        }
         return state.fetchImpl(url, init);
       }
       if (!u.hostname.endsWith('arcgis.com')) throw new Error('Unexpected URL: ' + url);
@@ -138,6 +145,11 @@ test('natural 168-to-60 expiry cliff preserves publication and reports incomplet
   assert.match(result.error, /Incomplete PortWatch coverage/);
   assert.match(result.logs, /60\/174 usable countries/);
   assert.doesNotMatch(result.logs, /Seeded 60 countries/);
+  assert.match(result.logs, /60 usable country payloads assembled.*persistence pending/);
+  assert.match(result.logs, /Recovery state saved; canonical list retained at 168 countries; usable coverage 60\/174; full publication blocked; 0 unresolved refresh failures/);
+  assert.match(result.logs, /TEST transaction confirmed/);
+  assert.ok(result.logs.indexOf('TEST transaction confirmed') < result.logs.indexOf('Recovery state saved'));
+  assert.doesNotMatch(result.logs, /countries published|unpublished countries|asof behind/);
   assert.deepEqual(result.redis[CANONICAL], input[CANONICAL]);
   assert.equal(result.redis[META].fetchedAt, input[META].fetchedAt);
   assert.equal(result.redis[META].recordCount, 168);
@@ -366,6 +378,7 @@ test('a deferred refresh failure cannot be hidden by otherwise complete retained
   const failed = runProducer(input, 'activity-page');
   assert.match(failed.error, /Incomplete PortWatch coverage/);
   assert.equal(failed.redis[META].coverage.published, 174);
+  assert.match(failed.logs, /usable coverage 174\/174; full publication blocked; 1 unresolved refresh failures/);
   const deferred = runProducer(failed.redis, 'moving', NOW + DAY / 2);
   assert.match(deferred.error, /Incomplete PortWatch coverage/);
   assert.equal(deferred.redis[META].fetchedAt, input[META].fetchedAt);
@@ -386,6 +399,9 @@ test('unchanged upstream data uses the cache without any activity downloads', ()
   assert.equal(activityRequests.length, 0);
   assert.equal(result.redis[META].coverage.currentCountryCount, 174);
   assert.equal(result.redis[META].coverage.retainedCountryCount, 0);
+  assert.match(result.logs, /State saved; canonical list advanced to 174 countries; usable coverage 174\/174; 0 unresolved refresh failures/);
+  assert.match(result.logs, /TEST transaction confirmed/);
+  assert.ok(result.logs.indexOf('TEST transaction confirmed') < result.logs.indexOf('State saved'));
   for (const [, code] of countries) {
     assert.deepEqual(result.redis[`${PREFIX}${code}`], input[`${PREFIX}${code}`]);
   }
@@ -432,3 +448,29 @@ test('complete verified zero activity is a successful observation, not a source 
   assert.equal(response.available, true);
   assert.deepEqual(response.ports, []);
 });
+
+for (const canonical of [null, []]) {
+  test(`partial cold start reports ${canonical === null ? 'absent' : 'empty'} canonical list`, () => {
+    const result = runProducer(canonical === null ? {} : { [CANONICAL]: canonical, [META]: { recordCount: 60 } });
+    assert.match(result.error, /Incomplete PortWatch coverage/);
+    assert.match(result.logs, canonical === null
+      ? /Recovery state saved; no prior canonical list; usable coverage 30\/174; full publication blocked/
+      : /Recovery state saved; canonical list retained at 0 countries; usable coverage 30\/174; full publication blocked/);
+  });
+}
+
+for (const mode of ['transaction-rejected', 'transaction-ambiguous']) {
+  test(`${mode} never reports confirmed persistence or publication`, () => {
+    const input = fixtures();
+    for (const [, code] of countries) {
+      input[`${PREFIX}${code}`].cacheWrittenAt = NOW - DAY;
+      input[`${PREFIX}${code}`].asof = '2026-09-09';
+    }
+    const result = runProducer(input, mode);
+    assert.match(result.error, /Redis transaction/);
+    assert.doesNotMatch(result.logs, /State saved|Recovery state saved|canonical list advanced|canonical list retained/);
+    assert.match(result.logs, /Persistence pending/);
+    if (mode === 'transaction-rejected') assert.deepEqual(result.redis[CANONICAL], input[CANONICAL]);
+    else assert.equal(result.redis[CANONICAL].length, 174, 'write can commit despite an unconfirmed response');
+  });
+}


### PR DESCRIPTION
## Summary

PortWatch batch logs could say “150 countries published” while the canonical list still contained 60 countries and publication was blocked. Logs now distinguish usable payloads assembled in memory from saved state and canonical-list membership. Saved-state and publication summaries appear only after a confirmed Redis transaction.

Partial runs report the canonical count only when its TTL extension confirms retention; otherwise they label the run-start count as historical and retention as unconfirmed. Usable coverage and unresolved refresh failures are reported separately. Missing and empty prior lists are distinct. The health documentation explains that the legacy `coverage.published` field is usable run coverage, and canonical membership alone does not prove current API availability. Refresh scheduling, stored fields, publication gates, and failure exits are unchanged.

Related: #7970

## Validation

- Seven new or strengthened reporting checks failed on the original output before implementation.
- All 27 producer publication tests and 33 recovery tests pass with mocked upstream/Redis and synthetic data. Coverage includes partial recovery, full success, missing/empty prior lists, stale metadata counts, unresolved refresh failures, rejected writes, a committed write with an ambiguous response, and canonical-key expiry or an unconfirmed TTL extension during a partial run. Failed/ambiguous transaction responses produce no saved-state or publication-success message. The review-reported canonical-expiry case failed before the correction and passes afterward.
- Focused Biome lint, Node syntax, documentation checks, and `git diff --check` pass. Sequential local simplification and code review found no remaining actionable issues.
- No production execution or live recovery claim is part of this reporting change.

## Post-Deploy Monitoring & Validation

Owner: deploying maintainer. During the first natural `seed-bundle-portwatch-port-activity` run after an authorized deployment, inspect `Persistence pending`, `State saved` / `Recovery state saved`, and the bundle exit. Compare usable coverage with the canonical-list count and failure metadata. Expect publication confirmation only after successful persistence; incomplete coverage must still exit nonzero. Investigate any success message accompanying a transaction error, or any changed publication/exit behavior; revert this reporting change if it causes such a regression. Do not trigger a production run solely to validate wording.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
