### PR TITLE
fix(aviation): read international delays from the raw seed key

### DIFF
--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -74,7 +74,7 @@ export async function listAirportDelays(
     let intlCoverage: IntlCoverage[] = [];
     let intlCoveredIatas = new Set<string>();
     try {
-      const cached = await getCachedJson(INTL_CACHE_KEY) as { alerts: AirportDelayAlert[]; coverage?: IntlCoverage[] } | null;
+      const cached = await getCachedJson(INTL_CACHE_KEY, true) as { alerts: AirportDelayAlert[]; coverage?: IntlCoverage[] } | null;
       if (cached && Array.isArray(cached.alerts)) {
         intlAlerts = cached.alerts;
         if (Array.isArray(cached.coverage)) {

--- a/tests/airport-delays-raw-key.test.mjs
+++ b/tests/airport-delays-raw-key.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// redis.ts memoizes the deployment prefix, so each environment needs a fresh process.
+const fixture = `
+import assert from 'node:assert/strict';
+import { seedIntlDelays, publishTransform } from './scripts/seed-aviation.mjs';
+import { buildEnvelope } from './scripts/_seed-envelope-source.mjs';
+import { listAirportDelays } from './server/worldmonitor/aviation/v1/list-airport-delays.ts';
+
+const intlKey = 'aviation:delays:intl:v3';
+const produced = await seedIntlDelays({
+  apiKey: 'fixture-only',
+  airports: ['LHR', 'FRA', 'CDG'].map(iata => ({ iata })),
+  logger: { log() {}, warn() {} },
+  fetchFn: async url => {
+    const iata = new URL(url).searchParams.get('dep_iata');
+    return Response.json({ data: iata === 'CDG' ? [] : [{ flight_status: 'scheduled', departure: { delay: iata === 'FRA' ? 90 : 0 } }] });
+  },
+});
+assert.deepEqual(produced.coverage.map(hub => hub.status), ['normal', 'disruption', 'omitted']);
+const envelope = buildEnvelope({ fetchedAt: Date.now(), recordCount: produced.alerts.length, sourceVersion: 'fixture', schemaVersion: 1, state: 'OK', data: publishTransform(produced) });
+const reads = [];
+const origins = new Set();
+const writes = [];
+globalThis.fetch = async (input, init) => {
+  const url = new URL(String(input));
+  origins.add(url.origin);
+  assert.equal(url.origin, 'https://redis.test');
+  if (url.pathname.startsWith('/get/')) {
+    const key = decodeURIComponent(url.pathname.slice(5));
+    reads.push(key);
+    const value = key === intlKey ? envelope : key === 'aviation:delays:faa:v1' ? { alerts: [] } : null;
+    return Response.json({ result: value === null ? null : JSON.stringify(value) });
+  }
+  // Finding 5 removes the independent bootstrap write. Accept it here so this
+  // regression is valid before and after that separate repair.
+  const command = JSON.parse(String(init.body));
+  writes.push(command);
+  return Response.json({ result: 'OK' });
+};
+const response = await listAirportDelays({}, {});
+assert.ok(reads.includes(intlKey), 'must read the bare key written by the seeder; saw ' + reads.join(', '));
+assert.ok(reads.includes('aviation:delays:faa:v1'));
+assert.ok(reads.every(key => !key.startsWith('preview:') && !key.startsWith('development:')));
+const alert = iata => response.alerts.find(row => row.iata === iata);
+assert.equal(alert('LHR').severity, 'FLIGHT_DELAY_SEVERITY_NORMAL');
+assert.equal(alert('LHR').source, 'FLIGHT_DELAY_SOURCE_AVIATIONSTACK');
+assert.equal(alert('FRA').severity, 'FLIGHT_DELAY_SEVERITY_SEVERE');
+assert.equal(alert('FRA').avgDelayMinutes, 90);
+assert.equal(alert('CDG').severity, 'FLIGHT_DELAY_SEVERITY_UNKNOWN');
+assert.equal(alert('JFK').severity, 'FLIGHT_DELAY_SEVERITY_NORMAL');
+assert.deepEqual([...origins], ['https://redis.test']);
+assert.ok(writes.every(command => command[0] === 'SET' && command[1].endsWith('aviation:delays-bootstrap:v2')));
+`;
+
+for (const environment of ['preview', 'development', 'production', '']) {
+  test(`airport delays read producer data with VERCEL_ENV=${environment || '(empty)'}`, () => {
+    assert.doesNotThrow(() => execFileSync(process.execPath, ['--import', 'tsx', '--input-type=module', '-e', fixture], {
+      cwd: fileURLToPath(new URL('..', import.meta.url)),
+      env: {
+        ...process.env, VERCEL_ENV: environment, VERCEL_GIT_COMMIT_SHA: '0123456789abcdef',
+        UPSTASH_REDIS_REST_URL: 'https://redis.test', UPSTASH_REDIS_REST_TOKEN: 'fixture-token',
+        LOCAL_API_MODE: '', ICAO_API_KEY: '', SEED_FALLBACK_NOTAM: '',
+      },
+      timeout: 15_000,
+      stdio: 'pipe',
+    }));
+  });
+}


### PR DESCRIPTION
## Summary
Read international airport delays from the bare seeder-owned Redis key. Preview and development previously requested a deployment-prefixed key that the aviation seeder does not write, so valid international coverage appeared unavailable. Production hid the error because its prefix is empty.

The call now passes `raw=true`, matching the FAA read and airport-ops summary. No shared helper, bootstrap registry or response changes.

Related: DeepSec finding 6.

## Validation
- Before the fix, fresh-process preview and development tests failed on the requested key; production and empty-prefix cases passed.
- Real producer aggregation and envelope construction from synthetic normal, disrupted and omitted hubs now reach the handler correctly in all four environments.
- 30 focused tests, API typecheck and diff check passed. Sequential ce-code-review completed with no actionable findings.
- No live provider calls or production mutations. The scheduled publisher was source-traced; its aggregation and response transform were executed with fixtures.

## Merge order and compatibility
Recommended order: PR #8027, then this PR. #8027 removes the independent request-driven bootstrap write; this branch does not duplicate that change. The combined tree with #8027 at `55ca09b34a3f818196d8e3405e541d0b544baa06` has no conflicts and passed 71 tests, including degraded-read write-ownership checks and the environment matrix. Refresh combined verification if either head changes.

## Post-Deploy Monitoring & Validation
Owner: repository operator. After authorized deployment, compare international airport status from preview and production against the current canonical seed. Covered normal and disrupted hubs should match the seed; omitted hubs must remain UNKNOWN. Check that preview reads use the raw international key and monitor RPC errors and coverage through one natural seed cycle. If coverage differs, inspect the deployed head and canonical seed freshness. No deployment or live acceptance was performed here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_6-000000)
