### PR TITLE
fix(telemetry): omit widget relay credentials from customer identity

### DIFF
--- a/docs/architecture/usage-telemetry.md
+++ b/docs/architecture/usage-telemetry.md
@@ -32,7 +32,7 @@ Two event types in dataset `wm_api_usage`:
 | `method`, `status` | `"GET"`, `200`                            |                                              |
 | `duration_ms`      | `412`                                     | wall-clock at the gateway                    |
 | `req_bytes`, `res_bytes` |                                     | response counted only on 200/304 GET         |
-| `customer_id`      | Clerk user ID, org ID, enterprise slug, or widget key | `null` only for anon                |
+| `customer_id`      | Clerk user ID, org ID, enterprise slug, or static `widget` label | `null` only for anon                |
 | `principal_id`     | user ID or **hash** of API/widget key     | never the raw secret                         |
 | `auth_kind`        | `clerk_jwt` \| `user_api_key` \| `enterprise_api_key` \| `widget_key` \| `anon` | |
 | `tier`             | `0` free / `1` pro / `2` api / `3` enterprise | `0` if unknown                          |

--- a/server/__tests__/usage-identity.test.ts
+++ b/server/__tests__/usage-identity.test.ts
@@ -105,12 +105,12 @@ describe('buildUsageIdentity — auth_kind branches', () => {
     expect(ident.tier).toBe(3);
   });
 
-  test('widget_key: customer_id is the widget key itself, principal_id is hashed', () => {
+  test('widget_key: customer_id is a static label, principal_id is hashed', () => {
     const ident = buildUsageIdentity(baseInput({
       widgetKey: 'widget_pub_xyz',
     }));
     expect(ident.auth_kind).toBe('widget_key');
-    expect(ident.customer_id).toBe('widget_pub_xyz');
+    expect(ident.customer_id).toBe('widget');
     expect(ident.principal_id).not.toBe('widget_pub_xyz');
     expect(ident.principal_id).toMatch(/^[0-9a-z]+$/);
     expect(ident.tier).toBe(0);
@@ -157,10 +157,9 @@ describe('buildUsageIdentity — secret handling', () => {
     expect(JSON.stringify(ident)).not.toContain(secret);
   });
 
-  test('widget key appears as customer_id (intentional — widget keys are public)', () => {
-    // Widget keys are embeds installed on third-party sites; treating them as
-    // customer attribution is the contract documented in usage-identity.ts:73-79.
-    const ident = buildUsageIdentity(baseInput({ widgetKey: 'widget_public_xyz' }));
-    expect(ident.customer_id).toBe('widget_public_xyz');
+  test('widget relay credential never appears verbatim in any output field', () => {
+    const secret = 'synthetic-widget-relay-secret';
+    const ident = buildUsageIdentity(baseInput({ widgetKey: secret }));
+    expect(JSON.stringify(ident)).not.toContain(secret);
   });
 });

--- a/server/_shared/usage-identity.ts
+++ b/server/_shared/usage-identity.ts
@@ -85,7 +85,7 @@ export function buildUsageIdentity(input: UsageIdentityInput): UsageIdentity {
     return {
       auth_kind: 'widget_key',
       principal_id: hashKeySync(input.widgetKey),
-      customer_id: input.widgetKey,
+      customer_id: 'widget',
       tier,
       plan_key: null,
     };

--- a/tests/usage-telemetry-emission.test.mts
+++ b/tests/usage-telemetry-emission.test.mts
@@ -120,8 +120,11 @@ const ORIGINAL_CONVEX_SHARED_SECRET = process.env.CONVEX_SERVER_SHARED_SECRET;
 const ORIGINAL_REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
 const ORIGINAL_REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
 const ORIGINAL_CF_EDGE_PROOF_SECRET = process.env.CF_EDGE_PROOF_SECRET;
+const ORIGINAL_WIDGET_AGENT_KEY = process.env.WIDGET_AGENT_KEY;
 
 afterEach(() => {
+  if (ORIGINAL_WIDGET_AGENT_KEY == null) delete process.env.WIDGET_AGENT_KEY;
+  else process.env.WIDGET_AGENT_KEY = ORIGINAL_WIDGET_AGENT_KEY;
   globalThis.fetch = ORIGINAL_FETCH;
   if (ORIGINAL_USAGE_FLAG == null) delete process.env.USAGE_TELEMETRY;
   else process.env.USAGE_TELEMETRY = ORIGINAL_USAGE_FLAG;
@@ -139,6 +142,26 @@ afterEach(() => {
   else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_REDIS_TOKEN;
   if (ORIGINAL_CF_EDGE_PROOF_SECRET == null) delete process.env.CF_EDGE_PROOF_SECRET;
   else process.env.CF_EDGE_PROOF_SECRET = ORIGINAL_CF_EDGE_PROOF_SECRET;
+});
+
+describe('gateway telemetry payload — widget credential', () => {
+  it('omits the validated relay credential from the Axiom payload', async () => {
+    const secret = 'synthetic-widget-relay-secret';
+    process.env.WIDGET_AGENT_KEY = secret;
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-token';
+    const spy = installAxiomFetchSpy(ORIGINAL_FETCH);
+    const handler = createDomainGateway([]);
+    const recorder = makeRecordingCtx();
+    await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes', {
+      headers: { Origin: 'https://worldmonitor.app', 'x-widget-key': secret },
+    }), recorder.ctx);
+    await recorder.settled;
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0]!.auth_kind, 'widget_key');
+    assert.equal(spy.events[0]!.customer_id, 'widget');
+    assert.ok(!JSON.stringify(spy.events).includes(secret));
+  });
 });
 
 describe('gateway telemetry payload — domain extraction', () => {


### PR DESCRIPTION
## Summary
Widget usage events now use the static `widget` customer label. The principal hash and authentication behavior stay the same. The telemetry contract and tests now enforce this attribution.

Related: DeepSec finding 41.

## Validation
- The new synthetic gateway-to-Axiom regression failed before the fix and passes afterward.
- Identity tests: 16 passed. Gateway telemetry tests: 17 passed, with mocked Redis, Axiom and identity providers.
- `npm run typecheck:api` and `git diff --check` passed.
- Sequential ce-code-review checks found no actionable issues. Optional cross-model review was unavailable.

## Post-Deploy Monitoring & Validation
Owner: repository operator. During the first 24 hours after an authorized deployment, filter new `wm_api_usage` events by `auth_kind == "widget_key"` and count records where `customer_id != "widget"`, without selecting raw customer values. Expected count is zero, with normal widget request volume and status distribution. Any nonzero count requires checking deployment coverage and stopping the affected telemetry emission. Historical telemetry and credential rotation require separate owner handling; neither was inspected or changed here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
