### PR TITLE
fix(saskalert): preserve usable alerts after CAP verification failure

### DIFF
--- a/scripts/lib/canada-alerts-union.mjs
+++ b/scripts/lib/canada-alerts-union.mjs
@@ -36,6 +36,14 @@ export const CANADA_ALERT_SOURCES = Object.freeze([
 
 const SEVERITY_RANK = Object.freeze({ Extreme: 0, Severe: 1, Moderate: 2, Minor: 3 });
 
+function sortAndCapAlerts(alerts) {
+  alerts.sort((a, b) => (
+    (SEVERITY_RANK[a.severity] ?? 9) - (SEVERITY_RANK[b.severity] ?? 9)
+    || (b.updatedAt ?? 0) - (a.updatedAt ?? 0)
+  ));
+  if (alerts.length > CANADA_ALERTS_MAX_PUBLISHED) alerts.length = CANADA_ALERTS_MAX_PUBLISHED;
+}
+
 export function buildCanadaAlertsUnion(inputs, nowMs = Date.now()) {
   const alerts = [];
   const seen = new Set();
@@ -58,6 +66,7 @@ export function buildCanadaAlertsUnion(inputs, nowMs = Date.now()) {
     if (!validSnapshot) continue;
     for (const alert of snapshot.alerts) {
       if (!alert || alert.province !== source.province || !alert.id) continue;
+      if (alert.expires && !(Date.parse(alert.expires) > nowMs)) continue;
       const identity = `${source.province}:${alert.id}`;
       if (seen.has(identity)) continue;
       seen.add(identity);
@@ -65,13 +74,7 @@ export function buildCanadaAlertsUnion(inputs, nowMs = Date.now()) {
     }
   }
 
-  alerts.sort((a, b) => (
-    (SEVERITY_RANK[a.severity] ?? 9) - (SEVERITY_RANK[b.severity] ?? 9)
-    || (b.updatedAt ?? 0) - (a.updatedAt ?? 0)
-  ));
-  if (alerts.length > CANADA_ALERTS_MAX_PUBLISHED) {
-    alerts.length = CANADA_ALERTS_MAX_PUBLISHED;
-  }
+  sortAndCapAlerts(alerts);
   const degraded = missingSources.length > 0 || staleSources.length > 0 || degradedSources.length > 0;
   return {
     alerts,
@@ -125,10 +128,24 @@ export async function rebuildCanadaAlertsUnion({
       ? existing.alerts
       : [];
     if (existingAlerts.length > 0) {
-      const extended = await extendTtl([CANADA_ALERTS_KEY], CANADA_ALERTS_TTL_SECONDS);
+      const retainedAlerts = existingAlerts.filter(alert => (
+        (!alert.expires || Date.parse(alert.expires) > nowMs)
+        && alert.province !== currentSource?.province
+      ));
+      if (currentSource) {
+        retainedAlerts.push(...result.alerts.filter(alert => alert.province === currentSource.province));
+      }
+      sortAndCapAlerts(retainedAlerts);
+      const identities = new Map(retainedAlerts.map(alert => [`${alert.province}:${alert.id}`, JSON.stringify(alert)]));
+      const changed = retainedAlerts.length !== existingAlerts.length
+        || existingAlerts.some(alert => identities.get(`${alert.province}:${alert.id}`) !== JSON.stringify(alert));
+      const extended = !changed && await extendTtl([CANADA_ALERTS_KEY], CANADA_ALERTS_TTL_SECONDS);
       if (extended === true) {
         preserved = true;
         publishedCount = existingAlerts.length;
+      } else if (changed) {
+        result.alerts = retainedAlerts;
+        publishedCount = retainedAlerts.length;
       }
     }
   }
@@ -143,7 +160,7 @@ export async function rebuildCanadaAlertsUnion({
         recordCount: publishedCount,
         sourceVersion: CANADA_ALERTS_SOURCE_VERSION,
         schemaVersion: 1,
-        state: publishedCount > 0 ? 'OK' : 'OK_ZERO',
+        state: result.sourceState === 'degraded' ? 'ERROR' : publishedCount > 0 ? 'OK' : 'OK_ZERO',
       },
     );
   }

--- a/scripts/lib/saskalert.mjs
+++ b/scripts/lib/saskalert.mjs
@@ -5,10 +5,11 @@
  * This is not Pelmorex LMD, NAAD, weather:alerts, or a roads feed.
  * The summary JSON carries lifecycle/level; CAP 1.2 JSON details carry
  * severity. Missing CAP severity fails closed at the record — colour/level
- * is not CAP. One bad enclosure degrades the tick; it does not abort SK.
+ * is not CAP. Incomplete verification preserves usable data without declaring success.
  */
 
-import { CHROME_UA, MAX_PAYLOAD_BYTES } from '../_seed-utils.mjs';
+import { CHROME_UA, MAX_PAYLOAD_BYTES, readSeedSnapshot, writeExtraKey, writeFreshnessMetadataSafely } from '../_seed-utils.mjs';
+import { CANADA_ALERT_SOURCES, rebuildCanadaAlertsUnion } from './canada-alerts-union.mjs';
 
 export const SASKALERT_HOST = 'emergencyalert.saskatchewan.ca';
 export const SASKALERT_FEED_URL = 'https://emergencyalert.saskatchewan.ca/sapublic/feed.json';
@@ -274,7 +275,9 @@ export async function fetchSaskAlerts(opts = {}) {
     throw new Error(`saskalert: active entry count exceeds ${MAX_CAP_FETCHES}`);
   }
 
-  const verification = { attempted: 0, failed: 0, skippedDeadline: 0 };
+  const verification = { attempted: 0, failed: 0, skippedDeadline: 0, reasons: {} };
+  const unverifiedIds = new Set();
+  const failedLinks = new Set();
   const alerts = [];
   const seen = new Set();
   const seenCapLinks = new Set();
@@ -284,13 +287,19 @@ export async function fetchSaskAlerts(opts = {}) {
   let nextIndex = 0;
 
   async function hydrateOne(entry) {
+    const rememberFailure = (reason) => {
+      unverifiedIds.add(`sk-saskalert-${String(entry.identifier || entry.id || '').trim()}`);
+      verification.reasons[reason] = (verification.reasons[reason] || 0) + 1;
+    };
     if ((opts.nowWallMs ?? Date.now()) - wallStart >= budgetMs) {
       verification.skippedDeadline += 1;
+      rememberFailure('deadline');
       return;
     }
     const capLink = String(entry?.cap_link || '').trim();
     if (!capLink) {
       verification.failed += 1;
+      rememberFailure('missing_link');
       return;
     }
     if (seenCapLinks.has(capLink)) return;
@@ -302,8 +311,10 @@ export async function fetchSaskAlerts(opts = {}) {
       if (!record || seen.has(record.id)) return;
       seen.add(record.id);
       alerts.push(record);
-    } catch {
+    } catch (error) {
       verification.failed += 1;
+      failedLinks.add(capLink);
+      rememberFailure(capFailureReason(error));
     }
   }
 
@@ -329,7 +340,58 @@ export async function fetchSaskAlerts(opts = {}) {
     (SEVERITY_RANK[a.severity] ?? 9) - (SEVERITY_RANK[b.severity] ?? 9)
     || (b.updatedAt ?? 0) - (a.updatedAt ?? 0)
   ));
-  return { alerts, _capVerification: verification };
+  for (const entry of active) {
+    if (failedLinks.has(String(entry.cap_link || '').trim())) {
+      unverifiedIds.add(`sk-saskalert-${String(entry.identifier || entry.id || '').trim()}`);
+    }
+  }
+  return { alerts, _capVerification: verification, _unverifiedIds: [...unverifiedIds] };
+}
+
+function capFailureReason(error) {
+  const codes = [error?.name, error?.code, error?.cause?.code];
+  if (codes.some(code => ['TimeoutError', 'AbortError', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT'].includes(code))) return 'timeout';
+  if (/CAP HTTP \d{3}$/.test(error?.message || '')) return 'http';
+  if (/parseable JSON|CAP 1.2 JSON|CAP alert\/info/.test(error?.message || '')) return 'parsing';
+  if (/allowlist/.test(error?.message || '')) return 'invalid_link';
+  if (/CAP severity|missing identifier/.test(error?.message || '')) return 'validation';
+  return 'transport';
+}
+
+export async function saskAlertBeforePublish(data, { canonicalKey, ttlSeconds }) {
+  const diagnostics = saskAlertAfterPublish(data).freshnessMetaPatch;
+  if (diagnostics.sourceState === 'ok') return;
+  console.warn(`saskalert: CAP_VERIFICATION_FAILED failed=${diagnostics.capVerificationFailed} deadline=${diagnostics.capSkippedDeadline} reasons=${JSON.stringify(diagnostics.capFailureReasons)}`);
+
+  const nowMs = Date.now();
+  const source = CANADA_ALERT_SOURCES.find(entry => entry.province === 'SK');
+  const previous = await readSeedSnapshot(canonicalKey, { strict: true, includeEnvelopeMeta: true });
+  const previousMeta = previous?.meta;
+  const fetchedAt = Number.isFinite(previousMeta?.fetchedAt) ? previousMeta.fetchedAt : 0;
+  const usable = fetchedAt > 0 && nowMs - fetchedAt <= source.maxStaleMin * 60_000;
+  const unverified = new Set(data._unverifiedIds);
+  const retained = usable && Array.isArray(previous?.data?.alerts)
+    ? previous.data.alerts.filter(alert => unverified.has(alert.id)
+      && alert.province === 'SK'
+      && (!alert.expires || Date.parse(alert.expires) > nowMs)
+      && Number.isFinite(alert.updatedAt ?? alert.publishedAt)
+      && nowMs - (alert.updatedAt ?? alert.publishedAt) <= SASKALERT_MAX_CONTENT_AGE_MIN * 60_000)
+    : [];
+  const verifiedIds = new Set(data.alerts.map(alert => alert.id));
+  const snapshot = { alerts: [...data.alerts, ...retained.filter(alert => !verifiedIds.has(alert.id))] };
+  const contentAge = { ...saskAlertContentMeta(snapshot, nowMs), maxContentAgeMin: SASKALERT_MAX_CONTENT_AGE_MIN };
+  const metaPatch = { ...diagnostics, lastAttemptAt: nowMs, retainedRecords: retained.length };
+  // An incomplete attempt can remove ended records, but cannot advance the success clock.
+  await writeExtraKey(canonicalKey, snapshot, ttlSeconds, {
+    ...previousMeta, fetchedAt, recordCount: snapshot.alerts.length,
+    sourceVersion: 'saskalert-v1', schemaVersion: 1, state: 'ERROR',
+    errorReason: 'CAP_VERIFICATION_FAILED', ...contentAge,
+  });
+  const written = await writeFreshnessMetadataSafely('alerts', 'saskalert', snapshot.alerts.length,
+    'saskalert-v1', ttlSeconds, fetchedAt, contentAge, metaPatch);
+  if (!written) throw new Error('saskalert: failed to persist verification diagnostics');
+  await rebuildCanadaAlertsUnion({ currentSource: { province: 'SK', snapshot, metaPatch: { ...metaPatch, fetchedAt } } });
+  throw Object.assign(new Error('saskalert: incomplete CAP verification; success clock unchanged'), { code: 'CAP_VERIFICATION_FAILED' });
 }
 
 export function saskAlertPublishTransform(data) {
@@ -346,6 +408,7 @@ export function saskAlertAfterPublish(data) {
         errorCode: 'CAP_VERIFICATION_FAILED',
         capVerificationFailed: failed,
         capSkippedDeadline: skippedDeadline,
+        capFailureReasons: data._capVerification.reasons,
       },
     };
   }

--- a/scripts/seed-saskalert.mjs
+++ b/scripts/seed-saskalert.mjs
@@ -7,6 +7,7 @@ import {
   declareSaskAlertRecords,
   fetchSaskAlerts,
   saskAlertAfterPublish,
+  saskAlertBeforePublish,
   saskAlertContentMeta,
   saskAlertPublishTransform,
   validateSaskAlertEnvelope,
@@ -34,6 +35,7 @@ runSeed('alerts', 'saskalert', SOURCE.key, () => (
   contentMeta: saskAlertContentMeta,
   maxContentAgeMin: SASKALERT_MAX_CONTENT_AGE_MIN,
   publishTransform: saskAlertPublishTransform,
+  beforePublish: saskAlertBeforePublish,
   afterPublish: async (data) => {
     const diagnostics = saskAlertAfterPublish(data);
     try {

--- a/tests/canada-alerts-union.test.mjs
+++ b/tests/canada-alerts-union.test.mjs
@@ -268,3 +268,25 @@ test('defaults union metadata writes to the non-throwing seed-meta helper', () =
   assert.match(UNION_SOURCE, /writeMeta = writeFreshnessMetadataSafely/);
   assert.match(UNION_SOURCE, /import \{[\s\S]*writeFreshnessMetadataSafely[\s\S]*\} from '\.\.\/_seed-utils\.mjs'/);
 });
+
+test('retention removes expired alerts and applies current source updates within the union cap', async () => {
+  const existing = { alerts: Array.from({ length: 200 }, (_, index) => ({
+    ...ab, id: `ab-${index}`, expires: index === 0 ? new Date(NOW - 1).toISOString() : '',
+  })) };
+  const current = [{ ...sk, id: 'new-1', severity: 'Extreme' }, { ...sk, id: 'new-2', severity: 'Extreme' }];
+  const writes = [];
+  const result = await rebuildCanadaAlertsUnion({
+    nowMs: NOW,
+    currentSource: { province: 'SK', snapshot: { alerts: current } },
+    readSnapshot: async key => key === CANADA_ALERTS_KEY ? existing : null,
+    writeKey: async (...args) => writes.push(args),
+    writeMeta: async () => {},
+    extendTtl: async () => { throw new Error('changed union must be rewritten'); },
+  });
+  assert.equal(result.alerts.length, 200);
+  assert.deepEqual(result.alerts.slice(0, 2), current);
+  assert.equal(result.alerts.some(alert => alert.id === 'ab-0'), false);
+  assert.equal(writes[0][2], 5400);
+  assert.equal(writes[0][3].recordCount, 200);
+  assert.equal(writes[0][3].state, 'ERROR');
+});

--- a/tests/saskalert-retention.test.mjs
+++ b/tests/saskalert-retention.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import * as sask from '../scripts/lib/saskalert.mjs';
+import { runSeed } from '../scripts/_seed-utils.mjs';
+import { CANADA_ALERT_SOURCES, CANADA_ALERTS_KEY, rebuildCanadaAlertsUnion } from '../scripts/lib/canada-alerts-union.mjs';
+import { __testing__ } from '../api/health.js';
+
+const feed = JSON.parse(readFileSync(new URL('./fixtures/saskalert-feed.json', import.meta.url)));
+const cap = JSON.parse(readFileSync(new URL('./fixtures/saskalert-cap-active.json', import.meta.url)));
+const SOURCE = CANADA_ALERT_SOURCES.find(s => s.province === 'SK');
+const COMPLETE = 'seed-completion:alerts:saskalert';
+const NOW = Date.parse('2026-08-18T06:00:00Z');
+
+async function fixture(fn) {
+  const oldFetch = globalThis.fetch;
+  const oldExit = process.exit;
+  const oldNow = Date.now;
+  const oldLog = console.log;
+  const oldWarn = console.warn;
+  const oldError = console.error;
+  const env = { ...process.env };
+  const listeners = new Set(process.rawListeners('SIGTERM'));
+  const values = new Map();
+  const logs = [];
+  const state = { now: NOW, feed: structuredClone(feed), fail: false, values, logs };
+  Date.now = () => state.now;
+  console.log = console.warn = console.error = (...args) => logs.push(args.join(' '));
+  Object.assign(process.env, {
+    UPSTASH_REDIS_REST_URL: 'https://redis.fixture', UPSTASH_REDIS_REST_TOKEN: 'fixture',
+    WM_BUNDLE_COMPLETION_META_KEY: COMPLETE, WM_SEED_RETRY_DELAY_MS: '0',
+  });
+  process.exit = code => { throw Object.assign(new Error('fixture exit'), { exitCode: code }); };
+  const response = result => new Response(JSON.stringify({ result }));
+  function command(cmd) {
+    const [op, key, value] = cmd;
+    if (op === 'SET') { values.set(key, value); return 'OK'; }
+    if (op === 'GET') return values.get(key) ?? null;
+    if (op === 'EXPIRE' || op === 'EXISTS') return values.has(key) ? 1 : 0;
+    if (op === 'DEL') return Number(values.delete(key));
+    if (op === 'EVAL') return 1;
+    throw new Error(`Unexpected Redis command ${op}`);
+  }
+  globalThis.fetch = async (url, options = {}) => {
+    const parsed = new URL(url);
+    if (parsed.hostname === 'redis.fixture') {
+      if (parsed.pathname.startsWith('/get/')) return response(values.get(decodeURIComponent(parsed.pathname.slice(5))) ?? null);
+      const body = JSON.parse(options.body);
+      if (Array.isArray(body[0])) return new Response(JSON.stringify(body.map(c => ({ result: command(c) }))));
+      return response(command(body));
+    }
+    if (String(url) === sask.SASKALERT_FEED_URL) return new Response(JSON.stringify(state.feed));
+    if (state.fail) return new Response('private upstream body', { status: 503 });
+    return new Response(JSON.stringify(cap));
+  };
+  for (const source of CANADA_ALERT_SOURCES.filter(s => s.province !== 'SK')) {
+    values.set(source.key, JSON.stringify({ alerts: [] }));
+    values.set(source.metaKey, JSON.stringify({ fetchedAt: NOW, recordCount: 0, sourceState: 'ok' }));
+  }
+  state.read = key => JSON.parse(values.get(key) ?? 'null');
+  state.run = async () => {
+    try {
+      await runSeed('alerts', 'saskalert', SOURCE.key, () => sask.fetchSaskAlerts(), {
+        validateFn: sask.validateSaskAlertEnvelope, ttlSeconds: 5400, sourceVersion: 'saskalert-v1',
+        declareRecords: sask.declareSaskAlertRecords, zeroIsValid: true, schemaVersion: 1,
+        maxStaleMin: 45, contentMeta: sask.saskAlertContentMeta,
+        maxContentAgeMin: sask.SASKALERT_MAX_CONTENT_AGE_MIN,
+        publishTransform: sask.saskAlertPublishTransform,
+        beforePublish: sask.saskAlertBeforePublish,
+        afterPublish: async data => {
+          const diagnostics = sask.saskAlertAfterPublish(data);
+          await rebuildCanadaAlertsUnion({ currentSource: {
+            province: 'SK', snapshot: sask.saskAlertPublishTransform(data), metaPatch: diagnostics.freshnessMetaPatch,
+          } });
+          return diagnostics;
+        },
+      });
+    } catch (error) {
+      if (error.exitCode !== undefined) return error.exitCode;
+      if (error.code === 'CAP_VERIFICATION_FAILED') return 1;
+      throw error;
+    }
+  };
+  try { await fn(state); }
+  finally {
+    globalThis.fetch = oldFetch; process.exit = oldExit; Date.now = oldNow;
+    console.log = oldLog; console.warn = oldWarn; console.error = oldError;
+    for (const key of Object.keys(process.env)) if (!(key in env)) delete process.env[key];
+    Object.assign(process.env, env);
+    for (const listener of process.rawListeners('SIGTERM')) if (!listeners.has(listener)) process.removeListener('SIGTERM', listener);
+  }
+}
+
+test('CAP failure retains the active alert and success clocks, then recovers', async () => fixture(async f => {
+  assert.equal(await f.run(), 0);
+  const previous = f.read(SOURCE.key);
+  assert.equal(previous.data.alerts.length, 1);
+  const completion = f.read(COMPLETE);
+  f.now += 15 * 60_000;
+  f.fail = true;
+  const exit = await f.run();
+  assert.equal(f.read(SOURCE.key).data.alerts.length, 1, 'CAP failure must not publish an empty alert snapshot');
+  assert.equal(exit, 1);
+  assert.equal(f.read(SOURCE.key)._seed.fetchedAt, NOW);
+  assert.equal(f.read(SOURCE.metaKey).fetchedAt, NOW);
+  assert.deepEqual(f.read(COMPLETE), completion);
+  assert.equal(f.read(SOURCE.metaKey).errorCode, 'CAP_VERIFICATION_FAILED');
+  assert.equal(f.read(CANADA_ALERTS_KEY).data.alerts.length, 1);
+  assert.equal(f.read('seed-meta:alerts:canada-union').sourceState, 'degraded');
+  f.fail = false;
+  f.now += 5 * 60_000;
+  assert.equal(await f.run(), 0);
+  assert.equal(f.read(SOURCE.metaKey).sourceState, 'ok');
+  assert.equal(f.read(SOURCE.metaKey).fetchedAt, f.now);
+  assert.equal(f.read('seed-meta:alerts:canada-union').sourceState, 'ok');
+}));

--- a/tests/saskalert-retention.test.mjs
+++ b/tests/saskalert-retention.test.mjs
@@ -5,6 +5,7 @@ import * as sask from '../scripts/lib/saskalert.mjs';
 import { runSeed } from '../scripts/_seed-utils.mjs';
 import { CANADA_ALERT_SOURCES, CANADA_ALERTS_KEY, rebuildCanadaAlertsUnion } from '../scripts/lib/canada-alerts-union.mjs';
 import { __testing__ } from '../api/health.js';
+import { readSectionFreshness } from '../scripts/_bundle-runner.mjs';
 
 const feed = JSON.parse(readFileSync(new URL('./fixtures/saskalert-feed.json', import.meta.url)));
 const cap = JSON.parse(readFileSync(new URL('./fixtures/saskalert-cap-active.json', import.meta.url)));
@@ -44,13 +45,15 @@ async function fixture(fn) {
   globalThis.fetch = async (url, options = {}) => {
     const parsed = new URL(url);
     if (parsed.hostname === 'redis.fixture') {
+      if (state.rejectRead && parsed.pathname === `/get/${encodeURIComponent(SOURCE.key)}`) return new Response('{}', { status: 403 });
       if (parsed.pathname.startsWith('/get/')) return response(values.get(decodeURIComponent(parsed.pathname.slice(5))) ?? null);
       const body = JSON.parse(options.body);
+      if (body[0] === 'SET' && body[1] === state.rejectWrite) return new Response(JSON.stringify({ error: 'fixture write rejected' }), { status: 403 });
       if (Array.isArray(body[0])) return new Response(JSON.stringify(body.map(c => ({ result: command(c) }))));
       return response(command(body));
     }
     if (String(url) === sask.SASKALERT_FEED_URL) return new Response(JSON.stringify(state.feed));
-    if (state.fail) return new Response('private upstream body', { status: 503 });
+    if (state.fail && (!state.failUrl || String(url) === state.failUrl)) return new Response('private upstream body', { status: 503 });
     return new Response(JSON.stringify(cap));
   };
   for (const source of CANADA_ALERT_SOURCES.filter(s => s.province !== 'SK')) {
@@ -58,6 +61,11 @@ async function fixture(fn) {
     values.set(source.metaKey, JSON.stringify({ fetchedAt: NOW, recordCount: 0, sourceState: 'ok' }));
   }
   state.read = key => JSON.parse(values.get(key) ?? 'null');
+  state.health = (name, key) => __testing__.classifyKey(name, key, { allowOnDemand: false }, {
+    keyStrens: new Map([[key, values.get(key)?.length ?? 0]]), keyErrors: new Map(),
+    keyMetaValues: new Map([...values].filter(([key]) => key.startsWith('seed-meta:'))),
+    keyMetaErrors: new Map(), now: state.now,
+  });
   state.run = async () => {
     try {
       await runSeed('alerts', 'saskalert', SOURCE.key, () => sask.fetchSaskAlerts(), {
@@ -107,6 +115,13 @@ test('CAP failure retains the active alert and success clocks, then recovers', a
   assert.equal(f.read(SOURCE.metaKey).errorCode, 'CAP_VERIFICATION_FAILED');
   assert.equal(f.read(CANADA_ALERTS_KEY).data.alerts.length, 1);
   assert.equal(f.read('seed-meta:alerts:canada-union').sourceState, 'degraded');
+  assert.equal(f.health('canadaAlertsSkSource', SOURCE.key).status, 'SEED_ERROR');
+  assert.equal(f.health('canadaAlerts', CANADA_ALERTS_KEY).status, 'SEED_ERROR');
+  assert.equal(f.read(SOURCE.metaKey).capFailureReasons.http, 1);
+  assert.deepEqual(await readSectionFreshness({ canonicalKey: SOURCE.key, seedMetaKey: SOURCE.metaKey,
+    completionMetaKey: COMPLETE }, async key => f.read(key)), { fetchedAt: NOW });
+  assert.equal(f.logs.filter(line => line.includes('seed_complete')).length, 1);
+  assert.equal(f.logs.some(line => line.includes('private upstream body')), false);
   f.fail = false;
   f.now += 5 * 60_000;
   assert.equal(await f.run(), 0);
@@ -114,3 +129,78 @@ test('CAP failure retains the active alert and success clocks, then recovers', a
   assert.equal(f.read(SOURCE.metaKey).fetchedAt, f.now);
   assert.equal(f.read('seed-meta:alerts:canada-union').sourceState, 'ok');
 }));
+
+test('successfully verified empty clears active alerts and records OK_ZERO', async () => fixture(async f => {
+  assert.equal(await f.run(), 0);
+  f.now += 15 * 60_000;
+  f.feed.entries = [];
+  assert.equal(await f.run(), 0);
+  assert.deepEqual(f.read(SOURCE.key).data.alerts, []);
+  assert.equal(f.read(SOURCE.key)._seed.state, 'OK_ZERO');
+  assert.equal(f.read(SOURCE.metaKey).fetchedAt, f.now);
+  assert.equal(f.read(SOURCE.metaKey).sourceState, 'ok');
+  assert.equal(f.read(CANADA_ALERTS_KEY)._seed.state, 'OK_ZERO');
+}));
+
+test('partial verification retains failed siblings while serving verified records', async () => fixture(async f => {
+  assert.equal(await f.run(), 0);
+  f.feed.entries.push({ ...feed.entries[1], identifier: 'new', cap_link: 'https://emergencyalert.saskatchewan.ca/new.json' });
+  f.now += 15 * 60_000;
+  f.fail = true;
+  f.failUrl = feed.entries[1].cap_link;
+  assert.equal(await f.run(), 1);
+  assert.deepEqual(f.read(SOURCE.key).data.alerts.map(a => a.id).sort(), [
+    'sk-saskalert-E746FB63-2A32-48EC-8AAF-D30FFC1CDDE0', 'sk-saskalert-new',
+  ]);
+  assert.equal(f.read(SOURCE.key)._seed.fetchedAt, NOW);
+  assert.equal(f.read(CANADA_ALERTS_KEY).data.alerts.length, 2);
+}));
+
+for (const reason of ['expired', 'cancelled', 'stale', 'old-content', 'missing']) {
+  test(`does not retain ${reason} last-good data or report unknown zero as OK_ZERO`, async () => fixture(async f => {
+    assert.equal(await f.run(), 0);
+    const oldCompletion = f.read(COMPLETE);
+    const old = f.read(SOURCE.key);
+    if (reason === 'expired') {
+      old.data.alerts[0].expires = new Date(NOW + 60_000).toISOString();
+      f.values.set(SOURCE.key, JSON.stringify(old));
+    }
+    if (reason === 'missing') f.values.delete(SOURCE.key);
+    if (reason === 'old-content') {
+      old.data.alerts[0].updatedAt = NOW - 4 * 24 * 60 * 60_000;
+      f.values.set(SOURCE.key, JSON.stringify(old));
+    }
+    if (reason === 'cancelled') {
+      f.feed.entries[1].state = 'ended';
+      f.feed.entries.push({ ...feed.entries[1], state: 'active', identifier: 'unknown', cap_link: 'https://emergencyalert.saskatchewan.ca/unknown.json' });
+      f.values.delete(CANADA_ALERT_SOURCES[0].key);
+    }
+    f.now += (reason === 'stale' ? 46 : 15) * 60_000;
+    f.fail = true;
+    assert.equal(await f.run(), 1);
+    assert.deepEqual(f.read(SOURCE.key).data.alerts, []);
+    assert.equal(f.read(SOURCE.key)._seed.state, 'ERROR');
+    assert.equal(f.read(SOURCE.key)._seed.fetchedAt, reason === 'missing' ? 0 : NOW);
+    assert.deepEqual(f.read(CANADA_ALERTS_KEY).data.alerts, []);
+    assert.notEqual(f.read(CANADA_ALERTS_KEY)._seed.state, 'OK_ZERO');
+    assert.deepEqual(f.read(COMPLETE), oldCompletion);
+    assert.notEqual(f.health('canadaAlertsSkSource', SOURCE.key).status, 'OK');
+  }));
+}
+
+for (const failure of ['read', 'write']) {
+  test(`Redis ${failure} failure cannot claim retention or completion`, async () => fixture(async f => {
+    assert.equal(await f.run(), 0);
+    const previous = f.read(SOURCE.key);
+    const completion = f.read(COMPLETE);
+    f.now += 15 * 60_000;
+    f.fail = true;
+    if (failure === 'read') f.rejectRead = true;
+    else f.rejectWrite = SOURCE.key;
+    await assert.rejects(f.run(), /403/);
+    assert.deepEqual(f.read(SOURCE.key), previous);
+    assert.deepEqual(f.read(COMPLETE), completion);
+    assert.equal(f.logs.filter(line => line.includes('seed_complete')).length, 1);
+    assert.ok(f.logs.some(line => line.includes('CAP_VERIFICATION_FAILED')));
+  }));
+}

--- a/tests/saskalert.test.mjs
+++ b/tests/saskalert.test.mjs
@@ -153,6 +153,7 @@ test('skips a missing cap_link instead of aborting the SK tick', async () => {
   const data = await fetchSaskAlerts({ fetchFn, nowMs: NOW });
   assert.equal(data.alerts.length, 0);
   assert.equal(data._capVerification.failed, 1);
+  assert.deepEqual(data._capVerification.reasons, { missing_link: 1 });
 });
 
 test('rejects an off-host feed URL before fetchFn runs', async () => {
@@ -260,9 +261,30 @@ test('stops starting CAP fetches once the section budget is spent', async () => 
   });
   assert.equal(data.alerts.length, 0);
   assert.ok(data._capVerification.skippedDeadline >= 2);
+  assert.deepEqual(data._capVerification.reasons, { deadline: 2 });
   assert.equal(requested.length, 1);
   assert.ok(requested[0].endsWith('feed.json'));
 });
+
+for (const [reason, fail] of [
+  ['timeout', () => { throw new DOMException('sensitive URL', 'TimeoutError'); }],
+  ['transport', () => { throw new TypeError('sensitive transport details'); }],
+  ['http', () => new Response('sensitive body', { status: 502 })],
+  ['parsing', () => new Response('sensitive invalid JSON')],
+  ['validation', () => {
+    const document = structuredClone(capActive);
+    document.alert.info[0].severity = '';
+    return new Response(JSON.stringify(document));
+  }],
+]) {
+  test(`records a bounded ${reason} diagnostic without upstream details`, async () => {
+    const data = await fetchSaskAlerts({ nowMs: NOW, fetchFn: async url => (
+      url === SASKALERT_FEED_URL ? new Response(JSON.stringify(feed)) : fail()
+    ) });
+    assert.deepEqual(data._capVerification.reasons, { [reason]: 1 });
+    assert.doesNotMatch(JSON.stringify(saskAlertAfterPublish(data)), /sensitive/);
+  });
+}
 
 test('drops expired, Exercise, Restricted, and Cancel CAP records without AllClear tokens', () => {
   const baseEntry = { ...feed.entries[1], summary_en: 'Active advisory', event_en: 'Drinking Water' };
@@ -316,6 +338,7 @@ test('registers the province seeder in the Canada bundle without touching roads 
   assert.match(union, /province: 'SK'/);
   assert.match(union, /alerts:canada:saskalert:v1/);
   assert.match(seeder, /publishTransform: saskAlertPublishTransform/);
+  assert.match(seeder, /beforePublish: saskAlertBeforePublish/);
   assert.match(seeder, /CANADA_ALERT_UNION_REBUILD_FAILED/);
   // Both sibling acks were pruned on 2026-08-20 once the probes published, so
   // assert the pairing directionally: #6659 was allowed to own four rows only


### PR DESCRIPTION
## Summary

Saskatchewan alerts could disappear after a CAP verification failure because an empty result was published as `OK_ZERO`. The September 11 incident showed one alert becoming zero before returning on a later run; its underlying CAP exception was not captured.

Incomplete verification now retains usable alerts for the unresolved entries, includes verified siblings, removes ended/expired or unusable prior records, and keeps the original success clock. The source and union remain degraded, the member fails without `seed_complete` or a new completion marker, and normal bundle cadence can retry. Only established empty results produce `OK_ZERO`. Bounded diagnostics distinguish timeout, HTTP, parsing, validation, transport, missing/invalid link, and deadline outcomes without raw bodies or URLs.

The union's peer-gap preservation also applies the current province's removals and the existing 200-alert cap. This prevents it from restoring a cancelled Saskatchewan alert from the older aggregate.

## Validation

- Red before repair, committed separately: a real `fetchSaskAlerts -> runSeed -> synthetic Redis -> union` run first published one alert, then a synthetic CAP HTTP failure produced `0 !== 1` at “CAP failure must not publish an empty alert snapshot.” This demonstrates the unsafe publication mechanism, not the original incident's transport cause.
- 124 focused checks pass across producer, retention, union, bootstrap, health, bundle configuration/completion, and seed helpers. Cases include failure-retention-recovery, legitimate empty, partial verification, expired/cancelled/stale/missing prior data, old content, bounded diagnostics, Redis read/write rejection, and unchanged success/completion clocks. Both source and aggregate health remain degraded while retained data is usable.
- Three real bundle-process checks also pass, including nonzero child exit reporting and hard failure alongside a graceful skip.
- Browser/API TypeScript checks and all pre-push gates pass. Focused Biome lint, Node syntax and `git diff --check` pass. Biome reports one existing informational `noUselessContinue` in unchanged coordinate parsing.
- CI browser smoke initially failed in the unchanged dashboard early-scroll test, then its Playwright retry hit an unbound response object. One bounded rerun passed on the same head without code changes. All unit shards, browser smoke, type/lint, security analysis and preview checks passed. Automatic PR review completed with no findings.
- Sequential local simplification and ce-code-review completed under the repository tool mapping; no independent cross-model review. Applied timeout-classification, union-cap and diagnostic-ordering fixes.
- Read-only Railway deployment metadata confirms latest successful Canada deploy `c12751fb9f9300d3f2f12436ea5bc82430f6bcc3` is an ancestor of the base and has identical Saskatchewan/union code. Newer deployment records were skipped.

Alberta's adapter has the same pre-existing CAP catch-and-publish pattern. It needs a separate focused repair; this PR does not change its adapter or seeder. No production seeders, Redis/config writes, paid probes, deployment or merge were performed.

## Post-Deploy Monitoring & Validation

Owner: deploying maintainer. After an authorized deployment, inspect the next two natural Canada cycles and the first naturally occurring Saskatchewan verification failure/recovery. Do not trigger a run to manufacture acceptance.

Search for `SaskAlert`, `CAP_VERIFICATION_FAILED`, `seed_complete`, and the bundle section summary. On incomplete verification, expect bounded reason counts, a failed member, no successful completion message or new completion marker, retained usable alert records, and unchanged source `fetchedAt`. Check `canadaAlertsSkSource` and `canadaAlerts` health together. Verified recovery must advance the success clock and clear degradation. Verify expired/cancelled alerts are absent from the union, including when another province is missing.

A failed verification reported as `OK_ZERO`/section `OK`, a moved success clock, suppressed degradation, or restored expired/cancelled records blocks acceptance and requires investigation or rollback. Green local tests and CI do not establish production recovery. Natural-run acceptance remains pending.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
