### PR TITLE
fix(payments): treat empty normalized emails as backfilled

### DIFF
--- a/convex/__tests__/backfillCustomerNormalizedEmail.test.ts
+++ b/convex/__tests__/backfillCustomerNormalizedEmail.test.ts
@@ -1,0 +1,50 @@
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+const backfillApi = internal.payments.backfillCustomerNormalizedEmail;
+
+test("empty-email backfill reaches zero pending and remains complete on rerun", async () => {
+  const t = convexTest(schema, modules);
+  await t.run((ctx) => ctx.db.insert("customers", {
+    userId: "synthetic_empty", email: "", createdAt: 1, updatedAt: 1,
+  }));
+  expect(await t.query(backfillApi.countPending, {}))
+    .toEqual({ total: 1, pending: 1, withEmail: 0 });
+  expect(await t.mutation(backfillApi.backfill, {}))
+    .toEqual({ read: 1, patched: 1, emptyEmail: 1, done: true });
+  expect(await t.query(backfillApi.countPending, {}))
+    .toEqual({ total: 1, pending: 0, withEmail: 0 });
+  expect(await t.mutation(backfillApi.backfill, {}))
+    .toEqual({ read: 0, patched: 0, emptyEmail: 0, done: true });
+});
+
+test("pending count matches unprocessed rows across mixed-email batches", async () => {
+  const t = convexTest(schema, modules);
+  await t.run(async (ctx) => {
+    for (const [index, fields] of [
+      { email: " User@Example.test " },
+      { email: "   " },
+      { email: "", normalizedEmail: "" },
+      { email: "ready@example.test", normalizedEmail: "ready@example.test" },
+    ].entries()) {
+      await ctx.db.insert("customers", {
+        userId: `synthetic_${index}`, createdAt: 1, updatedAt: 1, ...fields,
+      });
+    }
+  });
+  expect(await t.query(backfillApi.countPending, {}))
+    .toEqual({ total: 4, pending: 2, withEmail: 3 });
+  await t.mutation(backfillApi.backfill, { batchSize: 1 });
+  expect((await t.query(backfillApi.countPending, {})).pending).toBe(1);
+  await t.mutation(backfillApi.backfill, { batchSize: 1 });
+  expect(await t.query(backfillApi.countPending, {}))
+    .toEqual({ total: 4, pending: 0, withEmail: 3 });
+  expect(await t.mutation(backfillApi.backfill, { batchSize: 1 }))
+    .toEqual({ read: 0, patched: 0, emptyEmail: 0, done: true });
+  const rows = await t.run((ctx) => ctx.db.query("customers").collect());
+  expect(rows.map((row) => row.normalizedEmail))
+    .toEqual(["user@example.test", "", "", "ready@example.test"]);
+});

--- a/convex/payments/backfillCustomerNormalizedEmail.ts
+++ b/convex/payments/backfillCustomerNormalizedEmail.ts
@@ -66,7 +66,7 @@ export const countPending = internalQuery({
     let withEmail = 0;
     const total = all.length;
     for (const row of all) {
-      if (!row.normalizedEmail || row.normalizedEmail.length === 0) pending++;
+      if (row.normalizedEmail === undefined) pending++;
       if (row.email && row.email.length > 0) withEmail++;
     }
     return { total, pending, withEmail };


### PR DESCRIPTION
## Summary

An empty-email customer is backfilled to `normalizedEmail: ""`, but `countPending` still counted it as unfinished. Operators could therefore see a nonzero pending count after the backfill had completed.

Count only an absent `normalizedEmail`, matching the backfill's selection rule. Existing empty-string values are complete. Total and with-email counts retain their current semantics.

## Validation

- Two synthetic Convex tests fail before the fix and pass after: empty-email completion/idempotency, and mixed-email progress across batches.
- Full Convex suite: 1,943 tests passed across 95 files.
- Convex typecheck and diff checks passed.
- Sequential ce-code-review at `127353567a18774a6fa5afbb14efbe81902904db`: no actionable findings.
- No production migration or external provider calls were run. No UI changes.

## Post-Deploy Monitoring & Validation

Owner: payments maintainer, at the next planned backfill check after separately authorized deployment. Use the read-only `payments/backfillCustomerNormalizedEmail:countPending` diagnostic: processed empty-string rows must not contribute to `pending`. Existing missing rows must still count. Compare `pending` with genuinely absent normalizedEmail fields in an authorized data audit. A mismatch is the failure signal; investigate the field shape before rerunning any mutation. This diagnostic-only change needs no data rollback or new backfill execution.
