### PR TITLE
fix(shipping): bound pinned webhook response resources

### DIFF
--- a/server/worldmonitor/shipping/v2/deliver-webhook.ts
+++ b/server/worldmonitor/shipping/v2/deliver-webhook.ts
@@ -1,6 +1,7 @@
 import dns from 'node:dns/promises';
 import { createHmac } from 'node:crypto';
 import https from 'node:https';
+import type { IncomingMessage } from 'node:http';
 
 import {
   isBlockedCallbackUrl,
@@ -39,21 +40,14 @@ export interface WebhookDeliveryResult {
 }
 
 const WEBHOOK_DELIVERY_TIMEOUT_MS = 10_000;
-
-function responseFromNode(statusCode: number | undefined, statusMessage: string | undefined, headers: Headers, body: Buffer): Response {
-  return new Response(new Uint8Array(body), {
-    status: statusCode ?? 502,
-    statusText: statusMessage,
-    headers,
-  });
-}
+const MAX_WEBHOOK_RESPONSE_BYTES = 1024 * 1024;
 
 async function postJsonWithPinnedAddress(
   url: URL,
   body: string,
   headers: Record<string, string>,
   resolvedAddresses: string[],
-): Promise<Response> {
+): Promise<Pick<Response, 'status' | 'ok'>> {
   const pinnedAddress = resolvedAddresses.find(address => address.includes('.')) ?? resolvedAddresses[0];
   if (!pinnedAddress) {
     throw new WebhookDeliverySsrfError('callbackUrl DNS resolution returned no addresses');
@@ -61,6 +55,17 @@ async function postJsonWithPinnedAddress(
   const family: 4 | 6 = pinnedAddress.includes(':') ? 6 : 4;
 
   return new Promise((resolve, reject) => {
+    let settled = false;
+    let response: IncomingMessage | undefined;
+    let hardDeadline: ReturnType<typeof setTimeout> | undefined;
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(hardDeadline);
+      req.destroy();
+      response?.destroy();
+      reject(error);
+    };
     const req = https.request({
       hostname: url.hostname,
       port: url.port || 443,
@@ -73,22 +78,35 @@ async function postJsonWithPinnedAddress(
       family,
       lookup: (_hostname, _options, callback) => callback(null, pinnedAddress, family),
     }, (res) => {
-      const chunks: Buffer[] = [];
-      res.on('error', reject);
-      res.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
-      res.on('end', () => {
-        const responseHeaders = new Headers();
-        for (const [key, value] of Object.entries(res.headers)) {
-          if (!value) continue;
-          responseHeaders.set(key, Array.isArray(value) ? value.join(', ') : value);
+      response = res;
+      if (settled) { res.destroy(); return; }
+      let totalBytes = 0;
+      res.on('error', fail);
+      res.on('aborted', () => fail(new Error('webhook response aborted')));
+      // Only delivery status is consumed; discard body chunks without buffering.
+      res.on('data', chunk => {
+        if (settled) return;
+        totalBytes += Buffer.byteLength(chunk);
+        if (totalBytes > MAX_WEBHOOK_RESPONSE_BYTES) {
+          fail(new Error('webhook response too large'));
         }
-        resolve(responseFromNode(res.statusCode, res.statusMessage, responseHeaders, Buffer.concat(chunks)));
+      });
+      res.on('end', () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(hardDeadline);
+        const status = res.statusCode ?? 502;
+        resolve({ status, ok: status >= 200 && status < 300 });
       });
     });
-    req.on('error', reject);
+    req.on('error', fail);
     req.setTimeout(WEBHOOK_DELIVERY_TIMEOUT_MS, () => {
-      req.destroy(new Error('webhook delivery timed out'));
+      fail(new Error('webhook delivery timed out'));
     });
+    // Socket activity must not extend the total request lifetime.
+    hardDeadline = setTimeout(() => {
+      fail(new Error('webhook delivery timed out'));
+    }, WEBHOOK_DELIVERY_TIMEOUT_MS);
     req.write(body);
     req.end();
   });

--- a/tests/shipping-v2-delivery-bounds.test.mts
+++ b/tests/shipping-v2-delivery-bounds.test.mts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import https from 'node:https';
+import { PassThrough } from 'node:stream';
+import { setImmediate } from 'node:timers/promises';
+import { test, type TestContext } from 'node:test';
+import { deliverShippingV2Webhook } from '../server/worldmonitor/shipping/v2/deliver-webhook.ts';
+
+const record = {
+  subscriberId: 'synthetic', callbackUrl: 'https://callback.example/hook?test=1',
+  secret: 'synthetic-secret', active: true, ownerTag: 'test',
+  chokepointIds: ['suez'], alertThreshold: 50, createdAt: '2026-09-11T00:00:00Z',
+};
+const payload = {
+  subscriberId: 'synthetic', chokepointId: 'suez', score: 60, alertThreshold: 50,
+  triggeredAt: '2026-09-11T00:00:00Z', reason: 'synthetic',
+};
+
+function fixture(t: TestContext, statusCode = 200, address = '93.184.216.34', respond = true) {
+  const response = Object.assign(new PassThrough(), { statusCode, statusMessage: 'test', headers: {} });
+  const request = Object.assign(new EventEmitter(), {
+    destroyed: false,
+    setTimeout: () => request,
+    write: () => true,
+    end: () => {},
+    destroy(error?: Error) {
+      request.destroyed = true;
+      if (error) queueMicrotask(() => request.emit('error', error));
+      return request;
+    },
+  });
+  let options!: https.RequestOptions;
+  t.mock.method(https, 'request', (opts: https.RequestOptions, callback: (res: unknown) => void) => {
+    options = opts;
+    if (respond) queueMicrotask(() => callback(response));
+    return request;
+  });
+  const promise = deliverShippingV2Webhook(record, payload, {
+    deliveryId: 'synthetic-delivery', resolveHostname: async () => [address],
+  });
+  return { response, request, promise, get options() { return options; } };
+}
+
+test('rejects and stops a response larger than 1 MiB', async (t) => {
+  const f = fixture(t);
+  const outcome = f.promise.then(() => null, error => error);
+  await setImmediate();
+  f.response.write(Buffer.alloc(1024 * 1024));
+  f.response.end(Buffer.from('x'));
+  const error = await outcome;
+  assert.match(String(error), /response too large/);
+  assert.equal(f.request.destroyed, true);
+  assert.equal(f.response.destroyed, true);
+});
+
+test('hard deadline rejects an active trickle without a socket timeout', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const f = fixture(t);
+  let outcome: unknown = 'pending';
+  const done = f.promise.then(value => { outcome = value; }, error => { outcome = error; });
+  await setImmediate();
+  for (let i = 0; i < 10; i++) {
+    f.response.write(Buffer.from('x'));
+    t.mock.timers.tick(1000);
+    await setImmediate();
+  }
+  const atDeadline = outcome;
+  // Finish the pre-fix request too, so a failed reproduction leaves no promise open.
+  f.response.end();
+  await done;
+  assert.match(String(atDeadline), /timed out/);
+  assert.equal(f.request.destroyed, true);
+  assert.equal(f.response.destroyed, true);
+});
+
+for (const status of [200, 204, 302, 304, 500]) {
+  test(`returns status ${status} without retaining a response body`, async (t) => {
+    const f = fixture(t, status);
+    await setImmediate();
+    f.response.end();
+    assert.deepEqual(await f.promise, { status, ok: status >= 200 && status < 300, resolvedAddresses: ['93.184.216.34'] });
+  });
+}
+
+for (const address of ['93.184.216.34', '2606:4700:4700::1111', '::ffff:93.184.216.34']) {
+  test(`keeps the validated pin and TLS hostname for ${address}`, async (t) => {
+    const f = fixture(t, 200, address);
+    await setImmediate();
+    assert.equal(f.options.hostname, 'callback.example');
+    assert.equal(f.options.path, '/hook?test=1');
+    assert.equal(f.options.rejectUnauthorized, undefined);
+    assert.equal(f.options.checkServerIdentity, undefined);
+    const lookup = f.options.lookup as (hostname: string, options: object, callback: (error: unknown, address: string, family: number) => void) => void;
+    lookup('callback.example', {}, (error: unknown, pinned: string, family: number) => {
+      assert.equal(error, null);
+      assert.equal(pinned, address);
+      assert.equal(family, address.includes(':') ? 6 : 4);
+    });
+    f.response.end();
+    await f.promise;
+  });
+}
+
+test('bounds time before response headers arrive', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const f = fixture(t, 200, '93.184.216.34', false);
+  let outcome: unknown = 'pending';
+  const done = f.promise.then(value => { outcome = value; }, error => { outcome = error; });
+  await setImmediate();
+  t.mock.timers.tick(10_000);
+  await setImmediate();
+  assert.match(String(outcome), /timed out/);
+  assert.equal(f.request.destroyed, true);
+  await done;
+});
+
+test('allows exactly 1 MiB and clears the deadline after success', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const f = fixture(t);
+  await setImmediate();
+  f.response.end(Buffer.alloc(1024 * 1024));
+  assert.equal((await f.promise).ok, true);
+  t.mock.timers.tick(10_000);
+  assert.equal(f.request.destroyed, false);
+});
+
+test('rejects an aborted response and stops the request', async (t) => {
+  const f = fixture(t);
+  const outcome = f.promise.then(() => null, error => error);
+  await setImmediate();
+  f.response.emit('aborted');
+  assert.match(String(await outcome), /aborted/);
+  assert.equal(f.request.destroyed, true);
+  assert.equal(f.response.destroyed, true);
+});


### PR DESCRIPTION
A callback could keep the pinned Shipping v2 delivery request open by trickling response bytes, or grow memory through an unbounded response body. The native HTTPS path now discards unused body chunks, rejects responses over 1 MiB, and applies a 10-second hard request deadline in addition to the socket inactivity timer. Failures destroy the request and response; completion clears the deadline.

The public status result is unchanged. Removing unused `Response` construction also handles normal 204/304 responses. DNS pinning and Node TLS defaults remain intact. A native Node 24.20 local HTTPS probe returned 302 after exactly one request, disproving automatic redirect following; no redundant redirect policy was added.

Validation: both size/time regressions failed before the fix. All 58 focused delivery, handler, SSRF, and OpenAPI tests passed, as did API typecheck. Tests cover active dribbles, missing headers, aborts, exact size limit, deadline cleanup, and IPv4/IPv6/mapped pins. Sequential review covered `4ed3768c81021d3c3c2dd0b07ba5456de941282f`.

## Post-Deploy Monitoring & Validation

After a separately approved rollout, verify bounded timeout/oversize failures and successful small responses. The hard deadline starts after DNS validation; the injected fetch override is unchanged. No live subscriber callbacks or production delivery were performed.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
