### PR TITLE
fix(trade): read unprefixed Comtrade seed keys

### DIFF
--- a/server/__tests__/comtrade-raw-keys.test.ts
+++ b/server/__tests__/comtrade-raw-keys.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { KEY_PREFIX } from '../../scripts/seed-trade-flows.mjs';
+import { writeExtraKey } from '../../scripts/_seed-utils.mjs';
+import type { ComtradeFlowRecord, ServerContext } from '../../src/generated/server/worldmonitor/trade/v1/service_server';
+
+vi.mock('../_shared/premium-check', () => ({ isCallerPremium: vi.fn(async () => true) }));
+
+const key = `${KEY_PREFIX}:842:2709`;
+const fetchedAt = '2026-09-01T00:00:00Z';
+const older: ComtradeFlowRecord = {
+  reporterCode: '842', reporterName: 'United States', partnerCode: '124', partnerName: 'Canada',
+  cmdCode: '2709', cmdDesc: 'Crude petroleum', year: 2023, tradeValueUsd: 1000,
+  netWeightKg: 100, yoyChange: 50, isAnomaly: true,
+};
+const newer = { ...older, year: 2024, yoyChange: 10, isAnomaly: false };
+const request = { reporterCode: '842', cmdCode: '2709', anomaliesOnly: false };
+const ctx = { request: new Request('https://worldmonitor.app/api/trade/v1/list-comtrade-flows') } as ServerContext;
+let store: Map<string, string>;
+let reads: string[];
+let writes: string[];
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://redis.test');
+  vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'synthetic-token');
+  vi.stubEnv('LOCAL_API_MODE', '');
+  vi.stubEnv('VERCEL_ENV', 'preview');
+  vi.stubEnv('VERCEL_GIT_COMMIT_SHA', 'deadbeef12345678');
+  store = new Map();
+  reads = [];
+  writes = [];
+  vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input) === 'https://redis.test/pipeline') {
+      const commands = JSON.parse(String(init?.body)) as string[][];
+      return Response.json(commands.map(([command, cacheKey]) => {
+        expect(command).toBe('GET');
+        reads.push(cacheKey);
+        return { result: store.get(cacheKey) ?? null };
+      }));
+    }
+    expect(String(input)).toBe('https://redis.test');
+    const [command, cacheKey, payload] = JSON.parse(String(init?.body)) as string[];
+    expect(command).toBe('SET');
+    writes.push(cacheKey);
+    store.set(cacheKey, payload);
+    return Response.json({ result: 'OK' });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+test.each(['preview', 'development', 'production'])('reads seeder-owned keys in %s', async (env) => {
+  vi.stubEnv('VERCEL_ENV', env);
+  await writeExtraKey(key, { flows: [older, newer], fetchedAt }, 3600);
+  const { listComtradeFlows } = await import('../worldmonitor/trade/v1/list-comtrade-flows');
+  const result = await listComtradeFlows(ctx, request);
+  expect(writes).toEqual([key]);
+  expect(reads).toEqual([key]);
+  expect(result).toEqual({ flows: [newer, older], fetchedAt, upstreamUnavailable: false });
+});
+
+test('preserves anomaly filtering and missing-data response', async () => {
+  const { listComtradeFlows } = await import('../worldmonitor/trade/v1/list-comtrade-flows');
+  expect(await listComtradeFlows(ctx, request)).toEqual({ flows: [], fetchedAt: '', upstreamUnavailable: true });
+  await writeExtraKey(key, { flows: [older, newer], fetchedAt }, 3600);
+  expect(await listComtradeFlows(ctx, { ...request, anomaliesOnly: true })).toEqual({
+    flows: [older], fetchedAt, upstreamUnavailable: false,
+  });
+});
+
+test('premium denial still returns no data without reading Redis', async () => {
+  const { isCallerPremium } = await import('../_shared/premium-check');
+  vi.mocked(isCallerPremium).mockResolvedValueOnce(false);
+  const { listComtradeFlows } = await import('../worldmonitor/trade/v1/list-comtrade-flows');
+  expect(await listComtradeFlows(ctx, request)).toEqual({ flows: [], fetchedAt: '', upstreamUnavailable: true });
+  expect(reads).toEqual([]);
+  expect(writes).toEqual([]);
+});

--- a/server/worldmonitor/trade/v1/list-comtrade-flows.ts
+++ b/server/worldmonitor/trade/v1/list-comtrade-flows.ts
@@ -35,7 +35,7 @@ export async function listComtradeFlows(
     const cmdCodes = req.cmdCode && CMD_CODE_RE.test(req.cmdCode) ? [req.cmdCode] : CMD_CODES;
 
     const keys = reporters.flatMap((r) => cmdCodes.map((c) => `${KEY_PREFIX}:${r}:${c}`));
-    const batch = await getCachedJsonBatch(keys);
+    const batch = await getCachedJsonBatch(keys, true);
 
     const flows: ComtradeFlowRecord[] = [];
     let fetchedAt = '';


### PR DESCRIPTION
## Summary
Comtrade flow reads now find Railway-seeded records on preview and development deployments. The handler requests unprefixed seed keys, matching the seeder and sibling readers. Production behavior, premium gating and response fields remain unchanged.

Related: DeepSec finding 56.

## Validation
- Before the fix, preview and development missed records written by the real seed write helper to mocked Redis; production passed. All three environments now return the same records.
- Five handler tests cover exact keys, sorting, timestamps, anomaly filtering, missing data and premium denial. Twenty-nine existing seeder tests passed.
- API typecheck and diff whitespace checks passed. Sequential ce-code-review found no actionable issues.
- No production Redis access or seeder run was performed.

## Post-Deploy Monitoring & Validation
Owner: repository operator. On an authorized preview, use a premium test session to request a known seeded reporter/commodity pair and compare its `flows`, `fetchedAt` and `upstreamUnavailable` against the seed record. Expected: populated records and `upstreamUnavailable=false`; an unseeded pair should remain unavailable. Check production parity during the first 24 hours after authorized deployment. Unexpected empty results or changed filtering require checking the requested key and seed freshness before mitigation. This change introduces no cache writes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
