### PR TITLE
fix(broadcast): preserve recipient stamps after send

### DIFF
--- a/convex/__tests__/waveRuns-discard.test.ts
+++ b/convex/__tests__/waveRuns-discard.test.ts
@@ -1,0 +1,124 @@
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+const waveLabel = "test-wave-1";
+const runId = "test-run";
+
+async function setup() {
+  const t = convexTest(schema, modules);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("broadcastRampConfig", {
+      key: "current", active: true, rampCurve: [100, 200], currentTier: 0,
+      waveLabelPrefix: "test-wave", waveLabelOffset: 0,
+      bounceKillThreshold: 0.04, complaintKillThreshold: 0.001, killGateTripped: false,
+    });
+    await ctx.db.insert("registrations", {
+      email: "recipient@example.com", normalizedEmail: "recipient@example.com",
+      registeredAt: Date.now(), appVersion: "test",
+    });
+  });
+  await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+    runId, waveLabel, requestedCount: 1, batchSize: 1,
+  });
+  await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
+    runId, contacts: ["recipient@example.com"],
+  });
+  await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+    runId, segmentId: "test-segment", totalCount: 1, underfilled: false,
+  });
+  await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId });
+  const contact = await t.run((ctx) => ctx.db.query("wavePickedContacts").first());
+  await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+    contactId: contact!._id, runId, normalizedEmail: "recipient@example.com", waveLabel,
+  });
+  return t;
+}
+
+async function state(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => ({
+    run: await ctx.db.query("waveRuns").first(),
+    config: await ctx.db.query("broadcastRampConfig").first(),
+    registration: await ctx.db.query("registrations").first(),
+    contacts: await ctx.db.query("wavePickedContacts").collect(),
+  }));
+}
+
+describe("discard never makes emailed recipients eligible again", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+
+  test("a successfully sent broadcast retains its stamp through discard and direct cleanup", async () => {
+    const t = await setup();
+    vi.stubEnv("RESEND_API_KEY", "synthetic-key");
+    const urls: string[] = [];
+    vi.stubGlobal("fetch", async (url: string) => {
+      urls.push(url);
+      return Response.json({ id: "test-broadcast" });
+    });
+    await t.action(internal.broadcast.waveRuns.finalizeWaveAction, { runId });
+    expect(urls).toEqual(["https://api.resend.com/broadcasts", "https://api.resend.com/broadcasts/test-broadcast/send"]);
+    const before = await state(t);
+    expect(before.run!.status).toBe("sent");
+    await expect(t.mutation(internal.broadcast.waveRuns.discardWaveRun, { runId, reason: "test" })).rejects.toThrow(/discard/i);
+    expect(await t.action(internal.broadcast.waveRuns.cleanupDiscardedWavePickedContactsAction, { runId })).toEqual({ deleted: 0, unstamped: 0, hasMore: false });
+    expect(await state(t)).toEqual(before);
+  });
+
+  test("discard and cleanup cannot erase stamps while the send request is in flight", async () => {
+    const t = await setup();
+    vi.stubEnv("RESEND_API_KEY", "synthetic-key");
+    let release!: () => void;
+    let entered!: () => void;
+    const sending = new Promise<void>((resolve) => { entered = resolve; });
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    vi.stubGlobal("fetch", async (url: string) => {
+      if (url.endsWith("/send")) { entered(); await pending; }
+      return Response.json({ id: "test-broadcast" });
+    });
+    const finalizing = t.action(internal.broadcast.waveRuns.finalizeWaveAction, { runId }).catch((error) => error);
+    await sending;
+    let discardError: unknown;
+    let cleanup;
+    try {
+      discardError = await t.mutation(internal.broadcast.waveRuns.discardWaveRun, { runId, reason: "test" }).then(() => null, (error) => error);
+      cleanup = await t.mutation(internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts, { runId });
+    } finally { release(); }
+    await finalizing;
+    expect(discardError).toBeInstanceOf(Error);
+    expect(cleanup).toEqual({ deleted: 0, unstamped: 0, hasMore: false });
+    const after = await state(t);
+    expect(after.run!.status).toBe("sent");
+    expect(after.registration!.proLaunchWave).toBe(waveLabel);
+  });
+
+  test.each(["pushing", "create-broadcast-failed", "send-broadcast-failed"])("preserves %s runs", async (phase) => {
+    const t = await setup();
+    if (phase === "send-broadcast-failed") await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, { runId, broadcastId: "test-broadcast" });
+    if (phase !== "pushing") await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, { runId, substatus: phase as "create-broadcast-failed" | "send-broadcast-failed", error: "synthetic failure" });
+    const before = await state(t);
+    await expect(t.mutation(internal.broadcast.waveRuns.discardWaveRun, { runId, reason: "test" })).rejects.toThrow(/discard/i);
+    expect(await t.mutation(internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts, { runId })).toEqual({ deleted: 0, unstamped: 0, hasMore: false });
+    expect(await state(t)).toEqual(before);
+  });
+
+  test("a terminal failure with a broadcast ID is excluded from direct and daily cleanup", async () => {
+    const t = await setup();
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, { runId, broadcastId: "test-broadcast" });
+    // Model a legacy or delayed failure marker after broadcast creation.
+    await t.run(async (ctx) => {
+      const run = await ctx.db.query("waveRuns").first();
+      await ctx.db.patch(run!._id, {
+        status: "failed", failureSubstatus: "discarded-by-operator",
+        updatedAt: Date.now() - 48 * 60 * 60 * 1000,
+      });
+    });
+    const before = await state(t);
+    await expect(t.mutation(internal.broadcast.waveRuns.discardWaveRun, { runId, reason: "test" })).rejects.toThrow(/discard/i);
+    expect(await t.query(internal.broadcast.waveRuns._listFailedWaveRunsForCleanup, {})).toEqual([]);
+    expect(await t.mutation(internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts, { runId })).toEqual({ deleted: 0, unstamped: 0, hasMore: false });
+    expect(await state(t)).toEqual(before);
+  });
+});

--- a/convex/__tests__/waveRuns-discard.test.ts
+++ b/convex/__tests__/waveRuns-discard.test.ts
@@ -7,7 +7,7 @@ const modules = import.meta.glob("../**/*.ts");
 const waveLabel = "test-wave-1";
 const runId = "test-run";
 
-async function setup() {
+async function setup(picking = false) {
   const t = convexTest(schema, modules);
   await t.run(async (ctx) => {
     await ctx.db.insert("broadcastRampConfig", {
@@ -26,6 +26,7 @@ async function setup() {
   await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
     runId, contacts: ["recipient@example.com"],
   });
+  if (picking) return t;
   await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
     runId, segmentId: "test-segment", totalCount: 1, underfilled: false,
   });
@@ -49,6 +50,18 @@ async function state(t: ReturnType<typeof convexTest>) {
 describe("discard never makes emailed recipients eligible again", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+
+  test("an interrupted picker can be discarded without permitting late completion", async () => {
+    const t = await setup(true);
+    await expect(t.mutation(internal.broadcast.waveRuns.discardWaveRun, { runId, reason: "picker stopped" })).resolves.toMatchObject({ ok: true });
+    await expect(t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId, segmentId: "late-segment", totalCount: 1, underfilled: false,
+    })).rejects.toThrow(/expected picking/);
+    expect(await t.mutation(internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts, { runId })).toMatchObject({ deleted: 1, hasMore: false });
+    expect(await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      runId: "next-run", waveLabel: "test-wave-2", requestedCount: 1, batchSize: 1,
+    })).toMatchObject({ ok: true });
+  });
 
   test("a successfully sent broadcast retains its stamp through discard and direct cleanup", async () => {
     const t = await setup();

--- a/convex/__tests__/waveRuns.test.ts
+++ b/convex/__tests__/waveRuns.test.ts
@@ -530,6 +530,9 @@ describe("operator recovery", () => {
     await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
       waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
     });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "persist-failed", error: "synthetic terminal failure",
+    });
     const r = await t.mutation(internal.broadcast.waveRuns.discardWaveRun, {
       runId: "run-1", reason: "operator decision",
     });
@@ -616,6 +619,9 @@ describe("_listInFlightWaveRuns + cleanup", () => {
     });
     await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
       runId: "run-1", contacts: ["a@t", "b@t", "c@t"],
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "persist-failed", error: "synthetic terminal failure",
     });
     const r = await t.mutation(
       internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
@@ -792,6 +798,9 @@ describe("review-fix 2: unstamp on discard", () => {
     expect(stampedBefore.filter((r) => r.proLaunchWave === "pro-launch-wave-4")).toHaveLength(2);
 
     // Cleanup should unstamp the 2 pushed contacts and delete all 3 wavePickedContacts rows.
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "persist-failed", error: "synthetic terminal failure",
+    });
     const r = await t.mutation(
       internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
       { runId: "run-1" },
@@ -836,6 +845,9 @@ describe("review-fix 2: unstamp on discard", () => {
       await ctx.db.patch(reg!._id, { proLaunchWave: "pro-launch-wave-5" });
     });
     // Cleanup run-1 — must leave the wave-5 stamp alone.
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "persist-failed", error: "synthetic terminal failure",
+    });
     const r = await t.mutation(
       internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
       { runId: "run-1" },
@@ -867,6 +879,9 @@ describe("review-fix 2: unstamp on discard", () => {
     await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
       contactId: await findContactId(t, "run-1", "a@t"),
       runId: "run-1", normalizedEmail: "a@t", waveLabel: "pro-launch-wave-4",
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "persist-failed", error: "synthetic terminal failure",
     });
     // Operator discard — flips the run to failed/discarded-by-operator and
     // schedules cleanup (we exercise the cleanup mutation directly here

--- a/convex/broadcast/waveRuns.ts
+++ b/convex/broadcast/waveRuns.ts
@@ -1709,8 +1709,8 @@ export const markFinalizeRecovered = internalMutation({
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
- * Discard a terminal pre-broadcast failure and schedule chunked cleanup.
- * Active and finalize-phase runs must use their recovery path: a send may
+ * Abort picking or discard a terminal pre-broadcast failure, then clean up.
+ * Push and finalize-phase runs must use their recovery path: a send may
  * already be in flight even when its completion has not been recorded.
  */
 export const discardWaveRun = internalMutation({
@@ -1724,10 +1724,13 @@ export const discardWaveRun = internalMutation({
       .withIndex("by_runId", (q) => q.eq("runId", runId))
       .unique();
     if (!run) throw new Error(`[discardWaveRun] no run ${runId}`);
-    if (!canUnstampAbandonedWave(run)) {
+    // Picking can be aborted safely: _markPickComplete requires picking, so
+    // a late picker cannot advance after this transaction marks it failed.
+    const canAbortPicking = run.status === "picking" && run.broadcastId === undefined;
+    if (!canAbortPicking && !canUnstampAbandonedWave(run)) {
       throw new Error(
         `[discardWaveRun] cannot discard run ${runId} in status=${run.status} ` +
-        `substatus=${run.failureSubstatus ?? "<none>"}; only terminal pre-broadcast failures can be discarded. ` +
+        `substatus=${run.failureSubstatus ?? "<none>"}; only picking runs or terminal pre-broadcast failures can be discarded. ` +
         `Use resumeStalledWaveRun or resumeFinalizeWaveRun; use markFinalizeRecovered when the provider confirms the broadcast was sent.`,
       );
     }

--- a/convex/broadcast/waveRuns.ts
+++ b/convex/broadcast/waveRuns.ts
@@ -1709,12 +1709,9 @@ export const markFinalizeRecovered = internalMutation({
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
- * Soft-discard. Marks the run failed and rotates `waveLabelOffset` so the
- * NEXT wave doesn't reuse the discarded label. Does NOT physically delete
- * `wavePickedContacts` rows — the daily cleanup cron does that in chunks.
- *
- * Operator must inspect Resend dashboard separately for the segment +
- * any partially-created broadcast.
+ * Discard a terminal pre-broadcast failure and schedule chunked cleanup.
+ * Active and finalize-phase runs must use their recovery path: a send may
+ * already be in flight even when its completion has not been recorded.
  */
 export const discardWaveRun = internalMutation({
   args: {
@@ -1727,6 +1724,13 @@ export const discardWaveRun = internalMutation({
       .withIndex("by_runId", (q) => q.eq("runId", runId))
       .unique();
     if (!run) throw new Error(`[discardWaveRun] no run ${runId}`);
+    if (!canUnstampAbandonedWave(run)) {
+      throw new Error(
+        `[discardWaveRun] cannot discard run ${runId} in status=${run.status} ` +
+        `substatus=${run.failureSubstatus ?? "<none>"}; only terminal pre-broadcast failures can be discarded. ` +
+        `Use resumeStalledWaveRun or resumeFinalizeWaveRun; use markFinalizeRecovered when the provider confirms the broadcast was sent.`,
+      );
+    }
     const config = await ctx.db
       .query("broadcastRampConfig")
       .withIndex("by_key", (q) => q.eq("key", "current"))
@@ -1912,7 +1916,12 @@ export const _cleanupDiscardedWavePickedContacts = internalMutation({
       .query("waveRuns")
       .withIndex("by_runId", (q) => q.eq("runId", runId))
       .unique();
-    const waveLabel = run?.waveLabel;
+    // Recheck in the write transaction; callers and queued cleanup jobs may
+    // hold stale state. A recorded broadcast makes prior delivery uncertain.
+    if (!run || !canUnstampAbandonedWave(run)) {
+      return { deleted: 0, unstamped: 0, hasMore: false };
+    }
+    const waveLabel = run.waveLabel;
 
     const rows = await ctx.db
       .query("wavePickedContacts")
@@ -2050,6 +2059,17 @@ const TERMINAL_FAILURE_SUBSTATUSES = [
   "batch-failure-rate-exceeded",
 ] as const;
 
+function canUnstampAbandonedWave(run: {
+  status: string;
+  broadcastId?: string;
+  failureSubstatus?: string;
+}): boolean {
+  return run.status === "failed"
+    && run.broadcastId === undefined
+    && run.failureSubstatus !== undefined
+    && (TERMINAL_FAILURE_SUBSTATUSES as readonly string[]).includes(run.failureSubstatus);
+}
+
 /** Max failed runs to consider per cleanup cron tick. Bounded so a
  *  long-lived deployment with many discarded waves doesn't load the
  *  whole table into memory at once. The cron runs daily — at 100/day,
@@ -2065,14 +2085,7 @@ export const _listFailedWaveRunsForCleanup = internalQuery({
       .withIndex("by_status", (q) => q.eq("status", "failed"))
       .take(CLEANUP_CANDIDATES_PER_TICK);
     return failed
-      .filter(
-        (r) =>
-          r.updatedAt < cutoff &&
-          r.failureSubstatus !== undefined &&
-          (TERMINAL_FAILURE_SUBSTATUSES as readonly string[]).includes(
-            r.failureSubstatus,
-          ),
-      )
+      .filter((r) => r.updatedAt < cutoff && canUnstampAbandonedWave(r))
       .map((r) => r.runId);
   },
 });


### PR DESCRIPTION
Discarding a sent or in-flight wave could clear recipient stamps and make that audience eligible for another email. Discard accepts picking runs or terminal pre-broadcast failures with no broadcast ID. Each cleanup chunk requires the terminal failure state. Late picker completion cannot advance a discarded run. Daily cleanup uses the same guard; recoverable finalize failures retain their existing recovery path.

Validation: five regressions failed before the fix. All 56 focused Convex tests now pass, including an actual finalize action with mocked transport and a paused send request. The full unit suite passed (1,948 tests), Convex typecheck passed, and all pre-push gates passed. Existing tests continue to prove cleanup of eligible failures. Sequential code review completed on `faaba4abfbea0672517619abc3bfa5763d11738f`.

## Post-Deploy Monitoring & Validation

After a separately approved Convex rollout, verify that discard refuses sent and broadcast-created runs, their recipient stamps remain unchanged, and terminal pre-broadcast cleanup still completes. Inspect operator recovery errors for unexpected refusals. The fix does not restore stamps already lost before deployment. No production or live provider calls were made.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
