### PR TITLE
fix(broadcast): correct minimum-pool recovery guidance

### DIFF
--- a/convex/__tests__/waveRuns-minimum-pool.test.ts
+++ b/convex/__tests__/waveRuns-minimum-pool.test.ts
@@ -1,0 +1,59 @@
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+
+describe("direct picker calls enforce the minimum cohort", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+
+  test.each([
+    { available: 99, requestedCount: 100, proceeds: false },
+    { available: 100, requestedCount: 99, proceeds: false },
+    { available: 100, requestedCount: 100, proceeds: true },
+  ])("$available eligible contacts, requestedCount=$requestedCount", async ({ available, requestedCount, proceeds }) => {
+    const t = convexTest(schema, modules);
+    vi.stubEnv("RESEND_API_KEY", "synthetic-key");
+    const fetchMock = vi.fn(async () => Response.json({ id: "test-segment" }));
+    vi.stubGlobal("fetch", fetchMock);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("broadcastRampConfig", {
+        key: "current", active: true, rampCurve: [requestedCount], currentTier: 0,
+        waveLabelPrefix: "test-wave", waveLabelOffset: 0,
+        bounceKillThreshold: 0.04, complaintKillThreshold: 0.001, killGateTripped: false,
+      });
+      for (let i = 0; i < available; i++) {
+        await ctx.db.insert("registrations", {
+          email: `recipient-${i}@example.com`, normalizedEmail: `recipient-${i}@example.com`,
+          registeredAt: Date.now(), appVersion: "test",
+        });
+      }
+    });
+    const result = await t.action(internal.broadcast.waveRuns.pickWaveAction, {
+      runId: "test-run", waveLabel: "test-wave-1", requestedCount,
+    });
+    const state = await t.run(async (ctx) => ({
+      run: await ctx.db.query("waveRuns").first(),
+      config: await ctx.db.query("broadcastRampConfig").first(),
+      contacts: await ctx.db.query("wavePickedContacts").collect(),
+    }));
+    if (proceeds) {
+      expect(result).toEqual({ ok: true });
+      expect(state.run!.status).toBe("segment-created");
+      expect(state.contacts).toHaveLength(100);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } else {
+      expect(result).toEqual({ ok: false, reason: "pool-too-small" });
+      expect(state.run).toMatchObject({ status: "failed", failureSubstatus: "pool-too-small" });
+      expect(state.config!.active).toBe(false);
+      expect(state.config!.pendingRunId).toBeUndefined();
+      expect(state.contacts).toHaveLength(0);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(state.run!.error).toContain("at least 100 eligible contacts");
+      expect(state.run!.error).toContain("requestedCount >= 100");
+      expect(state.run!.error).not.toContain("final wave manually");
+    }
+  });
+});

--- a/convex/__tests__/waveRuns-minimum-pool.test.ts
+++ b/convex/__tests__/waveRuns-minimum-pool.test.ts
@@ -10,6 +10,7 @@ describe("direct picker calls enforce the minimum cohort", () => {
   afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
 
   test.each([
+    { available: 100, requestedCount: 99.5, proceeds: false },
     { available: 99, requestedCount: 100, proceeds: false },
     { available: 100, requestedCount: 99, proceeds: false },
     { available: 100, requestedCount: 100, proceeds: true },
@@ -31,9 +32,16 @@ describe("direct picker calls enforce the minimum cohort", () => {
         });
       }
     });
-    const result = await t.action(internal.broadcast.waveRuns.pickWaveAction, {
+    const picking = t.action(internal.broadcast.waveRuns.pickWaveAction, {
       runId: "test-run", waveLabel: "test-wave-1", requestedCount,
     });
+    if (!Number.isInteger(requestedCount)) {
+      await expect(picking).rejects.toThrow("requestedCount must be a positive integer");
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(await t.run((ctx) => ctx.db.query("waveRuns").first())).toBeNull();
+      return;
+    }
+    const result = await picking;
     const state = await t.run(async (ctx) => ({
       run: await ctx.db.query("waveRuns").first(),
       config: await ctx.db.query("broadcastRampConfig").first(),

--- a/convex/broadcast/waveRuns.ts
+++ b/convex/broadcast/waveRuns.ts
@@ -697,7 +697,7 @@ export const pickWaveAction = internalAction({
     if (!apiKey) {
       throw new Error("[pickWaveAction] RESEND_API_KEY not set");
     }
-    if (!Number.isFinite(args.requestedCount) || args.requestedCount <= 0) {
+    if (!Number.isInteger(args.requestedCount) || args.requestedCount <= 0) {
       throw new Error(
         `[pickWaveAction] requestedCount must be a positive integer; got ${args.requestedCount}`,
       );

--- a/convex/broadcast/waveRuns.ts
+++ b/convex/broadcast/waveRuns.ts
@@ -102,8 +102,8 @@ const REGISTRATIONS_PAGE_SIZE = 1000;
  *
  *  Below this threshold, pickWaveAction treats the run as terminal —
  *  marks `failed/pool-too-small`, deactivates the ramp, and clears the
- *  lease. The waitlist is effectively drained; operator must extend the
- *  curve OR restart the ramp manually if more contacts are wanted. */
+ *  lease. Resume only when at least 100 eligible contacts are available
+ *  and the requested count is at least 100. Direct calls use this guard too. */
 const MIN_USABLE_POOL_SIZE = 100;
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -650,7 +650,7 @@ export const _markPickFailed = internalMutation({
 
     // Terminal-completion substatuses: clear the lease AND deactivate the
     // ramp. Both 'empty-pool' (zero picked) and 'pool-too-small' (picked
-    // below MIN_USABLE_POOL_SIZE) mean the waitlist is drained — without
+    // below MIN_USABLE_POOL_SIZE) cannot produce a usable wave — without
     // deactivating, the next cron tick would re-fire pickWaveAction and
     // hit the same condition repeatedly. For 'pool-too-small' specifically,
     // the alternative — let the wave proceed with say 50 contacts — would
@@ -832,11 +832,9 @@ export const pickWaveAction = internalAction({
       // Pool-too-small guard. picked.length < MIN_USABLE_POOL_SIZE means
       // the wave's delivered count will never reach the kill-gate threshold,
       // so the next cron tick would get stuck on `awaiting-prior-stats`
-      // forever. Treat as terminal completion: deactivate the ramp + clear
-      // the lease, surface for operator triage. Operator can re-activate
-      // and extend `rampCurve` if more sends are wanted, OR run a final
-      // wave manually via direct `pickWaveAction` call (which bypasses this
-      // guard since the operator is taking deliberate action).
+      // forever. Deactivate the ramp and clear the lease. Resume only when
+      // both the eligible pool and requested count meet the minimum;
+      // direct operator calls enforce the same guard.
       if (picked.length < MIN_USABLE_POOL_SIZE) {
         await ctx.runMutation(internal.broadcast.waveRuns._markPickFailed, {
           runId: args.runId,
@@ -844,7 +842,8 @@ export const pickWaveAction = internalAction({
           error:
             `picked ${picked.length} contacts (< MIN_USABLE_POOL_SIZE=${MIN_USABLE_POOL_SIZE}); ` +
             `ramp deactivated to avoid stranding the next cron tick on awaiting-prior-stats. ` +
-            `Operator: extend rampCurve + resumeRamp if more sends desired, or run a final wave manually.`,
+            `Operator: resume only with at least ${MIN_USABLE_POOL_SIZE} eligible contacts and ` +
+            `requestedCount >= ${MIN_USABLE_POOL_SIZE} (set the ramp tier accordingly). Direct calls use the same minimum.`,
         });
         return { ok: false, reason: "pool-too-small" };
       }


### PR DESCRIPTION
The picker’s comments and stored operator error recommended a direct manual call to bypass the 100-contact minimum, but that call enforces the same guard. The guidance now requires at least 100 eligible contacts and a requested count of at least 100 before resuming. The 100-contact guard is unchanged. Validation now also enforces the existing positive-integer `requestedCount` contract, rejecting fractional direct requests before a run is claimed.

The existing terminal-failure test and downstream 100-delivered safety gate support retaining the minimum. No supported bypass was found in the original implementation or operator contract.

Validation: direct action tests prove that pool99/request100 and pool100/request99 stop before provider I/O, deactivate the ramp, and clear the lease; pool100/request100 proceeds. Both new guidance checks failed before the correction. A fractional `99.5` request also reproduced a validation gap and now rejects before provider I/O. All 53 focused tests, Convex typecheck, and pre-push gates passed. Sequential review covered `041f127a57971eadc93da612de57ab5a76a5f07b`.

Related: #8011 and #8014 touch separate hunks in the same file. A clean combined tree passed all 64 broadcast tests; the three PRs can merge in any order at their reviewed heads.

## Post-Deploy Monitoring & Validation

After a separately approved Convex rollout, verify that new `pool-too-small` errors state both minimum requirements. Existing stored errors are not backfilled. No production provider calls were made.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
