### PR TITLE
fix(gdelt): discard partial manifest range prefixes

### DIFF
--- a/scripts/seed-gdelt-bulk-materializer.mjs
+++ b/scripts/seed-gdelt-bulk-materializer.mjs
@@ -157,7 +157,7 @@ function validateCurrentFeedCohort(values, nowMs) {
   }
 }
 
-async function fetchBoundedBuffer(fetchImpl, url, maxBytes, { expectedStatus, ...options } = {}) {
+async function fetchBoundedBuffer(fetchImpl, url, maxBytes, { expectedStatus, discardRangePrefix = false, ...options } = {}) {
   const response = await fetchImpl(url, {
     ...options,
     headers: {
@@ -183,7 +183,19 @@ async function fetchBoundedBuffer(fetchImpl, url, maxBytes, { expectedStatus, ..
     if (total > maxBytes) throw new Error(`GDELT bulk response exceeds ${maxBytes} bytes`);
     chunks.push(Buffer.from(chunk));
   }
-  return Buffer.concat(chunks, total);
+  const buffer = Buffer.concat(chunks, total);
+  if (!discardRangePrefix) return buffer;
+  const range = /^bytes (\d+)-(\d+)\/(\d+)$/.exec(response.headers.get('content-range') ?? '');
+  const [start, end, size] = range ? range.slice(1).map(Number) : [];
+  if (!range || ![start, end, size].every(Number.isSafeInteger)
+    || start < 0 || end < start || end >= size || end - start + 1 !== total) {
+    throw new Error('GDELT bulk manifest has invalid Content-Range');
+  }
+  // A nonzero offset can split the size field, leaving a valid-looking "0".
+  // Only byte zero establishes that the first descriptor is complete.
+  if (start === 0) return buffer;
+  const newline = buffer.indexOf(10);
+  return newline < 0 ? Buffer.alloc(0) : buffer.subarray(newline + 1);
 }
 
 async function mapWithConcurrency(values, limit, fn) {
@@ -214,6 +226,7 @@ export async function fetchGdeltBulkFiles({
     {
       headers: { Range: `bytes=-${MASTER_TAIL_BYTES}` },
       expectedStatus: 206,
+      discardRangePrefix: true,
     },
   );
   const descriptors = parseGdeltBulkDescriptors(manifest.toString('utf8'), {

--- a/tests/seed-gdelt-bulk-materializer.test.mjs
+++ b/tests/seed-gdelt-bulk-materializer.test.mjs
@@ -133,7 +133,7 @@ function bulkFixture({
   return { manifest: `${gkgLine}\n${exportLine}\n`, files };
 }
 
-function fakeBulkFetch(manifest, files, manifestStatus = 206) {
+function fakeBulkFetch(manifest, files, manifestStatus = 206, rangeStart = 0) {
   let requestNumber = 0;
   return async (url) => {
     requestNumber += 1;
@@ -141,7 +141,12 @@ function fakeBulkFetch(manifest, files, manifestStatus = 206) {
     assert.ok(body, `unexpected bulk request: ${url}`);
     return new Response(body, {
       status: requestNumber === 1 ? manifestStatus : 200,
-      headers: { 'content-length': String(body.length) },
+      headers: {
+        'content-length': String(body.length),
+        ...(requestNumber === 1 ? {
+          'content-range': `bytes ${rangeStart}-${rangeStart + body.length - 1}/${rangeStart + body.length}`,
+        } : {}),
+      },
     });
   };
 }
@@ -160,6 +165,52 @@ describe('seed-gdelt-bulk-materializer download boundaries', () => {
     );
     assert.equal(downloaded.find(({ descriptor }) => descriptor.kind === 'gkg').records[0].id, 'gkg-1');
     assert.equal(downloaded.find(({ descriptor }) => descriptor.kind === 'export').events[0].id, 'gdelt-event-event-1');
+  });
+
+  it('discards an ambiguous suffix prefix before parsing size or applying cursors', async () => {
+    const fixture = bulkFixture();
+    for (const size of ['0', '9']) {
+      const prefix = `${size} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa https://data.gdeltproject.org/gdeltv2/20260730114500.export.CSV.zip\n`;
+      const downloaded = await fetchGdeltBulkFiles({
+        fetchImpl: fakeBulkFetch(prefix + fixture.manifest, fixture.files, 206, 123),
+        nowMs: Date.parse('2026-07-30T12:05:00Z'),
+      });
+      assert.equal(downloaded.length, 2);
+    }
+  });
+
+  it('still rejects a complete zero-size descriptor after the range prefix or at byte zero', async () => {
+    const fixture = bulkFixture({ gkgDescriptor: { size: 0 } });
+    for (const rangeStart of [0, 123]) {
+      await assert.rejects(fetchGdeltBulkFiles({
+        fetchImpl: fakeBulkFetch(
+          (rangeStart ? 'partial line\n' : '') + fixture.manifest,
+          fixture.files, 206, rangeStart,
+        ),
+        nowMs: Date.parse('2026-07-30T12:05:00Z'),
+      }), /invalid GDELT gkg ZIP size: 0/);
+    }
+  });
+
+  it('rejects missing or inconsistent range metadata before downloading files', async () => {
+    const fixture = bulkFixture();
+    for (const contentRange of [null, 'bytes */100', 'bytes 5-4/100', 'bytes 0-9/9', 'bytes 0-9/100']) {
+      await assert.rejects(fetchGdeltBulkFiles({
+        fetchImpl: async () => new Response(fixture.manifest, {
+          status: 206,
+          headers: contentRange ? { 'content-range': contentRange } : {},
+        }),
+        nowMs: Date.parse('2026-07-30T12:05:00Z'),
+      }), /invalid Content-Range/);
+    }
+  });
+
+  it('cannot download a descriptor from a prefix without a line boundary', async () => {
+    const fixture = bulkFixture();
+    await assert.rejects(fetchGdeltBulkFiles({
+      fetchImpl: fakeBulkFetch(fixture.manifest.split('\n')[0], fixture.files, 206, 123),
+      nowMs: Date.parse('2026-07-30T12:05:00Z'),
+    }), /no newer GKG or export snapshot/);
   });
 
   it('requires a partial-content manifest response', async () => {
@@ -233,7 +284,10 @@ describe('seed-gdelt-bulk-materializer download boundaries', () => {
           assert.equal(requestCount, 1, 'cohort validation must run before file downloads');
           return new Response(Buffer.from(manifest), {
             status: 206,
-            headers: { 'content-length': String(Buffer.byteLength(manifest)) },
+            headers: {
+              'content-length': String(Buffer.byteLength(manifest)),
+              'content-range': `bytes 0-${Buffer.byteLength(manifest) - 1}/${Buffer.byteLength(manifest)}`,
+            },
           });
         },
         nowMs: Date.parse('2026-07-30T12:05:00Z'),


### PR DESCRIPTION
## Summary

The GDELT worker can refresh intelligence when a suffix-range manifest response starts inside a file-size field. Previously a remaining `0` could be treated as a complete zero-size export and fail the whole run. The HTTP range offset now establishes whether the first line is trustworthy; at a nonzero offset that ambiguous line is discarded, while complete descriptors and cohort checks remain strict. Byte-zero responses retain their first entry, and missing or inconsistent range metadata fails closed.

Railway's September 11 18:00 UTC run exited 75 after `invalid GDELT export ZIP size: 0`; the preceding 34 observed runs completed OK. The exact failed response was not captured, so range truncation is a reproduced defect and likely incident cause, not a proven historical fact. No production seeder, configuration, or Redis mutation was performed.

## Validation

- Before repair, the new download-boundary regression failed with the exact zero-size error. After repair, 90 focused checks pass across real descriptor parsing, ZIP decoding, materialization, publication, consumer cutover, country search, health and failure TTL preservation, using controlled fixtures.
- A bounded live GCS manifest read returned HTTP 206 with matching Content-Range and a 65,536-byte body. Its first size token was `8`; a 126-byte overlap read proved the complete token was `77108`. This confirms the clipping mechanism without running the seeder.
- Covers zero and nonzero numeric fragments, complete zero-size rejection at byte zero and after a prefix, missing/inconsistent range metadata, and a prefix without a newline. Existing checksum, size, freshness, symmetry and gap checks still pass.
- Browser/API type checks, boundary lint and `git diff --check` pass. Focused Biome check passes with one pre-existing informational ternary suggestion in an unchanged test.
- Sequential ce-simplify-code and ce-code-review under repository tool mapping found no actionable issues; no independent agent or external review automation was invoked. The country-search test initially lacked the `tsx` loader; the corrected `node --import tsx --test` run passes all 90 checks.

## Post-Deploy Monitoring & Validation

Owner: maintainer authorizing deployment. Inspect the first two natural 15-minute runs after deployment. Search `seed-gdelt-intel` logs for `seed_complete`, `FETCH FAILED`, `invalid Content-Range`, and `ZIP size`; verify `seed-meta:intelligence:gdelt-intel` success time and both source cursors advance. Expect `state=OK` with published data; retained TTLs alone do not establish recovery. Repeated range failures, missing cohort coverage, or incorrect publication blocks acceptance and warrants investigation or rollback. No merge, deployment or production acceptance is claimed by this PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
