### PR TITLE
fix(wildfire): preserve total count through bootstrap compaction

### DIFF
--- a/api/_wildfire-dashboard.js
+++ b/api/_wildfire-dashboard.js
@@ -138,6 +138,8 @@ export function compactWildfireDashboardPayload(value, limit = WILDFIRE_DASHBOAR
   const needsByteCap = Number.isFinite(options.maxBytes) && typeof options.measureBytes === 'function';
   if (!needsCountCap && !needsDashboardFilter && !needsByteCap) return value;
 
+  // A bootstrap payload may already be capped by the producer.
+  const totalCount = Math.max(numeric(value.pagination?.totalCount), value.fireDetections.length);
   let fireDetections = (needsCountCap || needsDashboardFilter)
     ? limitFireDetectionsForDashboard(value.fireDetections, limit)
     : value.fireDetections;
@@ -145,13 +147,13 @@ export function compactWildfireDashboardPayload(value, limit = WILDFIRE_DASHBOAR
     fireDetections = trimFireDetectionsToByteBudget(fireDetections, {
       maxBytes: options.maxBytes,
       measureBytes: (candidate) => options.measureBytes({ ...value, ...candidate }),
-      totalCount: value.fireDetections.length,
+      totalCount,
     });
   }
   if (fireDetections === value.fireDetections) return value;
   return {
     ...value,
     fireDetections,
-    pagination: { nextCursor: '', totalCount: value.fireDetections.length },
+    pagination: { nextCursor: '', totalCount },
   };
 }

--- a/scripts/_wildfire-dashboard.mjs
+++ b/scripts/_wildfire-dashboard.mjs
@@ -138,6 +138,8 @@ export function compactWildfireDashboardPayload(value, limit = WILDFIRE_DASHBOAR
   const needsByteCap = Number.isFinite(options.maxBytes) && typeof options.measureBytes === 'function';
   if (!needsCountCap && !needsDashboardFilter && !needsByteCap) return value;
 
+  // A bootstrap payload may already be capped by the producer.
+  const totalCount = Math.max(numeric(value.pagination?.totalCount), value.fireDetections.length);
   let fireDetections = (needsCountCap || needsDashboardFilter)
     ? limitFireDetectionsForDashboard(value.fireDetections, limit)
     : value.fireDetections;
@@ -145,13 +147,13 @@ export function compactWildfireDashboardPayload(value, limit = WILDFIRE_DASHBOAR
     fireDetections = trimFireDetectionsToByteBudget(fireDetections, {
       maxBytes: options.maxBytes,
       measureBytes: (candidate) => options.measureBytes({ ...value, ...candidate }),
-      totalCount: value.fireDetections.length,
+      totalCount,
     });
   }
   if (fireDetections === value.fireDetections) return value;
   return {
     ...value,
     fireDetections,
-    pagination: { nextCursor: '', totalCount: value.fireDetections.length },
+    pagination: { nextCursor: '', totalCount },
   };
 }

--- a/tests/wildfire-payload-cap.test.mts
+++ b/tests/wildfire-payload-cap.test.mts
@@ -17,6 +17,7 @@ import {
   WILDFIRE_CWFIS_SOURCE,
   compactWildfireDashboardPayload,
 } from '../scripts/_wildfire-dashboard.mjs';
+import { assembleBootstrapTierPayload } from '../scripts/publish-bootstrap-tiers.mjs';
 import { MAX_PAYLOAD_BYTES, runSeed } from '../scripts/_seed-utils.mjs';
 import { buildEnvelope, unwrapEnvelope } from '../scripts/_seed-envelope-source.mjs';
 import type { FireDetection } from '../src/generated/server/worldmonitor/wildfire/v1/service_server';
@@ -191,6 +192,38 @@ describe('wildfire dashboard payload cap', () => {
     assert.equal(compacted.fireDetections.length, WILDFIRE_DASHBOARD_DETECTION_LIMIT);
     assert.deepEqual(compacted.pagination, { nextCursor: '', totalCount: WILDFIRE_DASHBOARD_DETECTION_LIMIT + 1 });
     assert.equal(payload.fireDetections.length, WILDFIRE_DASHBOARD_DETECTION_LIMIT + 1);
+  });
+
+  it('preserves valid totals and floors invalid totals at the input count on repeated compaction', () => {
+    const fireDetections = [fireDetection(1), fireDetection(2)];
+    for (const [totalCount, expected] of [
+      [undefined, 2], [null, 2], [-1, 2], [1, 2], [NaN, 2], [Infinity, 2],
+      ['invalid', 2], [2, 2], [20_442, 20_442], ['20442', 20_442],
+    ]) {
+      const payload = { fireDetections, pagination: { nextCursor: '', totalCount } };
+      for (const compact of [compactWildfireDashboardPayload, compactWildfireBootstrapPayload]) {
+        const first = compact(payload);
+        const second = compact(first);
+        assert.equal(first.pagination.totalCount, expected);
+        assert.deepEqual(second, first);
+        assert.equal(payload.pagination.totalCount, totalCount);
+      }
+    }
+  });
+
+  it('measures the preserved total when trimming an already compacted payload to a byte budget', () => {
+    const payload = {
+      fireDetections: [fireDetection(1), fireDetection(2)],
+      pagination: { nextCursor: '', totalCount: 20_442 },
+    };
+    const measureBytes = (value: unknown) => Buffer.byteLength(JSON.stringify(value));
+    const maxBytes = measureBytes(payload) - 1;
+    for (const compact of [compactWildfireDashboardPayload, compactWildfireBootstrapPayload]) {
+      const compacted = compact(payload, WILDFIRE_DASHBOARD_DETECTION_LIMIT, { maxBytes, measureBytes });
+      assert.equal(compacted.fireDetections.length, 1);
+      assert.equal(compacted.pagination.totalCount, 20_442);
+      assert.ok(measureBytes(compacted) <= maxBytes);
+    }
   });
 
   it('keeps bootstrap and RPC caps in ranking parity', () => {
@@ -515,6 +548,20 @@ describe('canonical wildfire payload cap (#5866)', () => {
       assert.deepEqual(canonical.pagination, { nextCursor: '', totalCount: FIRMS_PEAK_DETECTIONS });
       assert.equal(bootstrap.fireDetections.length, WILDFIRE_DASHBOARD_DETECTION_LIMIT);
       assert.deepEqual(bootstrap.pagination, { nextCursor: '', totalCount: FIRMS_PEAK_DETECTIONS });
+      const published = await assembleBootstrapTierPayload({ wildfires: bootstrapKey }, {
+        env: { UPSTASH_REDIS_REST_URL: 'https://redis.test', UPSTASH_REDIS_REST_TOKEN: 'test-token' },
+        fetchFn: async (_input, init) => {
+          assert.deepEqual(JSON.parse(String(init.body)), [['GET', bootstrapKey]]);
+          return Response.json([{ result: JSON.stringify(bootstrapEnvelope) }]);
+        },
+      });
+      const redisFallback = compactWildfireBootstrapPayload(bootstrap);
+      for (const response of [published.data.wildfires, redisFallback]) {
+        assert.deepEqual(response.fireDetections, bootstrap.fireDetections);
+        assert.equal(response.pagination.totalCount, FIRMS_PEAK_DETECTIONS);
+        assert.equal(resolveFireDetectionTotalCount(response), FIRMS_PEAK_DETECTIONS);
+      }
+      assert.deepEqual(published.missing, []);
       assert.equal(canonicalEnvelope._seed.recordCount, WILDFIRE_CANONICAL_DETECTION_LIMIT);
       assert.equal(bootstrapEnvelope._seed.recordCount, WILDFIRE_DASHBOARD_DETECTION_LIMIT);
       assert.ok(


### PR DESCRIPTION
## Summary
Preserve the uncapped wildfire total when bootstrap data is compacted again. A producer snapshot with 20,442 detections previously became a 500-record bootstrap payload with the correct total, but CDN assembly and the Redis fallback then reset that total to 500.

Both packaged helper copies now retain a larger finite reported total and use it during byte-budget measurement. Detection ranking, filtering and caps remain unchanged.

Related: DeepSec finding 11. Finding 12 is separate and outside this change. No bootstrap registry changes.

## Validation
- Synthetic `runSeed` publication through CDN tier assembly and the Redis fallback compactor preserves 20,442 while retaining 500 detections; the browser count resolver reads that total.
- Regression failed before the fix with `500 !== 20442`.
- 54 focused tests and 487 sidecar tests passed; API typecheck and diff check passed.
- Repeated compaction, invalid count metadata, input immutability and byte-budget measurement covered. Sequential ce-code-review completed with no actionable findings.
- No live provider calls or production access. Complete browser hydration and rendered UI were not exercised; this change is confined to the shared payload helper and tests.

## Post-Deploy Monitoring & Validation
Owner: repository operator. After authorized worker and API deployment, compare the producer bootstrap seed total against the CDN tier and Redis fallback on a snapshot above 500 detections. Each should report the same total and at most 500 detections. Allow existing CDN artifacts to refresh, then check the satellite-fire count and monitor wildfire seed freshness and bootstrap errors over one natural publication cycle. A falling total on an unchanged snapshot or a payload-budget failure requires inspecting the deployed helper copies and cached artifact age. Deployment and live acceptance were not performed here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
