### PR TITLE
fix(tenders): retry full World Bank responses within budget

### DIFF
--- a/docs/global-procurement-intelligence.mdx
+++ b/docs/global-procurement-intelligence.mdx
@@ -34,6 +34,10 @@ The Railway seeder runs hourly and stores a canonical snapshot at `economic:glob
 
 Per-source state, record counts, retrieval-attempt time, last-success time, and stale flag are included in the feed response. Every per-source seed key is independently registered in `/api/health`. Unsupported country filters are never treated as a confirmed zero-result source.
 
+World Bank requests cover a sample of up to 100 notices, not the full upstream catalogue. Each request can make three attempts, including response-body reading, with a 20-second attempt timeout and 5- and 10-second retry delays. All attempts and `Retry-After` waits share a 75-second budget. A failed body read can retry; missing or malformed notices and incomplete declared result windows cannot become an empty success.
+
+World Bank and Contracts Finder retain usable open notices only within three hours of the source's last success. Failed attempts and successful aggregate publications do not renew that source clock. A valid empty response clears prior records; a failed request remains a source error, including when the last successful result was empty. If the seeder cannot read the previous canonical snapshot, it preserves the existing publication instead of treating the read failure as missing data. Aggregate completion is not proof that every source succeeded; failed sources remain visible in health and are attempted on the normal hourly cadence.
+
 ## Deployment configuration
 
 Only the U.S. SAM.gov adapter needs a new credential:

--- a/scripts/_global-tenders.mjs
+++ b/scripts/_global-tenders.mjs
@@ -245,7 +245,7 @@ export function mergeTenderSourceResults({ settled, sourceNames, previousSnapsho
         fetchedAt: result.value.status.fetchedAt || attemptedAt,
         lastSuccessfulAt: result.value.status.lastSuccessfulAt || result.value.status.fetchedAt || attemptedAt,
         stale: false,
-        ...(source === 'contracts-finder' ? { consecutiveFailures: 0, firstFailureAt: '' } : {}),
+        ...(['contracts-finder', 'world-bank'].includes(source) ? { consecutiveFailures: 0, firstFailureAt: '' } : {}),
       });
       continue;
     }
@@ -255,7 +255,7 @@ export function mergeTenderSourceResults({ settled, sourceNames, previousSnapsho
     const priorStatus = previousStatuses.get(source);
     const fulfilledStatus = result.status === 'fulfilled' ? result.value?.status : null;
     const error = string(fulfilledStatus?.error || result.reason?.message || 'upstream request failed').slice(0, 200);
-    if (source === 'contracts-finder') {
+    if (['contracts-finder', 'world-bank'].includes(source)) {
       // A bundle success or a failed source attempt is not a source success.
       const lastSuccessfulAt = firstString(priorStatus?.lastSuccessfulAt,
         priorStatus?.state === 'ok' ? priorStatus.fetchedAt : '');

--- a/scripts/seed-global-tenders.mjs
+++ b/scripts/seed-global-tenders.mjs
@@ -74,10 +74,8 @@ function samIpv4ResponseTransport(httpsGetFn = httpsGet) {
   });
 }
 
-// Every tender source funnels through here, so this is the one place a transient
-// upstream blip can be absorbed. Without it a single failed fetch failed the whole
-// source and raised a health warn that self-healed on the next tick — noise the
-// operator cannot act on.
+// Most sources share this HTTP retry path. World Bank wraps the complete JSON
+// read separately so body failures share its bounded retry budget.
 //
 // The retry budget is BOUNDED by the bundle section, not chosen for its own sake:
 // Global-Tenders has timeoutMs 180_000 and CanadaBuys uses a 60s per-attempt
@@ -313,7 +311,42 @@ export async function fetchGets({ now = Date.now(), fetchTextFn = fetchText } = 
   return { records, status: sourceStatus('gets', 'ok', records, '', now) };
 }
 
-export async function fetchWorldBank({ now = Date.now(), fetchJsonFn = fetchJson } = {}) {
+async function fetchWorldBankJson(url) {
+  // Include body consumption in each attempt. Retrying only fetch() leaves
+  // timeouts and truncated JSON after successful headers outside the retry loop.
+  const deadline = Date.now() + 75_000;
+  let attempt = 0;
+  return withRetry(async () => {
+    attempt += 1;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw Object.assign(new Error('World Bank request budget exhausted'), { nonRetryable: true });
+    }
+    let phase = 'headers';
+    try {
+      const response = await fetchResponseTransport(url, {
+        timeoutMs: Math.min(20_000, remaining),
+        headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+      });
+      if (!response.ok) {
+        const error = httpRetryError(response, { remainingBudgetMs: deadline - Date.now() });
+        await response.body?.cancel().catch(() => {});
+        throw error;
+      }
+      phase = 'body';
+      return await response.json();
+    } catch (error) {
+      const wait = Math.max(5000 * 2 ** (attempt - 1), error.retryAfterMs || 0);
+      if (wait >= deadline - Date.now()) error.nonRetryable = true;
+      const reason = error.status ? `HTTP_${error.status}`
+        : ['TimeoutError', 'AbortError', 'SyntaxError'].includes(error.name) ? error.name : 'transport';
+      console.warn(`[World-Bank] attempt=${attempt}/3 phase=${phase} failure=${reason}`);
+      throw error;
+    }
+  }, 2, 5000);
+}
+
+export async function fetchWorldBank({ now = Date.now(), fetchJsonFn = fetchWorldBankJson } = {}) {
   const url = new URL('https://search.worldbank.org/api/v2/procnotices');
   url.searchParams.set('format', 'json');
   url.searchParams.set('rows', String(MAX_PER_SOURCE));
@@ -325,13 +358,27 @@ export async function fetchWorldBank({ now = Date.now(), fetchJsonFn = fetchJson
   url.searchParams.set('srce', 'both');
   url.searchParams.set('notice_type_exact', 'Invitation for Bids^Invitation for Prequalification^Request for Expression of Interest');
   url.searchParams.set('deadline_strdate', new Date(now).toISOString().slice(0, 10));
-  const payload = await fetchJsonFn(url, { retryDelayMs: 5000 });
+  const payload = await fetchJsonFn(url);
   const rawNotices = payload?.procnotices;
-  if (!rawNotices || (typeof rawNotices !== 'object' && !Array.isArray(rawNotices))) {
+  if (!rawNotices || typeof rawNotices !== 'object') {
     throw new Error('World Bank response is missing procnotices');
   }
-  const notices = Array.isArray(rawNotices) ? rawNotices : Object.values(rawNotices || {});
-  const records = notices.map(normalizeWorldBankNotice).filter((tender) => isOpenOpportunity(tender, now));
+  const notices = Array.isArray(rawNotices) ? rawNotices : Object.values(rawNotices);
+  const normalized = notices.map(normalizeWorldBankNotice);
+  if (normalized.some((tender) => !tender?.sourceNoticeId || !tender.title || !Number.isFinite(Date.parse(tender.deadline)))) {
+    throw new Error('World Bank response contains malformed notices');
+  }
+  // This is a bounded sample, not a full-corpus crawl. When the provider
+  // declares its result window, a truncated window must not clear prior data.
+  if (payload.total != null) {
+    const total = Number(payload.total);
+    if (!/^\d+$/.test(String(payload.total)) || !Number.isSafeInteger(total)
+      || notices.length !== Math.min(MAX_PER_SOURCE, total)
+      || (payload.os != null && Number(payload.os) !== 0)) {
+      throw new Error('World Bank response contains an incomplete notice window');
+    }
+  }
+  const records = normalized.filter((tender) => isOpenOpportunity(tender, now));
   return { records, status: sourceStatus('world-bank', 'ok', records, '', now) };
 }
 
@@ -385,8 +432,8 @@ async function recordUnavailableSourceHealth(snapshot) {
 }
 
 export function sourceHealthMeta(status) {
-  const contractsFinder = status.source === 'contracts-finder';
-  const successTime = status.lastSuccessfulAt || ((!contractsFinder || status.state === 'ok') ? status.fetchedAt : '');
+  const trackedSource = ['contracts-finder', 'world-bank'].includes(status.source);
+  const successTime = status.lastSuccessfulAt || ((!trackedSource || status.state === 'ok') ? status.fetchedAt : '');
   const successfulAt = Date.parse(successTime || '');
   const failed = status.state !== 'ok';
   return {
@@ -394,7 +441,7 @@ export function sourceHealthMeta(status) {
     recordCount: status.recordCount || 0,
     sourceState: status.state,
     stale: Boolean(status.stale || failed),
-    ...(contractsFinder ? {
+    ...(trackedSource ? {
       lastAttemptAt: status.fetchedAt,
       lastSuccessfulAt: status.lastSuccessfulAt || '',
       consecutiveFailures: status.consecutiveFailures,
@@ -412,11 +459,12 @@ async function writeSourceStatus(status) {
   await writeExtraKey(metaKey, sourceHealthMeta(status), SOURCE_STATUS_TTL_SECONDS);
 }
 
-async function main() {
+export async function main({ adapters, now } = {}) {
   loadEnvFile(import.meta.url);
   await runSeed('economic', 'global-tenders', GLOBAL_TENDER_KEY, async () => {
     const snapshot = await fetchGlobalTenders({
-      previousSnapshot: await readCanonicalValue(GLOBAL_TENDER_KEY).catch(() => null),
+      adapters, now,
+      previousSnapshot: await readCanonicalValue(GLOBAL_TENDER_KEY, { strict: true }),
     });
     // A fully unavailable initial run fails canonical validation by design, but
     // operators still need the per-source failure states written to health.

--- a/tests/global-tenders-world-bank-pipeline.test.mts
+++ b/tests/global-tenders-world-bank-pipeline.test.mts
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict';
+import test, { type TestContext } from 'node:test';
+import { main, fetchWorldBank } from '../scripts/seed-global-tenders.mjs';
+import { listGlobalTenders } from '../server/worldmonitor/economic/v1/list-global-tenders';
+import type { ListGlobalTendersRequest, ServerContext } from '../src/generated/server/worldmonitor/economic/v1/service_server';
+import { __testing__ as health } from '../api/health.js';
+import { readSectionFreshness } from '../scripts/_bundle-runner.mjs';
+
+const NOW = Date.parse('2026-09-11T14:00:00Z');
+const KEY = 'economic:global-tenders:v1';
+const SOURCE_KEY = `${KEY}:source:world-bank`;
+const SOURCE_META = 'seed-meta:economic:global-tenders:world-bank';
+const COMPLETE = 'seed-completion:economic:global-tenders';
+const PAYLOAD = { procnotices: [{ id: 'OP1', notice_type: 'Invitation for Bids', bid_description: 'Network services',
+  project_ctry_code: 'IN', submission_deadline_date: '2026-10-01T00:00:00Z' }] };
+const REQUEST: ListGlobalTendersRequest = {
+  country: '', countries: [], region: '', source: 'world-bank', status: '', deadlineFrom: '', deadlineTo: '',
+  minValue: 0, maxValue: 0, currency: '', category: '', query: '', pageSize: 100, cursor: '', sort: 'closing_soon',
+  buyer: '', publishedFrom: '', publishedTo: '', minAutomationScore: 0,
+};
+
+function fixture(t: TestContext) {
+  const values = new Map<string, string>();
+  const expires = new Map<string, number>();
+  const logs: string[] = [];
+  const state = { now: NOW, payload: structuredClone(PAYLOAD) as unknown, mode: 'ok', attempts: 0,
+    siblingCalls: 0, siblingFailed: false, rejectWrite: '', rejectRead: false };
+  const priorEnv = { ...process.env };
+  const listeners = new Set(process.rawListeners('SIGTERM'));
+  Object.assign(process.env, { UPSTASH_REDIS_REST_URL: 'https://redis.fixture', UPSTASH_REDIS_REST_TOKEN: 'fixture',
+    WM_BUNDLE_COMPLETION_META_KEY: COMPLETE, WM_SEED_RETRY_DELAY_MS: '0' });
+  delete process.env.LOCAL_API_MODE;
+  t.after(() => {
+    for (const key of Object.keys(process.env)) if (!(key in priorEnv)) delete process.env[key];
+    Object.assign(process.env, priorEnv);
+    for (const listener of process.rawListeners('SIGTERM')) if (!listeners.has(listener)) process.removeListener('SIGTERM', listener);
+  });
+  t.mock.method(Date, 'now', () => state.now);
+  for (const level of ['log', 'warn', 'error'] as const) t.mock.method(console, level, (...args) => logs.push(args.join(' ')));
+  t.mock.method(process, 'exit', (code) => { throw new Error(`exit ${code}`); });
+  const get = (key: string) => {
+    if ((expires.get(key) ?? Infinity) <= state.now) { values.delete(key); expires.delete(key); }
+    return values.get(key) ?? null;
+  };
+  const read = (key: string) => JSON.parse(get(key) ?? 'null');
+  const command = (cmd: Array<string | number>) => {
+    const [op, rawKey, value] = cmd;
+    const key = String(rawKey);
+    if (op === 'SET') {
+      values.set(key, String(value));
+      const ex = cmd.indexOf('EX');
+      if (ex >= 0) expires.set(key, state.now + Number(cmd[ex + 1]) * 1000);
+      else expires.delete(key);
+      return 'OK';
+    }
+    if (op === 'GET') return get(key);
+    if (op === 'EXISTS') return get(key) == null ? 0 : 1;
+    if (op === 'EXPIRE') { if (get(key) == null) return 0; expires.set(key, state.now + Number(value) * 1000); return 1; }
+    if (op === 'DEL') return Number(values.delete(key));
+    if (op === 'EVAL') return 1;
+    throw new Error(`Unexpected Redis command ${op}`);
+  };
+  t.mock.method(globalThis, 'fetch', async (url, options = {}) => {
+    const parsed = new URL(String(url));
+    if (parsed.hostname === 'redis.fixture') {
+      if (parsed.pathname.startsWith('/get/')) {
+        const key = decodeURIComponent(parsed.pathname.slice(5));
+        if (state.rejectRead && key === KEY) return new Response('{}', { status: 403 });
+        return Response.json({ result: get(key) });
+      }
+      const body = JSON.parse(String(options.body));
+      const cmds = Array.isArray(body[0]) ? body : [body];
+      if (cmds.some((cmd: string[]) => cmd[0] === 'SET' && cmd[1] === state.rejectWrite)) return new Response('{}', { status: 403 });
+      const results = cmds.map((cmd: Array<string | number>) => ({ result: command(cmd) }));
+      return Response.json(Array.isArray(body[0]) ? results : results[0]);
+    }
+    assert.equal(parsed.hostname, 'search.worldbank.org', 'no unmocked provider requests');
+    state.attempts++;
+    if (state.mode === '500') return new Response('private upstream body', { status: 500 });
+    if (state.mode === 'body-timeout-once' && state.attempts === 1) {
+      return new Response(new ReadableStream({ start(controller) {
+        controller.error(new DOMException('body timeout', 'TimeoutError'));
+      } }));
+    }
+    return Response.json(state.payload);
+  });
+  const adapters = [['world-bank', fetchWorldBank], ['ted', async ({ now }: { now: number }) => {
+    state.siblingCalls++;
+    if (state.siblingFailed) throw new Error('sibling failed');
+    return { records: [], status: { source: 'ted', state: 'ok', recordCount: 0,
+      fetchedAt: new Date(now).toISOString(), lastSuccessfulAt: new Date(now).toISOString() } };
+  }]];
+  const run = async () => {
+    try { await main({ adapters, now: state.now }); }
+    catch (error) { if (!(error instanceof Error) || error.message !== 'exit 0') throw error; }
+  };
+  const rpc = () => listGlobalTenders({ request: new Request('https://fixture/rpc') } as ServerContext, REQUEST);
+  const sourceHealth = () => health.classifyKey('globalTendersWorldBank', SOURCE_KEY, { allowOnDemand: true }, {
+    keyStrens: new Map([[SOURCE_KEY, get(SOURCE_KEY)?.length ?? 0]]), keyErrors: new Map(),
+    keyMetaValues: new Map([[SOURCE_META, get(SOURCE_META)]]), keyMetaErrors: new Map(), now: state.now,
+  });
+  return { state, values, read, run, rpc, sourceHealth, logs };
+}
+
+test('actual producer/cache/RPC chain retries a failed body before publication', async t => {
+  const f = fixture(t);
+  f.state.mode = 'body-timeout-once';
+  await f.run();
+  assert.equal(f.state.attempts, 2);
+  const response = await f.rpc();
+  assert.equal(response.total, 1);
+  assert.equal(response.sourceStatuses[0].state, 'ok');
+  assert.equal(f.sourceHealth().status, 'OK');
+  assert.equal(f.read(COMPLETE).fetchedAt, f.read(KEY)._seed.fetchedAt);
+});
+
+test('repeated HTTP 500 retains usable records and source clocks independently of the aggregate, then recovers', async t => {
+  const f = fixture(t);
+  await f.run();
+  f.state.mode = '500';
+  for (const minutes of [60, 120]) {
+    f.state.now = NOW + minutes * 60_000;
+    await f.run();
+    const response = await f.rpc();
+    assert.equal(response.total, 1);
+    assert.equal(response.availability, 'partial');
+    assert.equal(response.sourceStatuses[0].state, 'stale');
+    assert.equal(Date.parse(response.sourceStatuses[0].lastSuccessfulAt), NOW);
+    assert.equal(f.read(SOURCE_META).fetchedAt, NOW);
+    assert.equal(f.read(SOURCE_META).lastAttemptAt, new Date(f.state.now).toISOString());
+    assert.equal(f.sourceHealth().status, 'SEED_ERROR');
+    assert.equal(f.read(KEY)._seed.fetchedAt, f.state.now);
+    const freshness = await readSectionFreshness({ canonicalKey: KEY, completionMetaKey: COMPLETE }, async key => f.read(key));
+    assert.equal(freshness.fetchedAt, f.state.now);
+    assert.ok(f.state.now + 60 * 60_000 - freshness.fetchedAt >= 0.8 * 60 * 60_000, 'next hourly run remains due');
+  }
+  assert.equal(f.state.attempts, 7, 'one initial success and three attempts per failed run');
+  assert.equal(f.read(SOURCE_META).consecutiveFailures, 2);
+  assert.equal(f.logs.some(line => line.includes('private upstream body')), false);
+  f.state.now += 30 * 60_000;
+  f.state.mode = 'ok';
+  await f.run();
+  assert.equal((await f.rpc()).sourceStatuses[0].state, 'ok');
+  assert.equal(f.read(SOURCE_META).fetchedAt, f.state.now);
+  assert.equal(f.read(SOURCE_META).consecutiveFailures, 0);
+  assert.equal(f.read(SOURCE_META).error, undefined);
+});
+
+for (const payload of [null, { procnotices: [{}] }, { total: 2, procnotices: PAYLOAD.procnotices }]) {
+  test(`missing/malformed/partial provider data cannot clear a usable source: ${JSON.stringify(payload)}`, async t => {
+    const f = fixture(t);
+    await f.run();
+    f.state.now += 60 * 60_000;
+    f.state.payload = payload;
+    await f.run();
+    assert.equal((await f.rpc()).total, 1);
+    assert.equal(f.sourceHealth().status, 'SEED_ERROR');
+    assert.equal(f.read(SOURCE_META).fetchedAt, NOW);
+  });
+}
+
+test('confirmed empty clears old data, and a subsequent failure stays distinct from empty success', async t => {
+  const f = fixture(t);
+  await f.run();
+  f.state.now += 30 * 60_000;
+  f.state.payload = { total: '0', procnotices: {} };
+  await f.run();
+  assert.equal((await f.rpc()).total, 0);
+  assert.equal(f.read(SOURCE_META).sourceState, 'ok');
+  const emptyAt = f.state.now;
+  f.state.now += 30 * 60_000;
+  f.state.mode = '500';
+  await f.run();
+  assert.equal(f.read(SOURCE_META).confirmedEmpty, true);
+  assert.equal(f.read(SOURCE_META).fetchedAt, emptyAt);
+  assert.equal(f.sourceHealth().status, 'SEED_ERROR');
+});
+
+for (const scenario of ['expired-deadline', 'expired-source', 'missing', 'unusable', 'unknown-clock']) {
+  test(`failed source does not retain ${scenario} data or borrow the aggregate success clock`, async t => {
+    const f = fixture(t);
+    await f.run();
+    const snapshot = f.read(KEY);
+    if (scenario === 'expired-deadline') snapshot.data.tenders[0].deadline = new Date(NOW + 1).toISOString();
+    if (scenario === 'unusable') snapshot.data.tenders[0].officialUrl = 'https://untrusted.test/';
+    if (scenario === 'unknown-clock') snapshot.data.sourceStatuses[0] = { source: 'world-bank', state: 'error', fetchedAt: new Date(NOW).toISOString() };
+    f.values.set(KEY, JSON.stringify(snapshot));
+    if (scenario === 'missing') f.values.delete(KEY);
+    f.state.mode = '500';
+    // Keep refreshing the aggregate through healthy siblings, while World Bank ages out.
+    for (const minutes of scenario === 'expired-source' ? [60, 120, 180] : [60]) {
+      f.state.now = NOW + minutes * 60_000;
+      await f.run();
+    }
+    assert.equal((await f.rpc()).total, 0);
+    assert.equal(f.read(SOURCE_META).sourceState, 'error');
+    assert.equal(f.read(SOURCE_META).fetchedAt, ['missing', 'unknown-clock'].includes(scenario) ? 0 : NOW);
+    assert.notEqual(f.sourceHealth().status, 'OK');
+  });
+}
+
+test('expired Redis canonical is unavailable at the actual reader', async t => {
+  const f = fixture(t);
+  await f.run();
+  f.state.now += 181 * 60_000;
+  assert.equal((await f.rpc()).availability, 'unavailable');
+});
+
+test('an initial all-source failure writes actionable source health without canonical or completion success', async t => {
+  const f = fixture(t);
+  f.state.mode = '500';
+  f.state.siblingFailed = true;
+  await f.run();
+  assert.equal(f.read(KEY), null);
+  assert.equal(f.read(COMPLETE), null);
+  assert.equal(f.read(SOURCE_META).fetchedAt, 0);
+  assert.equal(f.read(SOURCE_META).sourceState, 'error');
+  assert.equal((await f.rpc()).availability, 'unavailable');
+  assert.notEqual(f.sourceHealth().status, 'OK');
+  assert.equal(f.logs.some(line => line.includes('seed_complete')), false);
+});
+
+test('failed source-status write prevents a new aggregate completion attestation', async t => {
+  const f = fixture(t);
+  await f.run();
+  const completed = f.read(COMPLETE);
+  f.state.now += 60 * 60_000;
+  f.state.rejectWrite = SOURCE_META;
+  await assert.rejects(f.run(), /403|exit 1/);
+  assert.deepEqual(f.read(COMPLETE), completed);
+  assert.equal(await readSectionFreshness({ canonicalKey: KEY, completionMetaKey: COMPLETE }, async key => f.read(key)), null);
+});
+
+test('a failed canonical read cannot publish an aggregate that silently drops retained World Bank data', async t => {
+  const f = fixture(t);
+  await f.run();
+  const prior = f.read(KEY);
+  const completed = f.read(COMPLETE);
+  f.state.now += 60 * 60_000;
+  f.state.mode = '500';
+  f.state.rejectRead = true;
+  await assert.rejects(f.run(), /exit 75/);
+  assert.deepEqual(f.read(KEY), prior);
+  assert.deepEqual(f.read(COMPLETE), completed);
+  assert.equal(f.state.attempts, 1, 'failed cache dependency must stop before provider requests');
+  assert.equal(f.state.siblingCalls, 1);
+});

--- a/tests/global-tenders-world-bank-retry.test.mjs
+++ b/tests/global-tenders-world-bank-retry.test.mjs
@@ -27,7 +27,7 @@ function provider(t, respond) {
     calls.push({ url: String(url), options });
     return respond({ elapsed, attempt: calls.length });
   });
-  return { calls, waits, timeouts };
+  return { calls, waits, timeouts, elapse: (ms) => { elapsed += ms; }, elapsed: () => elapsed };
 }
 
 test('World Bank can recover after the former three-second retry window', async (t) => {
@@ -87,4 +87,82 @@ test('World Bank distinguishes a valid empty response from malformed data', asyn
   assert.equal(result.status.state, 'ok');
   await assert.rejects(fetchWorldBank({ now: NOW }), /missing procnotices/);
   assert.equal(calls.length, 2);
+});
+
+test('World Bank retries a timeout while reading the response body', async (t) => {
+  const { calls, waits } = provider(t, ({ attempt }) => attempt === 1
+    ? { ok: true, json: async () => { throw new DOMException('body timeout', 'TimeoutError'); } }
+    : Response.json(PAYLOAD));
+  const result = await fetchWorldBank({ now: NOW });
+  assert.equal(result.records.length, 1);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(waits, [5000]);
+});
+
+test('World Bank retries truncated JSON before publishing a source result', async (t) => {
+  const { calls } = provider(t, ({ attempt }) => attempt === 1
+    ? new Response('{"procnotices":[')
+    : Response.json(PAYLOAD));
+  assert.equal((await fetchWorldBank({ now: NOW })).status.state, 'ok');
+  assert.equal(calls.length, 2);
+});
+
+test('World Bank does not sleep through its source budget on Retry-After', async (t) => {
+  const { calls, waits } = provider(t, () => new Response('', { status: 503, headers: { 'Retry-After': '120' } }));
+  await assert.rejects(fetchWorldBank({ now: NOW }), /503/);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(waits, []);
+});
+
+test('malformed World Bank rows and incomplete windows are failures, not empty success', async () => {
+  for (const payload of [
+    { procnotices: [null] }, { procnotices: [{}] },
+    { procnotices: [{ id: 'OP1', bid_description: 'Missing deadline' }] },
+    { rows: 100, os: 0, total: '2', procnotices: PAYLOAD.procnotices },
+  ]) {
+    await assert.rejects(fetchWorldBank({ now: NOW, fetchJsonFn: async () => payload }), /World Bank/);
+  }
+});
+
+test('World Bank failure without prior success never gains a success clock', () => {
+  const status = { source: 'world-bank', state: 'error', fetchedAt: new Date(NOW).toISOString(), lastSuccessfulAt: '', recordCount: 0 };
+  assert.equal(sourceHealthMeta(status).fetchedAt, 0);
+});
+
+test('persistent full-attempt timeouts consume at most 75 seconds and three attempts', async (t) => {
+  const clock = provider(t, () => {
+    clock.elapse(20_000);
+    throw new DOMException('request timeout', 'TimeoutError');
+  });
+  t.mock.method(Date, 'now', () => NOW + clock.elapsed());
+  await assert.rejects(fetchWorldBank({ now: NOW }), /timeout/);
+  assert.equal(clock.calls.length, 3);
+  assert.equal(clock.elapsed(), 75_000);
+  assert.deepEqual(clock.timeouts, [20_000, 20_000, 20_000]);
+});
+
+test('Retry-After reduces the remaining attempt timeout instead of exceeding the source budget', async (t) => {
+  const clock = provider(t, ({ attempt }) => {
+    if (attempt === 1) return new Response('', { status: 503, headers: { 'Retry-After': '60' } });
+    clock.elapse(clock.timeouts.at(-1));
+    throw new DOMException('request timeout', 'TimeoutError');
+  });
+  t.mock.method(Date, 'now', () => NOW + clock.elapsed());
+  await assert.rejects(fetchWorldBank({ now: NOW }), /timeout/);
+  assert.equal(clock.calls.length, 2);
+  assert.deepEqual(clock.timeouts, [20_000, 15_000]);
+  assert.deepEqual(clock.waits, [60_000]);
+  assert.equal(clock.elapsed(), 75_000);
+});
+
+test('repeated body failures use the same three-attempt cap and identify the failed phase', async (t) => {
+  const warnings = [];
+  t.mock.method(console, 'warn', (message) => warnings.push(message));
+  const { calls, waits } = provider(t, () => new Response(new ReadableStream({ start(controller) {
+    controller.error(new DOMException('body timeout', 'TimeoutError'));
+  } })));
+  await assert.rejects(fetchWorldBank({ now: NOW }), /body timeout/);
+  assert.equal(calls.length, 3);
+  assert.deepEqual(waits, [5000, 10_000]);
+  assert.equal(warnings.filter(line => /\[World-Bank\].*phase=body failure=TimeoutError/.test(line)).length, 3);
 });


### PR DESCRIPTION
## Summary

World Bank retries stopped at successful HTTP headers: a timeout or truncated JSON while reading the body bypassed the remaining attempts. Retry the complete response, with at most three attempts, the existing 20-second attempt timeout and 5/10-second delays, and a 75-second total budget that also bounds Retry-After waits. Add provider/attempt/phase diagnostics for subsequent failures.

Reject malformed notices and incomplete declared result windows instead of clearing usable records as an empty success. Apply the existing Contracts Finder retention rules to World Bank: keep usable open records within the three-hour source budget and never borrow an attempt or aggregate timestamp as source success. Use the existing strict canonical reader so a failed Redis read cannot discard retained records during an aggregate publish. Valid empty, unavailable and failed remain distinct. The hourly cadence and 100-notice sample are unchanged.

## Incident evidence

The September 11 15:02 source record reported a timeout, 56 retained records, and last success at 14:01:13 UTC. Aggregate publication of 518 records was not World Bank success. Railway's successful deployed revision `c12751fb9f9300d3f2f12436ea5bc82430f6bcc3` includes #7966 and has identical affected code to this PR's main base. #7966 only widened retry spacing; it did not cover body reads, total Retry-After budget, or missing-source success clocks.

Old retry lines were not provider-labelled and did not identify the timeout phase; the reproduced body-read gap is a proven remaining defect, not a claim about the exact phase of that incident. Natural source metadata later confirmed World Bank success at 17:00:53 UTC. Two bounded, read-only public GETs completed in 468/664 ms with 56 open records, so this PR does not speculate by raising the timeout. Natural hourly runs continued; no missed hourly admission was established.

## Validation

- Five new regression cases failed before implementation: body timeout, truncated JSON, excessive Retry-After, malformed notices, and a failed source gaining a success timestamp.
- A separate producer/cache test reproduced lost retention after a failed canonical read before the strict-read repair.
- 113 focused checks pass, including actual main/runSeed -> synthetic Redis -> real RPC/health/bundle freshness. Covers repeated 500, partial payloads, recovery, missing/unusable/expired data, confirmed empty, independent source/aggregate clocks, cache read/write failures, and completion attestation. Virtual-clock cases prove three-attempt/75-second bounds and reduced remaining timeout after Retry-After.
- Browser and API TypeScript checks, boundary lint, focused Biome lint and diff checks pass. Full lint passes with existing warnings outside the changed files. All pre-push gates and CI checks pass on `11bfd45a53bffa69ce06a76b9d629c8f5384bcf9`, including all three unit shards, browser smoke, WebMCP smoke, sidecar, security analysis and previews. No CI rerun or repair was needed.
- ce-simplify-code and ce-code-review completed sequentially under repository instructions; applicable findings were fixed. No independent cross-model review or external review automation was invoked.

No production seeder, paid probe, Redis/config write, deployment or merge was performed.

## Post-Deploy Monitoring & Validation

Owner: deploying maintainer. After an authorized deployment, observe two natural hourly `Global-Tenders` runs on Railway `seed-bundle-relay-backup` and the first naturally occurring World Bank failure/recovery. Search logs for `[World-Bank]`, `phase=headers`, `phase=body`, `seed_complete` and the bundle section summary. Expect at most three World Bank attempts and at most 75 seconds of request/wait budget, with time left for publication inside the 180-second section.

Read `economic:global-tenders:v1:source:world-bank`, `seed-meta:economic:global-tenders:world-bank` and health `globalTendersWorldBank`. A real success must refresh lastSuccessfulAt and clear the error. Failure must remain visible, retain only usable records within the source budget, and never advance source success from an aggregate publish. A failed canonical read must preserve the old publication/completion marker. Valid empty must clear records without being classified as a failed request. Compare the RPC response with source metadata; aggregate OK alone is insufficient.

Investigate persistent malformed-window errors or rejected previously valid source data; revert if validation incorrectly rejects the real provider contract, retained data disappears before its budget/deadline, or the bounded operation exceeds the section budget. Do not trigger production runs solely to manufacture acceptance. This repair cannot eliminate external outages; post-deploy natural acceptance remains open.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
