### PR TITLE
fix(aviation): keep bootstrap publication out of delay requests

### DIFF
--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -18,7 +18,7 @@ import {
   loadNotamClosures,
   mergeNotamWithExistingAlert,
 } from './_shared';
-import { getCachedJson, setCachedJson } from '../../../_shared/redis';
+import { getCachedJson } from '../../../_shared/redis';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../../../../api/_sentry-edge.js';
 
@@ -69,16 +69,14 @@ export async function listAirportDelays(
   // A cache hit alone does not prove every configured hub was covered. The
   // seeder records each hub as normal/disruption/omitted/failed so an omitted
   // hub remains UNKNOWN instead of being synthesized as normal.
-  const intlRead = (async (): Promise<{ intlAlerts: AirportDelayAlert[]; intlCoverage: IntlCoverage[]; intlCoveredIatas: Set<string> }> => {
+  const intlRead = (async (): Promise<{ intlAlerts: AirportDelayAlert[]; intlCoveredIatas: Set<string> }> => {
     let intlAlerts: AirportDelayAlert[] = [];
-    let intlCoverage: IntlCoverage[] = [];
     let intlCoveredIatas = new Set<string>();
     try {
       const cached = await getCachedJson(INTL_CACHE_KEY) as { alerts: AirportDelayAlert[]; coverage?: IntlCoverage[] } | null;
       if (cached && Array.isArray(cached.alerts)) {
         intlAlerts = cached.alerts;
         if (Array.isArray(cached.coverage)) {
-          intlCoverage = cached.coverage;
           intlCoveredIatas = new Set(cached.coverage
             .filter((hub) => hub.status === 'normal' || hub.status === 'disruption')
             .map((hub) => hub.iata));
@@ -88,7 +86,7 @@ export async function listAirportDelays(
       console.warn(`[Aviation] Intl fetch failed: ${err instanceof Error ? err.message : 'unknown'}`);
       void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'intl-cache-read' } });
     }
-    return { intlAlerts, intlCoverage, intlCoveredIatas };
+    return { intlAlerts, intlCoveredIatas };
   })();
 
   // 3. NOTAM alerts — shared loader (seed-first with live fallback).
@@ -98,7 +96,7 @@ export async function listAirportDelays(
   // bubbling and tripping every airport to UNKNOWN at the handler boundary.
   const notamRead = loadNotamClosures();
 
-  const [{ faaAlerts, faaSourceCovered }, { intlAlerts, intlCoverage, intlCoveredIatas }, notamResult] =
+  const [{ faaAlerts, faaSourceCovered }, { intlAlerts, intlCoveredIatas }, notamResult] =
     await Promise.all([faaRead, intlRead, notamRead]);
 
   const allAlerts = [...faaAlerts, ...intlAlerts];
@@ -187,15 +185,6 @@ export async function listAirportDelays(
       });
     }
   }
-
-  // Write bootstrap key for initial page load hydration. Canonical writer is
-  // scripts/seed-aviation.mjs (BOOTSTRAP_TTL=7200). This RPC-side write is a
-  // courtesy mid-tick refresh — TTL kept in lockstep so a user-triggered RPC
-  // doesn't shorten the seeder's expiry and re-create the EMPTY-on-quiet-traffic
-  // failure mode that motivated the canonical seeder write.
-  try {
-    await setCachedJson('aviation:delays-bootstrap:v2', { alerts: allAlerts, coverage: intlCoverage }, 7200);
-  } catch { /* non-critical */ }
 
   return { alerts: allAlerts };
 }

--- a/tests/airport-bootstrap-write-ownership.test.mts
+++ b/tests/airport-bootstrap-write-ownership.test.mts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
+import { listAirportDelays } from '../server/worldmonitor/aviation/v1/list-airport-delays.ts';
+import bootstrap from '../api/bootstrap.js';
+import { buildDelaysBootstrapPayload, BOOTSTRAP_KEY, BOOTSTRAP_META_KEY } from '../scripts/seed-aviation.mjs';
+import { MONITORED_AIRPORTS } from '../src/config/airports.ts';
+
+const FAA_KEY = 'aviation:delays:faa:v1';
+const INTL_KEY = 'aviation:delays:intl:v3';
+const coverage = [{ iata: 'LHR', status: 'normal', flightCount: 12 }];
+const faa = { alerts: [] };
+const intl = { alerts: [], coverage };
+
+for (const mode of ['healthy', 'miss', 'intl-error', 'timeout'] as const) {
+  test(`airport RPC preserves the producer bootstrap and metadata after ${mode} source reads`, async (t) => {
+    for (const [name, value] of Object.entries({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test', UPSTASH_REDIS_REST_TOKEN: 'fixture-token',
+      VERCEL_ENV: 'production', ICAO_API_KEY: undefined, SEED_FALLBACK_NOTAM: undefined,
+      BOOTSTRAP_R2_SHADOW_MEASURE: '0',
+    })) {
+      const original = process.env[name];
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+      t.after(() => {
+        if (original === undefined) delete process.env[name];
+        else process.env[name] = original;
+      });
+    }
+    const seeded = buildDelaysBootstrapPayload({
+      faaPayload: faa, intlPayload: intl, notamPayload: null,
+      fillerRegistry: MONITORED_AIRPORTS.filter(a => ['JFK', 'LHR'].includes(a.iata)),
+    });
+    const originalPayload = JSON.stringify(seeded);
+    const originalMeta = JSON.stringify({ fetchedAt: 1_789_000_000_000, recordCount: seeded.alerts.length });
+    const store = new Map([[BOOTSTRAP_KEY, originalPayload], [BOOTSTRAP_META_KEY, originalMeta]]);
+    let bootstrapTtl = 3_600;
+    const writes: unknown[][] = [];
+    const reads: string[] = [];
+    const origins = new Set<string>();
+    t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+      origins.add(url.origin);
+      assert.equal(url.origin, 'https://redis.test', 'no provider access allowed');
+      if (url.pathname.startsWith('/get/')) {
+        const key = decodeURIComponent(url.pathname.slice(5));
+        reads.push(key);
+        if ([FAA_KEY, INTL_KEY].includes(key)) {
+          if (mode === 'timeout') {
+            await delay(5_000, undefined, { signal: init?.signal ?? undefined });
+            assert.fail('cache read must abort before five seconds');
+          }
+          if (mode === 'intl-error' && key === INTL_KEY) return Response.json({ error: 'fixture read failure' }, { status: 503 });
+          if (mode === 'miss') return Response.json({ result: null });
+          return Response.json({ result: JSON.stringify(key === FAA_KEY ? faa : intl) });
+        }
+        return Response.json({ result: null });
+      }
+      const command = JSON.parse(String(init?.body));
+      if (url.pathname === '/pipeline') {
+        assert.ok(command.every(([op]: string[]) => op === 'GET'));
+        return Response.json(command.map(([, key]: string[]) => ({ result: store.get(key) ?? null })));
+      }
+      writes.push(command);
+      assert.equal(command[0], 'SET');
+      store.set(command[1], command[2]);
+      if (command[1] === BOOTSTRAP_KEY) bootstrapTtl = Number(command[4]);
+      return Response.json({ result: 'OK' });
+    });
+
+    const rpc = await listAirportDelays({} as never, {} as never);
+    assert.ok(reads.includes(FAA_KEY) && reads.includes(INTL_KEY));
+    const severity = (iata: string) => rpc.alerts.find(a => a.iata === iata)?.severity;
+    assert.equal(severity('JFK'), mode === 'healthy' || mode === 'intl-error' ? 'FLIGHT_DELAY_SEVERITY_NORMAL' : 'FLIGHT_DELAY_SEVERITY_UNKNOWN');
+    assert.equal(severity('LHR'), mode === 'healthy' ? 'FLIGHT_DELAY_SEVERITY_NORMAL' : 'FLIGHT_DELAY_SEVERITY_UNKNOWN');
+
+    const response = await bootstrap(new Request('https://api.worldmonitor.app/api/bootstrap?keys=flightDelays&public=1'));
+    assert.equal(response.status, 200);
+    const hydrated = (await response.json()).data.flightDelays;
+    assert.ok(JSON.stringify(hydrated) === originalPayload, 'public bootstrap must still return the producer snapshot');
+    assert.equal(store.get(BOOTSTRAP_META_KEY), originalMeta);
+    assert.equal(bootstrapTtl, 3_600, 'request must not refresh the shared seed TTL');
+    assert.deepEqual(writes, [], 'request must not publish a bootstrap snapshot');
+    assert.deepEqual([...origins], ['https://redis.test']);
+  });
+}


### PR DESCRIPTION
## Summary
Airport-delay requests no longer publish `aviation:delays-bootstrap:v2`. The handler previously replaced the shared producer snapshot after every request, including when source reads missed, returned errors or timed out. Those responses could contain UNKNOWN rows and missing international coverage, and the write refreshed the shared TTL without updating seed metadata.

The seeder remains responsible for bootstrap publication and its metadata. The RPC keeps its existing alert response and coverage behavior. Removed the coverage variable used only by the deleted write.

Related: DeepSec finding 5. Finding 6 (international raw-key mismatch) remains separate and unchanged. No shared rate, gateway or bootstrap registry changes.

## Validation
- Synthetic producer payload passed through the real handler and public bootstrap reader reproduces the overwrite before the fix.
- Healthy reads, cache misses, HTTP 503 and actual 1.5-second read timeouts now preserve the shared payload, TTL and metadata while returning the expected RPC statuses.
- 67 focused aviation, bootstrap and China-coverage regressions passed; API typecheck and diff check passed.
- Sequential ce-code-review completed with no actionable findings. Mock command/origin assertions remain observable even when the handler catches errors.
- No production provider calls or load tests. The overwrite is confirmed; inducing Redis degradation through request volume was not demonstrated. The scheduled publisher and full CII score computation were source-traced, not executed.

## Post-Deploy Monitoring & Validation
Owner: repository operator. After authorized API deployment, observe one natural aviation seed cycle and verify bootstrap and seed-meta freshness advance together. Confirm that ordinary delay RPC traffic no longer refreshes the aggregate key, and that map hydration and China-corridor coverage retain the producer data. Monitor UNKNOWN response rates separately from shared snapshot freshness. If freshness stops advancing, inspect the scheduled publisher rather than restoring request-driven writes. No deployment or live acceptance was performed here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
