### PR TITLE
fix(llm): bound streaming provider error body reads

### DIFF
--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -189,7 +189,7 @@ async function readBoundedErrorBody(resp: Response, cap: number): Promise<string
       out += decoder.decode(value, { stream: true });
     }
   } catch { /* best-effort diagnostics only */ } finally {
-    try { void reader.cancel(); } catch { /* already closed */ }
+    try { void reader.cancel().catch(() => {}); } catch { /* already closed */ }
   }
   return out.slice(0, cap);
 }
@@ -498,9 +498,9 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
           }
 
           if (!resp.ok || !resp.body) {
+            const errBody = await readBoundedErrorBody(resp, 300).catch(() => '');
             clearTimeout(timeoutId);
-            const errBody = resp.body ? await resp.text().catch(() => '') : '';
-            console.warn(`[llm-stream:${providerName}] HTTP ${resp.status} model=${creds.model} body=${errBody.slice(0, 300)}`);
+            console.warn(`[llm-stream:${providerName}] HTTP ${resp.status} model=${creds.model} body=${errBody}`);
             // The body already told us whether the MODEL was rejected; feeding
             // it back is what stops the next request re-sending the prompt.
             recordModelFailure(creds.apiUrl, creds.model, resp.status, errBody);

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { afterEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { callLlm, callLlmReasoning, callLlmReasoningStream, getLlmAttemptTimeoutMs } from '../server/_shared/llm.ts';
 import { __testing__ as llmHealth, isModelUsable } from '../server/_shared/llm-health.ts';
@@ -42,6 +42,82 @@ afterEach(() => {
 
   if (originalLlmApiKey === undefined) delete process.env.LLM_API_KEY;
   else process.env.LLM_API_KEY = originalLlmApiKey;
+});
+
+describe('callLlmReasoningStream error bodies', () => {
+  beforeEach(() => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    process.env.LLM_REASONING_PROVIDER = 'openrouter';
+    delete process.env.LLM_REASONING_MODEL;
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+  });
+
+  for (const mode of ['oversized', 'stalled', 'cancelled'] as const) {
+    it(`bounds ${mode} provider error reads without losing fallback diagnostics`, async (t) => {
+      const originalWarn = console.warn;
+      const warnings: string[] = [];
+      console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
+      t.after(() => { console.warn = originalWarn; });
+      let attempts = 0;
+      let cancelled = false;
+      let aborted = false;
+      let rescued = false;
+      let ready!: () => void;
+      const bodyStarted = new Promise<void>((resolve) => { ready = resolve; });
+      let rescueTimer: ReturnType<typeof setTimeout>;
+      t.after(() => { clearTimeout(rescueTimer); });
+      const diagnostic = `REGION_BLOCK ${'x'.repeat(4000)}`;
+
+      globalThis.fetch = async (_input, init) => {
+        if ((init?.method || 'GET') === 'GET') return new Response('');
+        attempts += 1;
+        if (attempts > 1) {
+          return new Response('data: {"choices":[{"delta":{"content":"fallback"}}]}\n\ndata: [DONE]\n\n');
+        }
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            if (mode === 'oversized') controller.enqueue(new TextEncoder().encode(diagnostic));
+            // Release a broken implementation so the regression fails instead of hanging.
+            rescueTimer = setTimeout(() => { rescued = true; controller.close(); }, 500);
+            init?.signal?.addEventListener('abort', () => {
+              aborted = true;
+              clearTimeout(rescueTimer);
+              controller.error(new DOMException('Aborted', 'AbortError'));
+            }, { once: true });
+            ready();
+          },
+          cancel() { cancelled = true; clearTimeout(rescueTimer); },
+        });
+        return new Response(body, { status: 503 });
+      };
+
+      const stream = callLlmReasoningStream({
+        messages: [{ role: 'user', content: 'synthetic prompt' }],
+        timeoutMs: mode === 'stalled' ? 20 : 2000,
+      });
+      if (mode === 'cancelled') {
+        await bodyStarted;
+        await stream.cancel();
+        await new Promise<void>((resolve) => { setImmediate(resolve); });
+        assert.equal(aborted, true, 'client cancellation must abort the provider body');
+        assert.equal(attempts, 1, 'client cancellation must not start a fallback');
+        return;
+      }
+      const output = await new Response(stream).text();
+      assert.equal(rescued, false, 'fallback must not wait for the safety release');
+      assert.equal(attempts, 2);
+      assert.match(output, /"delta":"fallback"/);
+      assert.match(output, /"done":true/);
+      if (mode === 'stalled') assert.equal(aborted, true, 'request timeout must cover the error body');
+      else {
+        assert.equal(cancelled, true, 'oversized body must be cancelled after the prefix');
+        assert.ok(warnings.some((line) => line.endsWith(`body=${diagnostic.slice(0, 300)}`)));
+      }
+    });
+  }
 });
 
 describe('callLlm', () => {


### PR DESCRIPTION
## Summary
A streaming provider error can no longer hold chat fallback open while its body keeps arriving or stalls. The stream path now uses the existing bounded diagnostic reader and keeps the request timeout active until that read finishes. Cancellation rejections from an already-aborted body are handled without waiting on cleanup.

Related: DeepSec finding 40.

## Validation
- Before the fix, oversized and stalled synthetic error bodies both delayed fallback until the test safety release. After the fix, the oversized body is cancelled after its diagnostic prefix and the stalled read ends at the request timeout.
- Client stream cancellation aborts the provider body and starts no fallback. Leading diagnostics remain capped at 300 characters.
- 49 shared LLM, model-health and usage-telemetry tests passed; API typecheck and diff whitespace checks passed.
- Sequential ce-code-review found no actionable issues. No live or paid provider calls were made.

## Post-Deploy Monitoring & Validation
Owner: repository operator. For the first 24 hours after authorized deployment, inspect `[llm-stream:` HTTP error counts and `llm_call` events for stage `chat-analyst`. Error attempts should end within their configured timeout and the next available provider should serve fallback; ordinary streams should still terminate with `done`. Investigate attempts exceeding the timeout, new unhandled `AbortError` rejections, or increased `llm_unavailable` rates before mitigation. Correlate model and status without recording full provider payloads or prompts. No deployment or production validation was performed here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
