### PR TITLE
fix(telemetry): cap caller-supplied trace headers

### DIFF
--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -419,7 +419,7 @@ export function deriveReqBytes(req: Request): number {
 }
 
 export function deriveSentryTraceId(req: Request): string | null {
-  return req.headers.get('sentry-trace') ?? null;
+  return capHeaderValue(req.headers.get('sentry-trace'));
 }
 
 // ua_hash: SHA-256(UA + monthly-rotated pepper). Pepper key: USAGE_UA_PEPPER.

--- a/tests/usage-trace-telemetry.test.mts
+++ b/tests/usage-trace-telemetry.test.mts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { createDomainGateway } from '../server/gateway.ts';
+import { deriveSentryTraceId } from '../server/_shared/usage.ts';
+
+test('trace header preserves absent, empty, valid and boundary values', () => {
+  const trace = '0123456789abcdef0123456789abcdef-0123456789abcdef-1';
+  for (const value of [null, '', trace, 'a'.repeat(512), 'a'.repeat(513)]) {
+    const req = new Request('https://worldmonitor.app/api/test', {
+      headers: value === null ? {} : { 'sentry-trace': value },
+    });
+    assert.equal(deriveSentryTraceId(req), value?.slice(0, 512) ?? null);
+    assert.equal(req.headers.get('sentry-trace'), value);
+  }
+});
+
+test('gateway caps caller-controlled trace data before Axiom delivery', async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalFlag = process.env.USAGE_TELEMETRY;
+  const originalToken = process.env.AXIOM_API_TOKEN;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalFlag === undefined) delete process.env.USAGE_TELEMETRY;
+    else process.env.USAGE_TELEMETRY = originalFlag;
+    if (originalToken === undefined) delete process.env.AXIOM_API_TOKEN;
+    else process.env.AXIOM_API_TOKEN = originalToken;
+  });
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'synthetic-axiom-token';
+  const events: { sentry_trace_id: string; reason: string }[] = [];
+  globalThis.fetch = async (input, init) => {
+    assert.equal(new URL(String(input)).hostname, 'api.axiom.co');
+    events.push(...JSON.parse(String(init?.body)));
+    return new Response('{}');
+  };
+  const trace = 'a'.repeat(8192);
+  const req = new Request('https://worldmonitor.app/api/market/v1/list-market-quotes', {
+    headers: { Origin: 'https://untrusted.example', 'sentry-trace': trace },
+  });
+  const pending: Promise<unknown>[] = [];
+  const res = await createDomainGateway([])(req, {
+    waitUntil: (promise) => { pending.push(promise); },
+  });
+  await Promise.all(pending);
+  assert.equal(res.status, 403);
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.reason, 'origin_403');
+  assert.equal(events[0]!.sentry_trace_id, trace.slice(0, 512));
+  assert.equal(req.headers.get('sentry-trace'), trace);
+});


### PR DESCRIPTION
## Summary
Trace headers written through the shared usage helper are now capped at 512 characters, matching the existing free-form telemetry header policy. Normal trace values and the original request remain unchanged. The new test file is independent of PR #8005.

Related: DeepSec finding 42.

## Validation
- Before the fix, an origin-rejected request sent an 8 KiB caller-supplied trace value to mocked Axiom. After the fix, the field is 512 characters.
- 18 focused tests passed, including absent, empty, valid and boundary trace values, plus the existing gateway telemetry suite.
- API typecheck and diff whitespace checks passed. Sequential ce-code-review found no actionable issues.
- Existing ingress bounds limit the exposure: [Vercel documents a 16 KB individual header limit](https://vercel.com/docs/errors/request_header_too_large). Production traffic and billing impact were not probed.

## Post-Deploy Monitoring & Validation
Owner: repository operator. For the first 24 hours after authorized deployment, monitor `wm_api_usage` records from gateway and MCP routes that use the shared helper. Check the maximum length of `sentry_trace_id`; expected maximum is 512 characters, and ordinary Sentry correlation should remain intact. A longer field on these routes indicates an old deployment or another emission path; investigate the source before mitigation. The separate legacy JavaScript telemetry implementation is outside this change. No production operation was performed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
