### PR TITLE
fix(market): keep unavailable stock seeds out of browser cache

### DIFF
--- a/server/worldmonitor/market/v1/list-market-quotes.ts
+++ b/server/worldmonitor/market/v1/list-market-quotes.ts
@@ -42,6 +42,8 @@ import {
 } from './_quote-provider';
 import { CachedFetchTimeoutError, cachedFetchJson, readCachedJson } from '../../../_shared/redis';
 
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
+
 const BOOTSTRAP_KEY = 'market:stocks-bootstrap:v1';
 
 /** Per-symbol gap-fetch cache. Prefixed (app-owned), unlike the seed key. */
@@ -373,7 +375,7 @@ function withQuoteAsOf(
 }
 
 export async function listMarketQuotes(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListMarketQuotesRequest,
 ): Promise<ListMarketQuotesResponse> {
   const { accepted, dropped } = normalizeRequestedSymbols(parseStringArray(req.symbols));
@@ -383,7 +385,7 @@ export async function listMarketQuotes(
     // Distinguished from a miss on purpose: a read failure that looks like an
     // empty snapshot is how a dead pipeline stays invisible.
     console.warn('[ListMarketQuotes] seed read failed — skipping the provider gap fetch');
-    return seedUnavailableResponse([...accepted, ...dropped]);
+    return markNoStoreFallbackResponse(ctx.request, seedUnavailableResponse([...accepted, ...dropped]));
   }
 
   const bootstrap = seed.status === 'hit' ? (seed.value as ListMarketQuotesResponse | null) : null;
@@ -392,7 +394,7 @@ export async function listMarketQuotes(
   // empty response instead of throwing. Validate the shape to keep that
   // fail-soft behaviour without the catch-all that also hid real bugs.
   if (!Array.isArray(bootstrap?.quotes) || bootstrap.quotes.length === 0) {
-    return seedUnavailableResponse([...accepted, ...dropped]);
+    return markNoStoreFallbackResponse(ctx.request, seedUnavailableResponse([...accepted, ...dropped]));
   }
 
   // No symbol filter: the caller wants the seed universe as-is.

--- a/tests/market-quotes-cache-fallback.test.mts
+++ b/tests/market-quotes-cache-fallback.test.mts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+import marketGateway from '../api/market/v1/[rpc].ts';
+import { __resetRateLimitForTest } from '../api/_rate-limit.js';
+import { issueSessionToken } from '../api/_session.js';
+
+const originalEnv = { ...process.env };
+const seed = {
+  quotes: [{ symbol: 'AAPL', name: 'Apple', display: 'AAPL', price: 100, change: 1, sparkline: [] }],
+  finnhubSkipped: false, skipReason: '', rateLimited: false, unavailableSymbols: [], asOf: '2026-09-11T00:00:00Z',
+};
+let snapshot: unknown;
+let seedFails: boolean;
+let limiterDecisions: number;
+let unexpectedFetches: string[];
+
+beforeEach(() => {
+  __resetRateLimitForTest();
+  snapshot = seed;
+  seedFails = false;
+  limiterDecisions = 0;
+  unexpectedFetches = [];
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'synthetic-token';
+  process.env.WM_SESSION_SECRET = 'synthetic-market-cache-session-secret';
+  process.env.FINNHUB_API_KEY = 'synthetic-finnhub-key';
+  delete process.env.ALPHA_VANTAGE_API_KEY;
+  delete process.env.LOCAL_API_MODE;
+  mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === 'https://redis.test/get/market%3Astocks-bootstrap%3Av1' || url === 'https://redis.test/get/market:stocks-bootstrap:v1') {
+      return new Response(JSON.stringify(seedFails ? { error: 'seed read failed' } : { result: snapshot == null ? null : JSON.stringify(snapshot) }), { status: seedFails ? 500 : 200 });
+    }
+    if (url === 'https://redis.test/pipeline') {
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      return new Response(JSON.stringify(commands.map((command) => {
+        assert.match(String(command[0]).toUpperCase(), /^EVAL(SHA)?$/);
+        limiterDecisions++;
+        return { result: [1, 1] };
+      })));
+    }
+    unexpectedFetches.push(url);
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+});
+afterEach(() => {
+  mock.restoreAll();
+  for (const key of Object.keys(process.env)) if (!(key in originalEnv)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+});
+
+async function request(symbols = 'AAPL') {
+  const { token } = await issueSessionToken();
+  return marketGateway(new Request(`https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=${encodeURIComponent(symbols)}&_debug=1`, {
+    headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': token },
+  }));
+}
+function assertPrivateCache(response: Response) {
+  assert.equal(response.headers.get('X-Cache-Tier'), 'slow-browser');
+  assert.match(response.headers.get('Cache-Control') ?? '', /private.*max-age=300/);
+  assert.equal(response.headers.get('CDN-Cache-Control'), null);
+  assert.equal(response.headers.get('Vercel-CDN-Cache-Control'), null);
+}
+
+describe('market seed fallback cache policy through authenticated gateway', () => {
+  for (const mode of ['miss', 'empty', 'corrupt', 'error'] as const) {
+    it(`${mode} is no-store without provider fan-out and recovers normally`, async () => {
+      snapshot = mode === 'miss' ? null : mode === 'empty' ? { quotes: [] } : mode === 'corrupt' ? { quotes: 'invalid' } : seed;
+      seedFails = mode === 'error';
+      const warnings = mock.method(console, 'warn', () => {});
+      const errors = mock.method(console, 'error', () => {});
+      const response = await request();
+      assert.equal(response.status, 200);
+      assert.equal((await response.json()).unavailableSymbols[0].reason, 'MARKET_QUOTE_UNAVAILABLE_REASON_SEED_UNAVAILABLE');
+      assert.ok(limiterDecisions > 0);
+      assert.deepEqual(unexpectedFetches, [], 'no provider calls on unavailable seed');
+      assert.doesNotMatch([...warnings.mock.calls, ...errors.mock.calls].flatMap(c => c.arguments).join(' '), /\[rate-limit\]/);
+      assert.equal(response.headers.get('Cache-Control'), 'no-store');
+      assert.equal(response.headers.get('X-Cache-Tier'), 'no-store');
+      assert.equal(response.headers.get('CDN-Cache-Control'), null);
+      assert.equal(response.headers.get('Vercel-CDN-Cache-Control'), null);
+      assert.equal(response.headers.get('X-No-Cache'), null);
+      const previousDecisions = limiterDecisions;
+      snapshot = seed;
+      seedFails = false;
+      const recovered = await request();
+      assert.equal(recovered.status, 200);
+      assert.deepEqual((await recovered.json()).quotes, seed.quotes);
+      assertPrivateCache(recovered);
+      assert.ok(limiterDecisions > previousDecisions);
+      assert.deepEqual(unexpectedFetches, []);
+      assert.doesNotMatch([...warnings.mock.calls, ...errors.mock.calls].flatMap(c => c.arguments).join(' '), /\[rate-limit\]/);
+    });
+  }
+  it('marks a missing default seed no-store even without unavailable-symbol entries', async () => {
+    snapshot = null;
+    const warnings = mock.method(console, 'warn', () => {});
+    const errors = mock.method(console, 'error', () => {});
+    const response = await request('');
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.deepEqual(body.quotes, []);
+    assert.deepEqual(body.unavailableSymbols, []);
+    assert.ok(limiterDecisions > 0);
+    assert.deepEqual(unexpectedFetches, []);
+    assert.doesNotMatch([...warnings.mock.calls, ...errors.mock.calls].flatMap(c => c.arguments).join(' '), /\[rate-limit\]/);
+    assert.equal(response.headers.get('Cache-Control'), 'no-store');
+    assert.equal(response.headers.get('CDN-Cache-Control'), null);
+    assert.equal(response.headers.get('Vercel-CDN-Cache-Control'), null);
+  });
+  it('preserves cache policy for a healthy seed filtered to an unsupported provider symbol', async () => {
+    const response = await request('^NOSUCH');
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.deepEqual(body.quotes, []);
+    assert.equal(body.unavailableSymbols[0].reason, 'MARKET_QUOTE_UNAVAILABLE_REASON_NOT_FOUND');
+    assertPrivateCache(response);
+    assert.deepEqual(unexpectedFetches, []);
+    assert.ok(limiterDecisions > 0);
+  });
+});

--- a/tests/market-quotes-seed-first.test.mts
+++ b/tests/market-quotes-seed-first.test.mts
@@ -33,7 +33,7 @@ import {
 } from '../server/worldmonitor/market/v1/list-market-quotes';
 
 const BOOTSTRAP_KEY = 'market:stocks-bootstrap:v1';
-const CTX = {} as ServerContext;
+const CTX = { request: new Request('https://worldmonitor.app/api/market/v1/list-market-quotes') } as ServerContext;
 
 const ORIGINAL_ENV = {
   UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,


### PR DESCRIPTION
## Summary
A missing, empty, corrupt, or unreadable stock seed returns a successful seed-unavailable envelope. The normal authenticated gateway previously gave this response a five-minute private browser cache lifetime, which could retain unavailable quotes after seed recovery.

Mark only the two seed-unavailable returns with the existing request-scoped no-store helper. Preserve the Redis error/miss distinction, unavailable-symbol reasons, provider fan-out prevention, and cache policy for healthy responses and legitimate empty filtered results.

The reported shared-CDN defect was not reproduced: the actual authenticated audience uses `private, max-age=300, stale-while-revalidate=60, stale-if-error=1800` with no CDN headers. This PR fixes the confirmed browser-cache defect. Shared gateway/cache policy is unchanged.

## Validation
- Five gateway cache regressions fail before the fix; 48 focused market, watchlist, and gateway tests pass after.
- Real market entrypoint and generated dispatch with synthetic session and successful Redis limiter wire fixtures; no degraded-limit diagnostics, no provider calls during unavailable-seed handling, and healthy recovery tested.
- Default-symbol miss and legitimate empty filtered results are covered separately.
- API typecheck and diff check pass. Sequential `ce-code-review` at `9e7a33f154fb20ecebabf733e6e21996bbb7c99c`: no actionable findings; no independent subagents.
- No files overlap PR #8031 (`c5d8392fc`); its separate commodity patch is preserved.

## Post-Deploy Monitoring & Validation
Owner: market API maintainer. During the first 24 hours after separately authorized deployment, inspect naturally occurring `/api/market/v1/list-market-quotes` requests and `[ListMarketQuotes] seed read failed` logs. Seed-unavailable responses should have `Cache-Control: no-store`, `X-Cache-Tier: no-store`, and no CDN cache headers. Healthy and legitimate empty filtered results retain their caller-specific cache policy.

Investigate cached seed-unavailable responses, unexpected provider fan-out, or changed healthy cache behavior. Revert this scoped patch if it causes a regression. No live provider calls, seed mutations, production acceptance or deployment were performed.
