### PR TITLE
fix(aviation): bound and rate-limit aircraft identifier lookups

### DIFF
--- a/docs/usage-rate-limits.mdx
+++ b/docs/usage-rate-limits.mdx
@@ -115,12 +115,17 @@ Routes that fetch a third-party host on our behalf carry their own per-IP budget
 |----------|-------|--------|-------|
 | `POST /api/skills/fetch-agentskills` | 30 | 60 s | Per IP |
 | `GET /api/youtube/live` | 30 | 60 s | Per IP |
+| `GET /api/aviation/v1/track-aircraft` with `icao24` or `callsign` | 30 | 60 s | Per IP; fail-closed |
 | `GET /api/reverse-geocode` | 60 | 60 s | Per IP |
 | `GET /api/infrastructure/v1/reverse-geocode` | 60 | 60 s | Per IP |
 
 The two edge handlers (`/api/skills/fetch-agentskills`, `/api/youtube/live`) enforce their budgets in-handler via `checkScopedRateLimit`/`checkRateLimit`; `/api/reverse-geocode` mirrors its per-IP budget as a literal constant per `api/*.js` constraints. `/api/infrastructure/v1/reverse-geocode` is a gateway RPC, so the gateway enforces its per-IP budget through `checkEndpointRateLimit` (fail-closed on Redis outage). After a shared-cache miss, both reverse-geocode handlers also use one fail-closed provider-wide Redis bucket capped at 1 request per second before they call Nominatim; cache hits do not consume that aggregate budget.
 
 Uncached `/api/symbol-search` requests also require admission to one shared 30 requests/minute Finnhub bucket, independent of query and caller. Cached results do not spend this budget. Exhaustion returns 429 with `Retry-After`; unavailable admission storage returns 503 before Finnhub is called.
+
+Aircraft identifier lookups consume the 30/minute budget before cache access, including cache hits and authenticated API or internal MCP requests. Accounts behind the same trusted client IP share this limit in addition to any account allowance; requests without a trusted IP share one fallback bucket. Bbox-only map requests keep the existing gateway policy. The native sidecar uses a separate 30/minute process-local window after local token authentication; restarting the process resets that window.
+
+ICAO addresses must normalize to six lowercase hexadecimal characters. Callsigns must normalize to 1–8 uppercase alphanumeric characters; substring matching remains supported. Both raw inputs are capped at 16 characters before surrounding whitespace is removed. Invalid identifiers return 400 before cache or provider access. Quota exhaustion returns 429 with the 30-request policy and `Retry-After`; unavailable limiter storage returns 503 with `X-RateLimit-Mode: degraded` and `Retry-After: 5`.
 
 ## Write endpoints
 

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -4,6 +4,8 @@ import type {
     TrackAircraftResponse,
     PositionSample,
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
+import { ApiError } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
+import { checkScopedRateLimit, getClientIp } from '../../../_shared/rate-limit';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { isOpenSkyProvider, requiresRedistributableProviders } from '../../../_shared/provider-redistribution';
@@ -18,6 +20,25 @@ const CACHE_TTL = 120;
 const CALLSIGN_CACHE_TTL = 60;
 const CALLSIGN_NEGATIVE_TTL = 10;
 const BBOX_RELAY_TIMEOUT_MS = 6_000;
+const IDENTIFIER_RATE_SCOPE = 'track-aircraft-identifiers';
+const IDENTIFIER_RATE_LIMIT = 30;
+const IDENTIFIER_RATE_WINDOW_MS = 60_000;
+let nativeIdentifierAdmissions: number[] = [];
+
+async function admitIdentifierLookup(request: Request): Promise<void> {
+    // Native transport authentication precedes the handler; its cache and budget
+    // remain local, while cloud and Docker require a healthy shared limiter.
+    if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
+        const now = Date.now();
+        nativeIdentifierAdmissions = nativeIdentifierAdmissions.filter(time => time > now - IDENTIFIER_RATE_WINDOW_MS);
+        if (nativeIdentifierAdmissions.length >= IDENTIFIER_RATE_LIMIT) throw new ApiError(429, 'Too many requests', '');
+        nativeIdentifierAdmissions.push(now);
+        return;
+    }
+    const limit = await checkScopedRateLimit(IDENTIFIER_RATE_SCOPE, IDENTIFIER_RATE_LIMIT, '60 s', getClientIp(request));
+    if (limit.degraded) throw new ApiError(503, 'Rate-limit service temporarily unavailable', '');
+    if (!limit.allowed) throw new ApiError(429, 'Too many requests', '');
+}
 
 function isDegenerateBbox(req: TrackAircraftRequest): boolean {
     return req.swLat === req.neLat && req.swLon === req.neLon;
@@ -76,6 +97,16 @@ export async function trackAircraft(
     ctx: ServerContext,
     req: TrackAircraftRequest,
 ): Promise<TrackAircraftResponse> {
+    const rawIcao24 = req.icao24 ?? '';
+    const rawCallsign = req.callsign ?? '';
+    if (rawIcao24.length > 16 || rawCallsign.length > 16) throw new ApiError(400, 'Aircraft identifier is too long', '');
+    const icao24 = rawIcao24.trim().toLowerCase();
+    const callsign = rawCallsign.trim().toUpperCase();
+    if (rawIcao24 && !/^[0-9a-f]{6}$/.test(icao24)) throw new ApiError(400, 'Expected a six-character hexadecimal ICAO address', '');
+    if (rawCallsign && !/^[A-Z0-9]{1,8}$/.test(callsign)) throw new ApiError(400, 'Expected an alphanumeric callsign of at most eight characters', '');
+    req = { ...req, icao24, callsign };
+    if (icao24 || callsign) await admitIdentifierLookup(ctx.request);
+
     const redistributableOnly = requiresRedistributableProviders(ctx.request);
     const cacheKey = `${buildCacheKey(req)}${redistributableOnly ? ':redistributable' : ''}`;
 
@@ -161,7 +192,7 @@ export async function trackAircraft(
                 // For icao24-only queries, try the OpenSky relay
                 if (!redistributableOnly && !isCallsignOnly && relayBase && req.icao24) {
                     try {
-                        const osUrl = `${relayBase}/opensky/states/all?icao24=${req.icao24}`;
+                        const osUrl = `${relayBase}/opensky/states/all?icao24=${encodeURIComponent(req.icao24)}`;
                         const resp = await fetch(osUrl, { headers: getRelayHeaders({}), signal: AbortSignal.timeout(8_000) });
                         if (resp.ok) {
                             const data = await resp.json() as OpenSkyResponse;

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -5,7 +5,9 @@ import type {
     PositionSample,
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { ApiError } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
-import { checkScopedRateLimit, getClientIp } from '../../../_shared/rate-limit';
+import { checkScopedRateLimit, getClientIp, RATE_LIMIT_DEGRADED_HEADERS } from '../../../_shared/rate-limit';
+import { setResponseHeader } from '../../../_shared/response-headers';
+import { attachApiErrorHttpResponseMetadata } from '../../../error-mapper';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { isOpenSkyProvider, requiresRedistributableProviders } from '../../../_shared/provider-redistribution';
@@ -25,19 +27,33 @@ const IDENTIFIER_RATE_LIMIT = 30;
 const IDENTIFIER_RATE_WINDOW_MS = 60_000;
 let nativeIdentifierAdmissions: number[] = [];
 
+function rejectIdentifierQuota(resetMs: number): never {
+    throw attachApiErrorHttpResponseMetadata(
+        Object.assign(new ApiError(429, 'Too many requests', ''), {
+            retryAfter: Math.max(1, Math.ceil((resetMs - Date.now()) / 1000)),
+        }),
+        { envelope: 'error', rateLimit: { limit: IDENTIFIER_RATE_LIMIT, remaining: 0, resetMs, windowSec: 60 } },
+    );
+}
+
 async function admitIdentifierLookup(request: Request): Promise<void> {
+    setResponseHeader(request, 'RateLimit-Policy', '"default";q=30;w=60');
+    setResponseHeader(request, 'RateLimit-Limit', String(IDENTIFIER_RATE_LIMIT));
     // Native transport authentication precedes the handler; its cache and budget
     // remain local, while cloud and Docker require a healthy shared limiter.
     if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
         const now = Date.now();
         nativeIdentifierAdmissions = nativeIdentifierAdmissions.filter(time => time > now - IDENTIFIER_RATE_WINDOW_MS);
-        if (nativeIdentifierAdmissions.length >= IDENTIFIER_RATE_LIMIT) throw new ApiError(429, 'Too many requests', '');
+        if (nativeIdentifierAdmissions.length >= IDENTIFIER_RATE_LIMIT) rejectIdentifierQuota(nativeIdentifierAdmissions[0]! + IDENTIFIER_RATE_WINDOW_MS);
         nativeIdentifierAdmissions.push(now);
         return;
     }
     const limit = await checkScopedRateLimit(IDENTIFIER_RATE_SCOPE, IDENTIFIER_RATE_LIMIT, '60 s', getClientIp(request));
-    if (limit.degraded) throw new ApiError(503, 'Rate-limit service temporarily unavailable', '');
-    if (!limit.allowed) throw new ApiError(429, 'Too many requests', '');
+    if (limit.degraded) {
+        for (const [key, value] of Object.entries(RATE_LIMIT_DEGRADED_HEADERS)) setResponseHeader(request, key, value);
+        throw Object.assign(new ApiError(503, 'Rate-limit service temporarily unavailable', ''), { retryAfter: 5, exposeMessage: true });
+    }
+    if (!limit.allowed) rejectIdentifierQuota(limit.reset);
 }
 
 function isDegenerateBbox(req: TrackAircraftRequest): boolean {

--- a/tests/aircraft-input-boundary.test.mts
+++ b/tests/aircraft-input-boundary.test.mts
@@ -82,7 +82,11 @@ test('identifier store outage fails closed while anonymous bbox remains availabl
   delete process.env.UPSTASH_REDIS_REST_URL;
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
   __resetRateLimitForTest();
-  assert.equal((await gateway(request({ icao24: 'abc123' }))).status, 503);
+  const unavailable = await gateway(request({ icao24: 'abc123' }));
+  assert.equal(unavailable.status, 503);
+  assert.equal(unavailable.headers.get('X-RateLimit-Mode'), 'degraded');
+  assert.equal(unavailable.headers.get('Retry-After'), '5');
+  assert.equal((await unavailable.json()).message, 'Rate-limit service temporarily unavailable');
   assert.equal(providers().length, 0);
   const bbox = await gateway(request({ sw_lat: '24', sw_lon: '54', ne_lat: '26', ne_lon: '56' }));
   assert.equal(bbox.status, 200);
@@ -101,8 +105,17 @@ test('identifier quota is 30/min across distinct cache keys', async () => {
     }
     return transport(input, init);
   }) as typeof fetch;
-  for (let i = 0; i < 30; i++) assert.equal((await gateway(request({ callsign: `UAE${i}` }))).status, 200);
-  assert.equal((await gateway(request({ callsign: 'UAE30' }))).status, 429);
+  for (let i = 0; i < 30; i++) {
+    const allowed = await gateway(request({ callsign: `UAE${i}` }));
+    assert.equal(allowed.status, 200);
+    assert.equal(allowed.headers.get('RateLimit-Limit'), '30');
+  }
+  const denied = await gateway(request({ callsign: 'UAE30' }));
+  assert.equal(denied.status, 429);
+  assert.equal(denied.headers.get('RateLimit-Policy'), '"default";q=30;w=60');
+  assert.equal(denied.headers.get('RateLimit-Remaining'), '0');
+  assert.ok(Number(denied.headers.get('Retry-After')) > 0);
+  assert.deepEqual(await denied.json(), { error: 'Too many requests' });
   assert.equal(admissions, 31);
   const sent = readLimiterRequest(wire);
   assert.equal(sent?.tokens, 30);
@@ -177,7 +190,10 @@ test('verified MCP identifier calls cannot bypass the handler budget', async () 
     return new Request(url, { headers: buildInternalMcpHeaders(signature) });
   };
   for (let i = 0; i < 30; i++) assert.equal((await gateway(await signed())).status, 200);
-  assert.equal((await gateway(await signed())).status, 429);
+  const denied = await gateway(await signed());
+  assert.equal(denied.status, 429);
+  assert.equal(denied.headers.get('RateLimit-Limit'), '30');
+  assert.ok(Number(denied.headers.get('Retry-After')) > 0);
   assert.equal(admissions, 31);
   assert.equal(providers().length, 1);
   assert.equal(providers()[0]!.pathname, '/wingbits/track');
@@ -215,7 +231,10 @@ test('native HTTP identifier admission preserves real auth, data, cache and wind
       assert.equal(body.source, 'opensky');
       assert.deepEqual(body.positions.map((p: { icao24: string }) => p.icao24), ['abc123']);
     }
-    assert.equal((await originalFetch(url, { headers })).status, 429);
+    const denied = await originalFetch(url, { headers });
+    assert.equal(denied.status, 429);
+    assert.equal(denied.headers.get('Retry-After'), '60');
+    assert.equal(denied.headers.get('RateLimit-Limit'), '30');
     now += 59_999;
     assert.equal((await originalFetch(url, { headers })).status, 429);
     now += 1;

--- a/tests/aircraft-input-boundary.test.mts
+++ b/tests/aircraft-input-boundary.test.mts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { trackAircraft } from '../server/worldmonitor/aviation/v1/track-aircraft.ts';
+import { ApiError, createAviationServiceRoutes, type TrackAircraftRequest } from '../src/generated/server/worldmonitor/aviation/v1/service_server.ts';
+import { aviationHandler } from '../server/worldmonitor/aviation/v1/handler.ts';
+import { createDomainGateway, serverOptions } from '../server/gateway.ts';
+import { __resetRateLimitForTest } from '../server/_shared/rate-limit.ts';
+import { installRedis } from './helpers/fake-upstash-redis.mts';
+import { readLimiterRequest } from './helpers/upstash-limiter-wire.mjs';
+import { issueSessionToken } from '../api/_session.js';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+const PATH = '/api/aviation/v1/track-aircraft';
+const gateway = createDomainGateway(createAviationServiceRoutes(aviationHandler, serverOptions));
+const defaults: TrackAircraftRequest = { icao24: '', callsign: '', swLat: 0, swLon: 0, neLat: 0, neLon: 0 };
+const wingbitsPosition = { icao24: 'abc123', callsign: 'UAE20', lat: 25, lon: 55, altitudeM: 1000, groundSpeedKts: 100, trackDeg: 90, verticalRate: 0, onGround: false, source: 'POSITION_SOURCE_WINGBITS', observedAt: 1 };
+let redis: ReturnType<typeof installRedis>;
+let calls: URL[];
+let session: string;
+let wingbitsStatus: number;
+let wingbitsPositions: typeof wingbitsPosition[];
+let openSkyStatus: number;
+beforeEach(async () => {
+  delete process.env.LOCAL_API_MODE;
+  delete process.env.WORLDMONITOR_VALID_KEYS;
+  delete process.env.VERCEL;
+  delete process.env.VERCEL_ENV;
+  process.env.WS_RELAY_URL = 'https://relay.example';
+  process.env.WM_SESSION_SECRET = 'synthetic-aircraft-session-secret';
+  session = (await issueSessionToken()).token;
+  __resetRateLimitForTest();
+  redis = installRedis({});
+  calls = [];
+  wingbitsStatus = 200;
+  wingbitsPositions = [wingbitsPosition];
+  openSkyStatus = 200;
+  globalThis.fetch = (async (input, init) => {
+    const url = new URL(String(input)); calls.push(url);
+    if (url.hostname === 'redis.example') return redis.fetchImpl(input, init);
+    assert.equal(url.hostname, 'relay.example');
+    if (url.pathname === '/wingbits/track') return Response.json({ positions: wingbitsPositions, source: 'wingbits' }, { status: wingbitsStatus });
+    assert.equal(url.pathname, '/opensky/states/all');
+    return Response.json({ states: [['abc123', 'UAE20 ', null, null, 1, 55, 25, 1000, false, 100, 90, 0]] }, { status: openSkyStatus });
+  }) as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const key of Object.keys(process.env)) if (!(key in originalEnv)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+  __resetRateLimitForTest();
+});
+const request = (query: Record<string, string> = {}) => new Request(`https://api.worldmonitor.app${PATH}?${new URLSearchParams(query)}`, { headers: { 'X-WorldMonitor-Key': session, 'x-real-ip': '192.0.2.10' } });
+const ctx = () => ({ request: request(), pathParams: {}, headers: {} });
+const read = (options: Partial<TrackAircraftRequest>) => trackAircraft(ctx(), { ...defaults, ...options });
+const providers = () => calls.filter(url => url.hostname === 'relay.example');
+
+test('invalid or oversized identifiers fail before cache or upstream I/O', async () => {
+  for (const options of [{ icao24: 'abc123&lamin=0' }, { icao24: 'abc12' }, { icao24: 'gggggg' }, { icao24: 'a'.repeat(1000) }, { callsign: 'UAE/20' }, { callsign: 'UAE20&x=1' }, { callsign: 'ABCDEFGHI' }, { callsign: ' '.repeat(1000) + 'UAE20' }]) {
+    await assert.rejects(read(options), (error: unknown) => error instanceof ApiError && error.statusCode === 400);
+    assert.equal(calls.length, 0);
+  }
+});
+test('canonical ICAO shares bounded key and retains OpenSky lookup/filter behavior', async () => {
+  const first = await read({ icao24: ' ABC123 ' });
+  const second = await read({ icao24: 'abc123' });
+  assert.equal(first.source, 'opensky');
+  assert.equal(first.positions[0]?.icao24, 'abc123');
+  assert.deepEqual(second.positions, first.positions);
+  assert.equal(providers().length, 1);
+  assert.equal(providers()[0]!.search, '?icao24=abc123');
+  assert.deepEqual([...redis.redis.keys()].filter(key => key.startsWith('aviation:track:')), ['aviation:track:icao:abc123:v2']);
+});
+test('canonical callsign retains substring matching and Wingbits priority', async () => {
+  assert.equal((await read({ callsign: ' uae ' })).positions[0]?.callsign, 'UAE20');
+  assert.equal((await read({ callsign: 'UAE' })).source, 'wingbits');
+  assert.equal(providers().length, 1);
+  assert.equal(providers()[0]!.search, '?callsign=UAE');
+  assert.deepEqual([...redis.redis.keys()].filter(key => key.startsWith('aviation:track:')), ['aviation:track:callsign:UAE:v2']);
+});
+test('identifier store outage fails closed while anonymous bbox remains available', async () => {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  __resetRateLimitForTest();
+  assert.equal((await gateway(request({ icao24: 'abc123' }))).status, 503);
+  assert.equal(providers().length, 0);
+  const bbox = await gateway(request({ sw_lat: '24', sw_lon: '54', ne_lat: '26', ne_lon: '56' }));
+  assert.equal(bbox.status, 200);
+  assert.equal((await bbox.json()).source, 'wingbits');
+  assert.equal(providers().length, 1);
+});
+test('identifier quota is 30/min across distinct cache keys', async () => {
+  const transport = globalThis.fetch;
+  let admissions = 0;
+  const wire: { init?: RequestInit }[] = [];
+  globalThis.fetch = (async (input, init) => {
+    const commands = init?.body ? JSON.parse(String(init.body)) : [];
+    if (Array.isArray(commands[0]) && commands.some((c: string[]) => c.some(value => String(value).includes('track-aircraft-identifiers')))) {
+      wire.push({ init });
+      return Response.json(commands.map(() => ({ result: [30 - ++admissions, 30] })));
+    }
+    return transport(input, init);
+  }) as typeof fetch;
+  for (let i = 0; i < 30; i++) assert.equal((await gateway(request({ callsign: `UAE${i}` }))).status, 200);
+  assert.equal((await gateway(request({ callsign: 'UAE30' }))).status, 429);
+  assert.equal(admissions, 31);
+  const sent = readLimiterRequest(wire);
+  assert.equal(sent?.tokens, 30);
+  assert.equal(sent?.windowMs, 60000);
+  assert.ok(sent?.keys.every(key => key.includes('track-aircraft-identifiers:192.0.2.10:')));
+  assert.equal(providers().length, 30);
+});
+
+test('Redis transport failure denies identifier lookups before provider work', async () => {
+  const transport = globalThis.fetch;
+  globalThis.fetch = (async (input, init) => {
+    if (new URL(String(input)).hostname === 'redis.example') throw new Error('Synthetic Redis outage');
+    return transport(input, init);
+  }) as typeof fetch;
+  await assert.rejects(read({ callsign: 'UAE20' }), (error: unknown) => error instanceof ApiError && error.statusCode === 503);
+  assert.equal(providers().length, 0);
+});
+test('bbox retains the global gateway budget, authoritative empty results and OpenSky recovery', async () => {
+  const transport = globalThis.fetch;
+  const wire: { init?: RequestInit }[] = [];
+  globalThis.fetch = (async (input, init) => { wire.push({ init }); return transport(input, init); }) as typeof fetch;
+  wingbitsPositions = [];
+  const empty = await gateway(request({ sw_lat: '10', sw_lon: '10', ne_lat: '11', ne_lon: '11' }));
+  assert.equal(empty.status, 200);
+  assert.deepEqual((await empty.json()).positions, []);
+  assert.equal(providers().length, 1);
+  assert.equal(readLimiterRequest(wire)?.tokens, 600);
+  assert.ok(!wire.some(item => String(item.init?.body).includes('track-aircraft-identifiers')));
+  wingbitsStatus = 502;
+  const recovered = await gateway(request({ sw_lat: '24', sw_lon: '54', ne_lat: '26', ne_lon: '56' }));
+  assert.equal((await recovered.json()).source, 'opensky');
+  assert.deepEqual(providers().map(url => url.pathname), ['/wingbits/track', '/wingbits/track', '/opensky/states/all']);
+});
+test('identifier provider failures preserve empty none responses and no-identifier requests do not fetch', async () => {
+  wingbitsStatus = 502;
+  assert.equal((await read({ callsign: 'FAIL1' })).source, 'none');
+  assert.equal(providers().length, 1);
+  openSkyStatus = 502;
+  assert.equal((await read({ icao24: 'fffffe' })).source, 'none');
+  assert.equal(providers().length, 2);
+  assert.deepEqual((await read({})).positions, []);
+  assert.equal(providers().length, 2);
+});
+test('both identifiers and identifiers with bbox are validated and admitted without changing filtering', async () => {
+  const both = await read({ icao24: 'ABC123', callsign: ' uae ' });
+  assert.equal(both.source, 'opensky');
+  assert.equal(both.positions[0]?.icao24, 'abc123');
+  const withBbox = await read({ icao24: 'abc123', callsign: 'UAE', swLat: 24, swLon: 54, neLat: 26, neLon: 56 });
+  assert.equal(withBbox.positions[0]?.icao24, 'abc123');
+  await assert.rejects(read({ icao24: 'bad', swLat: 24, swLon: 54, neLat: 26, neLon: 56 }), (error: unknown) => error instanceof ApiError && error.statusCode === 400);
+});
+test('verified MCP identifier calls cannot bypass the handler budget', async () => {
+  const { signInternalMcpRequest, buildInternalMcpHeaders } = await import('../server/_shared/mcp-internal-hmac.ts');
+  process.env.MCP_INTERNAL_HMAC_SECRET = 'synthetic-aircraft-mcp-secret';
+  process.env.CONVEX_SITE_URL = 'https://convex.example';
+  process.env.CONVEX_SERVER_SHARED_SECRET = 'synthetic-convex-secret';
+  const transport = globalThis.fetch;
+  let admissions = 0;
+  globalThis.fetch = (async (input, init) => {
+    const url = new URL(String(input));
+    if (url.hostname === 'convex.example') return Response.json({ planKey: 'pro', features: { tier: 1, mcpAccess: true, apiAccess: false }, validUntil: Date.now() + 86400000 });
+    const commands = init?.body ? JSON.parse(String(init.body)) : [];
+    if (Array.isArray(commands[0])) {
+      if (commands.some((c: string[]) => String(c[1]).startsWith('internal-mcp-replay:'))) return Response.json(commands.map(() => ({ result: 'OK' })));
+      if (commands.some((c: string[]) => c.some(value => String(value).includes('track-aircraft-identifiers')))) return Response.json(commands.map(() => ({ result: [30 - ++admissions, 30] })));
+    }
+    return transport(input, init);
+  }) as typeof fetch;
+  const signed = async () => {
+    const url = request({ callsign: 'UAE20' }).url;
+    const signature = await signInternalMcpRequest({ method: 'GET', url, body: '', userId: 'synthetic_aircraft_user', secret: process.env.MCP_INTERNAL_HMAC_SECRET! });
+    return new Request(url, { headers: buildInternalMcpHeaders(signature) });
+  };
+  for (let i = 0; i < 30; i++) assert.equal((await gateway(await signed())).status, 200);
+  assert.equal((await gateway(await signed())).status, 429);
+  assert.equal(admissions, 31);
+  assert.equal(providers().length, 1);
+  assert.equal(providers()[0]!.pathname, '/wingbits/track');
+});
+test('native HTTP identifier admission preserves real auth, data, cache and window recovery without Redis', async () => {
+  const { mkdtemp, mkdir, writeFile } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const providerFetch = globalThis.fetch;
+  const { createLocalApiServer } = await import('../src-tauri/sidecar/local-api-server.mjs');
+  globalThis.fetch = providerFetch;
+  const root = await mkdtemp(join(tmpdir(), 'aircraft-native-'));
+  await mkdir(join(root, 'aviation/v1'), { recursive: true });
+  const serviceUrl = new URL('../src/generated/server/worldmonitor/aviation/v1/service_server.ts', import.meta.url).href;
+  const gatewayUrl = new URL('../server/gateway.ts', import.meta.url).href;
+  const handlerUrl = new URL('../server/worldmonitor/aviation/v1/handler.ts', import.meta.url).href;
+  await writeFile(join(root, 'aviation/v1/track-aircraft.js'), `import {createAviationServiceRoutes} from ${JSON.stringify(serviceUrl)}; import {createDomainGateway,serverOptions} from ${JSON.stringify(gatewayUrl)}; import {aviationHandler} from ${JSON.stringify(handlerUrl)}; export default createDomainGateway(createAviationServiceRoutes(aviationHandler,serverOptions));`);
+  process.env.LOCAL_API_MODE = 'tauri-sidecar';
+  process.env.LOCAL_API_TOKEN = 'synthetic-aircraft-native-token';
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  const app = await createLocalApiServer({ port: 0, apiDir: root, dataDir: root, mode: 'tauri-sidecar', cloudFallback: false, logger: { log() {}, warn() {}, error() {} } });
+  const { port } = await app.start();
+  const realNow = Date.now;
+  let now = realNow();
+  Date.now = () => now;
+  try {
+    const url = `http://127.0.0.1:${port}${PATH}?icao24=ABC123`;
+    assert.equal((await originalFetch(url)).status, 401);
+    const headers = { 'x-worldmonitor-local-token': process.env.LOCAL_API_TOKEN, 'X-WorldMonitor-Key': session };
+    for (let i = 0; i < 30; i++) {
+      const response = await originalFetch(url, { headers });
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.equal(body.source, 'opensky');
+      assert.deepEqual(body.positions.map((p: { icao24: string }) => p.icao24), ['abc123']);
+    }
+    assert.equal((await originalFetch(url, { headers })).status, 429);
+    now += 59_999;
+    assert.equal((await originalFetch(url, { headers })).status, 429);
+    now += 1;
+    const recovered = await originalFetch(url, { headers });
+    assert.equal(recovered.status, 200);
+    assert.equal((await recovered.json()).source, 'opensky');
+    assert.equal(providers().length, 1);
+  } finally {
+    Date.now = realNow;
+    await app.close();
+  }
+});

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -620,7 +620,7 @@ describe('scoped rate-limit degraded call-site policy (#3531)', () => {
   const SCOPED_RATE_LIMIT_CALLERS = [
     {
       path: 'server/worldmonitor/aviation/v1/track-aircraft.ts',
-      expected: /if\s*\(limit\.degraded\)\s*throw new ApiError\(503,/,
+      expected: /if\s*\(limit\.degraded\)\s*\{[\s\S]*?throw Object\.assign\(new ApiError\(503,/,
       reason: 'aircraft identifier lookups must fail closed before cache or provider work when the shared limiter is unavailable',
     },
     {

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -619,6 +619,11 @@ describe('rate-limit fail-closed call-site policy (#3531)', () => {
 describe('scoped rate-limit degraded call-site policy (#3531)', () => {
   const SCOPED_RATE_LIMIT_CALLERS = [
     {
+      path: 'server/worldmonitor/aviation/v1/track-aircraft.ts',
+      expected: /if\s*\(limit\.degraded\)\s*throw new ApiError\(503,/,
+      reason: 'aircraft identifier lookups must fail closed before cache or provider work when the shared limiter is unavailable',
+    },
+    {
       path: 'api/reverse-geocode.js',
       expected: /failClosed:\s*true/,
       reason: 'the provider-wide Nominatim bucket is shared across both routes and must fail closed before upstream work',

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2462,12 +2462,20 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
 
 describe('aviation aircraft provider priority', { concurrency: 1 }, () => {
   async function importTrackAircraft() {
-    return importPatchedTsModule('server/worldmonitor/aviation/v1/track-aircraft.ts', {
+    // Provider-priority tests isolate admission; aircraft-input-boundary tests
+    // exercise the real scoped limiter through the generated gateway.
+    const stubDir = createTempDir('wm-aircraft-rate-');
+    const rateStub = join(stubDir, 'rate.mjs');
+    writeFileSync(rateStub, `export const getClientIp = () => 'test';
+export const checkScopedRateLimit = async () => ({ allowed: true, degraded: false });`);
+    const imported = await importPatchedTsModule('server/worldmonitor/aviation/v1/track-aircraft.ts', {
       './_shared': resolve(root, 'server/_shared/relay.ts'),
       '../../../_shared/constants': resolve(root, 'server/_shared/constants.ts'),
       '../../../_shared/redis': resolve(root, 'server/_shared/redis.ts'),
       '../../../_shared/provider-redistribution': resolve(root, 'server/_shared/provider-redistribution.ts'),
+      '../../../_shared/rate-limit': rateStub,
     });
+    return { module: imported.module, cleanup() { imported.cleanup(); removeTempDir(stubDir); } };
   }
 
   it('serves a bbox from Wingbits without spending an OpenSky request', async () => {

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2467,7 +2467,8 @@ describe('aviation aircraft provider priority', { concurrency: 1 }, () => {
     const stubDir = createTempDir('wm-aircraft-rate-');
     const rateStub = join(stubDir, 'rate.mjs');
     writeFileSync(rateStub, `export const getClientIp = () => 'test';
-export const checkScopedRateLimit = async () => ({ allowed: true, degraded: false });`);
+export const checkScopedRateLimit = async () => ({ allowed: true, degraded: false });
+export const RATE_LIMIT_DEGRADED_HEADERS = { 'X-RateLimit-Mode': 'degraded', 'Retry-After': '5' };`);
     const imported = await importPatchedTsModule('server/worldmonitor/aviation/v1/track-aircraft.ts', {
       './_shared': resolve(root, 'server/_shared/relay.ts'),
       '../../../_shared/constants': resolve(root, 'server/_shared/constants.ts'),
@@ -2508,7 +2509,7 @@ export const checkScopedRateLimit = async () => ({ allowed: true, degraded: fals
     };
 
     try {
-      const result = await module.trackAircraft({}, {
+      const result = await module.trackAircraft({ request: new Request('https://api.worldmonitor.app/api/aviation/v1/track-aircraft') }, {
         swLat: 10,
         swLon: 10,
         neLat: 11,
@@ -2556,13 +2557,13 @@ export const checkScopedRateLimit = async () => ({ allowed: true, degraded: fals
     };
 
     try {
-      const quiet = await module.trackAircraft({}, {
+      const quiet = await module.trackAircraft({ request: new Request('https://api.worldmonitor.app/api/aviation/v1/track-aircraft') }, {
         swLat: 10,
         swLon: 10,
         neLat: 11,
         neLon: 11,
       });
-      const recovered = await module.trackAircraft({}, {
+      const recovered = await module.trackAircraft({ request: new Request('https://api.worldmonitor.app/api/aviation/v1/track-aircraft') }, {
         swLat: 20,
         swLon: 20,
         neLat: 21,
@@ -2616,7 +2617,7 @@ export const checkScopedRateLimit = async () => ({ allowed: true, degraded: fals
     };
 
     try {
-      const result = await module.trackAircraft({}, {
+      const result = await module.trackAircraft({ request: new Request('https://api.worldmonitor.app/api/aviation/v1/track-aircraft') }, {
         icao24: '4b1805',
         swLat: 0,
         swLon: 0,
@@ -2660,7 +2661,7 @@ export const checkScopedRateLimit = async () => ({ allowed: true, degraded: fals
     };
 
     try {
-      const result = await module.trackAircraft({}, {
+      const result = await module.trackAircraft({ request: new Request('https://api.worldmonitor.app/api/aviation/v1/track-aircraft') }, {
         icao24: '4b1805',
         swLat: 0,
         swLon: 0,
@@ -2706,7 +2707,7 @@ export const checkScopedRateLimit = async () => ({ allowed: true, degraded: fals
     };
 
     try {
-      const result = await module.trackAircraft({}, {
+      const result = await module.trackAircraft({ request: new Request('https://api.worldmonitor.app/api/aviation/v1/track-aircraft') }, {
         icao24: '4b1805',
         swLat: 0,
         swLon: 0,
@@ -2795,7 +2796,7 @@ export const checkScopedRateLimit = async () => ({ allowed: true, degraded: fals
     };
 
     try {
-      const result = await module.trackAircraft({}, {
+      const result = await module.trackAircraft({ request: new Request('https://api.worldmonitor.app/api/aviation/v1/track-aircraft') }, {
         icao24: '',
         callsign: '',
         swLat: 10,
@@ -2834,7 +2835,7 @@ export const checkScopedRateLimit = async () => ({ allowed: true, degraded: fals
     };
 
     try {
-      const result = await module.trackAircraft({}, {
+      const result = await module.trackAircraft({ request: new Request('https://api.worldmonitor.app/api/aviation/v1/track-aircraft') }, {
         swLat: 10,
         swLon: 10,
         neLat: 11,


### PR DESCRIPTION
## Summary

Aircraft identifier searches now reject malformed or oversized input before cache and provider work. Equivalent ICAO and callsign inputs share normalized cache keys, and callsign substring searches remain supported. Identifier lookups have a fail-closed 30/minute budget; bbox-only map requests retain their existing gateway limit and provider behavior.

Cloud and Docker requests use the shared trusted-IP limiter, including requests admitted by internal MCP authentication. Missing or failed limiter storage returns 503 with a degraded marker and retry delay; exhausted quota returns 429 with the scoped policy, remaining count and retry delay. The authenticated native sidecar uses a bounded process-local window. These are admission limits, not a global provider spending cap.

Related: DeepSec finding 10.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Desktop app (Tauri)

## Validation

- 88 focused tests passed: input rejection before I/O, canonical cache reuse, actual configured limiter budget and client IP, distinct-key exhaustion, Redis outage, verified MCP admission, bbox global budget, authoritative empty results and provider recovery.
- 96 existing Redis caching tests passed, including all aircraft provider-priority and deadline tests.
- API TypeScript check and Convex call audit passed.
- Native proof uses the actual localhost HTTP server, transport token authentication and generated gateway. It verifies useful OpenSky data, one cached provider request, 30 allowed requests, denial and recovery at the window boundary.
- Full ce-code-review completed sequentially on the committed diff with no actionable findings. The optional cross-model CLI returned no usable output.

External providers and Redis were mocked. No live provider billing, deployed behavior, or production acceptance is claimed. After a separately authorized deployment, verify valid searches and rejection responses, monitor limiter degradation, and confirm bbox/map availability. Rate-limit documentation now records the identifier scope and error headers; no UI or generated files changed.

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript API compiles without errors
- [ ] Live dashboard variant verification (not performed; backend fixture proof above)

Documentation claims were checked against the handler and HTTP fixtures. No screenshots are needed because no UI changed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
