### PR TITLE
fix(market): bound crypto quote provider requests

### DIFF
--- a/server/__tests__/gateway-direct-llm-quota.test.ts
+++ b/server/__tests__/gateway-direct-llm-quota.test.ts
@@ -79,9 +79,8 @@ const BACKTEST_PATH = "/api/market/v1/backtest-stock";
 // GLOBAL limiter these tests exercise. The gateway skips the global limiter for
 // any route carrying an endpoint policy (gateway.ts, `!hasEndpointRatePolicy`),
 // so a policied route here would silently stop testing what it claims to.
-// list-market-quotes used to sit here and gained a policy in #6305 when its
-// seed misses started reaching a paid provider.
-const GLOBAL_LIMITED_PATH = "/api/market/v1/list-crypto-quotes";
+// Crypto quotes now has an endpoint policy for its paid-provider gap fetch.
+const GLOBAL_LIMITED_PATH = "/api/market/v1/list-gulf-quotes";
 const CACHE_PATH = "/api/news/v1/summarize-article-cache";
 
 function json(body: unknown, status = 200) {

--- a/server/__tests__/gateway-post-to-get-compat-rate-limit.test.ts
+++ b/server/__tests__/gateway-post-to-get-compat-rate-limit.test.ts
@@ -48,7 +48,7 @@ import { createDomainGateway } from "../gateway";
 
 const ENDPOINT_LIMITED_PATH = "/api/market/v1/list-market-quotes";
 // No endpoint policy, so the gateway falls through to the global limiter.
-const GLOBAL_LIMITED_PATH = "/api/market/v1/list-crypto-quotes";
+const GLOBAL_LIMITED_PATH = "/api/market/v1/list-gulf-quotes";
 
 function json(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -400,6 +400,7 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   // when that read fails, so the fail-closed 503 is a second line, not the
   // only thing standing between a Redis outage and a CoinGecko fan-out. (#6308)
   '/api/market/v1/list-stablecoin-markets': { limit: 60, window: '60 s' },
+  '/api/market/v1/list-crypto-quotes': { limit: 60, window: '60 s' },
   '/api/economic/v1/list-world-bank-indicators': { limit: 30, window: '60 s' },
   // #6305: list-market-quotes stopped being a pure seed read. The fixed seed
   // still answers the default universe with no upstream call, but a symbol the
@@ -579,6 +580,9 @@ export const FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: Record<string, RateLimit
   },
   '/api/market/v1/get-country-stock-index': {
     reason: 'Per-country stock-index lookups proxy Yahoo Finance on cache miss.',
+  },
+  '/api/market/v1/list-crypto-quotes': {
+    reason: 'Caller-named coin IDs absent from the seed snapshot fan out to CoinGecko on cache miss.',
   },
   '/api/market/v1/list-stablecoin-markets': {
     reason: 'Caller-named coin IDs absent from the seed snapshot fan out to CoinGecko on cache miss with unbounded ID cardinality.',

--- a/server/worldmonitor/market/v1/_shared.ts
+++ b/server/worldmonitor/market/v1/_shared.ts
@@ -110,7 +110,7 @@ export async function fetchCoinGeckoMarkets(
 ): Promise<CoinGeckoMarketItem[]> {
   const { sparkline = true, priceChangePercentage = '24h' } = opts;
   const { baseUrl, headers } = coingeckoEndpoint();
-  const url = `${baseUrl}/coins/markets?vs_currency=usd&ids=${ids.join(',')}&order=market_cap_desc&sparkline=${sparkline}&price_change_percentage=${encodeURIComponent(priceChangePercentage)}`;
+  const url = `${baseUrl}/coins/markets?vs_currency=usd&ids=${encodeURIComponent(ids.join(','))}&order=market_cap_desc&sparkline=${sparkline}&price_change_percentage=${encodeURIComponent(priceChangePercentage)}`;
 
   const resp = await fetch(url, {
     headers,

--- a/server/worldmonitor/market/v1/list-crypto-quotes.ts
+++ b/server/worldmonitor/market/v1/list-crypto-quotes.ts
@@ -33,7 +33,7 @@ import {
   parseStringArray,
   UPSTREAM_TIMEOUT_MS,
 } from './_shared';
-import { cachedFetchJson, readCachedJson } from '../../../_shared/redis';
+import { cachedFetchJson, logCacheReadError, readCachedJson } from '../../../_shared/redis';
 import { sha256Hex } from '../../../_shared/hash';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 import { markNoCacheResponse, setResponseHeader } from '../../../_shared/response-headers';
@@ -187,6 +187,7 @@ export async function listCryptoQuotes(
 
   // A cache outage must not turn every requested coin into provider work.
   const seedRead = await readCachedJson(SEED_CACHE_KEY, true);
+  if (seedRead.status === 'error') logCacheReadError(SEED_CACHE_KEY, seedRead.error);
   const seedData = seedRead.status === 'hit' ? seedRead.value as { quotes?: SeedQuote[] } | null : null;
   const seedQuotes = Array.isArray(seedData?.quotes) ? seedData.quotes : [];
   const seedUnavailable = seedRead.status === 'error'

--- a/server/worldmonitor/market/v1/list-crypto-quotes.ts
+++ b/server/worldmonitor/market/v1/list-crypto-quotes.ts
@@ -33,13 +33,15 @@ import {
   parseStringArray,
   UPSTREAM_TIMEOUT_MS,
 } from './_shared';
-import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
+import { cachedFetchJson, readCachedJson } from '../../../_shared/redis';
+import { sha256Hex } from '../../../_shared/hash';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 import { markNoCacheResponse, setResponseHeader } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'market:crypto:v1';
 const GAP_CACHE_TTL = 600; // 10 min — matches the pre-#1684 REDIS_CACHE_TTL
 const MAX_IDS = 25;
+const COINGECKO_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
 // CoinGecko ID per seed quote symbol. Seed snapshots are keyed by symbol, so
 // request ids are matched to seed members via this reverse map.
@@ -168,30 +170,30 @@ export async function listCryptoQuotes(
   ctx: ServerContext,
   req: ListCryptoQuotesRequest,
 ): Promise<ListCryptoQuotesResponse> {
-  // Normalize + de-duplicate requested ids (trimmed, first-seen order).
-  const requested = parseStringArray(req.ids);
+  // Repeated query parameters may themselves contain comma-separated IDs.
+  // Validate individual tokens before counting them toward the provider cap.
   const ids: string[] = [];
+  const invalid: string[] = [];
   const seen = new Set<string>();
-  for (const raw of requested) {
-    const id = raw.trim().toLowerCase();
-    if (id && !seen.has(id)) {
+  for (const raw of parseStringArray(req.ids)) {
+    for (const part of raw.split(',')) {
+      const id = part.trim().toLowerCase();
+      if (!id || seen.has(id)) continue;
       seen.add(id);
-      ids.push(id);
+      if (COINGECKO_ID_PATTERN.test(id)) ids.push(id);
+      else invalid.push(id.slice(0, 64));
     }
   }
 
-  // Never trust Redis reads to break the request.
-  let seedQuotes: SeedQuote[] = [];
-  try {
-    const seedData = await getCachedJson(SEED_CACHE_KEY, true) as { quotes: SeedQuote[] } | null;
-    seedQuotes = seedData?.quotes ?? [];
-  } catch {
-    // sentry-coverage-ok: a seed read failure degrades to seed-only/empty behavior by design; no error to surface.
-    seedQuotes = [];
-  }
+  // A cache outage must not turn every requested coin into provider work.
+  const seedRead = await readCachedJson(SEED_CACHE_KEY, true);
+  const seedData = seedRead.status === 'hit' ? seedRead.value as { quotes?: SeedQuote[] } | null : null;
+  const seedQuotes = Array.isArray(seedData?.quotes) ? seedData.quotes : [];
+  const seedUnavailable = seedRead.status === 'error'
+    || (seedRead.status === 'hit' && !Array.isArray(seedData?.quotes));
 
   // Default request: return the seeded default crypto set, never the provider.
-  if (ids.length === 0) {
+  if (ids.length === 0 && invalid.length === 0) {
     if (seedQuotes.length === 0) {
       return { quotes: [], unresolvedIds: [], provider: 'degraded' };
     }
@@ -230,17 +232,22 @@ export async function listCryptoQuotes(
   let provider: 'seed' | 'upstream' | 'mixed' | 'degraded' =
     gapIds.length === 0 ? 'seed' : (seedHits.length > 0 ? 'mixed' : 'upstream');
 
-  if (gapIds.length > 0) {
+  if (gapIds.length > 0 && !seedUnavailable) {
     // Bounded upstream fetch, Redis-cached per sorted gap set. cacheFetcherErrors
     // is false so provider failures rethrow and never write a negative cache.
     // An empty provider result is treated as a negative (120s NEG_SENTINEL) via
     // a `null` fetcher return, never as a positive 600s `{}` cache entry.
-    const cacheKey = `market:crypto:gap:v1:${[...gapIds].sort().join(',')}`;
+    const cacheKey = `market:crypto:gap:v2:${await sha256Hex([...gapIds].sort().join(','))}`;
     try {
       const cached = await cachedFetchJson<Record<string, CryptoQuote>>(
         cacheKey,
         GAP_CACHE_TTL,
         async () => {
+          // cachedFetchJson treats read errors as misses. Recheck inside its
+          // coalesced fetcher so an unreadable cache cannot trigger paid work.
+          if ((await readCachedJson(cacheKey)).status === 'error') {
+            throw new Error('Crypto gap cache unavailable');
+          }
           const got = await fetchGapQuotes(gapIds);
           return got.size > 0 ? Object.fromEntries(got) : null;
         },
@@ -258,13 +265,13 @@ export async function listCryptoQuotes(
     // Any gap id the provider could not resolve gets a relay attempt (separate
     // egress IP). Relay results are applied per-request and not Redis-cached.
     const stillMissing = gapIds.filter((id) => !resolved.has(id));
-    if (stillMissing.length > 0) {
+    if (stillMissing.length > 0 && (await readCachedJson(cacheKey)).status !== 'error') {
       const relayed = await fetchGapQuotesViaRelay(stillMissing);
       for (const [id, quote] of relayed) resolved.set(id, quote);
     }
   }
 
-  const unresolvedIds = [...overflow, ...gapIds.filter((id) => !resolved.has(id))];
+  const unresolvedIds = [...invalid, ...overflow, ...gapIds.filter((id) => !resolved.has(id))];
   if (unresolvedIds.length > 0) provider = 'degraded';
 
   const quotes = accepted

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -29,7 +29,7 @@ function createHandler(options: { handlerCdnCacheHeader?: string; publicRouteBod
   return createDomainGateway([
     {
       method: 'GET',
-      path: '/api/market/v1/list-crypto-quotes',
+      path: '/api/market/v1/list-gulf-quotes',
       handler: async () => new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: options.handlerCdnCacheHeader ? { 'CDN-Cache-Control': options.handlerCdnCacheHeader } : undefined,
@@ -65,7 +65,7 @@ function createHandler(options: { handlerCdnCacheHeader?: string; publicRouteBod
 
 async function requestPublicRoute(origin: string) {
   const handler = createHandler();
-  return handler(new Request('https://worldmonitor.app/api/market/v1/list-crypto-quotes?ids=bitcoin', {
+  return handler(new Request('https://worldmonitor.app/api/market/v1/list-gulf-quotes', {
     headers: { Origin: origin, 'X-WorldMonitor-Key': sessionToken },
   }));
 }
@@ -114,7 +114,7 @@ describe('gateway CDN origin policy', () => {
     const origin = 'tauri://localhost';
     process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
     const handler = createHandler();
-    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-crypto-quotes?ids=bitcoin', {
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-gulf-quotes', {
       headers: {
         Origin: origin,
         'X-WorldMonitor-Key': 'real-key-123',
@@ -236,7 +236,7 @@ describe('gateway CDN origin policy', () => {
     const handler = createHandler({
       handlerCdnCacheHeader: 'public, s-maxage=9999, stale-while-revalidate=9999',
     });
-    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-crypto-quotes?ids=bitcoin', {
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-gulf-quotes', {
       headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': sessionToken },
     }));
 
@@ -246,7 +246,7 @@ describe('gateway CDN origin policy', () => {
 
   it('still blocks disallowed origins before route handling', async () => {
     const handler = createHandler();
-    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-crypto-quotes?ids=bitcoin', {
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-gulf-quotes', {
       headers: { Origin: 'https://evil.example.com' },
     }));
     assert.equal(res.status, 403);
@@ -279,7 +279,7 @@ describe('gateway CDN origin policy', () => {
 
   it('fails closed before unknown wm_ validation when the pre-auth limiter is unavailable', async () => {
     const handler = createHandler();
-    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-crypto-quotes?ids=bitcoin', {
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-gulf-quotes', {
       headers: {
         Origin: 'https://worldmonitor.app',
         'X-WorldMonitor-Key': 'wm_revoked_or_unknown_key',

--- a/tests/gateway-required-bbox.test.mts
+++ b/tests/gateway-required-bbox.test.mts
@@ -162,14 +162,14 @@ describe('gateway required-bbox diagnostics', () => {
 
   it('does not add bbox diagnostics to unrelated API endpoints', async () => {
     const hits = new Map<string, number>();
-    const handler = createGatewayForPaths(hits, ['/api/market/v1/list-crypto-quotes']);
+    const handler = createGatewayForPaths(hits, ['/api/market/v1/list-gulf-quotes']);
 
-    const res = await handler(makeRequest('/api/market/v1/list-crypto-quotes?ids=bitcoin'));
+    const res = await handler(makeRequest('/api/market/v1/list-gulf-quotes'));
     const body = await res.json();
 
     assert.equal(res.status, 200);
     assert.deepEqual(body, { ok: true });
-    assert.equal(hits.get('/api/market/v1/list-crypto-quotes'), 1);
+    assert.equal(hits.get('/api/market/v1/list-gulf-quotes'), 1);
     assertNoBboxDiagnostic(res);
   });
 

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -435,6 +435,52 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     assert.deepEqual(calls, [], 'no cache or provider transport reached');
   });
 
+  it('crypto quote requests stop at the 60/min budget before additional provider work', async () => {
+    const { installRedis } = await import('./helpers/fake-upstash-redis.mts');
+    const redis = installRedis({ 'market:crypto:v1': { quotes: [] } });
+    process.env.WM_SESSION_SECRET = 'synthetic-crypto-cap-secret-at-least-32-bytes';
+    __resetRateLimitForTest();
+    const { issueSessionToken } = await import('../api/_session.js');
+    const { createDomainGateway } = await import('../server/gateway.ts');
+    const { createMarketServiceRoutes } = await import('../src/generated/server/worldmonitor/market/v1/service_server.ts');
+    const { marketHandler } = await import('../server/worldmonitor/market/v1/handler.ts');
+    let providerCalls = 0;
+    let admissions = 0;
+    globalThis.fetch = (async (input, init) => {
+      if (String(input).includes('coingecko.com')) {
+        providerCalls += 1;
+        return Response.json([{ id: 'budget-coin', name: 'Budget coin', symbol: 'bud', current_price: 1 }]);
+      }
+      const response = await redis.fetchImpl(input, init);
+      if (init?.body) {
+        const commands = JSON.parse(String(init.body));
+        if (Array.isArray(commands[0])) {
+          const results = await response.json();
+          for (let i = 0; i < commands.length; i += 1) {
+            if (String(commands[i][0]).toUpperCase() === 'EVALSHA') {
+              // The shared fake is always-allow. Model the storage reply for
+              // this route so the real SDK/gateway also exercise exhaustion.
+              results[i] = { result: [60 - ++admissions, 60] };
+            }
+          }
+          return Response.json(results);
+        }
+      }
+      return response;
+    }) as typeof fetch;
+    const token = (await issueSessionToken()).token;
+    const gateway = createDomainGateway(createMarketServiceRoutes(marketHandler));
+    const request = () => new Request('https://worldmonitor.app/api/market/v1/list-crypto-quotes?ids=budget-coin', {
+      headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': token, 'x-real-ip': '203.0.113.8' },
+    });
+    for (let i = 0; i < 60; i += 1) assert.equal((await gateway(request())).status, 200);
+    assert.equal(providerCalls, 1, 'successful calls reuse the gap cache');
+    const blocked = await gateway(request());
+    assert.equal(blocked.status, 429);
+    assert.ok(Number(blocked.headers.get('Retry-After')) > 0);
+    assert.equal(providerCalls, 1, 'exhausted callers cannot cause provider work');
+  });
+
   it('paid-provider market routes each have explicit fail-closed policies (#6236)', async () => {
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -410,6 +410,31 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     assert.equal(handlerCalls, 0, 'the gateway must reject before route execution');
   });
 
+  it('anonymous crypto quote requests fail closed before cache or provider I/O', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.WM_SESSION_SECRET = 'synthetic-crypto-session-secret-at-least-32-bytes';
+    __resetRateLimitForTest();
+    const { issueSessionToken } = await import('../api/_session.js');
+    const { createDomainGateway } = await import('../server/gateway.ts');
+    const { createMarketServiceRoutes } = await import('../src/generated/server/worldmonitor/market/v1/service_server.ts');
+    const { marketHandler } = await import('../server/worldmonitor/market/v1/handler.ts');
+    const token = (await issueSessionToken()).token;
+    const calls: string[] = [];
+    globalThis.fetch = (async (input) => {
+      calls.push(String(input));
+      return new Response('unexpected I/O', { status: 500 });
+    }) as typeof fetch;
+    const gateway = createDomainGateway(createMarketServiceRoutes(marketHandler));
+    const response = await gateway(new Request(
+      'https://worldmonitor.app/api/market/v1/list-crypto-quotes?ids=dogecoin',
+      { headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': token, 'x-real-ip': '203.0.113.7' } },
+    ));
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.deepEqual(calls, [], 'no cache or provider transport reached');
+  });
+
   it('paid-provider market routes each have explicit fail-closed policies (#6236)', async () => {
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -418,6 +443,7 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
       ['/api/market/v1/analyze-stock', { limit: 60, window: '60 s' }],
       ['/api/market/v1/backtest-stock', { limit: 60, window: '60 s' }],
       ['/api/market/v1/get-insider-transactions', { limit: 60, window: '60 s' }],
+      ['/api/market/v1/list-crypto-quotes', { limit: 60, window: '60 s' }],
       ['/api/market/v1/get-country-stock-index', { limit: 30, window: '60 s' }],
       ['/api/economic/v1/list-world-bank-indicators', { limit: 30, window: '60 s' }],
     ] as const);

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -447,7 +447,7 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     let providerCalls = 0;
     let admissions = 0;
     globalThis.fetch = (async (input, init) => {
-      if (String(input).includes('coingecko.com')) {
+      if (new URL(String(input)).hostname === 'api.coingecko.com') {
         providerCalls += 1;
         return Response.json([{ id: 'budget-coin', name: 'Budget coin', symbol: 'bud', current_price: 1 }]);
       }

--- a/tests/test-crypto-quotes-gap.mts
+++ b/tests/test-crypto-quotes-gap.mts
@@ -452,13 +452,17 @@ describe('crypto quote provider boundary', () => {
       configureRemoteRedis();
       process.env.WS_RELAY_URL = 'https://relay.example.test';
       const { calls, writes } = stubFetch({ seed: SEED, redisFailure });
-      console.warn = () => {};
+      const warnings: unknown[][] = [];
+      console.warn = (...args) => { warnings.push(args); };
       console.error = () => {};
       const out = await listCryptoQuotes(ctx(), { ids: ['bitcoin', `outage-${redisFailure}`] });
       assert.equal(out.provider, 'degraded');
       assert.deepEqual(out.quotes.map(quote => quote.symbol), redisFailure === 'seed' ? [] : ['BTC']);
       assert.ok(calls.every(url => !url.includes('coingecko') && !url.includes('coinpaprika') && !url.includes('/crypto-quotes')));
       assert.equal(writes.length, 0);
+      if (redisFailure === 'seed') {
+        assert.ok(warnings.some(args => args[0] === '[redis] getCachedJson failed:'));
+      }
     });
   }
 

--- a/tests/test-crypto-quotes-gap.mts
+++ b/tests/test-crypto-quotes-gap.mts
@@ -2,6 +2,8 @@ import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { listCryptoQuotes } from '../server/worldmonitor/market/v1/list-crypto-quotes';
+import { createMarketServiceRoutes, type MarketServiceHandler } from '../src/generated/server/worldmonitor/market/v1/service_server';
+import { fetchCoinGeckoMarkets } from '../server/worldmonitor/market/v1/_shared';
 import { GENERATED_MESSAGE_RULES } from '../src/generated/server/request_validation';
 
 const SEED = {
@@ -54,6 +56,7 @@ afterEach(() => {
  */
 interface FetchPlan {
   seed?: unknown;
+  redisFailure?: 'seed' | 'gap';
   provider?: Record<string, unknown[]>;
   relay?: { quotes?: Array<{ id?: string; name?: string; symbol?: string; price?: number; change?: number; sparkline?: number[] }> } | null;
 }
@@ -72,6 +75,10 @@ function stubFetch(plan: FetchPlan): { calls: string[]; writes: Array<{ url: str
       });
     }
     if (url.includes('/get/')) {
+      const isSeed = url.includes(encodeURIComponent('market:crypto:v1'));
+      if ((plan.redisFailure === 'seed' && isSeed) || (plan.redisFailure === 'gap' && !isSeed)) {
+        return new Response('unavailable', { status: 503 });
+      }
       if (plan.seed && url.includes(encodeURIComponent('market:crypto:v1'))) {
         return new Response(JSON.stringify({ result: JSON.stringify(plan.seed) }), {
           status: 200,
@@ -235,7 +242,7 @@ describe('listCryptoQuotes parameterized gap resolution (#6306)', () => {
     const negWrites = writes.filter((w) => w.body.includes('__WM_NEG__') && w.body.includes('"EX","120"'));
     assert.equal(negWrites.length, 1, 'exactly one short negative write for the unresolved gap set');
     assert.equal(
-      writes.some((w) => w.body.includes('market:crypto:gap:v1:') && w.body.endsWith('"EX","600"')),
+      writes.some((w) => w.body.includes('market:crypto:gap:v2:') && w.body.endsWith('"EX","600"')),
       false,
       'an empty provider result must NOT be cached as a 600s positive entry',
     );
@@ -307,7 +314,7 @@ describe('listCryptoQuotes parameterized gap resolution (#6306)', () => {
     assert.equal(out1.provider, 'degraded');
     assert.deepEqual(out1.unresolvedIds, ['dogecoin']);
     assert.equal(
-      writes.filter((w) => w.body.includes('market:crypto:gap:v1:dogecoin')).length,
+      writes.filter((w) => w.body.includes('market:crypto:gap:v2:')).length,
       0,
       'a throwing provider must NOT write a positive OR negative cache entry',
     );
@@ -345,6 +352,11 @@ describe('listCryptoQuotes parameterized gap resolution (#6306)', () => {
     const gapCache = new Map<string, Record<string, unknown>>();
     globalThis.fetch = (async (input: RequestInfo | URL, _init?: RequestInit) => {
       const url = String(input);
+      if (_init?.method === 'POST' && _init.body) {
+        const [command, key, value] = JSON.parse(String(_init.body));
+        if (command === 'SET') gapCache.set(key, JSON.parse(value));
+        return new Response(JSON.stringify({ result: 'OK' }));
+      }
       if (url.includes('/get/')) {
         const key = decodeURIComponent((url.match(/\/get\/([^/?]+)/) ?? [])[1] ?? '');
         if (key === 'market:crypto:v1') {
@@ -353,7 +365,7 @@ describe('listCryptoQuotes parameterized gap resolution (#6306)', () => {
             headers: { 'Content-Type': 'application/json' },
           });
         }
-        if (key.startsWith('market:crypto:gap:v1:')) {
+        if (key.startsWith('market:crypto:gap:v2:')) {
           const cached = gapCache.get(key);
           if (cached) {
             return new Response(JSON.stringify({ result: JSON.stringify(cached) }), {
@@ -373,9 +385,6 @@ describe('listCryptoQuotes parameterized gap resolution (#6306)', () => {
       }
       if (url.includes('coingecko')) {
         coingeckoCalls += 1;
-        const quote = { dogecoin: { name: 'Dogecoin', symbol: 'DOGE', price: 0.16, change: 4.2, sparkline: [1, 2] } };
-        // Record the cache write so the second request hits it.
-        gapCache.set('market:crypto:gap:v1:dogecoin', quote);
         return new Response(
           JSON.stringify([{ id: 'dogecoin', name: 'Dogecoin', symbol: 'doge', current_price: 0.16, price_change_percentage_24h: 4.2, sparkline_in_7d: { price: [1, 2] } }]),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
@@ -404,5 +413,66 @@ describe('listCryptoQuotes parameterized gap resolution (#6306)', () => {
     const rule = rules['worldmonitor.market.v1.ListCryptoQuotesRequest'];
     assert.ok(rule, 'ListCryptoQuotesRequest must have a generated validation rule');
     assert.equal(rule.fields.ids?.repeatedMaxItems, 25);
+  });
+});
+
+describe('crypto quote provider boundary', () => {
+  it('splits comma-bearing repeated parameters before applying the 25-ID bound', async () => {
+    configureRemoteRedis();
+    const ids = Array.from({ length: 30 }, (_, i) => `bounded-coin-${i}`);
+    const { calls } = stubFetch({ seed: SEED });
+    console.warn = () => {};
+    const route = createMarketServiceRoutes({ listCryptoQuotes } as MarketServiceHandler)
+      .find(route => route.path === '/api/market/v1/list-crypto-quotes')!;
+    const url = new URL('https://worldmonitor.app/api/market/v1/list-crypto-quotes');
+    url.searchParams.append('ids', ids.join(','));
+    url.searchParams.append('ids', ids[0]);
+    const response = await route.handler(new Request(url));
+    assert.equal(response.status, 200);
+    const gecko = new URL(calls.find(url => url.includes('coingecko'))!);
+    assert.deepEqual(gecko.searchParams.get('ids')!.split(','), ids.slice(0, 25));
+    const result = await response.json();
+    assert.deepEqual(result.unresolvedIds.slice(0, 5), ids.slice(25));
+  });
+
+  it('rejects query delimiters and overlong IDs without treating them as a default request', async () => {
+    configureRemoteRedis();
+    const { calls } = stubFetch({ seed: SEED });
+    console.warn = () => {};
+    const out = await listCryptoQuotes(ctx(), { ids: ['bitcoin&per_page=250', 'ethereum#fragment', 'x'.repeat(1000)] });
+    assert.deepEqual(out.quotes, []);
+    assert.equal(out.provider, 'degraded');
+    assert.equal(out.unresolvedIds.length, 3);
+    assert.ok(out.unresolvedIds.every(id => id.length <= 64));
+    assert.ok(calls.every(url => !url.includes('coingecko') && !url.includes('coinpaprika') && !url.includes('/crypto-quotes')));
+  });
+
+  for (const redisFailure of ['seed', 'gap'] as const) {
+    it(`${redisFailure} cache failure prevents provider and relay work`, async () => {
+      configureRemoteRedis();
+      process.env.WS_RELAY_URL = 'https://relay.example.test';
+      const { calls, writes } = stubFetch({ seed: SEED, redisFailure });
+      console.warn = () => {};
+      console.error = () => {};
+      const out = await listCryptoQuotes(ctx(), { ids: ['bitcoin', `outage-${redisFailure}`] });
+      assert.equal(out.provider, 'degraded');
+      assert.deepEqual(out.quotes.map(quote => quote.symbol), redisFailure === 'seed' ? [] : ['BTC']);
+      assert.ok(calls.every(url => !url.includes('coingecko') && !url.includes('coinpaprika') && !url.includes('/crypto-quotes')));
+      assert.equal(writes.length, 0);
+    });
+  }
+
+  it('uses fixed-size gap cache keys and encodes upstream IDs as a single parameter', async () => {
+    configureRemoteRedis();
+    const { calls } = stubFetch({ seed: SEED });
+    console.warn = () => {};
+    await listCryptoQuotes(ctx(), { ids: ['key-bound-coin'] });
+    const gapRead = calls.find(url => decodeURIComponent(url).includes('market:crypto:gap:'))!;
+    assert.match(decodeURIComponent(gapRead), /market:crypto:gap:v2:[a-f0-9]{64}$/);
+    await fetchCoinGeckoMarkets(['id&vs_currency=eur#fragment']);
+    const upstream = new URL(calls.filter(url => url.includes('coingecko')).at(-1)!);
+    assert.equal(upstream.searchParams.get('ids'), 'id&vs_currency=eur#fragment');
+    assert.equal(upstream.searchParams.get('vs_currency'), 'usd');
+    assert.equal(upstream.hash, '');
   });
 });


### PR DESCRIPTION
## Summary

Crypto quote requests now apply the 25-ID bound after splitting comma-separated values, and reject malformed IDs before provider work. A Redis read failure returns an explicit degraded result instead of treating every coin as an uncached provider lookup. Anonymous requests also use a fail-closed 60/min endpoint policy, matching the sibling CoinGecko stablecoin route.

Valid custom IDs, seed-only defaults, request ordering and unresolved IDs remain supported. Gap cache keys move to a fixed-size hashed v2 namespace; this causes bounded cold cache misses after deployment. The shared CoinGecko helper encodes the IDs parameter to preserve query boundaries.

## Validation

- Five new checks failed before the repair; all pass afterward.
- 109 gateway Node tests, 62 rate-limit tests, 46 crypto/stablecoin tests and all 415 server tests passed. Generic global-limiter, CDN and bbox fixtures use an unpolicied route while preserving their original assertions.
- The cap test exercises the generated RPC parser and real handler with mocked provider transport. Crypto-specific gateway tests use minted anonymous tokens: an unavailable limiter returns 503 before cache/provider I/O; with mocked Redis quota replies, 60 requests succeed using the gap cache and the next returns 429 without additional provider work.
- Seed and gap cache faults, invalid IDs, URL parameter boundaries, cached repeat requests, API typecheck and the rate-policy guard passed. The seed-error logging assertion failed before restoring the shared Redis logger; all 78 focused Node tests and API typecheck passed again after that repair.
- Sequential local code review found no actionable issues. No live paid-provider requests were made; deployment and production acceptance remain unverified.

## Post-Deploy Monitoring & Validation

Owner: deploying maintainer, first 24 hours after an authorized deployment. Watch `/api/market/v1/list-crypto-quotes` for `rate_limit_degraded`, 429/503 responses, `[crypto-quotes]` failures, and CoinGecko call volume. Seed-only requests should make no provider calls; valid misses must contain at most 25 IDs. In a synthetic environment, an unavailable rate store must return 503 before provider work, and seed/gap cache errors must suppress provider and relay calls. Unexpected provider fan-out or sustained new failures for valid requests blocks acceptance; disable gap fetching or ship a focused correction. Do not restore fail-open provider access. Per-IP limiting is not a global spend budget.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
