### PR TITLE
fix(forecast): allowlist public scorecard fields

### DIFF
--- a/server/worldmonitor/forecast/v1/get-forecast-scorecard.ts
+++ b/server/worldmonitor/forecast/v1/get-forecast-scorecard.ts
@@ -47,20 +47,20 @@ export const getForecastScorecard: ForecastServiceHandler['getForecastScorecard'
     const data = envelope.data as Partial<GetForecastScorecardResponse> | null;
     if (!data) return markNoStoreFallbackResponse(ctx.request, emptyScorecard());
     const fetchedAt = Number(envelope.fetchedAt);
-    // `judgedLane` (#7068) is judged-lane operator observability — attempt
-    // failure classes, SLA and attempt-count metrics. It lives in the Redis
-    // scorecard for the seeder's run summary and for ops, and is deliberately
-    // not part of this typed response: the spread below would otherwise emit an
-    // undeclared field that the proto and generated SDK do not describe, so
-    // typed consumers could not reach it anyway. Publishing it is a separate,
-    // deliberate proto change.
-    const { judgedLane: _judgedLane, ...servedData } = data as Record<string, unknown>;
+    // Seeder observability and experiments are not part of the public proto.
+    // Select declared fields so new seed fields cannot implicitly become API fields.
     return emptyScorecard({
-      ...servedData,
+      schemaVersion: data.schemaVersion ?? 1,
+      generatedAt: data.generatedAt ?? 0,
+      rollingWindowDays: data.rollingWindowDays ?? 180,
+      methodology: data.methodology ?? '',
       totals: data.totals ?? emptyScorecard().totals,
+      overall: data.overall,
       byDomain: data.byDomain ?? [],
       byGenerationOrigin: data.byGenerationOrigin ?? [],
       calibration: data.calibration ?? [],
+      vsMarketSkill: data.vsMarketSkill,
+      skill: data.skill,
       degraded: false,
       stale: Number.isFinite(fetchedAt) ? Date.now() - fetchedAt > MAX_STALE_MS : false,
       error: '',

--- a/tests/forecast-get-scorecard.test.mts
+++ b/tests/forecast-get-scorecard.test.mts
@@ -1,5 +1,9 @@
 import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
+import forecastRoute from '../api/forecast/v1/[rpc].ts';
+import { issueSessionToken } from '../api/_session.js';
+import { createRedisFetch } from './helpers/fake-upstash-redis.mts';
+import { SCORECARD_DECLARED_FIELDS } from '../scripts/build-accuracy-page.mjs';
 
 const originalFetch = globalThis.fetch;
 const originalConsoleError = console.error;
@@ -93,6 +97,46 @@ describe('getForecastScorecard backend status', () => {
     assert.equal(res.totals?.entries, 1, 'declared fields still pass through');
     assert.equal(JSON.stringify(res).includes('judgedLane'), false);
     assert.equal(JSON.stringify(res).includes('archive_incomplete'), false);
+  });
+
+  it('the public RPC serializes only declared top-level cache fields', async () => {
+    process.env.WM_SESSION_SECRET = 'synthetic-scorecard-session-secret-long-enough';
+    const token = (await issueSessionToken()).token;
+    const data = {
+      schemaVersion: 1, generatedAt: 456, rollingWindowDays: 180, methodology: 'fixture',
+      totals: { entries: 2, resolved: 1, pending: 1, pendingJudge: 0, scored: 1, void: 0, voidRate: 0, publicationCoverage: 0.5 },
+      overall: { count: 1, brier: 0.04, logScore: 0.22 },
+      byDomain: [{ domain: 'market', resolved: 1, scored: 1, void: 0, voidRate: 0, brier: 0.04, logScore: 0.22 }],
+      byGenerationOrigin: [{ generationOrigin: 'detector', resolved: 1, scored: 1, void: 0, voidRate: 0, brier: 0.04, logScore: 0.22 }],
+      calibration: [{ bucket: '80-90', minProbability: 0.8, maxProbability: 0.9, count: 1, predictedMean: 0.8, realizedRate: 1, brier: 0.04 }],
+      vsMarketSkill: { count: 1, forecastBrier: 0.04, marketBrier: 0.09, brierDelta: 0.05 },
+      skill: { count: 1, brier: 0.04, logScore: 0.22, excludedScored: 1, excludedOrigins: ['bet_engine'] },
+      degraded: false, stale: false, error: '',
+    };
+    const { fetchImpl } = createRedisFetch({});
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url.endsWith(`/get/${encodeURIComponent(REDIS_KEY)}`)) {
+        return Response.json({ result: JSON.stringify({
+          _seed: { fetchedAt: Date.now() },
+          data: {
+            ...data,
+            judgedLane: { pendingJudge: 3 },
+            betEngine: { count: 1, vsBaseRate: { brierDelta: 0.02 }, deviationSkill: { count: 1 } },
+            futureInternalMetric: { syntheticMarker: 'not-part-of-response' },
+          },
+        }) });
+      }
+      assert.ok(url.startsWith('https://fake-upstash.example'), 'all I/O must stay in the mock');
+      return fetchImpl(input, init);
+    };
+    const response = await forecastRoute(new Request(makeCtx().request.url, {
+      headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': token },
+    }));
+    assert.equal(response.status, 200);
+    const serialized = await response.json();
+    assert.deepEqual(Object.keys(serialized).sort(), [...SCORECARD_DECLARED_FIELDS].sort());
+    assert.deepEqual(serialized, data, 'every declared field must survive the real gateway and serializer');
   });
 
   it('marks cached scorecards stale when the seed envelope is older than the health budget', async () => {

--- a/tests/forecast-get-scorecard.test.mts
+++ b/tests/forecast-get-scorecard.test.mts
@@ -127,7 +127,7 @@ describe('getForecastScorecard backend status', () => {
           },
         }) });
       }
-      assert.ok(url.startsWith('https://fake-upstash.example'), 'all I/O must stay in the mock');
+      assert.equal(new URL(url).origin, 'https://fake-upstash.example', 'all I/O must stay in the mock');
       return fetchImpl(input, init);
     };
     const response = await forecastRoute(new Request(makeCtx().request.url, {


### PR DESCRIPTION
## Summary
The forecast scorecard RPC now selects its declared top-level fields instead of spreading the Redis payload. Seeder-only blocks such as `betEngine` and future undeclared fields no longer appear in the response. All declared fields, including `skill`, are preserved.

Related: DeepSec finding 53.

## Validation
- A synthetic free-session request through the real API gateway and generated serializer returned HTTP 200 with undeclared fields before the fix. Afterward its JSON matches the complete declared-field fixture.
- 19 scorecard tests and the proto-field parity test passed; API typecheck and diff whitespace checks passed.
- Sequential ce-code-review found no actionable issues. The exposed values inspected in source are aggregate experiment metrics, not credentials or raw forecasts.
- No production access. This is top-level response selection, not recursive validation of nested metric objects.

## Post-Deploy Monitoring & Validation
Owner: repository operator. After authorized deployment, request the scorecard with a test session and verify that its top-level keys match the proto, including preserved totals, calibration and skill fields. Check for absent `judgedLane`, `betEngine` and other undeclared top-level keys. Allow the fast-cache TTL to expire before judging rollout coverage. Over the first 24 hours, monitor `degraded`, `stale`, response errors and accuracy-page metric continuity. Missing declared fields or new backend errors require investigating the deployed head and seed shape before mitigation. No deployment or live acceptance was performed here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
