### PR TITLE
fix(sentry): filter three live third-party noise tails

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -584,11 +584,15 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // the same gap that let WORLDMONITOR-15/-102/-108/-117 through.
   //
   // Frame-gated rather than copied into `MARKETING_IGNORE_ERRORS` (see
-  // CSP_EVAL_BLOCK). Requiring an `<anonymous>` frame keeps a frameless event
-  // reporting, since absence of first-party frames alone is not evidence of
-  // injection; `!hasFirstParty` keeps a block that rides a `/pro/assets/*.js`
-  // frame reporting.
-  if (!hasFirstParty
+  // CSP_EVAL_BLOCK), and gated on the WHOLE stack being `<anonymous>` or infra
+  // rather than on `!hasFirstParty`. `hasFirstParty` does not count document
+  // frames, and this surface ships executable inline script (see
+  // MARKETING_DOCUMENT_FRAME): an eval issued by welcome.html's bootstrap puts
+  // the document URL below the `<anonymous>` frame, and that first-party CSP
+  // break must page (PR #8022 review). Requiring an `<anonymous>` frame keeps a
+  // frameless event reporting, since an empty stack is not evidence of
+  // injection.
+  if (nonInfraFrames.length === 0
       && CSP_EVAL_BLOCK.test(msg)
       && frames.some((f) => f.filename === '<anonymous>')) return null;
 

--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -424,6 +424,16 @@ const MARKETING_DOCUMENT_FRAME =
  */
 const MASKED_URL_FRAME = /^webkit-masked-url:/;
 /**
+ * The browser refusing `eval`/`new Function` under our `script-src`, which
+ * omits 'unsafe-eval'. Chrome says "Evaluating a string as JavaScript violates
+ * the following Content Security Policy directive because 'unsafe-eval'…";
+ * Safari says "Refused to evaluate … 'unsafe-eval' … Content Security Policy
+ * directive". Deliberately NOT in `MARKETING_IGNORE_ERRORS`: if our own bundle
+ * or a dependency ever evaluates a string, the CSP breaks that code path, and
+ * that must page.
+ */
+const CSP_EVAL_BLOCK = /unsafe-eval.*Content Security Policy|Content Security Policy.*unsafe-eval/;
+/**
  * A script the browser fetched but could not PARSE. Deliberately NOT in
  * `MARKETING_IGNORE_ERRORS`: a `SyntaxError` message is generic enough that our
  * own bundle could in principle produce one (a `JSON.parse` on a malformed API
@@ -565,6 +575,22 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // `Attempting to change value of a readonly property` entry in
   // `src/bootstrap/sentry-init.ts`.
   if (!hasFirstParty && nonInfraFrames.some((f) => MASKED_URL_FRAME.test(f.filename ?? ''))) return null;
+
+  // An injected script's `eval` refused by our CSP. WORLDMONITOR-129 is the
+  // shape: `EvalError` on Edge 150 / Windows at `/pro`, an `onerror` capture
+  // whose only frames are two `<anonymous>:1` entries, the filename V8 gives
+  // code evaluated from a string. The dashboard drops this message outright in
+  // its `ignoreErrors`; the two surfaces run separate Sentry clients, which is
+  // the same gap that let WORLDMONITOR-15/-102/-108/-117 through.
+  //
+  // Frame-gated rather than copied into `MARKETING_IGNORE_ERRORS` (see
+  // CSP_EVAL_BLOCK). Requiring an `<anonymous>` frame keeps a frameless event
+  // reporting, since absence of first-party frames alone is not evidence of
+  // injection; `!hasFirstParty` keeps a block that rides a `/pro/assets/*.js`
+  // frame reporting.
+  if (!hasFirstParty
+      && CSP_EVAL_BLOCK.test(msg)
+      && frames.some((f) => f.filename === '<anonymous>')) return null;
 
   // A module the browser fetched but could not parse. WORLDMONITOR-TS is the
   // shape: `action: load-clerk` on Chrome Mobile 80 / Android 10 (a 2020

--- a/src/main.ts
+++ b/src/main.ts
@@ -231,6 +231,23 @@ function shouldSuppressCspViolation(
       if (url.protocol === 'https:' && url.hostname === 'dhfs.heytapimage.com') return true;
     } catch { /* scheme-only values ('inline', 'eval') fall through */ }
   }
+  // UC Browser (Alibaba's Android browser) fetches its own bottom-banner ad
+  // plugin from `uc.gre`, a pseudo-host the browser resolves internally, and
+  // reports the result to its `*.uc.cn` tracker. Both are http:, which our
+  // `connect-src 'self' https: wss: blob: data:` never admits, so no policy
+  // state of ours can reach them. `uc.cn` and `uc.gre` appear nowhere in our
+  // sources, so this is the browser's injection failing, the HeyTap case above
+  // on a different directive. The only blockedURIs WORLDMONITOR-HN has recorded
+  // since 2026-08-19 are these two (UC Browser 12.3.0 / Android 14,
+  // 2026-09-09). Exact `uc.gre`; `uc.cn` by registrable-domain suffix with a
+  // leading `.` because its tracker hosts vary, so `uc.cn.evil.com` and
+  // `notuc.cn` still surface.
+  if (directive === 'connect-src') {
+    try {
+      const host = new URL(blockedURI).hostname;
+      if (host === 'uc.gre' || host === 'uc.cn' || host.endsWith('.uc.cn')) return true;
+    } catch { /* scheme-only values fall through */ }
+  }
   // Zscaler enterprise content-filter proxy: `gateway.zscloud.net` is injected into
   // corporate users' frames by Zscaler's web filter agent. We never load it ourselves;
   // it's inserted into the host page outside our control (WORLDMONITOR-HT). Match by
@@ -382,6 +399,14 @@ function shouldSuppressCspViolation(
       // script-src still surfaces.
       if (url.protocol === 'https:' && url.hostname === 'use.fontawesome.com'
           && url.pathname.startsWith('/releases/') && cssFile.test(url.pathname)) return true;
+      // Font Awesome's Kit service, the same vendor's other delivery host:
+      // `kit.fontawesome.com/<kit-id>.css`, where the hex kit ID is a per-account
+      // key. We never adopted Font Awesome, so the kit belongs to whoever
+      // injected it (WORLDMONITOR-J0 round 5, the only blockedURI since the
+      // unpkg rule shipped on 2026-08-16). Exact host + kit-ID path; the kit's
+      // JS loader under script-src still surfaces.
+      if (url.protocol === 'https:' && url.hostname === 'kit.fontawesome.com'
+          && /^\/[0-9a-f]+\.css$/.test(url.pathname)) return true;
       // Adobe Typekit / Adobe Fonts kit CSS, from both hosts it serves:
       // `use.typekit.net/<kit>.css` and the `p.typekit.net/p.css?...` tracking
       // sheet — together 17% of this issue's current volume. We self-host every

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -581,6 +581,22 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'style-src-elem', 'https://p.typekit.net/kit.js', '', false));
     });
 
+    it('suppresses Font Awesome Kit stylesheet injection (WORLDMONITOR-J0 round 5)', () => {
+      // Verbatim production value, 2026-09-11 on build 7169ec18: the Kit
+      // service's per-account CSS. We never used Font Awesome, and a Kit ID is
+      // an account key someone else's extension or userscript carries.
+      assert.ok(suppress('enforce', 'style-src-elem', 'https://kit.fontawesome.com/046138b2c6.css', '', false));
+      assert.ok(suppress('enforce', 'style-src', 'https://kit.fontawesome.com/046138b2c6.css', '', false));
+    });
+
+    it('does NOT suppress a Font Awesome Kit lookalike host, its JS loader, or a non-kit path', () => {
+      // One negative per conjunct of the guard: drop any one and this goes red.
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://kit.fontawesome.com.evil.com/046138b2c6.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'http://kit.fontawesome.com/046138b2c6.css', '', false));
+      assert.ok(!suppress('enforce', 'script-src-elem', 'https://kit.fontawesome.com/046138b2c6.js', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://kit.fontawesome.com/releases/v6/css/all.css', '', false));
+    });
+
     it('does NOT suppress arbitrary third-party style-src hosts', () => {
       assert.ok(!suppress('enforce', 'style-src-elem', 'https://styles.evil.example/inject.css', '', false));
     });
@@ -664,6 +680,27 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('does NOT suppress a heytapimage lookalike host', () => {
       assert.ok(!suppress('enforce', 'script-src-elem', 'https://dhfs.heytapimage.com.evil.com/a.js', '', false, FIRST_PARTY_CONVEX));
       assert.ok(!suppress('enforce', 'script-src-elem', 'https://cdn.heytapimage.com/a.js', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('suppresses UC Browser ad-plugin and tracker connect-src injection (WORLDMONITOR-HN)', () => {
+      // Verbatim production values, 2026-09-09: UC Browser 12.3.0 / Android 14
+      // fetching its own bottom-banner ad plugin from the browser-internal
+      // `uc.gre` pseudo-host and reporting the failure to its tracker. Both are
+      // http:, so no https: policy state can reach them; `uc.cn` and `uc.gre`
+      // appear nowhere in our sources.
+      for (const allowsHttps of [true, false]) {
+        assert.ok(suppress('enforce', 'connect-src', 'http://uc.gre/pass/uc_gre_ad_buss/plugin.php?uc_param_str=cpfrvelakt&namespace=bottom-ad-i18n&domain=www.worldmonitor.app&isMaxcms=false', '', allowsHttps, FIRST_PARTY_CONVEX));
+        assert.ok(suppress('enforce', 'connect-src', 'http://gj.track.uc.cn/collect?uc_param_str=cpfrveladnkt&appid=4e54ac8a118f&lt=event&e_c=bottom_ad&e_a=index&e_n=req_pp_fail&domain=www.worldmonitor.app', '', allowsHttps, FIRST_PARTY_CONVEX));
+      }
+    });
+
+    it('does NOT suppress UC lookalike hosts, other directives, or a first-party http: block', () => {
+      assert.ok(!suppress('enforce', 'connect-src', 'http://uc.gre.evil.com/pass/plugin.php', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'connect-src', 'http://gj.track.uc.cn.evil.com/collect', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'connect-src', 'http://notuc.cn/collect', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'script-src-elem', 'http://gj.track.uc.cn/sdk.js', '', false, FIRST_PARTY_CONVEX));
+      // A real mixed-content regression on our own API must still report.
+      assert.ok(!suppress('enforce', 'connect-src', 'http://api.worldmonitor.app/api/oref-alerts', '', true, FIRST_PARTY_CONVEX));
     });
 
     it('does NOT suppress first-party script-src blocks that share the cross-origin shape (WORLDMONITOR-HP history)', () => {

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -588,6 +588,51 @@ describe('marketingBeforeSend — Safari-masked injected script (WORLDMONITOR-11
   });
 });
 
+describe('marketingBeforeSend — injected eval blocked by CSP (WORLDMONITOR-129)', () => {
+  // Verbatim production event: Edge 150 / Windows on `/pro`, an `onerror`
+  // capture whose only frames are two `<anonymous>:1` entries — a script
+  // evaluated by an extension, which our `script-src` (no 'unsafe-eval') refused.
+  const CSP_EVAL_MESSAGE = "Evaluating a string as JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is not an allowed source of script: script-src 'self' 'strict-dynamic' 'nonce-wm-static-bootstrap'";
+  const evalEvent = (value: string, filenames: string[]): PolicyEvent => ({
+    exception: {
+      values: [{
+        type: 'EvalError',
+        value,
+        stacktrace: { frames: filenames.map((filename) => ({ filename })) },
+      }],
+    },
+  });
+
+  it('drops the CSP eval block raised from an evaluated script', () => {
+    assert.equal(marketingBeforeSend(evalEvent(CSP_EVAL_MESSAGE, ['<anonymous>', '<anonymous>'])), null);
+  });
+
+  it("drops Safari's phrasing of the same block", () => {
+    const safari = "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self'\".";
+    assert.equal(marketingBeforeSend(evalEvent(safari, ['<anonymous>'])), null);
+  });
+
+  // Positive control for `!hasFirstParty`: if our own bundle ever reaches for
+  // eval or `new Function`, the CSP breaks that code path and it must page. It
+  // would ride a `/pro/assets/*.js` frame. Delete the gate and this goes red.
+  it('keeps the block when a marketing-bundle frame is on the stack', () => {
+    const kept = evalEvent(CSP_EVAL_MESSAGE, ['<anonymous>', '/pro/assets/index-a1b2c3.js']);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  // Positive control for the evaluated-frame requirement: no frames at all is
+  // absence of evidence, not proof of injection.
+  it('keeps a frameless block', () => {
+    const kept = evalEvent(CSP_EVAL_MESSAGE, []);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  it('keeps an unrelated error from an evaluated script', () => {
+    const kept = evalEvent('Invalid array length', ['<anonymous>']);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+});
+
 describe('marketingBeforeSend — unparseable module (WORLDMONITOR-TS)', () => {
   // `action: null` means "no tags on the event at all". It must NOT be spelled
   // `undefined`: a default parameter fires on an explicit `undefined` argument,

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -620,6 +620,17 @@ describe('marketingBeforeSend — injected eval blocked by CSP (WORLDMONITOR-129
     assert.equal(marketingBeforeSend(kept), kept);
   });
 
+  // The same control for our INLINE first-party scripts (welcome.html's WebMCP
+  // bootstrap, prerender.mjs's DEFERRED_STYLES_SCRIPT): an eval they issue puts
+  // the document URL on the stack below the `<anonymous>` frame, and
+  // `hasFirstParty` does not count document frames (PR #8022 review).
+  it('keeps the block when the caller is an inline script on the marketing document', () => {
+    for (const doc of ['https://www.worldmonitor.app/', 'https://www.worldmonitor.app/pro']) {
+      const kept = evalEvent(CSP_EVAL_MESSAGE, ['<anonymous>', doc]);
+      assert.equal(marketingBeforeSend(kept), kept);
+    }
+  });
+
   // Positive control for the evaluated-frame requirement: no frames at all is
   // absence of evidence, not proof of injection.
   it('keeps a frameless block', () => {


### PR DESCRIPTION
## Summary

Three Sentry issues kept firing on browser noise that our code doesn't cause. This PR adds a narrow filter for each one. All three were resolved plainly, with no release pin, so an issue reopens on its next event. That covers events from pre-deploy builds and any new noise source.

| Issue | What is still firing | Filter |
|---|---|---|
| WORLDMONITOR-129 | `EvalError` on `/pro`: an extension's `eval` refused by our CSP, with only `<anonymous>` frames | `marketingBeforeSend` drops it only when every frame is `<anonymous>` or SDK infrastructure, and at least one is `<anonymous>` |
| WORLDMONITOR-J0 | `kit.fontawesome.com/046138b2c6.css`, round 5. It is the only blocked URL since the unpkg rule shipped on Aug 16 | `style-src*`, https only, exact host, hex kit-ID `.css` path |
| WORLDMONITOR-HN | UC Browser 12.3 fetching its own ad plugin (`http://uc.gre/...`) and reporting to its tracker (`http://gj.track.uc.cn/...`) | `connect-src`, exact `uc.gre`, plus `uc.cn` and `*.uc.cn` |

The marketing rule checks stack frames instead of matching the message in `ignoreErrors`. The dashboard does drop this message in `ignoreErrors`, but the marketing surface needs the stricter check. If our own bundle or a dependency there ever evaluated a string, our CSP would break that code path and the error should page. Such an event carries a `/pro/assets/*.js` frame, or, when an inline script on the page makes the call, the document URL. Either one keeps the event reporting, and so does a frameless event.

The other 34 unresolved issues are deliberate monitors or intentional `warning` captures, so they stay open. An audit of all 239 resolved issues found no release or commit pins.

## Validation

- **Tests:** the four new "should be filtered" cases failed before the fix and pass now. `csp-filter` passes 138/138 and `pro-sentry-filter-policy` 106/106.
- **Mutation checks:** I removed each safeguard in turn and a test failed every time. The safeguards are the first-party check, the `<anonymous>`-frame requirement, the leading dot in `.uc.cn`, and the kit `https:` check. The inline-script case came from review and was also confirmed failing before the fix.
- **Build:** `tsc --noEmit` passes for the root project and `pro-test`, and the pre-push gates passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_015TbeHTDFd4n97VMwp69hsy
