### PR TITLE
fix(market): prevent caching unavailable commodity seeds

### DIFF
--- a/server/worldmonitor/market/v1/list-commodity-quotes.ts
+++ b/server/worldmonitor/market/v1/list-commodity-quotes.ts
@@ -19,6 +19,7 @@ import type {
 import { ValidationError } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { parseStringArray } from './_shared';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 import commodityConfig from '../../../../shared/commodities.json';
 
 const BOOTSTRAP_KEY = 'market:commodities-bootstrap:v1';
@@ -102,7 +103,7 @@ export function filterCommoditySeed(
 }
 
 export async function listCommodityQuotes(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListCommodityQuotesRequest,
 ): Promise<ListCommodityQuotesResponse> {
   const parsed = parseStringArray(req.symbols);
@@ -115,9 +116,9 @@ export async function listCommodityQuotes(
 
   try {
     const bootstrap = await getCachedJson(BOOTSTRAP_KEY, true) as ListCommodityQuotesResponse | null;
-    if (!bootstrap?.quotes?.length) return { quotes: [] };
+    if (!bootstrap?.quotes?.length) return markNoStoreFallbackResponse(ctx.request, { quotes: [] });
     return { quotes: filterCommoditySeed(bootstrap.quotes, symbols) };
   } catch {
-    return { quotes: [] };
+    return markNoStoreFallbackResponse(ctx.request, { quotes: [] });
   }
 }

--- a/tests/commodity-quotes.test.mts
+++ b/tests/commodity-quotes.test.mts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { createMarketServiceRoutes, ValidationError } from '../src/generated/server/worldmonitor/market/v1/service_server.ts';
+import { __resetRateLimitForTest } from '../api/_rate-limit.js';
 import { issueSessionToken } from '../api/_session.js';
 import marketGateway from '../api/market/v1/[rpc].ts';
 import { marketHandler } from '../server/worldmonitor/market/v1/handler.ts';
@@ -138,6 +139,8 @@ function routeHandler() {
   return descriptor.handler;
 }
 
+let limiterDecisions = 0;
+
 function installRedisMock(redis: RedisMode) {
   mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -151,7 +154,17 @@ function installRedisMock(redis: RedisMode) {
       }
       return new Response(JSON.stringify({ result: null }), { status: 200 });
     }
-    void init;
+    if (url === 'https://redis.test/pipeline') {
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      const results = commands.map((command) => {
+        const verb = String(command[0]).toUpperCase();
+        assert.ok(verb === 'EVALSHA' || verb === 'EVAL', `unexpected limiter command: ${verb}`);
+        limiterDecisions++;
+        // Same successful [remaining, limit] wire shape as gateway-internal-mcp.
+        return { result: [1, 1] };
+      });
+      return new Response(JSON.stringify(results), { status: 200 });
+    }
     throw new Error(`unexpected fetch: ${url}`);
   });
 }
@@ -163,6 +176,8 @@ function requestFor(path: string): Request {
 const DEFAULT_SEED = ['GC=F', 'CL=F', 'SI=F', 'BZ=F'].map(seedQuote);
 
 beforeEach(() => {
+  __resetRateLimitForTest();
+  limiterDecisions = 0;
   for (const key of ENV_KEYS) {
     originalEnv.set(key, process.env[key]);
     delete process.env[key];
@@ -258,17 +273,21 @@ describe('commodity seed cache policy through the market gateway', () => {
     { kind: 'error' },
   ] as RedisMode[]) {
     it(`does not cache ${redis.kind === 'seed' ? 'empty seed' : redis.kind} fallbacks and permits recovery`, async () => {
+      const errors = mock.method(console, 'error', () => {});
+      const warnings = mock.method(console, 'warn', () => {});
       installRedisMock(redis);
       const response = await marketGateway(await request());
       assert.equal(response.status, 200);
       assert.deepEqual(await response.json(), { quotes: [] });
+      assert.ok(limiterDecisions > 0, 'limiter returned a successful wire decision');
+      assert.doesNotMatch([...errors.mock.calls, ...warnings.mock.calls].flatMap((call) => call.arguments).join(' '), /\[rate-limit\]/);
       assert.equal(response.headers.get('Cache-Control'), 'no-store');
       assert.equal(response.headers.get('X-Cache-Tier'), 'no-store');
       assert.equal(response.headers.get('CDN-Cache-Control'), null);
       assert.equal(response.headers.get('Vercel-CDN-Cache-Control'), null);
       assert.equal(response.headers.get('X-No-Cache'), null);
 
-      mock.restoreAll();
+      const beforeRecovery = limiterDecisions;
       installRedisMock({ kind: 'seed', payload: { quotes: DEFAULT_SEED } });
       const recovered = await marketGateway(await request());
       assert.equal(recovered.status, 200);
@@ -277,6 +296,9 @@ describe('commodity seed cache policy through the market gateway', () => {
       assert.match(recovered.headers.get('Cache-Control') ?? '', /private.*max-age=300/);
       assert.equal(recovered.headers.get('CDN-Cache-Control'), null);
       assert.equal(recovered.headers.get('Vercel-CDN-Cache-Control'), null);
+      assert.ok(limiterDecisions > beforeRecovery, 'recovery also passes the Redis limiter');
+      const diagnostics = [...errors.mock.calls, ...warnings.mock.calls].flatMap((call) => call.arguments).join(' ');
+      assert.doesNotMatch(diagnostics, /\[rate-limit\]/, 'no degraded limiter path or warning');
     });
   }
 });

--- a/tests/commodity-quotes.test.mts
+++ b/tests/commodity-quotes.test.mts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { createMarketServiceRoutes, ValidationError } from '../src/generated/server/worldmonitor/market/v1/service_server.ts';
+import { issueSessionToken } from '../api/_session.js';
+import marketGateway from '../api/market/v1/[rpc].ts';
 import { marketHandler } from '../server/worldmonitor/market/v1/handler.ts';
 import {
   SUPPORTED_COMMODITY_SYMBOLS,
@@ -228,4 +230,53 @@ describe('ListCommodityQuotes async handler paths (mocked Redis)', () => {
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), { quotes: [] });
   });
+});
+
+
+describe('commodity seed cache policy through the market gateway', () => {
+  async function request() {
+    process.env.WM_SESSION_SECRET = "synthetic-commodity-cache-session-secret";
+    const { token } = await issueSessionToken();
+    return new Request('https://worldmonitor.app/api/market/v1/list-commodity-quotes?_debug=1', {
+      headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': token },
+    });
+  }
+
+  it('requires authentication before reading the seed', async () => {
+    installRedisMock({ kind: 'error' });
+    const response = await marketGateway(new Request('https://worldmonitor.app/api/market/v1/list-commodity-quotes', {
+      headers: { Origin: 'https://worldmonitor.app' },
+    }));
+    assert.equal(response.status, 401);
+    assert.equal(response.headers.get('CDN-Cache-Control'), null);
+    assert.equal(response.headers.get('Vercel-CDN-Cache-Control'), null);
+  });
+
+  for (const redis of [
+    { kind: 'null' },
+    { kind: 'seed', payload: { quotes: [] } },
+    { kind: 'error' },
+  ] as RedisMode[]) {
+    it(`does not cache ${redis.kind === 'seed' ? 'empty seed' : redis.kind} fallbacks and permits recovery`, async () => {
+      installRedisMock(redis);
+      const response = await marketGateway(await request());
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { quotes: [] });
+      assert.equal(response.headers.get('Cache-Control'), 'no-store');
+      assert.equal(response.headers.get('X-Cache-Tier'), 'no-store');
+      assert.equal(response.headers.get('CDN-Cache-Control'), null);
+      assert.equal(response.headers.get('Vercel-CDN-Cache-Control'), null);
+      assert.equal(response.headers.get('X-No-Cache'), null);
+
+      mock.restoreAll();
+      installRedisMock({ kind: 'seed', payload: { quotes: DEFAULT_SEED } });
+      const recovered = await marketGateway(await request());
+      assert.equal(recovered.status, 200);
+      assert.deepEqual((await recovered.json()).quotes, DEFAULT_SEED);
+      assert.equal(recovered.headers.get('X-Cache-Tier'), 'slow-browser');
+      assert.match(recovered.headers.get('Cache-Control') ?? '', /private.*max-age=300/);
+      assert.equal(recovered.headers.get('CDN-Cache-Control'), null);
+      assert.equal(recovered.headers.get('Vercel-CDN-Cache-Control'), null);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
When the commodity seed is missing, empty, or unreadable, the handler returns an empty successful envelope. The gateway previously gave that fallback a browser cache lifetime, so an empty response could remain after the seed recovered.

Mark both unavailable fallback paths with the existing no-store response helper. Healthy responses and the HTTP 200 `{ quotes: [] }` wire contract remain unchanged. No shared gateway or cache policy changes.

The reported shared-CDN premise was not reproduced against current code: unauthenticated requests return 401, and authenticated ordinary requests use `private, max-age=300, stale-while-revalidate=60, stale-if-error=1800` with no CDN headers. This change fixes the confirmed browser-cache fallback defect.

## Validation
- Three gateway regressions failed before the fix on the cache header; 25 focused commodity and gateway-contract tests pass after.
- Tests import the production market gateway, exercise generated dispatch, use synthetic session tokens and successful Redis limiter wire responses, and check no-store, absence of both CDN headers, and healthy recovery.
- Both fallback and recovery requests must receive a successful Redis limiter decision with no degraded-limit errors or warnings. The before-fix proof also passes these limiter assertions before failing on cache headers.
- Existing symbol validation, ordering and seed behavior tests pass. API typecheck and diff check pass.
- Sequential `ce-code-review` at `c5d8392fc563eb0447c84c1ba38d54dcfaefe0b2`: no actionable findings. No independent subagents or live provider calls.

## Post-Deploy Monitoring & Validation
Owner: market API maintainer. During the first 24 hours after a separately authorized deployment, inspect naturally occurring requests to `/api/market/v1/list-commodity-quotes` and Redis read-failure logs. An unavailable seed response should have `Cache-Control: no-store`, `X-Cache-Tier: no-store`, and no CDN cache headers. A recovered seed should return quotes with the normal caller-specific cache policy.

Investigate cached empty fallback responses or unexpected healthy-response cache changes; revert this scoped change if it causes a regression. No provider probes, production seed mutation, live CDN acceptance, or deployment were performed for this PR.
