### PR TITLE
fix(shipping): prevent caching tenant webhook status

### DIFF
--- a/api/v2/shipping/webhooks/[subscriberId].ts
+++ b/api/v2/shipping/webhooks/[subscriberId].ts
@@ -20,7 +20,11 @@ import {
 } from '../../../../server/worldmonitor/shipping/v2/webhook-shared';
 
 export default async function handler(req: Request): Promise<Response> {
-  const cors = getCorsHeaders(req);
+  const cors = {
+    ...getCorsHeaders(req),
+    'Cache-Control': 'private, no-store',
+    'CDN-Cache-Control': 'no-store',
+  };
 
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: cors });

--- a/server/__tests__/shipping-status-cache.test.ts
+++ b/server/__tests__/shipping-status-cache.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { createHash } from 'node:crypto';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const record = {
+  subscriberId: 'wh_test', ownerTag: createHash('sha256').update('tenant-a').digest('hex'),
+  callbackUrl: 'https://example.com/hook', chokepointIds: ['suez'], alertThreshold: 50,
+  createdAt: '2026-09-11T00:00:00Z', active: true, secret: 'synthetic-secret',
+};
+const getCachedJson = vi.fn(async () => record as typeof record | null);
+vi.mock('../_shared/redis', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../_shared/redis')>(),
+  getCachedJson: () => getCachedJson(),
+}));
+import handler from '../../api/v2/shipping/webhooks/[subscriberId]';
+
+beforeEach(() => {
+  vi.stubEnv('WORLDMONITOR_VALID_KEYS', 'tenant-a,tenant-b');
+  getCachedJson.mockReset().mockResolvedValue(record);
+});
+afterEach(() => vi.unstubAllEnvs());
+
+for (const scenario of [
+  { name: 'owner success', method: 'GET', key: 'tenant-a', id: 'wh_test', status: 200 },
+  { name: 'foreign owner', method: 'GET', key: 'tenant-b', id: 'wh_test', status: 403 },
+  { name: 'missing credential', method: 'GET', key: '', id: 'wh_test', status: 401 },
+  { name: 'invalid credential', method: 'GET', key: 'invalid', id: 'wh_test', status: 401 },
+  { name: 'invalid subscriber ID', method: 'GET', key: 'tenant-a', id: 'invalid', status: 404 },
+  { name: 'missing record', method: 'GET', key: 'tenant-a', id: 'wh_missing', status: 404 },
+  { name: 'storage read failure', method: 'GET', key: 'tenant-a', id: 'wh_unavailable', status: 404 },
+  { name: 'unsupported method', method: 'POST', key: '', id: 'wh_test', status: 405 },
+  { name: 'preflight', method: 'OPTIONS', key: '', id: 'wh_test', status: 204 },
+]) {
+  test(`status response cannot be cached: ${scenario.name}`, async () => {
+    if (scenario.id === 'wh_missing') getCachedJson.mockResolvedValue(null);
+    if (scenario.id === 'wh_unavailable') getCachedJson.mockRejectedValue(new Error('synthetic storage outage'));
+    const response = await handler(new Request(`https://www.worldmonitor.app/api/v2/shipping/webhooks/${scenario.id}`, {
+      method: scenario.method,
+      headers: { Origin: 'https://www.worldmonitor.app', ...(scenario.key ? { 'X-Api-Key': scenario.key } : {}) },
+    }));
+    expect(response.status).toBe(scenario.status);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://www.worldmonitor.app');
+    if (response.status === 200) {
+      const body = await response.json();
+      expect(body).toMatchObject({ subscriberId: record.subscriberId, callbackUrl: record.callbackUrl });
+      expect(body).not.toHaveProperty('secret');
+      expect(body).not.toHaveProperty('ownerTag');
+    }
+  });
+}


### PR DESCRIPTION
The tenant webhook status route returned private subscription data without browser or CDN cache controls. It now sets `Cache-Control: private, no-store` and `CDN-Cache-Control: no-store` through the existing shared response headers, covering success, authentication errors, missing/foreign records, unsupported methods and OPTIONS.

Authentication, ownership, CORS and response payloads remain unchanged. Nine response-header tests failed before the fix and pass afterward; 29 existing shipping handler tests and API typecheck also pass. Sequential inline review covered `9821627cad7f76a6ab1e90d1c9edd28389b47c90`.

Compatibility: #8030 changes authentication in the same file and remains separate. A clean combined tree passes 31 tests, including cache denial for user-key and outage responses. Either merge order works at the reviewed heads. No auth code is duplicated; callback/quota finding 38 remains separate.

## Post-Deploy Monitoring & Validation

After a separately approved rollout, inspect status success/error responses for private/no-store and CDN no-store, and confirm CORS and tenant isolation remain intact. The existing billing-denial helper in #8030 emits no-store with CDN no-store. Tests use synthetic Redis data; no production cache leak, customer data access or live mutation was attempted.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
