### PR TITLE
fix(aviation): bound cached fare search inputs and request quota

### DIFF
--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -294,6 +294,9 @@ interface EndpointRatePolicy {
 // using checkEndpointRateLimit / hasEndpointRatePolicy below — the export is
 // for tooling, not new runtime callers.
 export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
+  // Interactive fare searches use one provider request on a cache miss.
+  // 30/min leaves headroom under the provider's 300-600/min shared quota.
+  '/api/aviation/v1/search-flight-prices': { limit: 30, window: '60 s' },
   // LLM article summarization is Pro-gated, but still needs a scoped,
   // fail-closed budget so Redis degradation cannot silently lift the
   // per-endpoint spend control.
@@ -538,6 +541,9 @@ interface RateLimitPolicyDecision {
 // defence. scripts/enforce-rate-limit-policies.mjs fails if any route listed
 // here can drift back to the gateway's availability-first global fallback.
 export const FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: Record<string, RateLimitPolicyDecision> = {
+  '/api/aviation/v1/search-flight-prices': {
+    reason: 'Caller-selected fare searches consume Travelpayouts request quota on cache misses.',
+  },
   '/api/news/v1/summarize-article': {
     reason: 'LLM-backed summarization can drive provider spend on cache misses.',
   },

--- a/server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts
+++ b/server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts
@@ -1,3 +1,4 @@
+/// <reference lib="es2022.intl" />
 /**
  * Travelpayouts Cached Data API provider
  * Auth: X-Access-Token header
@@ -10,8 +11,11 @@
  */
 
 import type { PriceQuote, CabinClass, Carrier } from '../../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
+import { ApiError } from '../../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../../_shared/redis';
 import { CHROME_UA } from '../../../../_shared/constants';
+import { normalizeCountryToIso2 } from '../../../../_shared/country-normalize';
+import { IATA_RE } from '../_shared';
 
 const BASE_V2 = 'https://api.travelpayouts.com/v2/prices';
 const BASE_V3 = 'https://api.travelpayouts.com/v3';
@@ -26,6 +30,16 @@ const CABIN_CLASS_MAP: Record<string, number> = {
     CABIN_CLASS_BUSINESS: 2,
     CABIN_CLASS_FIRST: 2,  // treat as business — most caches lack separate FIRST
 };
+
+const CURRENCIES = new Set(Intl.supportedValuesOf('currency').map(code => code.toLowerCase()));
+
+function validDate(value: string): boolean {
+    if (value === '') return true;
+    if (!/^\d{4}-\d{2}(?:-\d{2})?$/.test(value)) return false;
+    const date = value.length === 7 ? `${value}-01` : value;
+    const parsed = new Date(`${date}T00:00:00Z`);
+    return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === date;
+}
 
 // ---- Internal response shapes ----
 
@@ -205,11 +219,23 @@ export async function searchPricesTravelpayouts(opts: {
     market: string;
     token: string;
 }): Promise<TravelpayoutsResult> {
-    const { origin, destination, departureDate, returnDate, cabin, nonstopOnly, maxResults, currency, market, token } = opts;
+    const { departureDate, returnDate, nonstopOnly, maxResults, token } = opts;
+    const origin = opts.origin.trim().toUpperCase();
+    const destination = opts.destination.trim().toUpperCase();
+    const cabin = !opts.cabin || opts.cabin === 'CABIN_CLASS_UNSPECIFIED' ? 'CABIN_CLASS_ECONOMY' : opts.cabin;
+    const currency_ = (opts.currency || 'usd').trim().toLowerCase();
+    const market_ = (opts.market || inferMarket(origin)).trim().toLowerCase();
+    // Validate before constructing cache keys or accessing the provider. Unknown
+    // cabin strings otherwise issue the same economy query under unique keys.
+    if (!IATA_RE.test(origin) || !IATA_RE.test(destination)
+        || !validDate(departureDate) || !validDate(returnDate)
+        || !Object.prototype.hasOwnProperty.call(CABIN_CLASS_MAP, cabin)
+        || !CURRENCIES.has(currency_)
+        || !/^[a-z]{2}$/.test(market_) || !normalizeCountryToIso2(market_)) {
+        throw new ApiError(400, 'Invalid flight search airport, date, cabin, currency or market', '');
+    }
     const now = Date.now();
-    const tripClass = CABIN_CLASS_MAP[cabin] ?? 0;
-    const currency_ = currency || 'usd';
-    const market_ = market || inferMarket(origin);
+    const tripClass = CABIN_CLASS_MAP[cabin]!;
 
     // Determine query style:
     // - Day-precision date given → v3 prices_for_dates (most precise)

--- a/server/worldmonitor/aviation/v1/search-flight-prices.ts
+++ b/server/worldmonitor/aviation/v1/search-flight-prices.ts
@@ -8,6 +8,7 @@ import { captureSilentError } from '../../../../api/_sentry-edge.js';
 import { requireLiveAviationAccess } from './_shared';
 import { generateDemoPrices } from './_providers/demo_prices';
 import { searchPricesTravelpayouts } from './_providers/travelpayouts_data';
+import { ApiError } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 
 type DegradedError = 'missing_credentials' | 'upstream_error' | 'no_results';
 type DegradedProvider = 'none' | 'travelpayouts_data';
@@ -101,6 +102,7 @@ export async function searchFlightPrices(
             }
             return emptyDegraded(now, error, 'travelpayouts_data');
         } catch (err) {
+            if (err instanceof ApiError && err.statusCode === 400) throw err;
             console.warn(`[Aviation] Travelpayouts upstream error: ${err instanceof Error ? err.message : err}`);
             void captureSilentError(err, { tags: { route: 'aviation/search-flight-prices', step: 'travelpayouts-fetch' } });
             if (demoOptIn) {

--- a/tests/travelpayouts-input-boundary.test.mts
+++ b/tests/travelpayouts-input-boundary.test.mts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { searchPricesTravelpayouts } from '../server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts';
+import { ApiError, createAviationServiceRoutes } from '../src/generated/server/worldmonitor/aviation/v1/service_server.ts';
+import { aviationHandler } from '../server/worldmonitor/aviation/v1/handler.ts';
+import { createDomainGateway, serverOptions } from '../server/gateway.ts';
+import { __resetRateLimitForTest, checkEndpointRateLimit, ENDPOINT_RATE_POLICIES } from '../server/_shared/rate-limit.ts';
+import { installRedis } from './helpers/fake-upstash-redis.mts';
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+const PATH = '/api/aviation/v1/search-flight-prices';
+const KEY = 'synthetic-flight-key';
+const base = { origin: 'IST', destination: 'LHR', departureDate: '2028-02-29', returnDate: '', cabin: 'CABIN_CLASS_ECONOMY', nonstopOnly: false, maxResults: 5, currency: 'usd', market: 'us', token: 'synthetic-provider-token' };
+let calls: URL[];
+let redis: ReturnType<typeof installRedis>;
+
+beforeEach(() => {
+  delete process.env.VERCEL;
+  delete process.env.VERCEL_ENV;
+  delete process.env.AVIATION_DEMO_PRICES;
+  process.env.WORLDMONITOR_VALID_KEYS = KEY;
+  process.env.TRAVELPAYOUTS_API_TOKEN = base.token;
+  __resetRateLimitForTest();
+  calls = [];
+  redis = installRedis({});
+  globalThis.fetch = (async (input, init) => {
+    const url = new URL(String(input));
+    calls.push(url);
+    if (url.hostname === 'api.travelpayouts.com') return Response.json({ success: true, data: [] });
+    return redis.fetchImpl(input, init);
+  }) as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const key of Object.keys(process.env)) if (!(key in originalEnv)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+  __resetRateLimitForTest();
+});
+
+function request(overrides: Record<string, string> = {}, withKey = true) {
+  const params = new URLSearchParams({ origin: 'IST', destination: 'LHR', departure_date: '2028-02-29', cabin: 'CABIN_CLASS_ECONOMY', currency: 'usd', market: 'us', ...overrides });
+  return new Request(`https://api.worldmonitor.app${PATH}?${params}`, { headers: withKey ? { 'X-WorldMonitor-Key': KEY, 'x-vercel-forwarded-for': '192.0.2.1' } : {} });
+}
+const gateway = createDomainGateway(createAviationServiceRoutes(aviationHandler, serverOptions));
+const providerCalls = () => calls.filter(url => url.hostname === 'api.travelpayouts.com');
+
+describe('Travelpayouts input boundary', () => {
+  for (const [field, value] of [
+    ['origin', 'A:B'], ['destination', 'AB1'], ['origin', 'KJFK'],
+    ['departureDate', 'xxxxxxxxxx'], ['departureDate', '2028-13-01'],
+    ['departureDate', '2027-02-29'], ['returnDate', 'x'.repeat(1000)],
+    ['returnDate', '2028-02-30'], ['currency', 'usd:nonce'], ['currency', 'zzz'],
+    ['market', 'us:nonce'], ['market', 'zz'], ['cabin', 'constructor'], ['cabin', 'CABIN_CLASS_CUSTOM'],
+  ]) {
+    it(`rejects invalid ${field} before any cache or provider work: ${value.slice(0, 24)}`, async () => {
+      await assert.rejects(searchPricesTravelpayouts({ ...base, [field]: value }), (error: unknown) => error instanceof ApiError && error.statusCode === 400);
+      assert.equal(calls.length, 0);
+      assert.equal(redis.redis.size, 0);
+    });
+  }
+
+  it('normalizes equivalent input into one upstream request and cache entry', async () => {
+    await searchPricesTravelpayouts(base);
+    await searchPricesTravelpayouts({ ...base, origin: 'ist', destination: 'lhr', currency: 'USD', market: 'US', cabin: 'CABIN_CLASS_UNSPECIFIED' });
+    assert.equal(providerCalls().length, 1);
+    const params = providerCalls()[0]!.searchParams;
+    assert.equal(params.get('origin'), 'IST');
+    assert.equal(params.get('currency'), 'usd');
+    assert.equal(params.get('market'), 'us');
+  });
+
+  it('retains valid month and latest searches and caps provider results', async () => {
+    await searchPricesTravelpayouts({ ...base, departureDate: '2028-02' });
+    await searchPricesTravelpayouts({ ...base, departureDate: '', maxResults: 50 });
+    assert.deepEqual(providerCalls().map(url => url.pathname), ['/v2/prices/month-matrix', '/v2/prices/latest']);
+    assert.equal(providerCalls()[1]!.searchParams.get('limit'), '30');
+  });
+
+  it('preserves inferred market, currency and cabin defaults and valid return months', async () => {
+    await searchPricesTravelpayouts({ ...base, currency: '', market: '', cabin: '', returnDate: '2028-03' });
+    await searchPricesTravelpayouts({ ...base, currency: 'usd', market: 'tr', returnDate: '2028-03' });
+    assert.equal(providerCalls().length, 1);
+    const params = providerCalls()[0]!.searchParams;
+    assert.equal(params.get('market'), 'tr');
+    assert.equal(params.get('return_at'), '2028-03');
+    assert.equal(params.get('trip_class'), '0');
+  });
+
+  it('rejects malformed generated RPC input with HTTP400, without a provider call', async () => {
+    const response = await gateway(request({ currency: 'usd:nonce' }));
+    assert.equal(response.status, 400);
+    assert.equal(providerCalls().length, 0);
+    assert.ok([...redis.redis.keys()].every(key => !key.startsWith('tp:') && !key.startsWith('aviation:price-snapshot:')));
+  });
+
+  it('denies anonymous requests and permits a validated enterprise key', async () => {
+    const anonymous = await gateway(request({}, false));
+    assert.ok([401, 403].includes(anonymous.status));
+    assert.equal(providerCalls().length, 0);
+    const authorized = await gateway(request());
+    assert.equal(authorized.status, 200);
+    assert.equal(providerCalls().length, 1);
+  });
+
+  it('fails closed at the gateway when rate storage is unavailable', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const response = await gateway(request());
+    assert.equal(response.status, 503);
+    assert.equal(providerCalls().length, 0);
+  });
+
+  it('enforces 30/min before provider work and keeps principal buckets separate', async () => {
+    assert.equal(ENDPOINT_RATE_POLICIES[PATH]?.limit, 30);
+    const usage = new Map<string, number>();
+    const transport = globalThis.fetch;
+    globalThis.fetch = (async (input, init) => {
+      const response = await transport(input, init);
+      const commands = init?.body ? JSON.parse(String(init.body)) : [];
+      if (!Array.isArray(commands[0])) return response;
+      const results = await response.json();
+      for (let i = 0; i < commands.length; i++) {
+        if (String(commands[i][0]).toUpperCase() === 'EVALSHA') {
+          const key = String(commands[i][3]);
+          const count = (usage.get(key) ?? 0) + 1;
+          usage.set(key, count);
+          // Model quota storage replies; the SDK and limiter execute normally.
+          results[i] = { result: [30 - count, 60] };
+        }
+      }
+      return Response.json(results);
+    }) as typeof fetch;
+    for (let i = 0; i < 30; i++) assert.equal((await gateway(request())).status, 200);
+    const gatewayDenied = await gateway(request());
+    assert.equal(gatewayDenied.status, 429);
+    assert.equal(providerCalls().length, 1, 'cached valid searches share one provider call; denied request adds none');
+    for (let i = 0; i < 30; i++) assert.equal(await checkEndpointRateLimit(request(), PATH, {}, { principalUserId: 'user-a' }), null);
+    const denied = await checkEndpointRateLimit(request(), PATH, {}, { principalUserId: 'user-a' });
+    assert.equal(denied?.status, 429);
+    assert.ok(Number(denied?.headers.get('Retry-After')) > 0);
+    assert.equal(await checkEndpointRateLimit(request(), PATH, {}, { principalUserId: 'user-b' }), null);
+    assert.ok([...usage.keys()].some(key => key.includes('user:user-a')));
+  });
+});


### PR DESCRIPTION
## Summary

Fare searches now reject malformed airport codes, dates, cabin classes, currencies and markets before constructing Travelpayouts cache keys or making provider requests. Invalid live search inputs return HTTP400 instead of being treated as upstream failures. Equivalent valid input uses normalized cache keys; existing defaults and day/month/latest search behavior remain supported.

The route also gets a fail-closed 30/min endpoint policy. The command bar issues one request per user search; this budget permits interactive changes while leaving headroom below the provider's shared 300-600/min quotas. Existing gateway attribution stays intact: verified paid users use principal buckets, enterprise keys retain IP/account controls, and verified internalMCP retains its upstream quota enforcement. This is not a global provider-token budget. Per-search billing was not verified and is not claimed as the impact.

## Validation

- 18 of 20 initial boundary checks failed before the repair. The final 21 boundary checks and existing focused suites total 104 passing tests.
- Real generated RPC/gateway/auth/handler/cache behavior with mocked external transports verifies anonymous denial, validated-key access, malformed input 400, missing rate storage 503, and request 31 returning 429 without another provider call.
- Equivalent input/defaults reuse cache; real day/month date validation rejects rollover dates. Previous cache-key variation and degraded-response suites pass.
- 109 gateway tests and415 server tests pass. API typecheck, rate-policy guard and EdgeVM currency-enumeration smoke pass.
- Sequential same-agent code review found no actionable issue; no independent corroboration claimed. Redis quota replies are mocked, not real Lua execution. No production or paid-provider probes.

Provider contract references: [cached data API](https://support.travelpayouts.com/hc/en-us/articles/203956163-Aviasales-Data-API), [request quotas](https://support.travelpayouts.com/hc/en-us/articles/4402565416594-API-rate-limits).

## Integration

Independent addition to `server/_shared/rate-limit.ts` overlaps the file changed by unmerged PR8009. This branch starts from main and does not include its crypto policy or generic test-fixture changes. Refresh main and recheck both policies after integration.

## Post-Deploy Monitoring & Validation

Owner: deploying maintainer, first 24 hours after an authorized deployment. Monitor fare-search 400/429/503 rates, cache hit rate, and Travelpayouts 429/error volume. Valid command-bar searches must retain indicative results or their existing explicit degraded state. In a synthetic environment, malformed inputs must create no fare-cache/provider work and an unavailable limiter must return 503 before provider access. Unexpected rejection of documented valid inputs or sustained quota failures blocks acceptance; correct the focused validation/policy issue without lifting all rate control. No deployment is part of this PR delivery.
