### PR TITLE
fix(leads): require server authentication for contact storage

### DIFF
--- a/convex/__tests__/contactMessages.test.ts
+++ b/convex/__tests__/contactMessages.test.ts
@@ -1,14 +1,98 @@
 import { convexTest } from "convex-test";
-import { expect, test, describe } from "vitest";
+import { expect, test, describe, afterEach, vi } from "vitest";
 import schema from "../schema";
-import { api } from "../_generated/api";
+import { internal } from "../_generated/api";
+import { submit } from "../contactMessages";
+import { submitContact } from "../../server/worldmonitor/leads/v1/submit-contact";
 
 const modules = import.meta.glob("../**/*.ts");
 
+describe("contact HTTP storage boundary", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+  const payload = { name: "Ada", email: "ada@example.com", source: "test" };
+  const request = (secret?: string, body = JSON.stringify(payload)) => ({
+    method: "POST",
+    headers: secret ? { "x-convex-shared-secret": secret } : {},
+    body,
+  });
+
+  test.each([undefined, "wrong"])("rejects secret %s before writing", async (secret) => {
+    vi.stubEnv("CONVEX_SERVER_SHARED_SECRET", "synthetic-secret");
+    const t = convexTest(schema, modules);
+    expect((await t.fetch("/leads/submit-contact", request(secret))).status).toBe(401);
+    expect(await t.run((ctx) => ctx.db.query("contactMessages").collect())).toHaveLength(0);
+  });
+
+  test("fails closed when the server secret is absent", async () => {
+    vi.stubEnv("CONVEX_SERVER_SHARED_SECRET", "");
+    const t = convexTest(schema, modules);
+    expect((await t.fetch("/leads/submit-contact", request())).status).toBe(401);
+  });
+
+  test("authenticated route writes through the real mutation and retains email throttle", async () => {
+    vi.stubEnv("CONVEX_SERVER_SHARED_SECRET", "synthetic-secret");
+    const t = convexTest(schema, modules);
+    for (let i = 0; i < 5; i++) {
+      const response = await t.fetch("/leads/submit-contact", request("synthetic-secret"));
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ status: "sent" });
+    }
+    expect((await t.fetch("/leads/submit-contact", request("synthetic-secret"))).status).toBe(429);
+    expect(await t.run((ctx) => ctx.db.query("contactMessages").collect())).toHaveLength(5);
+  });
+
+  test("retains corporate email rejection", async () => {
+    vi.stubEnv("CONVEX_SERVER_SHARED_SECRET", "synthetic-secret");
+    const t = convexTest(schema, modules);
+    const body = JSON.stringify({ ...payload, email: "ada@gmail.com" });
+    expect((await t.fetch("/leads/submit-contact", request("synthetic-secret", body))).status).toBe(422);
+    expect(await t.run((ctx) => ctx.db.query("contactMessages").collect())).toHaveLength(0);
+  });
+
+  test.each(["null", "[]", "{", '{"name": 1}'])("rejects malformed body %s", async (body) => {
+    vi.stubEnv("CONVEX_SERVER_SHARED_SECRET", "synthetic-secret");
+    const t = convexTest(schema, modules);
+    expect((await t.fetch("/leads/submit-contact", request("synthetic-secret", body))).status).toBe(400);
+  });
+
+  test("edge handler reaches the real HTTP action and database with mocked providers", async () => {
+    vi.stubEnv("CONVEX_SERVER_SHARED_SECRET", "synthetic-secret");
+    vi.stubEnv("CONVEX_SITE_URL", "https://synthetic.convex.site");
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "synthetic-turnstile");
+    vi.stubEnv("RESEND_API_KEY", "synthetic-resend");
+    const t = convexTest(schema, modules);
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
+      if (url.includes("turnstile")) return Response.json({ success: true });
+      if (url === "https://synthetic.convex.site/leads/submit-contact") {
+        return t.fetch("/leads/submit-contact", init);
+      }
+      expect(url).toBe("https://api.resend.com/emails");
+      expect(await t.run((ctx) => ctx.db.query("contactMessages").collect())).toHaveLength(1);
+      return Response.json({ id: "synthetic-email" });
+    }));
+    const response = await submitContact({
+      request: new Request("https://worldmonitor.app/api/leads/v1/submit-contact"),
+      pathParams: {}, headers: {},
+    }, {
+      ...payload, organization: "Example", phone: "+1 555 123 4567",
+      message: "Hello", website: "", turnstileToken: "synthetic-token",
+    });
+    expect(response).toEqual({ status: "sent", emailSent: true });
+  });
+});
+
 describe("contactMessages.submit", () => {
+  test("contact writes are internal so anonymous clients cannot bypass the edge gates", () => {
+    const fn = submit as unknown as { isInternal?: boolean; isPublic?: boolean };
+    expect(fn.isInternal).toBe(true);
+    expect(fn.isPublic).toBeUndefined();
+  });
   test("stores a valid submission", async () => {
     const t = convexTest(schema, modules);
-    const res = await t.mutation(api.contactMessages.submit, {
+    const res = await t.mutation(internal.contactMessages.submit, {
       name: "Ada Lovelace",
       email: "ada@example.com",
       organization: "Analytical Engine Co",
@@ -27,7 +111,7 @@ describe("contactMessages.submit", () => {
   test("rejects malformed email", async () => {
     const t = convexTest(schema, modules);
     await expect(
-      t.mutation(api.contactMessages.submit, {
+      t.mutation(internal.contactMessages.submit, {
         name: "Ada",
         email: "not-an-email",
         source: "test",
@@ -40,7 +124,7 @@ describe("contactMessages.submit", () => {
     async (email) => {
       const t = convexTest(schema, modules);
       const error = await t
-        .mutation(api.contactMessages.submit, {
+        .mutation(internal.contactMessages.submit, {
           name: "Ada",
           email,
           source: "test",
@@ -61,7 +145,7 @@ describe("contactMessages.submit", () => {
   test("rejects empty name", async () => {
     const t = convexTest(schema, modules);
     await expect(
-      t.mutation(api.contactMessages.submit, {
+      t.mutation(internal.contactMessages.submit, {
         name: "   ",
         email: "ada@example.com",
         source: "test",
@@ -72,7 +156,7 @@ describe("contactMessages.submit", () => {
   test("clips oversized fields", async () => {
     const t = convexTest(schema, modules);
     const huge = "x".repeat(10_000);
-    await t.mutation(api.contactMessages.submit, {
+    await t.mutation(internal.contactMessages.submit, {
       name: huge,
       email: "ada@example.com",
       organization: huge,
@@ -92,7 +176,7 @@ describe("contactMessages.submit", () => {
 
   test("strips control characters from short fields (name/source)", async () => {
     const t = convexTest(schema, modules);
-    await t.mutation(api.contactMessages.submit, {
+    await t.mutation(internal.contactMessages.submit, {
       name: "Ada\u0000\nLovelace",
       email: "ada@example.com",
       source: "test\rline",
@@ -124,7 +208,7 @@ describe("contactMessages.submit", () => {
       " NUL strippedCR stripped";
 
     const t = convexTest(schema, modules);
-    await t.mutation(api.contactMessages.submit, {
+    await t.mutation(internal.contactMessages.submit, {
       name: "Ada",
       email: "ada@example.com",
       message: input,
@@ -142,9 +226,9 @@ describe("contactMessages.submit", () => {
       source: "test",
     };
     for (let i = 0; i < 5; i++) {
-      await t.mutation(api.contactMessages.submit, args);
+      await t.mutation(internal.contactMessages.submit, args);
     }
-    await expect(t.mutation(api.contactMessages.submit, args)).rejects.toThrow(
+    await expect(t.mutation(internal.contactMessages.submit, args)).rejects.toThrow(
       /Too many|rate_limited/i,
     );
   });
@@ -152,14 +236,14 @@ describe("contactMessages.submit", () => {
   test("normalizes email casing for the rate-limit bucket", async () => {
     const t = convexTest(schema, modules);
     for (let i = 0; i < 5; i++) {
-      await t.mutation(api.contactMessages.submit, {
+      await t.mutation(internal.contactMessages.submit, {
         name: "Ada",
         email: i % 2 === 0 ? "ada@example.com" : "ADA@Example.com",
         source: "test",
       });
     }
     await expect(
-      t.mutation(api.contactMessages.submit, {
+      t.mutation(internal.contactMessages.submit, {
         name: "Ada",
         email: "Ada@EXAMPLE.com",
         source: "test",

--- a/convex/contactMessages.ts
+++ b/convex/contactMessages.ts
@@ -1,11 +1,10 @@
-import { mutation } from "./_generated/server";
+import { internalMutation } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
 import { isCorporateDomain } from "./lib/emailDomain";
 
 // Field length caps. Aligned with `server/worldmonitor/leads/v1/submit-contact.ts`,
-// which already enforces these bounds at the edge — duplicating them here means
-// a direct Convex client call (bypassing the edge) cannot fill the table with
-// arbitrarily large blobs.
+// which already enforces these bounds at the edge. Keep storage bounds as
+// defense in depth for internal callers.
 const MAX_NAME = 500;
 const MAX_EMAIL = 254;          // RFC 5321
 const MAX_ORG = 500;
@@ -16,9 +15,7 @@ const MAX_SOURCE = 100;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 // Per-email throttle. Convex mutations don't have a request IP, so we bucket
-// by normalized email — a low-effort DoS would have to rotate emails to evade
-// it, which already makes the spam less useful and tends to fail edge-side
-// validation (free-email blocklist + Turnstile).
+// by normalized email in addition to the edge's IP limit and Turnstile check.
 const PER_EMAIL_WINDOW_MS = 60 * 60 * 1000;   // 1h
 const PER_EMAIL_LIMIT = 5;                    // submissions per email per window
 
@@ -44,7 +41,7 @@ function clip(
   return cleaned.slice(0, max);
 }
 
-export const submit = mutation({
+export const submit = internalMutation({
   args: {
     name: v.string(),
     email: v.string(),

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -358,6 +358,47 @@ export async function internalEntitlementsHttpHandler(
 
 const http = httpRouter();
 
+// Only the edge contact handler may write leads after its public abuse checks.
+http.route({
+  path: "/leads/submit-contact",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const expected = process.env.CONVEX_SERVER_SHARED_SECRET ?? "";
+    const provided = request.headers.get("x-convex-shared-secret") ?? "";
+    if (!expected || !(await timingSafeEqualStrings(provided, expected))) {
+      return Response.json({ error: "UNAUTHORIZED" }, { status: 401 });
+    }
+    const body = await parseJsonObjectBody<Record<string, unknown>>(request);
+    if (!body || typeof body.name !== "string" || typeof body.email !== "string"
+      || typeof body.source !== "string"
+      || [body.organization, body.phone, body.message].some(
+        (value) => value !== undefined && typeof value !== "string",
+      )) {
+      return Response.json({ error: "INVALID_CONTACT" }, { status: 400 });
+    }
+    try {
+      const result = await ctx.runMutation(internal.contactMessages.submit, {
+        name: body.name,
+        email: body.email,
+        source: body.source,
+        organization: body.organization as string | undefined,
+        phone: body.phone as string | undefined,
+        message: body.message as string | undefined,
+      });
+      return Response.json(result);
+    } catch (error) {
+      const code = extractConvexErrorCode(error);
+      if (code === "rate_limited") {
+        return Response.json({ error: code }, { status: 429 });
+      }
+      if (code === "FREE_EMAIL_NOT_ALLOWED") {
+        return Response.json({ error: code }, { status: 422 });
+      }
+      return Response.json({ error: "CONTACT_STORAGE_FAILED" }, { status: 503 });
+    }
+  }),
+});
+
 http.route({
   path: "/api/internal-register-interest",
   method: "POST",

--- a/server/worldmonitor/leads/v1/submit-contact.ts
+++ b/server/worldmonitor/leads/v1/submit-contact.ts
@@ -1,12 +1,9 @@
 /**
  * RPC: submitContact -- Stores an enterprise contact submission and emails ops.
  * Port from api/contact.js
- * Sources: Convex contactMessages:submit mutation + Resend notification email
+ * Sources: authenticated Convex contact HTTP route + Resend notification email
  */
 
-import { ConvexHttpClient } from 'convex/browser';
-import { ConvexError } from 'convex/values';
-import { api } from '../../../../convex/_generated/api';
 import type {
   ServerContext,
   SubmitContactRequest,
@@ -19,11 +16,6 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_RE = /^[+(]?\d[\d\s()./-]{4,23}\d$/;
 const MAX_FIELD = 500;
 const MAX_MESSAGE = 2000;
-
-type ConvexPolicyErrorData = {
-  kind?: string;
-  message?: string;
-};
 
 export const FREE_EMAIL_DOMAINS = new Set<string>([
   'gmail.com', 'googlemail.com', 'yahoo.com', 'yahoo.fr', 'yahoo.co.uk', 'yahoo.co.jp',
@@ -48,25 +40,6 @@ function escapeHtml(str: string): string {
 
 function sanitizeForSubject(str: string, maxLen = 50): string {
   return str.replace(/[\r\n\0]/g, '').slice(0, maxLen);
-}
-
-function getConvexPolicyErrorData(error: { data: unknown }): ConvexPolicyErrorData | null {
-  const rawData = error.data;
-  if (rawData && typeof rawData === 'object') {
-    return rawData as ConvexPolicyErrorData;
-  }
-  if (typeof rawData !== 'string') {
-    return null;
-  }
-
-  try {
-    const parsed: unknown = JSON.parse(rawData);
-    return parsed && typeof parsed === 'object'
-      ? parsed as ConvexPolicyErrorData
-      : null;
-  } catch {
-    return null;
-  }
 }
 
 async function sendNotificationEmail(
@@ -174,35 +147,47 @@ export async function submitContact(
   const safeMsg = message ? message.slice(0, MAX_MESSAGE) : undefined;
   const safeSource = source ? source.slice(0, 100) : 'enterprise-contact';
 
-  const convexUrl = process.env.CONVEX_URL;
-  if (!convexUrl) {
+  const convexUrl = (process.env.CONVEX_SITE_URL
+    ?? (process.env.CONVEX_URL ?? '').replace('.convex.cloud', '.convex.site')).replace(/\/$/, '');
+  const secret = process.env.CONVEX_SERVER_SHARED_SECRET;
+  if (!convexUrl || !secret) {
     throw new ApiError(503, 'Service unavailable', '');
   }
 
-  const client = new ConvexHttpClient(convexUrl);
+  let response: Response;
   try {
-    await client.mutation(api.contactMessages.submit, {
-      name: safeName,
-      email: email.trim(),
-      organization: safeOrg,
-      phone: safePhone,
-      message: safeMsg,
-      source: safeSource,
+    response = await fetch(`${convexUrl}/leads/submit-contact`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'worldmonitor-leads/1.0',
+        'x-convex-shared-secret': secret,
+      },
+      body: JSON.stringify({
+        name: safeName,
+        email: email.trim(),
+        organization: safeOrg,
+        phone: safePhone,
+        message: safeMsg,
+        source: safeSource,
+      }),
+      signal: AbortSignal.timeout(10_000),
     });
-  } catch (err) {
-    // Preserve policy failures from direct Convex enforcement at the HTTP seam
-    // instead of turning expected client errors into opaque 500 responses.
-    // Convex serializes ConvexError payloads onto err.data.
-    if (err instanceof ConvexError) {
-      const data = getConvexPolicyErrorData(err);
-      if (data?.kind === 'rate_limited') {
-        throw new ApiError(429, data.message || 'Too many requests', '');
-      }
-      if (data?.kind === 'FREE_EMAIL_NOT_ALLOWED') {
-        throw new ApiError(422, data.message || 'Please use your work email address', '');
-      }
-    }
-    throw err;
+  } catch {
+    throw new ApiError(503, 'Service unavailable', '');
+  }
+  if (response.status === 429) {
+    throw new ApiError(429, 'Too many recent submissions for this email; try again later.', '');
+  }
+  if (response.status === 422) {
+    throw new ApiError(422, 'Please use a corporate email address.', '');
+  }
+  if (!response.ok) {
+    throw new ApiError(503, 'Service unavailable', '');
+  }
+  const result: unknown = await response.json().catch(() => null);
+  if (!result || typeof result !== 'object' || !('status' in result) || result.status !== 'sent') {
+    throw new ApiError(503, 'Service unavailable', '');
   }
 
   const emailSent = await sendNotificationEmail(

--- a/tests/contact-handler.test.mjs
+++ b/tests/contact-handler.test.mjs
@@ -35,13 +35,12 @@ let submitContact;
 let ValidationError;
 let ApiError;
 let EdgeFreeEmailDomains;
-let ConvexHttpClient;
-let ConvexError;
-let originalConvexMutation;
 
 describe('LeadsService.submitContact', () => {
   beforeEach(async () => {
-    process.env.CONVEX_URL = 'https://fake-convex.cloud';
+    process.env.CONVEX_URL = 'https://fake-convex.convex.cloud';
+    delete process.env.CONVEX_SITE_URL;
+    process.env.CONVEX_SERVER_SHARED_SECRET = 'synthetic-contact-secret';
     process.env.TURNSTILE_SECRET_KEY = 'test-secret';
     process.env.RESEND_API_KEY = 'test-resend-key';
     process.env.VERCEL_ENV = 'production';
@@ -53,16 +52,11 @@ describe('LeadsService.submitContact', () => {
     const gen = await import('../src/generated/server/worldmonitor/leads/v1/service_server.ts');
     ValidationError = gen.ValidationError;
     ApiError = gen.ApiError;
-    ({ ConvexHttpClient } = await import('convex/browser'));
-    ({ ConvexError } = await import('convex/values'));
-    originalConvexMutation = ConvexHttpClient.prototype.mutation;
+
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
-    if (ConvexHttpClient && originalConvexMutation) {
-      ConvexHttpClient.prototype.mutation = originalConvexMutation;
-    }
     Object.keys(process.env).forEach((k) => {
       if (!(k in originalEnv)) delete process.env[k];
     });
@@ -196,7 +190,7 @@ describe('LeadsService.submitContact', () => {
       process.env.VERCEL_ENV = 'development';
       globalThis.fetch = async (url) => {
         if (typeof url === 'string' && url.includes('fake-convex')) {
-          return new Response(JSON.stringify({ status: 'success', value: { status: 'sent' } }));
+          return new Response(JSON.stringify({ status: 'sent' }));
         }
         if (typeof url === 'string' && url.includes('resend')) return new Response(JSON.stringify({ id: '1' }));
         return new Response('{}');
@@ -211,7 +205,7 @@ describe('LeadsService.submitContact', () => {
       delete process.env.RESEND_API_KEY;
       globalThis.fetch = async (url) => {
         if (typeof url === 'string' && url.includes('turnstile')) return new Response(JSON.stringify({ success: true }));
-        if (typeof url === 'string' && url.includes('fake-convex')) return new Response(JSON.stringify({ status: 'success', value: { status: 'sent' } }));
+        if (typeof url === 'string' && url.includes('fake-convex')) return new Response(JSON.stringify({ status: 'sent' }));
         return new Response('{}');
       };
       const res = await submitContact(makeCtx(), validReq());
@@ -222,7 +216,7 @@ describe('LeadsService.submitContact', () => {
     it('returns emailSent: false when Resend API returns error', async () => {
       globalThis.fetch = async (url) => {
         if (typeof url === 'string' && url.includes('turnstile')) return new Response(JSON.stringify({ success: true }));
-        if (typeof url === 'string' && url.includes('fake-convex')) return new Response(JSON.stringify({ status: 'success', value: { status: 'sent' } }));
+        if (typeof url === 'string' && url.includes('fake-convex')) return new Response(JSON.stringify({ status: 'sent' }));
         if (typeof url === 'string' && url.includes('resend')) return new Response('Rate limited', { status: 429 });
         return new Response('{}');
       };
@@ -234,7 +228,7 @@ describe('LeadsService.submitContact', () => {
     it('returns emailSent: true on successful notification', async () => {
       globalThis.fetch = async (url) => {
         if (typeof url === 'string' && url.includes('turnstile')) return new Response(JSON.stringify({ success: true }));
-        if (typeof url === 'string' && url.includes('fake-convex')) return new Response(JSON.stringify({ status: 'success', value: { status: 'sent' } }));
+        if (typeof url === 'string' && url.includes('fake-convex')) return new Response(JSON.stringify({ status: 'sent' }));
         if (typeof url === 'string' && url.includes('resend')) return new Response(JSON.stringify({ id: 'msg_123' }));
         return new Response('{}');
       };
@@ -246,7 +240,7 @@ describe('LeadsService.submitContact', () => {
     it('still succeeds (stores in Convex) even when email fails', async () => {
       globalThis.fetch = async (url) => {
         if (typeof url === 'string' && url.includes('turnstile')) return new Response(JSON.stringify({ success: true }));
-        if (typeof url === 'string' && url.includes('fake-convex')) return new Response(JSON.stringify({ status: 'success', value: { status: 'sent' } }));
+        if (typeof url === 'string' && url.includes('fake-convex')) return new Response(JSON.stringify({ status: 'sent' }));
         if (typeof url === 'string' && url.includes('resend')) throw new Error('Network failure');
         return new Response('{}');
       };
@@ -278,31 +272,57 @@ describe('LeadsService.submitContact', () => {
       await assert.rejects(() => submitContact(makeCtx(), validReq()));
     });
 
-    it('translates Convex free-email policy failures into 422 ApiError', async () => {
-      globalThis.fetch = async (url) => {
-        if (typeof url === 'string' && url.includes('turnstile')) {
-          return new Response(JSON.stringify({ success: true }));
-        }
-        return new Response('{}');
-      };
-      const policyError = {
-        kind: 'FREE_EMAIL_NOT_ALLOWED',
-        message: 'Please use a corporate email address.',
-      };
-
-      for (const errorData of [policyError, JSON.stringify(policyError)]) {
-        ConvexHttpClient.prototype.mutation = async () => {
-          throw new ConvexError(errorData);
+    for (const status of [422, 429]) {
+      it(`preserves storage policy status ${status} without notifying`, async () => {
+        globalThis.fetch = async (url) => {
+          if (url.includes('turnstile')) return Response.json({ success: true });
+          assert.ok(url.includes('/leads/submit-contact'));
+          return Response.json({ error: 'policy' }, { status });
         };
+        await assert.rejects(() => submitContact(makeCtx(), validReq()),
+          (err) => err instanceof ApiError && err.statusCode === status);
+      });
+    }
 
-        await assert.rejects(
-          () => submitContact(makeCtx(), validReq()),
-          (err) =>
-            err instanceof ApiError
-            && err.statusCode === 422
-            && /corporate email/i.test(err.message),
-        );
-      }
+    it('sends the server secret only to the contact bridge after Turnstile succeeds', async () => {
+      const calls = [];
+      globalThis.fetch = async (url, init) => {
+        calls.push(url);
+        if (url.includes('turnstile')) return Response.json({ success: true });
+        if (url.includes('fake-convex')) {
+          assert.equal(url, 'https://fake-convex.convex.site/leads/submit-contact');
+          assert.equal(init.headers['x-convex-shared-secret'], 'synthetic-contact-secret');
+          assert.equal(JSON.parse(init.body).email, 'test@example.com');
+          return Response.json({ status: 'sent' });
+        }
+        assert.equal(init.headers['x-convex-shared-secret'], undefined);
+        return Response.json({ id: 'synthetic-email' });
+      };
+      assert.deepEqual(await submitContact(makeCtx(), validReq()), { status: 'sent', emailSent: true });
+      assert.equal(calls.length, 3);
+      assert.ok(calls[0].includes('turnstile'));
     });
+
+    it('fails closed without the server secret', async () => {
+      delete process.env.CONVEX_SERVER_SHARED_SECRET;
+      globalThis.fetch = async (url) => {
+        assert.ok(url.includes('turnstile'));
+        return Response.json({ success: true });
+      };
+      await assert.rejects(() => submitContact(makeCtx(), validReq()),
+        (err) => err instanceof ApiError && err.statusCode === 503);
+    });
+
+    for (const body of ['not json', '{}', '{"status":"failed"}']) {
+      it(`does not notify on invalid storage acknowledgment ${body}`, async () => {
+        globalThis.fetch = async (url) => {
+          if (url.includes('turnstile')) return Response.json({ success: true });
+          assert.ok(url.includes('/leads/submit-contact'));
+          return new Response(body);
+        };
+        await assert.rejects(() => submitContact(makeCtx(), validReq()),
+          (err) => err instanceof ApiError && err.statusCode === 503);
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Enterprise contacts must pass the public handler's CAPTCHA and fail-closed IP budget before storage. The contact mutation is now internal, reached through the existing server shared-secret pattern. Corporate-email validation, field limits and the five-per-hour email limit remain enforced in Convex; policy failures still return 422/429 to the caller.

## Validation

- The new visibility test failed against the original public mutation; the existing anonymous storage test succeeded there.
- 21 contact Convex tests pass, including a real edge-handler -> HTTP action -> internal mutation -> database test with synthetic Turnstile and Resend responses. Missing/wrong secrets write no rows.
- 25 contact handler tests, 63 gateway/rate-limit tests, all 1,952 Vitest tests and 487 sidecar tests pass.
- API and Convex type checks, boundary lint and diff checks pass.
- Sequential local code review completed; no outstanding actionable findings. No production probes or UI changes.

## Post-Deploy Monitoring & Validation

Release owner: confirm the existing `CONVEX_SERVER_SHARED_SECRET` matches in Vercel and Convex, then coordinate deployment of both changes. Either version mismatch can temporarily make contact requests fail closed; do not claim live acceptance until both are deployed. No deployment is included in this PR.

For the first 30 minutes after an authorized rollout, inspect Vercel contact RPC 403/422/429/503 rates and Convex `/leads/submit-contact` failures (`UNAUTHORIZED`, `CONTACT_STORAGE_FAILED`). With an approved test submission, expect one stored contact and the normal notification result; unauthenticated bridge calls must return 401 with no write. Investigate sustained 503s or failed valid submissions immediately; correct configuration/version skew or temporarily disable intake rather than restore public storage access. A transport failure after commit can still leave a stored contact without notification; this change does not promise exactly-once delivery.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
