### PR TITLE
fix(ci): reconcile stacked merges through open parents

### DIFF
--- a/.github/workflows/orphaned-stacked-merge-monitor.yml
+++ b/.github/workflows/orphaned-stacked-merge-monitor.yml
@@ -1,10 +1,5 @@
 name: Orphaned Stacked Merge Monitor
 
-# Safety net for #7006. A required pre-merge check can miss a same-second
-# parent/child merge; after merge, GitHub still shows MERGED even when the
-# merge commit never became an ancestor of main. Fail loudly and open an
-# issue plus a PR comment — nobody re-reads checks on a closed purple PR.
-
 on:
   pull_request:
     types: [closed]
@@ -16,16 +11,12 @@ permissions:
 
 jobs:
   monitor:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          # The merge commit carries this workflow's script. origin/main is
-          # fetched in the next step for the ancestry proof; a tombstone merge
-          # is on the merge commit but not on main.
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           filter: blob:none
 
@@ -33,7 +24,7 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Verify merge commit reached main
+      - name: Reconcile closed PR and merged descendants
         env:
           GH_TOKEN: ${{ github.token }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/scripts/check-stacked-merge.mjs
+++ b/scripts/check-stacked-merge.mjs
@@ -374,7 +374,7 @@ export function checkClosedPull({ event, gh, git, issues, sleep } = {}) {
       mode: 'post-merge', event: { ...event, pull_request: pull }, gh, git, issues, sleep,
     });
     results.push({ pullNumber: pull.number, ...result });
-    if (!pull.head?.ref || pull.head.repo?.full_name && pull.head.repo.full_name !== repository) continue;
+    if (!pull.head?.ref || pull.head.repo?.full_name !== repository) continue;
     const children = flattenGhPages(gh([
       'api', '--paginate', '--slurp',
       `repos/${repository}/pulls?state=closed&base=${encodeURIComponent(pull.head.ref)}`,

--- a/scripts/check-stacked-merge.mjs
+++ b/scripts/check-stacked-merge.mjs
@@ -1,23 +1,12 @@
 #!/usr/bin/env node
 
-// Detects a stacked PR whose base already merged (and usually auto-deleted),
-// so a GitHub merge would land on a tombstone and never reach the default
-// branch. #6993 and #6997 both showed MERGED while main never received the
-// commits (#7006).
-//
-// Two modes:
-//   pre-merge  — required PR check. Fails when base is not the default branch
-//                and that base branch's own PR is already merged.
-//   post-merge — safety net after a merge. Fails when the merge commit is not
-//                an ancestor of the default branch, and files an issue plus a
-//                PR comment because nobody re-reads checks on a purple PR.
-
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 import { isMainModule } from './lib/main-module.mjs';
 
-export const ISSUE_TITLE_PREFIX = 'Orphaned stacked merge:';
+export const ISSUE_TITLE_PREFIX = 'Stacked merge integration:';
+const LEGACY_ISSUE_TITLE_PREFIX = 'Orphaned stacked merge:';
 
 const GH_CALL_TIMEOUT_MS = 30_000;
 const ANCESTRY_RETRY_ATTEMPTS = 3;
@@ -59,7 +48,7 @@ export function evaluatePreMergeGuard({ defaultBranch, baseRef, baseHeadPulls })
   return { ok: true, reason: 'base-pr-absent' };
 }
 
-export function evaluatePostMergeAncestry({ merged, mergeSha, isAncestor }) {
+export function evaluatePostMergeAncestry({ merged, mergeSha, isAncestor, pendingParent }) {
   if (!merged) {
     return { ok: true, reason: 'not-merged' };
   }
@@ -69,7 +58,10 @@ export function evaluatePostMergeAncestry({ merged, mergeSha, isAncestor }) {
   if (isAncestor) {
     return { ok: true, reason: 'merge-on-default' };
   }
-  return { ok: false, reason: 'orphaned-merge' };
+  if (pendingParent) {
+    return { ok: true, reason: 'pending-parent-integration', pendingParent };
+  }
+  return { ok: false, reason: 'integration-unproven' };
 }
 
 export function listPullsByHead({ gh, repository, owner, headRef }) {
@@ -96,47 +88,51 @@ export function isCommitAncestor({ git, commit, ref }) {
 function pullLabel(pull) {
   const number = pull?.number != null ? `#${pull.number}` : 'an unknown PR';
   const url = typeof pull?.html_url === 'string' ? ` (${pull.html_url})` : '';
-  const title = typeof pull?.title === 'string' && pull.title.length > 0 ? ` — ${pull.title}` : '';
+  const title = typeof pull?.title === 'string' && pull.title.length > 0 ? ` (${pull.title})` : '';
   return `${number}${title}${url}`;
 }
 
-function parentList(mergedParents) {
-  if (!Array.isArray(mergedParents) || mergedParents.length === 0) {
+function parentList(parents) {
+  if (!Array.isArray(parents) || parents.length === 0) {
     return 'none found for the stacked base branch';
   }
-  return mergedParents.map((pull) => `- ${pullLabel(pull)}`).join('\n');
+  return parents.map((pull) => `- ${pullLabel(pull)}. State: ${isMergedPull(pull) ? 'merged' : pull.state || 'unknown'}.`).join('\n');
 }
 
-export function formatOrphanIssue({ pull, mergeSha, defaultBranch, mergedParents, reason }) {
+export function formatOrphanIssue({ pull, mergeSha, defaultBranch, parents = [], reason }) {
   const number = pull?.number ?? '?';
-  const title = `${ISSUE_TITLE_PREFIX} #${number} never reached ${defaultBranch}`;
+  const title = `${ISSUE_TITLE_PREFIX} #${number} on ${defaultBranch}`;
+  if (reason === 'merge-on-default') {
+    return {
+      title,
+      body: `Integration of PR ${pullLabel(pull)} is confirmed. Merge commit \`${mergeSha}\` is an ancestor of \`${defaultBranch}\`.`,
+    };
+  }
   const body = [
-    `Merged PR ${pullLabel(pull)} is not on \`${defaultBranch}\`.`,
+    reason === 'pending-parent-integration'
+      ? `Merged PR ${pullLabel(pull)} is pending integration through an open parent that contains its merge commit.`
+      : `Integration of merged PR ${pullLabel(pull)} into \`${defaultBranch}\` is unproven.`,
     '',
     `- Merge SHA: \`${mergeSha || 'missing'}\``,
     `- PR base: \`${pull?.base?.ref || 'unknown'}\``,
     `- Reason: \`${reason}\``,
     '',
     'Parent PR(s) for that base branch:',
-    parentList(mergedParents),
+    parentList(parents),
     '',
-    `GitHub still reports this PR as MERGED when the base branch was deleted after its own PR merged, so the child lands on a tombstone. Re-land the commits onto \`${defaultBranch}\` (see #7006).`,
-    '',
-    'This issue is an alarm, not a close of #7006.',
+    `The merge commit has not been confirmed as an ancestor of \`${defaultBranch}\`. This does not establish branch deletion or lost changes. Squash and rebase merges can also change commit identity. Inspect the parent history and content before choosing a recovery action. See #7006.`,
   ].join('\n');
   return { title, body };
 }
 
-export function formatOrphanComment({ pull, mergeSha, defaultBranch, mergedParents, reason }) {
-  const parents = Array.isArray(mergedParents) && mergedParents.length > 0
-    ? mergedParents.map((parent) => `#${parent.number}`).join(', ')
-    : 'none found';
+export function formatOrphanComment({ pull, mergeSha, defaultBranch, parents = [], reason }) {
   return [
-    `This merge never reached \`${defaultBranch}\`. GitHub still shows MERGED, but \`${mergeSha || 'the merge commit'}\` is not an ancestor of \`${defaultBranch}\` (${reason}).`,
+    `Integration into \`${defaultBranch}\` is unproven for merge commit \`${mergeSha || 'missing'}\` (${reason}).`,
     '',
-    `Stacked base: \`${pull?.base?.ref || 'unknown'}\`. Parent PR(s): ${parents}.`,
+    `Stacked base: \`${pull?.base?.ref || 'unknown'}\`. Parent PR(s):`,
+    parentList(parents),
     '',
-    'Re-land onto the default branch. Tracking: #7006.',
+    'Inspect parent history and content before choosing a recovery action. See #7006.',
   ].join('\n');
 }
 
@@ -149,7 +145,7 @@ function postMergeAnnotation(verdict, mergeSha, defaultBranch) {
   if (verdict.reason === 'missing-merge-sha') {
     return `::error::Merged PR has no merge commit SHA, so it cannot be proven on \`${defaultBranch}\`. See #7006.`;
   }
-  return `::error::Merge commit \`${mergeSha}\` is not an ancestor of \`${defaultBranch}\`. The PR is MERGED but the commits never landed. See #7006.`;
+  return `::error::Merge commit \`${mergeSha}\` is not an ancestor of \`${defaultBranch}\` and no containing open parent was confirmed. Integration remains unproven. See #7006.`;
 }
 
 function repositoryFromEvent(event) {
@@ -164,6 +160,12 @@ function defaultBranchFromEvent(event) {
 }
 
 function confirmAncestry({ git, commit, ref, defaultBranch, shouldRetry, sleep }) {
+  try {
+    git(['cat-file', '-e', `${commit}^{commit}`]);
+  } catch (error) {
+    if (error?.status !== 1 && error?.status !== 128) throw error;
+    git(['fetch', '--quiet', 'origin', commit]);
+  }
   const attempts = shouldRetry ? ANCESTRY_RETRY_ATTEMPTS : 1;
   let last = false;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
@@ -173,6 +175,32 @@ function confirmAncestry({ git, commit, ref, defaultBranch, shouldRetry, sleep }
     if (attempt < attempts - 1) sleep(ANCESTRY_RETRY_MS);
   }
   return last;
+}
+
+function findPendingParent({ gh, git, repository, defaultBranch, pull, mergeSha }) {
+  const parents = [];
+  const queue = [pull];
+  const visited = new Set([pull.number]);
+  for (const current of queue) {
+    const baseRef = current.base?.ref;
+    if (!baseRef || baseRef === defaultBranch) continue;
+    const owner = current.base?.repo?.owner?.login || repository.split('/')[0];
+    for (const parent of listPullsByHead({ gh, repository, owner, headRef: baseRef })) {
+      if (parent.head?.repo?.full_name && parent.head.repo.full_name !== repository) continue;
+      if (visited.has(parent.number)) continue;
+      visited.add(parent.number);
+      parents.push(parent);
+      if (parent.state === 'open' && parent.head?.sha) {
+        git(['fetch', '--quiet', 'origin', parent.head.sha]);
+        if (isCommitAncestor({ git, commit: mergeSha, ref: parent.head.sha })) {
+          return { parents, pendingParent: parent };
+        }
+      } else if (isMergedPull(parent)) {
+        queue.push(parent);
+      }
+    }
+  }
+  return { parents };
 }
 
 function defaultIssues(gh, repository) {
@@ -188,7 +216,7 @@ function defaultIssues(gh, repository) {
         '--search',
         `${title} in:title`,
         '--json',
-        'number,title,url',
+        'number,title,url,state,body',
       ]);
       const parsed = JSON.parse(raw || '[]');
       return Array.isArray(parsed) ? parsed.filter((issue) => issue?.title === title) : [];
@@ -199,6 +227,15 @@ function defaultIssues(gh, repository) {
         { input: JSON.stringify({ title: issue.title, body: issue.body }) },
       );
       return JSON.parse(raw);
+    },
+    update(number, fields) {
+      gh(
+        ['api', `repos/${repository}/issues/${number}`, '--method', 'PATCH', '--input', '-'],
+        { input: JSON.stringify(fields) },
+      );
+    },
+    close(number, body) {
+      this.update(number, { state: 'closed', body });
     },
     comment(prNumber, body) {
       gh(
@@ -257,7 +294,8 @@ export function checkStackedMerge({
   }
 
   const mergeSha = pull.merge_commit_sha;
-  const merged = pull.merged === true;
+  const merged = isMergedPull(pull);
+  if (!merged) return { ok: true, reason: 'not-merged', exitCode: 0 };
   if (typeof git !== 'function') {
     throw new Error('git is required to prove the merge commit reached the default branch');
   }
@@ -272,52 +310,85 @@ export function checkStackedMerge({
       sleep,
     })
     : false;
-  const verdict = evaluatePostMergeAncestry({ merged, mergeSha, isAncestor });
-  if (verdict.ok) {
-    return { ...verdict, exitCode: 0 };
-  }
-
-  let mergedParents = [];
-  if (typeof gh === 'function' && baseRef && baseRef !== defaultBranch) {
-    mergedParents = listPullsByHead({ gh, repository, owner, headRef: baseRef }).filter(isMergedPull);
-  }
+  const { parents = [], pendingParent } = !isAncestor && mergeSha && typeof gh === 'function'
+    ? findPendingParent({ gh, git, repository, defaultBranch, pull, mergeSha })
+    : {};
+  const verdict = evaluatePostMergeAncestry({ merged, mergeSha, isAncestor, pendingParent });
 
   const alarm = formatOrphanIssue({
     pull,
     mergeSha,
     defaultBranch,
-    mergedParents,
+    parents,
     reason: verdict.reason,
   });
-  const comment = formatOrphanComment({
-    pull,
-    mergeSha,
-    defaultBranch,
-    mergedParents,
-    reason: verdict.reason,
-  });
-
   const issueClient = issues || (typeof gh === 'function' ? defaultIssues(gh, repository) : null);
   let existingIssue;
   if (issueClient) {
-    const found = issueClient.search(alarm.title);
-    if (Array.isArray(found) && found.length > 0) {
+    const legacyTitle = `${LEGACY_ISSUE_TITLE_PREFIX} #${pull.number} never reached ${defaultBranch}`;
+    const found = [...issueClient.search(alarm.title), ...issueClient.search(legacyTitle)];
+    if (found.length > 0) {
       existingIssue = found[0].number;
-    } else {
+      for (const issue of new Map(found.map((item) => [item.number, item])).values()) {
+        if (isAncestor) {
+          if (issue.state?.toLowerCase() !== 'closed') issueClient.close(issue.number, alarm.body);
+        } else {
+          const fields = { title: alarm.title, body: alarm.body };
+          if (!verdict.ok) fields.state = 'open';
+          if (issue.title !== fields.title || issue.body !== fields.body
+            || fields.state && issue.state?.toLowerCase() !== fields.state) {
+            issueClient.update(issue.number, fields);
+          }
+        }
+      }
+    } else if (!verdict.ok) {
       const created = issueClient.create(alarm);
       existingIssue = created?.number;
-    }
-    if (pull.number != null) {
-      issueClient.comment(pull.number, comment);
+      if (pull.number != null) {
+        issueClient.comment(pull.number, formatOrphanComment({
+          pull, mergeSha, defaultBranch, parents, reason: verdict.reason,
+        }));
+      }
     }
   }
 
   return {
     ...verdict,
-    mergedPrs: mergedParents,
+    parents,
     existingIssue,
-    exitCode: 1,
-    annotation: postMergeAnnotation(verdict, mergeSha, defaultBranch),
+    exitCode: verdict.ok ? 0 : 1,
+    ...(!verdict.ok && { annotation: postMergeAnnotation(verdict, mergeSha, defaultBranch) }),
+  };
+}
+
+export function checkClosedPull({ event, gh, git, issues, sleep } = {}) {
+  if (!event?.pull_request) throw new Error('a pull_request payload is required');
+  const repository = repositoryFromEvent(event);
+  const queue = [event.pull_request];
+  const visited = new Set();
+  const results = [];
+  for (const pull of queue) {
+    if (visited.has(pull.number)) continue;
+    visited.add(pull.number);
+    const result = checkStackedMerge({
+      mode: 'post-merge', event: { ...event, pull_request: pull }, gh, git, issues, sleep,
+    });
+    results.push({ pullNumber: pull.number, ...result });
+    if (!pull.head?.ref || pull.head.repo?.full_name && pull.head.repo.full_name !== repository) continue;
+    const children = flattenGhPages(gh([
+      'api', '--paginate', '--slurp',
+      `repos/${repository}/pulls?state=closed&base=${encodeURIComponent(pull.head.ref)}`,
+    ]));
+    queue.push(...children.filter((child) => isMergedPull(child)
+      && (!child.base?.repo?.full_name || child.base.repo.full_name === repository)));
+  }
+  const failures = results.filter((result) => !result.ok);
+  return {
+    ok: failures.length === 0,
+    reason: 'closed-pull-reconciled',
+    exitCode: failures.length > 0 ? 1 : 0,
+    results,
+    ...(failures.length > 0 && { annotation: failures.map((result) => result.annotation).join('\n') }),
   };
 }
 
@@ -375,7 +446,8 @@ function main(argv = process.argv, env = process.env) {
   const mode = readArg(argv, '--mode');
   const eventPath = readArg(argv, '--event-path');
   const event = loadEvent(env, eventPath);
-  const result = checkStackedMerge({
+  const check = mode === 'post-merge' ? checkClosedPull : checkStackedMerge;
+  const result = check({
     mode,
     event,
     gh: runGh,

--- a/tests/check-stacked-merge.test.mjs
+++ b/tests/check-stacked-merge.test.mjs
@@ -258,6 +258,38 @@ describe('orphan alarm copy', () => {
 });
 
 describe('checkStackedMerge orchestrator', () => {
+  it('keeps #8035 pending while the open #8003 head contains its merge', () => {
+    const mergeSha = 'dd30a8734b88ecea5f91533172b39cb4d20f5446';
+    const result = checkStackedMerge({
+      mode: 'post-merge',
+      event: pullEvent({
+        number: 8035,
+        merged: true,
+        merge_commit_sha: mergeSha,
+        base: { ref: 'codex/7990-commodity-evidence' },
+      }, { action: 'closed' }),
+      gh: () => JSON.stringify([{
+        number: 8003,
+        state: 'open',
+        merged_at: null,
+        head: { ref: 'codex/7990-commodity-evidence', sha: mergeSha },
+        base: { ref: 'main' },
+      }]),
+      git: (args) => {
+        if (args[0] !== 'merge-base' || args.at(-1) === mergeSha) return '';
+        throw Object.assign(new Error('not an ancestor of main'), { status: 1 });
+      },
+      issues: {
+        search: () => [],
+        create: () => assert.fail('a contained open stack must not create an orphan alarm'),
+        comment: () => assert.fail('a contained open stack must not post an orphan comment'),
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, 'pending-parent-integration');
+    assert.equal(result.exitCode, 0);
+  });
+
   it('passes a push to the default branch without calling GitHub', () => {
     let ghCalls = 0;
     const result = checkStackedMerge({

--- a/tests/check-stacked-merge.test.mjs
+++ b/tests/check-stacked-merge.test.mjs
@@ -259,6 +259,18 @@ describe('orphan alarm copy', () => {
 });
 
 describe('checkStackedMerge orchestrator', () => {
+  it('does not discover descendants when the head repository is unknown', () => {
+    for (const repo of [undefined, null, {}]) {
+      const result = checkClosedPull({
+        event: pullEvent({ number: 50, merged: false, head: { ref: 'main', repo } }, { action: 'closed' }),
+        gh: () => assert.fail('unknown head repository must not query upstream descendants'),
+        git: () => assert.fail('an unmerged closure needs no ancestry check'),
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.results.length, 1);
+    }
+  });
+
   it('does not discover upstream children from a same-named fork branch', () => {
     const result = checkClosedPull({
       event: pullEvent({ number: 50, merged: false, head: { ref: 'parent', repo: { full_name: 'contributor/worldmonitor' } } }, { action: 'closed' }),
@@ -299,8 +311,8 @@ describe('checkStackedMerge orchestrator', () => {
 
   it('rechecks nested descendants and keeps them pending through an open grandparent', () => {
     const grandparent = { number: 10, state: 'open', head: { ref: 'grandparent', sha: 'g'.repeat(40) }, base: { ref: 'main' } };
-    const parent = { number: 20, state: 'closed', merged_at: '2026-09-11T15:00:00Z', merge_commit_sha: 'b'.repeat(40), head: { ref: 'parent' }, base: { ref: 'grandparent' } };
-    const child = { number: 30, state: 'closed', merged_at: '2026-09-11T14:00:00Z', merge_commit_sha: 'c'.repeat(40), head: { ref: 'child' }, base: { ref: 'parent' } };
+    const parent = { number: 20, state: 'closed', merged_at: '2026-09-11T15:00:00Z', merge_commit_sha: 'b'.repeat(40), head: { ref: 'parent', repo: { full_name: 'koala73/worldmonitor' } }, base: { ref: 'grandparent' } };
+    const child = { number: 30, state: 'closed', merged_at: '2026-09-11T14:00:00Z', merge_commit_sha: 'c'.repeat(40), head: { ref: 'child', repo: { full_name: 'koala73/worldmonitor' } }, base: { ref: 'parent' } };
     const pulls = [grandparent, parent, child];
     const result = checkClosedPull({
       event: pullEvent(parent, { action: 'closed' }),
@@ -572,8 +584,8 @@ describe('closed stack CLI with real git ancestry', () => {
       git('commit', '--allow-empty', '-m', 'child merged into parent');
       const childSha = git('rev-parse', 'HEAD');
       git('branch', 'child');
-      const parent = { number: 8003, state: 'open', merged_at: null, head: { ref: 'parent', sha: childSha }, base: { ref: 'main' } };
-      const child = { number: 8035, state: 'closed', merged: true, merged_at: '2026-09-11T14:05:06Z', merge_commit_sha: childSha, head: { ref: 'child', sha: childSha }, base: { ref: 'parent' } };
+      const parent = { number: 8003, state: 'open', merged_at: null, head: { ref: 'parent', sha: childSha, repo: { full_name: 'koala73/worldmonitor' } }, base: { ref: 'main' } };
+      const child = { number: 8035, state: 'closed', merged: true, merged_at: '2026-09-11T14:05:06Z', merge_commit_sha: childSha, head: { ref: 'child', sha: childSha, repo: { full_name: 'koala73/worldmonitor' } }, base: { ref: 'parent' } };
       const statePath = join(dir, 'api.json');
       const eventPath = join(dir, 'event.json');
       const state = { pulls: [parent, child], issues: [], comments: [] };

--- a/tests/check-stacked-merge.test.mjs
+++ b/tests/check-stacked-merge.test.mjs
@@ -5,8 +5,8 @@
 // main and for a live stack whose parent is still open.
 
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   ISSUE_TITLE_PREFIX,
+  checkClosedPull,
   checkStackedMerge,
   evaluatePostMergeAncestry,
   evaluatePreMergeGuard,
@@ -165,7 +166,7 @@ describe('post-merge ancestry guard', () => {
       isAncestor: false,
     });
     assert.equal(verdict.ok, false);
-    assert.equal(verdict.reason, 'orphaned-merge');
+    assert.equal(verdict.reason, 'integration-unproven');
   });
 
   it('trips when the merge commit SHA is missing', () => {
@@ -235,10 +236,10 @@ describe('orphan alarm copy', () => {
       pull: CHILD_6997,
       mergeSha: CHILD_6997.merge_commit_sha,
       defaultBranch: 'main',
-      mergedParents: [PARENT_6996],
-      reason: 'orphaned-merge',
+      parents: [PARENT_6996],
+      reason: 'integration-unproven',
     });
-    assert.equal(issue.title, `${ISSUE_TITLE_PREFIX} #6997 never reached main`);
+    assert.equal(issue.title, `${ISSUE_TITLE_PREFIX} #6997 on main`);
     assert.match(issue.body, /#6997/);
     assert.match(issue.body, /#6996/);
     assert.match(issue.body, /fix\/aviation-budget-binds-v2/);
@@ -249,15 +250,78 @@ describe('orphan alarm copy', () => {
       pull: CHILD_6997,
       mergeSha: CHILD_6997.merge_commit_sha,
       defaultBranch: 'main',
-      mergedParents: [PARENT_6996],
-      reason: 'orphaned-merge',
+      parents: [PARENT_6996],
+      reason: 'integration-unproven',
     });
-    assert.match(comment, /never reached `main`/);
+    assert.match(comment, /Integration into `main` is unproven/);
     assert.match(comment, /#6996/);
   });
 });
 
 describe('checkStackedMerge orchestrator', () => {
+  it('does not discover upstream children from a same-named fork branch', () => {
+    const result = checkClosedPull({
+      event: pullEvent({ number: 50, merged: false, head: { ref: 'parent', repo: { full_name: 'contributor/worldmonitor' } } }, { action: 'closed' }),
+      gh: () => assert.fail('a fork head is not an upstream base'),
+    });
+    assert.deepEqual(result.results.map(item => item.pullNumber), [50]);
+    assert.equal(result.exitCode, 0);
+  });
+
+  it('does not treat an open parent without the child commit as pending', () => {
+    const parent = { ...PARENT_6996, state: 'open', merged_at: null, head: { sha: 'a'.repeat(40) } };
+    const result = checkStackedMerge({
+      mode: 'post-merge', event: pullEvent(CHILD_6997),
+      gh: () => JSON.stringify([parent]),
+      git: (args) => {
+        if (args[0] !== 'merge-base') return '';
+        throw Object.assign(new Error('not contained'), { status: 1 });
+      },
+      issues: { search: () => [], create: () => ({ number: 7007 }), comment: () => {} },
+    });
+    assert.equal(result.reason, 'integration-unproven');
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.parents[0].state, 'open');
+  });
+
+  it('propagates a parent fetch failure without issuing a false alarm', () => {
+    assert.throws(() => checkStackedMerge({
+      mode: 'post-merge', event: pullEvent(CHILD_6997),
+      gh: () => JSON.stringify([{ number: 6996, state: 'open', head: { sha: 'a'.repeat(40) } }]),
+      git: (args) => {
+        if (args[0] === 'fetch' && args.at(-1) === 'a'.repeat(40)) throw new Error('parent fetch unavailable');
+        if (args[0] !== 'merge-base') return '';
+        throw Object.assign(new Error('not on main'), { status: 1 });
+      },
+      issues: { search: () => assert.fail('must not manufacture an alarm from a fetch error') },
+    }), /parent fetch unavailable/);
+  });
+
+  it('rechecks nested descendants and keeps them pending through an open grandparent', () => {
+    const grandparent = { number: 10, state: 'open', head: { ref: 'grandparent', sha: 'g'.repeat(40) }, base: { ref: 'main' } };
+    const parent = { number: 20, state: 'closed', merged_at: '2026-09-11T15:00:00Z', merge_commit_sha: 'b'.repeat(40), head: { ref: 'parent' }, base: { ref: 'grandparent' } };
+    const child = { number: 30, state: 'closed', merged_at: '2026-09-11T14:00:00Z', merge_commit_sha: 'c'.repeat(40), head: { ref: 'child' }, base: { ref: 'parent' } };
+    const pulls = [grandparent, parent, child];
+    const result = checkClosedPull({
+      event: pullEvent(parent, { action: 'closed' }),
+      gh: (args) => {
+        const url = new URL(args.at(-1), 'https://api.github.test');
+        const base = url.searchParams.get('base');
+        const head = url.searchParams.get('head')?.split(':')[1];
+        return JSON.stringify(pulls.filter(pull => base ? pull.base.ref === base : pull.head.ref === head));
+      },
+      git: (args) => {
+        if (args[0] !== 'merge-base' || args.at(-1) === grandparent.head.sha) return '';
+        throw Object.assign(new Error('not on main'), { status: 1 });
+      },
+      issues: { search: () => [], create: () => assert.fail('nested stack is still pending') },
+    });
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(result.results.map(item => [item.pullNumber, item.reason]), [
+      [20, 'pending-parent-integration'], [30, 'pending-parent-integration'],
+    ]);
+  });
+
   it('keeps #8035 pending while the open #8003 head contains its merge', () => {
     const mergeSha = 'dd30a8734b88ecea5f91533172b39cb4d20f5446';
     const result = checkStackedMerge({
@@ -373,13 +437,13 @@ describe('checkStackedMerge orchestrator', () => {
       },
     });
     assert.equal(result.ok, false);
-    assert.equal(result.reason, 'orphaned-merge');
+    assert.equal(result.reason, 'integration-unproven');
     assert.equal(result.exitCode, 1);
     assert.equal(created.length, 1);
-    assert.equal(created[0].title, `${ISSUE_TITLE_PREFIX} #6997 never reached main`);
+    assert.equal(created[0].title, `${ISSUE_TITLE_PREFIX} #6997 on main`);
     assert.equal(comments.length, 1);
     assert.equal(comments[0].prNumber, 6997);
-    assert.equal(searches.length, 1);
+    assert.equal(searches.length, 2);
     assert.ok(gitLog.some((args) => args[0] === 'fetch' && args.includes('main')));
   });
 
@@ -396,12 +460,13 @@ describe('checkStackedMerge orchestrator', () => {
         throw error;
       },
       issues: {
-        search: () => [{ number: 7007, title: `${ISSUE_TITLE_PREFIX} #6997 never reached main` }],
+        search: () => [{ number: 7007, title: `${ISSUE_TITLE_PREFIX} #6997 on main` }],
         create: () => {
           created += 1;
           throw new Error('must not create a duplicate issue');
         },
-        comment: () => {},
+        comment: () => assert.fail('must not duplicate the comment'),
+        update: () => {},
       },
     });
     assert.equal(result.ok, false);
@@ -422,7 +487,7 @@ describe('checkStackedMerge orchestrator', () => {
         base: { ref: 'main', repo: { owner: { login: 'koala73' } } },
       }, { action: 'closed' }),
       git: (args) => {
-        if (args[0] === 'fetch') return '';
+        if (args[0] === 'fetch' || args[0] === 'cat-file') return '';
         if (args[0] === 'merge-base') return '';
         throw new Error(`unexpected git ${args.join(' ')}`);
       },
@@ -480,6 +545,127 @@ echo '[[{"number":6996,"merged_at":"2026-08-20T12:53:04Z","title":"parent","html
       assert.equal(result.status, 1);
       assert.match(result.stderr, /#6996/);
       assert.match(result.stderr, /tombstone/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('closed stack CLI with real git ancestry', () => {
+  it('keeps a live stack pending, alerts on abandonment, and closes the alarm after integration', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'stacked-lifecycle-'));
+    const script = resolve(dirname(fileURLToPath(import.meta.url)), '../scripts/check-stacked-merge.mjs');
+    const env = { ...process.env };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('GIT_')) delete env[key];
+    }
+    const git = (...args) => execFileSync('git', args, { cwd: dir, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    try {
+      git('init', '-b', 'main');
+      git('config', 'user.name', 'Detector test');
+      git('config', 'user.email', 'detector@example.invalid');
+      git('config', 'commit.gpgsign', 'false');
+      git('config', 'core.hooksPath', '/dev/null');
+      git('commit', '--allow-empty', '-m', 'main');
+      git('remote', 'add', 'origin', dir);
+      git('checkout', '-b', 'parent');
+      git('commit', '--allow-empty', '-m', 'child merged into parent');
+      const childSha = git('rev-parse', 'HEAD');
+      git('branch', 'child');
+      const parent = { number: 8003, state: 'open', merged_at: null, head: { ref: 'parent', sha: childSha }, base: { ref: 'main' } };
+      const child = { number: 8035, state: 'closed', merged: true, merged_at: '2026-09-11T14:05:06Z', merge_commit_sha: childSha, head: { ref: 'child', sha: childSha }, base: { ref: 'parent' } };
+      const statePath = join(dir, 'api.json');
+      const eventPath = join(dir, 'event.json');
+      const state = { pulls: [parent, child], issues: [], comments: [] };
+      writeFileSync(statePath, JSON.stringify(state));
+      writeFileSync(join(dir, 'gh'), `#!${process.execPath}
+const fs = require('node:fs');
+const state = JSON.parse(fs.readFileSync(process.env.DETECTOR_API));
+const args = process.argv.slice(2);
+let answer;
+if (args[0] === 'issue' && args[1] === 'list') {
+  const title = args[args.indexOf('--search') + 1].replace(/ in:title$/, '');
+  answer = state.issues.filter(issue => issue.title === title);
+} else {
+  const route = args.find(arg => arg.startsWith('repos/'));
+  const url = new URL(route, 'https://api.github.test/');
+  const input = args.includes('--input') ? JSON.parse(fs.readFileSync(0, 'utf8')) : {};
+  if (url.pathname.endsWith('/pulls')) {
+    answer = state.pulls.filter(pull => {
+      const head = url.searchParams.get('head');
+      const base = url.searchParams.get('base');
+      return (!head || pull.head.ref === head.slice(head.indexOf(':') + 1))
+        && (!base || pull.base.ref === base)
+        && (url.searchParams.get('state') !== 'closed' || pull.state === 'closed');
+    });
+  } else if (url.pathname.endsWith('/comments')) {
+    state.comments.push(input.body);
+    answer = {};
+  } else if (url.pathname.endsWith('/issues')) {
+    answer = { number: 8041, state: 'open', ...input };
+    state.issues.push(answer);
+  } else {
+    const issue = state.issues.find(item => item.number === Number(url.pathname.split('/').at(-1)));
+    if (!issue) throw new Error('unexpected request ' + args.join(' '));
+    Object.assign(issue, input);
+    answer = issue;
+  }
+}
+fs.writeFileSync(process.env.DETECTOR_API, JSON.stringify(state));
+console.log(JSON.stringify(answer));
+`, { mode: 0o755 });
+      const run = (pull) => {
+        writeFileSync(eventPath, JSON.stringify(pullEvent(pull, { action: 'closed' })));
+        const result = spawnSync(process.execPath, [script, '--mode', 'post-merge', '--json'], {
+          cwd: dir,
+          env: { ...env, PATH: `${dir}:${env.PATH}`, DETECTOR_API: statePath, GITHUB_EVENT_PATH: eventPath, GITHUB_EVENT_NAME: 'pull_request' },
+          encoding: 'utf8',
+          timeout: 15_000,
+        });
+        assert.ok(result.stdout, result.stderr);
+        return { status: result.status, result: JSON.parse(result.stdout), state: JSON.parse(readFileSync(statePath, 'utf8')) };
+      };
+      const pending = run(child);
+      assert.equal(pending.status, 0);
+      assert.equal(pending.result.results.find(item => item.pullNumber === 8035).reason, 'pending-parent-integration');
+      assert.equal(pending.state.issues.length, 0);
+
+      state.issues.push({ number: 8041, state: 'open', title: 'Orphaned stacked merge: #8035 never reached main', body: 'old false alarm' });
+      writeFileSync(statePath, JSON.stringify(state));
+      const corrected = run(child);
+      assert.equal(corrected.state.issues.length, 1);
+      assert.equal(corrected.state.issues[0].title, 'Stacked merge integration: #8035 on main');
+      assert.match(corrected.state.issues[0].body, /pending integration/);
+      assert.equal(corrected.state.issues[0].state, 'open');
+      assert.equal(corrected.state.comments.length, 0);
+
+      parent.state = 'closed';
+      state.issues = [];
+      writeFileSync(statePath, JSON.stringify(state));
+      const abandoned = run(parent);
+      assert.equal(abandoned.status, 1);
+      assert.equal(abandoned.result.results.find(item => item.pullNumber === 8035).reason, 'integration-unproven');
+      assert.equal(abandoned.state.issues.length, 1);
+      assert.doesNotMatch(abandoned.state.issues[0].body, /lands on a tombstone|Re-land the commits/);
+      const repeated = run(parent);
+      assert.equal(repeated.state.issues.length, 1);
+      assert.equal(repeated.state.comments.length, abandoned.state.comments.length);
+
+      git('checkout', 'main');
+      git('merge', '--ff-only', 'parent');
+      parent.merged = true;
+      parent.merged_at = '2026-09-11T18:00:06Z';
+      parent.merge_commit_sha = childSha;
+      repeated.state.pulls = [parent, child];
+      repeated.state.issues[0].title = 'Orphaned stacked merge: #8035 never reached main';
+      writeFileSync(statePath, JSON.stringify(repeated.state));
+      const integrated = run(parent);
+      assert.equal(integrated.status, 0);
+      assert.equal(integrated.result.results.find(item => item.pullNumber === 8035).reason, 'merge-on-default');
+      assert.equal(integrated.state.issues[0].state, 'closed');
+      assert.match(integrated.state.issues[0].body, /is confirmed/);
+      assert.doesNotMatch(integrated.state.issues[0].body, /is unproven|has not been confirmed/);
+      assert.equal(run(parent).state.comments.length, integrated.state.comments.length);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/stacked-merge-guard-workflow.test.mjs
+++ b/tests/stacked-merge-guard-workflow.test.mjs
@@ -57,10 +57,10 @@ describe('stacked merge guard workflow', () => {
 });
 
 describe('orphaned stacked merge monitor workflow', () => {
-  it('runs only after a merge and can open an issue plus a PR comment', () => {
+  it('runs after any PR closure and can reconcile integration alarms', () => {
     assert.equal(monitor.name, 'Orphaned Stacked Merge Monitor');
     assert.deepEqual(monitor.on.pull_request.types, ['closed']);
-    assert.equal(monitor.jobs.monitor.if, "github.event.pull_request.merged == true");
+    assert.equal(monitor.jobs.monitor.if, undefined);
     assert.deepEqual(monitor.permissions, {
       contents: 'read',
       issues: 'write',
@@ -68,11 +68,11 @@ describe('orphaned stacked merge monitor workflow', () => {
     });
   });
 
-  it('checks out the merge commit, refreshes main, and runs the post-merge checker', () => {
+  it('checks out the default branch and reconciles the closed stack', () => {
     const checkout = monitor.jobs.monitor.steps.find((step) => step.uses?.startsWith('actions/checkout@'));
-    const runStep = monitor.jobs.monitor.steps.find((step) => step.name === 'Verify merge commit reached main');
-    assert.ok(checkout, 'workflow must check out the merge commit so the script exists');
-    assert.equal(checkout.with.ref, '${{ github.event.pull_request.merge_commit_sha }}');
+    const runStep = monitor.jobs.monitor.steps.find((step) => step.name === 'Reconcile closed PR and merged descendants');
+    assert.ok(checkout, 'workflow must run trusted code even when the parent closes without merging');
+    assert.equal(checkout.with.ref, '${{ github.event.repository.default_branch }}');
     assert.equal(checkout.with['fetch-depth'], 0);
     assert.equal(checkout.with.filter, 'blob:none');
     pin(checkout.uses);


### PR DESCRIPTION
## Why

A child merged into an open parent triggered an orphan alarm because its merge commit was not yet on main. The detector also hid open parents from the alarm and did not revisit the child when its parent closed. This caused #8041 for #8035 while #8003 was open.

The detector now proves containment before classifying a stack as pending. Every parent closure rechecks merged descendants, including closure without merging. Existing alarms are corrected or closed when ancestry confirms integration. Repeated checks do not duplicate PR comments.

Fixes #8041.

## Scope

- Explicit integrated, pending, and unproven results in the existing detector.
- Paginated descendant discovery and nested parent checks using existing PR relationships.
- Default-branch workflow checkout for merged and unmerged closures.
- Regression tests for containment, abandonment, legacy alarms, nested stacks, fork isolation, and fetch failure.

## Tradeoffs

An absent merge SHA does not prove lost changes after a squash or rebase merge. The alarm reports unproven integration and asks for content inspection. Automatic patch-equivalence detection is outside this fix.

## Verification

- Failing regression committed first. Before the fix, 20 tests passed and 1 failed with "a contained open stack must not create an orphan alarm".
- After the fix, all 31 detector and workflow tests passed. The CLI test uses real Git commits and a controlled GitHub API to verify pending, abandoned, repeated, and integrated states.
- All 43 CI workflow coverage tests passed. Biome and git diff checks passed.
- Read-only live verification classified both #8003 and #8035 as integrated. Issue writes were disabled for that check.
