### PR TITLE
fix(conflict): reuse ACLED seed for default requests

### DIFF
--- a/server/worldmonitor/conflict/v1/list-acled-events.ts
+++ b/server/worldmonitor/conflict/v1/list-acled-events.ts
@@ -13,7 +13,7 @@ import type {
   AcledConflictEvent,
 } from '../../../../src/generated/server/worldmonitor/conflict/v1/service_server';
 
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 import { fetchAcledCached } from '../../../_shared/acled';
 
 const REDIS_CACHE_KEY = 'conflict:acled:v1';
@@ -84,6 +84,11 @@ export async function listAcledEvents(
   const window = resolveAcledEventWindow(req);
   const cacheKey = `${REDIS_CACHE_KEY}:${req.country || 'all'}:${window.startMs}:${window.endMs}`;
   try {
+    if (!req.country && req.start === 0 && req.end === 0) {
+      // Railway owns this unprefixed snapshot; misses keep the existing query fallback.
+      const seeded = await getCachedJson(`${REDIS_CACHE_KEY}:all:0:0`, true) as ListAcledEventsResponse | null;
+      if (seeded) return seeded;
+    }
     const result = await cachedFetchJson<ListAcledEventsResponse>(
       cacheKey,
       REDIS_CACHE_TTL,

--- a/server/worldmonitor/conflict/v1/list-acled-events.ts
+++ b/server/worldmonitor/conflict/v1/list-acled-events.ts
@@ -87,7 +87,13 @@ export async function listAcledEvents(
     if (!req.country && req.start === 0 && req.end === 0) {
       // Railway owns this unprefixed snapshot; misses keep the existing query fallback.
       const seeded = await getCachedJson(`${REDIS_CACHE_KEY}:all:0:0`, true) as ListAcledEventsResponse | null;
-      if (seeded) return seeded;
+      if (seeded) {
+        // GDELT fallback rows in this seed have no coordinates and cannot be mapped by this RPC.
+        const events = seeded.events.filter(event => event.location
+          && Number.isFinite(event.location.latitude) && Math.abs(event.location.latitude) <= 90
+          && Number.isFinite(event.location.longitude) && Math.abs(event.location.longitude) <= 180);
+        return { events, pagination: seeded.pagination };
+      }
     }
     const result = await cachedFetchJson<ListAcledEventsResponse>(
       cacheKey,

--- a/tests/acled-seed-key.test.mts
+++ b/tests/acled-seed-key.test.mts
@@ -6,6 +6,7 @@ import { conflictHandler } from '../server/worldmonitor/conflict/v1/handler.ts';
 import { ACLED_DEFAULT_WINDOW_MS } from '../server/worldmonitor/conflict/v1/list-acled-events.ts';
 import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
 import { installRedis } from './helpers/fake-upstash-redis.mts';
+import { mapGdeltExportToConflictEvents } from '../scripts/_conflict-gdelt-bulk.mjs';
 
 const seedKey = 'conflict:acled:v1:all:0:0';
 const route = createConflictServiceRoutes(conflictHandler).find(route => route.path.endsWith('/list-acled-events'))!;
@@ -69,6 +70,19 @@ test('an empty seed is authoritative and does not trigger live fallback', async 
   install({ [seedKey]: { events: [] } });
   assert.deepEqual(await request(), { events: [] });
   assert.deepEqual(keys, [seedKey]);
+});
+
+test('real GDELT fallback rows without coordinates do not become geographic RPC events', async () => {
+  const fields = Array<string>(61).fill('');
+  Object.assign(fields, { 0: 'synthetic-44', 25: '1', 26: '180', 28: '18', 29: '4', 53: 'UP', 59: '20260911120000', 60: 'https://example.com/report' });
+  const fallback = mapGdeltExportToConflictEvents(fields.join('\t'));
+  assert.equal(fallback.length, 1);
+  assert.equal(fallback[0].location, undefined);
+  const redis = install({ [seedKey]: { events: [...snapshot.events, ...fallback] } });
+  assert.deepEqual(await request(), snapshot);
+  redis.redis.set(seedKey, JSON.stringify({ events: fallback }));
+  assert.deepEqual(await request(), { events: [] });
+  assert.deepEqual(keys, [seedKey, seedKey]);
 });
 
 test('country and explicit or partial date filters retain their existing per-query cache identities', async () => {

--- a/tests/acled-seed-key.test.mts
+++ b/tests/acled-seed-key.test.mts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { createConflictServiceRoutes } from '../src/generated/server/worldmonitor/conflict/v1/service_server.ts';
+import { conflictHandler } from '../server/worldmonitor/conflict/v1/handler.ts';
+import { ACLED_DEFAULT_WINDOW_MS } from '../server/worldmonitor/conflict/v1/list-acled-events.ts';
+import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
+import { installRedis } from './helpers/fake-upstash-redis.mts';
+
+const seedKey = 'conflict:acled:v1:all:0:0';
+const route = createConflictServiceRoutes(conflictHandler).find(route => route.path.endsWith('/list-acled-events'))!;
+const originalFetch = globalThis.fetch;
+const originalNow = Date.now;
+const originalEnv = { ...process.env };
+const snapshot = { events: [{ id: 'acled-synthetic-1', eventType: 'Battles', country: 'Ukraine', location: { latitude: 48, longitude: 31 }, occurredAt: 1789000000000, fatalities: 0, actors: ['Synthetic actor'], source: 'Synthetic source', admin1: '' }] };
+let now: number;
+let keys: string[];
+beforeEach(() => {
+  now = Date.UTC(2026, 8, 11, 12);
+  Date.now = () => now;
+  for (const key of ['LOCAL_API_MODE', 'VERCEL_ENV', 'VERCEL_GIT_COMMIT_SHA', 'ACLED_EMAIL', 'ACLED_PASSWORD', 'ACLED_ACCESS_TOKEN']) delete process.env[key];
+  __resetKeyPrefixCacheForTests();
+  keys = [];
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  Date.now = originalNow;
+  for (const key of Object.keys(process.env)) if (!(key in originalEnv)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+  __resetKeyPrefixCacheForTests();
+});
+function install(fixtures: Record<string, unknown>, failSeed = false) {
+  const redis = installRedis(fixtures);
+  globalThis.fetch = (async (input, init) => {
+    const url = new URL(String(input));
+    assert.equal(url.hostname, 'redis.example', 'seed/cache hits must not call ACLED');
+    if (url.pathname.startsWith('/get/')) {
+      const key = decodeURIComponent(url.pathname.slice(5));
+      keys.push(key);
+      if (failSeed && key === seedKey) return Response.json({ error: 'synthetic read failure' }, { status: 503 });
+    }
+    return redis.fetchImpl(input, init);
+  }) as typeof fetch;
+  return redis;
+}
+async function request(query = '') {
+  const response = await route.handler(new Request(`https://api.worldmonitor.app/api/conflict/v1/list-acled-events${query}`));
+  assert.equal(response.status, 200);
+  return response.json();
+}
+
+test('raw default and supported explicit-zero requests read the producer seed across time and preview prefixes', async () => {
+  const producer = await readFile(new URL('../scripts/seed-conflict-intel.mjs', import.meta.url), 'utf8');
+  assert.match(producer, /const ACLED_CACHE_KEY = 'conflict:acled:v1:all:0:0'/);
+  assert.match(producer, /runSeed\('conflict', 'acled-intel', ACLED_CACHE_KEY, fetchAll/);
+  const redis = install({ [seedKey]: { _seed: { fetchedAt: now, recordCount: 1, sourceVersion: 'acled-hapi-pizzint', schemaVersion: 1, state: 'OK' }, data: snapshot } });
+  assert.deepEqual(await request(), snapshot);
+  now += 123456;
+  process.env.VERCEL_ENV = 'preview';
+  process.env.VERCEL_GIT_COMMIT_SHA = '12345678abcdef';
+  __resetKeyPrefixCacheForTests();
+  assert.deepEqual(await request('?country=&start=0&end=0&page_size=0&cursor='), snapshot);
+  assert.deepEqual(keys, [seedKey, seedKey]);
+  assert.deepEqual([...redis.redis.keys()], [seedKey], 'reader must not create or replace seed/cache entries on a hit');
+  assert.deepEqual(JSON.parse(redis.redis.get(seedKey)!).data, snapshot);
+});
+
+test('an empty seed is authoritative and does not trigger live fallback', async () => {
+  install({ [seedKey]: { events: [] } });
+  assert.deepEqual(await request(), { events: [] });
+  assert.deepEqual(keys, [seedKey]);
+});
+
+test('country and explicit or partial date filters retain their existing per-query cache identities', async () => {
+  const requests = [
+    { query: '?country=UA', key: `conflict:acled:v1:UA:${now - ACLED_DEFAULT_WINDOW_MS}:${now}` },
+    { query: '?start=1000&end=2000', key: 'conflict:acled:v1:all:1000:2000' },
+    { query: '?start=1000', key: `conflict:acled:v1:all:1000:${now}` },
+  ];
+  install({ [seedKey]: { events: [] }, ...Object.fromEntries(requests.map(row => [row.key, snapshot])) });
+  for (const row of requests) assert.deepEqual(await request(row.query), snapshot);
+  assert.deepEqual(keys, requests.map(row => row.key));
+});
+
+test('missing or unreadable seed retains the existing resolved-window cache fallback', async () => {
+  const key = `conflict:acled:v1:all:${now - ACLED_DEFAULT_WINDOW_MS}:${now}`;
+  for (const failSeed of [false, true]) {
+    keys = [];
+    install({ [key]: snapshot }, failSeed);
+    assert.deepEqual(await request(), snapshot);
+    assert.deepEqual(keys, [seedKey, key]);
+  }
+});


### PR DESCRIPTION
## Summary

Default ACLED requests can now return the Railway snapshot instead of missing it through a time-dependent query key. The exact all-country default (`country` empty, `start=0`, `end=0`) first reads `conflict:acled:v1:all:0:0` without a deployment prefix. This works for raw GET defaults and the explicit defaults used by the browser and Country Brief, including preview deployments.

The read does not write to the seed key. Only rows with valid coordinates enter this geographic RPC: the seed can contain GDELT fallback rows without coordinates or fatality fields, which are omitted instead of inventing locations or counts. An empty seed is authoritative; a missing or unreadable seed retains the existing query-cache/live fallback. Country and date filters are unchanged.

Related: DeepSec finding 44.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Validation

- The regression failed before the fix: the default request read a timestamp-based key instead of the published seed identity.
- 87 focused tests passed, including real generated RPC decoding and Redis helper reads, wrapped and empty seeds, time advancement, preview prefixes, filtered requests, seed miss/error fallback, and Country Brief regressions, and real GDELT fallback record compatibility.
- API typecheck and Convex call audit passed.
- Full ce-code-review completed sequentially with no actionable findings. Optional independent CLI review was unavailable.

Storage is synthetic. No live ACLED requests, deployed freshness, CDN behavior, or browser rendering is claimed. No UI, gateway, policy, shared ACLED helper, proto, or generated files changed.

## Dependency for finding 43

Finding 43 must inspect this unmerged PR before modifying `list-acled-events.ts` and must not duplicate the default seed read. This PR deliberately preserves live fallback behavior and does not address parameter validation or rate policy. Coordinate overlapping changes against this exact head, then recheck against main after integration.

## Post-Deploy Monitoring & Validation

After separate deployment authorization, the release owner should compare the default origin RPC event IDs with the geolocated rows in the current `conflict:acled:v1:all:0:0` snapshot over one seed cycle. A seed hit should return those rows without ACLED fallback; check origin traces and Redis reads for the fixed key. Watch the existing `acledIntel` freshness status and ACLED error logs. Unexpected empty output with geolocated rows in the seed, or provider work on a seed hit, is a failed acceptance check requiring investigation before acceptance.

## Checklist

- [x] No secrets committed
- [x] TypeScript API compiles
- [x] Focused behavior checks pass
- [ ] Production acceptance (not performed)

Documentation alignment and screenshots are not applicable: no published documentation or UI change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
