### PR TITLE
fix(mcp): fingerprint the Pro-token gate's Sentry captures

### DIFF
--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -19,6 +19,7 @@ import {
 } from '../../server/_shared/entitlement-check';
 import { checkProMcpAccess } from '../../server/_shared/pro-mcp-gate';
 import type { BillingVerificationCode } from './billing-denial';
+import { mcpErrorFingerprint } from './error-fingerprint';
 import {
   buildInternalMcpHeaders,
   signInternalMcpRequest,
@@ -550,7 +551,16 @@ export async function validateProMcpAuthorization(
   try {
     validation = await deps.validateProMcpToken(context.mcpTokenId);
   } catch (err) {
-    captureSilentError(err, { tags: { route: 'api/mcp', step: 'pro-token-validate' }, ctx });
+    // Explicit fingerprint: this capture shares the minified edge bundle's
+    // anonymous frames with every other `api/mcp` capture, so Sentry's default
+    // stack grouping merges it into the WORLDMONITOR-T8 catch-all. `threw`
+    // keeps the defect arm in its own group, separable from the fail-soft
+    // `transient` arm below — see api/mcp/error-fingerprint.ts.
+    captureSilentError(err, {
+      tags: { route: 'api/mcp', step: 'pro-token-validate' },
+      fingerprint: mcpErrorFingerprint('pro-token-validate', 'threw', err),
+      ctx,
+    });
     return { ok: false, response: new Response(
       JSON.stringify({ jsonrpc: '2.0', id: id ?? null, error: { code: -32603, message: 'Service temporarily unavailable, retry in a moment.' } }),
       { status: 503, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders }) },
@@ -575,8 +585,17 @@ export async function validateProMcpAuthorization(
     //
     // The `catch` above stays at `error`: a THROWN validator is an unexpected
     // defect, not this fail-soft path.
-    captureSilentError(new Error('Pro MCP token validation temporarily unavailable'), {
+    //
+    // The explicit fingerprint is what makes "escalates by volume" true. These
+    // frames are the minified edge bundle's anonymous `(vc/edge/function`, so
+    // default stack grouping merged this capture into the T8 catch-all
+    // alongside unrelated tool-execution 4xx — WORLDMONITOR-ZR and T8 held the
+    // SAME message concurrently, and ZR read as drained while the condition was
+    // still firing into T8.
+    const transientError = new Error('Pro MCP token validation temporarily unavailable');
+    captureSilentError(transientError, {
       tags: { route: 'api/mcp', step: 'pro-token-validate' },
+      fingerprint: mcpErrorFingerprint('pro-token-validate', 'transient', transientError),
       level: 'warning',
       ctx,
     });

--- a/tests/mcp-pro-token-fingerprint.test.mts
+++ b/tests/mcp-pro-token-fingerprint.test.mts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
+
+import { HMAC_SECRET, PRO_TOKEN_ID, PRO_USER_ID, makeProDeps } from './helpers/mcp-pro-deps.mjs';
+
+// ─── WORLDMONITOR-ZR / T8: the Pro-token gate needs an explicit fingerprint ──
+//
+// Both `api/mcp` capture sites in the Pro-token gate run inside the minified
+// edge bundle, whose frames are all anonymous `(vc/edge/function` with no
+// source map and `in_app=false`. Sentry's default grouping keys on that stack,
+// so every capture sharing it collapses into the WORLDMONITOR-T8 catch-all —
+// the exact pathology `api/mcp/error-fingerprint.ts` was written to close.
+//
+// Observed 2026-09-11: `Pro MCP token validation temporarily unavailable` was
+// live in TWO groups at once. WORLDMONITOR-ZR held six events and was resolved
+// 2026-09-04; the identical message kept firing into T8 (three events that day
+// alone), so the condition read as drained while it was still occurring. That
+// defeats the stated intent of PR #7601 (`aacb0b7e1`), whose commit message
+// says a sustained Convex outage "still escalates by volume" — volume split
+// across two groups, one of them a permanently noisy catch-all, escalates
+// nothing.
+//
+// dispatch.ts already fingerprints its two capture sites; auth.ts never did.
+// These tests pin BOTH arms of the gate:
+//   - the fail-soft `transient` verdict (warning), and
+//   - the thrown-validator `catch` (error, an unexpected defect).
+// They must carry DISTINCT fingerprints. The code comment on the transient
+// branch is explicit that the two arms are different failure classes ("The
+// `catch` above stays at `error`: a THROWN validator is an unexpected defect,
+// not this fail-soft path"), so a shared fingerprint would re-merge exactly the
+// distinction that comment protects.
+//
+// `captureSilentError` no-ops unless `_sentry-common.js` parsed a DSN in its
+// import-time `parseDsn()` IIFE, so the DSN is set BEFORE the dynamic import
+// below. Each `*.test.mts` runs in its own `tsx --test` subprocess, so this DSN
+// never leaks into suites that import auth.ts statically.
+
+const previousNodeTestContext = process.env.NODE_TEST_CONTEXT;
+delete process.env.NODE_TEST_CONTEXT;
+
+process.env.VITE_SENTRY_DSN = 'https://testpublickey@sentry.test/12345';
+process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+process.env.MCP_TELEMETRY = 'false';
+process.env.UPSTASH_REDIS_REST_URL = 'https://stub.upstash.invalid';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'stub-token';
+process.env.CONVEX_SITE_URL = 'https://fake.convex.site';
+process.env.CONVEX_SERVER_SHARED_SECRET = 'test-convex-shared-secret';
+
+const ENVELOPE_URL_PREFIX = 'https://sentry.test/api/12345/envelope';
+
+const { validateProMcpAuthorization } = await import('../api/mcp/auth.ts');
+
+const originalFetch = globalThis.fetch;
+after(() => {
+  globalThis.fetch = originalFetch;
+  if (previousNodeTestContext === undefined) delete process.env.NODE_TEST_CONTEXT;
+  else process.env.NODE_TEST_CONTEXT = previousNodeTestContext;
+});
+
+const PRO_CONTEXT = { kind: 'pro', userId: PRO_USER_ID, mcpTokenId: PRO_TOKEN_ID } as never;
+const RESOURCE_METADATA_URL = 'https://worldmonitor.app/.well-known/oauth-protected-resource';
+
+/**
+ * Drive the Pro-token gate against a stubbed `validateProMcpToken` and return
+ * every Sentry event it delivered. Awaiting the capture promise matters: the
+ * helper only routes through `ctx.waitUntil` when a ctx is supplied, so the
+ * collected promises are awaited here to avoid asserting on an empty array.
+ */
+async function captureEvents(
+  validateProMcpToken: () => Promise<unknown>,
+): Promise<Array<Record<string, unknown>>> {
+  const events: Array<Record<string, unknown>> = [];
+  const pending: Array<Promise<unknown>> = [];
+
+  globalThis.fetch = (async (input: unknown, init?: { body?: string }) => {
+    const url = typeof input === 'string' ? input : String((input as { url?: string })?.url ?? '');
+    if (url.startsWith(ENVELOPE_URL_PREFIX)) {
+      // Envelope format: header line, item header line, item payload line.
+      const lines = String(init?.body ?? '').trim().split('\n');
+      events.push(JSON.parse(lines[lines.length - 1]));
+      return new Response('{}', { status: 200 });
+    }
+    throw new Error(`unexpected fetch to ${url}`);
+  }) as typeof globalThis.fetch;
+
+  const { deps } = makeProDeps({ validateProMcpToken });
+  await validateProMcpAuthorization(
+    PRO_CONTEXT,
+    deps as never,
+    RESOURCE_METADATA_URL,
+    {},
+    { waitUntil: (p: Promise<unknown>) => { pending.push(p); } },
+  );
+  await Promise.all(pending);
+  return events;
+}
+
+function fingerprintOf(event: Record<string, unknown>): unknown {
+  return event.fingerprint;
+}
+
+describe('Pro MCP token gate — Sentry grouping fingerprint', () => {
+  it('fingerprints the fail-soft transient verdict so it cannot merge into the T8 catch-all', async () => {
+    const events = await captureEvents(async () => ({ ok: 'transient' }));
+
+    assert.equal(events.length, 1, 'the transient verdict captures exactly one event');
+    const [event] = events;
+    assert.equal(
+      (event.exception as { values: Array<{ value: string }> }).values[0].value,
+      'Pro MCP token validation temporarily unavailable',
+      'positive control — the DSN activated and this is the transient-arm capture',
+    );
+    assert.equal(event.level, 'warning', 'PR #7601 downgraded this arm; it must stay warning');
+    assert.deepEqual(
+      fingerprintOf(event),
+      ['mcp-pro-token-validate', 'transient', 'Error'],
+      'without an explicit fingerprint Sentry groups on the anonymous edge stack and re-merges into T8',
+    );
+  });
+
+  it('fingerprints the thrown-validator defect arm separately from the fail-soft arm', async () => {
+    const events = await captureEvents(async () => {
+      throw new TypeError('validator exploded');
+    });
+
+    assert.equal(events.length, 1, 'the thrown validator captures exactly one event');
+    const [event] = events;
+    assert.notEqual(event.level, 'warning', 'a thrown validator is a defect, not the fail-soft path');
+    assert.deepEqual(
+      fingerprintOf(event),
+      ['mcp-pro-token-validate', 'threw', 'TypeError'],
+      'the defect arm keys on the error name so distinct runtime faults stay separable',
+    );
+  });
+
+  it('keeps the two arms in different Sentry groups', async () => {
+    const [transient] = await captureEvents(async () => ({ ok: 'transient' }));
+    const [threw] = await captureEvents(async () => {
+      throw new TypeError('validator exploded');
+    });
+
+    // Assert both are PRESENT before comparing them. `notDeepEqual` alone is
+    // satisfied by `undefined !== [...]`, so a missing fingerprint on either
+    // arm would pass this test vacuously — caught by mutation-testing this
+    // file against a dropped fingerprint.
+    assert.ok(Array.isArray(fingerprintOf(transient)), 'the transient arm must carry a fingerprint');
+    assert.ok(Array.isArray(fingerprintOf(threw)), 'the defect arm must carry a fingerprint');
+    assert.notDeepEqual(
+      fingerprintOf(transient),
+      fingerprintOf(threw),
+      'a shared fingerprint would re-merge the defect arm into the fail-soft arm — the exact '
+      + 'distinction the transient branch comment protects',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

A live Pro-MCP failure condition currently reads as drained when it is not. On 2026-09-11, `Pro MCP token validation temporarily unavailable` was firing in two Sentry groups at the same time: WORLDMONITOR-ZR, resolved 2026-09-04 and quiet since, and WORLDMONITOR-T8, which took three events that same day. Anyone looking at ZR concludes the condition stopped. It has not.

The cause is that `api/mcp/error-fingerprint.ts` was only ever wired into `dispatch.ts`. The two captures in `validateProMcpAuthorization` fall back to Sentry's default stack grouping, and on the minified edge bundle every frame is an anonymous `(vc/edge/function` with no source map — so they collapse into the T8 catch-all, exactly the pathology that helper's own docstring was written to close.

This also means PR #7601 does not do what its commit message says. That PR downgraded the transient arm to `warning` so a sustained Convex outage would "still escalate by volume." Volume split across two groups, one of them a permanently noisy catch-all, escalates nothing. A 25-event T8 sample held seven distinct messages across three steps and two routes.

Both arms now carry an explicit fingerprint and stay separable from each other: `threw` for the defect arm, `transient` for the fail-soft arm. That preserves a distinction the surrounding comment already protects — a thrown validator is an unexpected defect, not the fail-soft path. Using distinct discriminators rather than leaning on the error name means the two arms cannot merge even when the thrown error is a plain `Error`.

## What a reviewer should expect after deploy

Sentry applies grouping at ingest, so the existing T8 and ZR groups are untouched. New transient-verdict events will land in a **new** group rather than in T8. That new issue appearing is the fix working, not a regression. ZR stays resolved and should remain so, since its own fingerprint no longer receives traffic.

Tags and levels are unchanged on both paths, so existing `step:pro-token-validate` queries keep working.

## Validation

Written test-first against the real code path, not a source-text pin. The test activates a throwaway DSN before importing the module, stubs `fetch`, and asserts on the delivered Sentry envelope.

- Failing first: both arms delivered no `fingerprint` at all (`actual: undefined`). The message and `level: warning` assertions passed in the same run, so the harness was provably exercising the real capture rather than silently no-opping.
- After the fix: 3/3 green.
- Neighbouring suites: 137 pass across `mcp-pro-token-fingerprint`, `mcp-auth-entitlement-and-limits`, `mcp-error-fingerprint` and `pro-mcp-token`; a further 206 across `mcp`, `mcp-user-key-auth` and `mcp-billing-denial`. The pre-existing WORLDMONITOR-ZR level test still passes.
- Mutation-tested per guard: dropping either fingerprint reds two tests; giving both arms the same discriminator reds one.
- Lint clean on both changed files.

That mutation pass found a real weakness in my own test. The separability assertion used `notDeepEqual` alone, which is satisfied by `undefined !== [...]`, so it passed vacuously when a fingerprint was missing entirely. It now asserts both fingerprints are present before comparing them, and only then does the mutation red it.

`npm run typecheck` reports one error in `src/services/webmcp.ts`. It is pre-existing and unrelated — I confirmed it reproduces identically on a clean tree with this change reverted.

## Related

- Sentry: WORLDMONITOR-ZR, WORLDMONITOR-T8
- Prior art for this pattern: koala73/worldmonitor#6409, koala73/worldmonitor#6458, koala73/worldmonitor#7228
- Level downgrade this restores the intent of: koala73/worldmonitor#7601

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
