### PR TITLE
fix(rate-limit): separate a principal's API-key bucket from their session

### DIFF
--- a/server/__tests__/gateway-api-rate-limit.test.ts
+++ b/server/__tests__/gateway-api-rate-limit.test.ts
@@ -174,7 +174,7 @@ describe("#3199 U4 — gateway per-account rate-limit wiring", () => {
     expect(checkRateLimit).toHaveBeenCalledWith(
       expect.any(Request),
       expect.any(Object),
-      { principalUserId: "acct_starter" },
+      { principalUserId: "acct_starter", principalScope: "api_key" },
     ); // protection retained in shadow, isolated by the validated key owner
   });
 

--- a/server/__tests__/gateway-direct-llm-quota.test.ts
+++ b/server/__tests__/gateway-direct-llm-quota.test.ts
@@ -505,7 +505,7 @@ describe("gateway direct LLM quota", () => {
       expect.any(Request),
       CLASSIFY_PATH,
       expect.any(Object),
-      { principalUserId: "user_pro" },
+      { principalUserId: "user_pro", principalScope: "session" },
     );
     expect(reserveDirectLlmQuota).toHaveBeenCalledWith(
       expect.objectContaining({ userId: "user_pro" }),
@@ -530,7 +530,7 @@ describe("gateway direct LLM quota", () => {
       expect.any(Request),
       ANALYZE_PATH,
       expect.any(Object),
-      { principalUserId: "user_pro" },
+      { principalUserId: "user_pro", principalScope: "session" },
     );
     expect(checkRateLimit).not.toHaveBeenCalled();
   });
@@ -553,7 +553,7 @@ describe("gateway direct LLM quota", () => {
       expect.any(Request),
       BACKTEST_PATH,
       expect.any(Object),
-      { principalUserId: "user_pro" },
+      { principalUserId: "user_pro", principalScope: "session" },
     );
     expect(reserveDirectLlmQuota).not.toHaveBeenCalled();
   });
@@ -580,7 +580,7 @@ describe("gateway direct LLM quota", () => {
     expect(checkRateLimit).toHaveBeenCalledWith(
       expect.any(Request),
       expect.any(Object),
-      { principalUserId: "user_pro" },
+      { principalUserId: "user_pro", principalScope: "session" },
     );
   });
 

--- a/server/__tests__/gateway-summarize-article-security.test.ts
+++ b/server/__tests__/gateway-summarize-article-security.test.ts
@@ -196,7 +196,7 @@ describe("summarize-article gateway spend controls", () => {
       expect.any(Request),
       SUMMARIZE_PATH,
       expect.any(Object),
-      { principalUserId: "pro_user" },
+      { principalUserId: "pro_user", principalScope: "session" },
     );
     expect(checkFailClosedScopedIpRateLimit).toHaveBeenCalledWith(
       expect.any(Request),
@@ -270,7 +270,7 @@ describe("summarize-article gateway spend controls", () => {
       expect.any(Request),
       SUMMARIZE_PATH,
       expect.any(Object),
-      { principalUserId: "api_user" },
+      { principalUserId: "api_user", principalScope: "api_key" },
     );
     expect(calls.summarize).toBe(1);
   });

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -236,12 +236,34 @@ export interface RateLimitOptions {
    * so user IDs cannot collide with anonymous IP buckets.
    */
   principalUserId?: string;
+  /**
+   * Which credential the caller presented. A user's API key and their browser
+   * session resolve to the SAME Clerk user id, so without this they share one
+   * per-minute bucket and programmatic traffic starves the interactive session
+   * behind the same account (WORLDMONITOR-12A: a scraper on an api_starter key
+   * spent 598 of 600, leaving that customer's own dashboard 2 successes and 22
+   * × 429). Defaults to `session`, which keeps the established `user:` key so
+   * in-flight buckets are not reset.
+   *
+   * This separates namespaces; it does not exempt anyone. Each scope is still
+   * capped at the same per-minute limit, so the aggregate a single account can
+   * spend across both credentials doubles by design — programmatic use is
+   * metered by the plan's own `apiRateLimit` + daily allowance, which is the
+   * meter that should bound it.
+   */
+  principalScope?: PrincipalRateLimitScope;
 }
+
+export type PrincipalRateLimitScope = 'session' | 'api_key';
 
 export type EndpointRateLimitOptions = RateLimitOptions;
 
-function getPrincipalRateLimitIdentifier(principalUserId?: string): string | null {
-  return principalUserId ? `user:${principalUserId}` : null;
+function getPrincipalRateLimitIdentifier(
+  principalUserId?: string,
+  scope: PrincipalRateLimitScope = 'session',
+): string | null {
+  if (!principalUserId) return null;
+  return scope === 'api_key' ? `apikey-user:${principalUserId}` : `user:${principalUserId}`;
 }
 
 export async function checkRateLimit(request: Request, corsHeaders: Record<string, string>, opts: RateLimitOptions = {}): Promise<Response | null> {
@@ -258,7 +280,7 @@ export async function checkRateLimit(request: Request, corsHeaders: Record<strin
   // in-flight 60-second bucket does not reset during rollout. Trusted
   // principals use a separate namespace.
   const identifier =
-    getPrincipalRateLimitIdentifier(opts.principalUserId) ??
+    getPrincipalRateLimitIdentifier(opts.principalUserId, opts.principalScope) ??
     getClientIp(request);
 
   try {
@@ -732,7 +754,7 @@ export async function checkEndpointRateLimit(request: Request, pathname: string,
   }
 
   const identifier =
-    getPrincipalRateLimitIdentifier(opts.principalUserId) ??
+    getPrincipalRateLimitIdentifier(opts.principalUserId, opts.principalScope) ??
     `ip:${getClientIp(request)}`;
   const policy = ENDPOINT_RATE_POLICIES[pathname];
   // hasEndpointRatePolicy(pathname) above already guarantees this — the

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -2006,6 +2006,7 @@ export function createDomainGateway(
       const endpointRlResponse = rateLimitPrincipalUserId
         ? await checkEndpointRateLimit(request, pathname, corsHeaders, {
             principalUserId: rateLimitPrincipalUserId,
+            principalScope: isUserApiKey ? 'api_key' : 'session',
           })
         : await checkEndpointRateLimit(request, pathname, corsHeaders);
       if (endpointRlResponse) {
@@ -2153,9 +2154,15 @@ export function createDomainGateway(
       }
 
       if (!governedByApiKeyLayer && !hasEndpointRatePolicy(pathname)) {
+        // WORLDMONITOR-12A: scope the bucket to the credential, not just the
+        // user. An API key and a browser session resolve to the same Clerk id,
+        // so without this a customer's own scraper drains the 600/min budget
+        // and their dashboard 429s. In production on 2026-09-11 that was 598
+        // scraper successes against 2 for the same person's browser.
         const rateLimitResponse = rateLimitPrincipalUserId
           ? await checkRateLimit(request, corsHeaders, {
               principalUserId: rateLimitPrincipalUserId,
+              principalScope: isUserApiKey ? 'api_key' : 'session',
             })
           : await checkRateLimit(request, corsHeaders);
         if (rateLimitResponse) {

--- a/tests/gateway-rate-limit-principal-scope.test.mts
+++ b/tests/gateway-rate-limit-principal-scope.test.mts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+// ─── WORLDMONITOR-12A: the limiter scope must be wired at the CALL SITE ──────
+//
+// `server/_shared/rate-limit.ts` can separate an API key's bucket from an
+// interactive session's, but only if the gateway actually tells it which
+// credential the caller presented. Those are two different failures, and the
+// module-level test in `tests/rate-limit.test.mts` cannot see the second one:
+// deleting both `principalScope` arguments from gateway.ts leaves that suite
+// fully green (verified by mutation, 2026-09-11).
+//
+// Rather than pin the two literal call sites — which a third limiter call would
+// silently slip past — assert the invariant: every limiter option object that
+// names a principal must also name that principal's scope. A new call site that
+// forgets the scope re-opens the bug, and re-opening it means a paying customer's
+// own scraper can starve their dashboard again.
+//
+// This is a source pin because driving a real API-key request through
+// `createDomainGateway` needs key validation, entitlement resolution and Redis;
+// the behaviour it guards is already proven against the limiter itself.
+
+const GATEWAY_SOURCE = readFileSync(
+  new URL('../server/gateway.ts', import.meta.url),
+  'utf8',
+);
+
+describe('gateway rate-limit principal scoping (WORLDMONITOR-12A)', () => {
+  it('passes principalScope wherever it passes principalUserId', () => {
+    const principals = GATEWAY_SOURCE.match(/\bprincipalUserId:/g) ?? [];
+    const scopes = GATEWAY_SOURCE.match(/\bprincipalScope:/g) ?? [];
+
+    assert.ok(
+      principals.length > 0,
+      'sanity: gateway.ts must still pass a principal to the limiter — if this '
+      + 'fails the regex has drifted, not the behaviour',
+    );
+    assert.equal(
+      scopes.length,
+      principals.length,
+      `every limiter call naming a principal must also name its scope; found `
+      + `${principals.length} principalUserId vs ${scopes.length} principalScope. `
+      + 'An unscoped call shares one bucket between a customer\'s API key and '
+      + 'their browser session.',
+    );
+  });
+
+  it('derives the scope from the credential, not from a constant', () => {
+    // A hardcoded 'session' everywhere would satisfy the count check above while
+    // restoring the original bug, so pin that the scope is actually branched on
+    // the API-key signal.
+    assert.match(
+      GATEWAY_SOURCE,
+      /principalScope:\s*isUserApiKey\s*\?\s*'api_key'\s*:\s*'session'/,
+      'principalScope must be derived from isUserApiKey so API-key traffic lands '
+      + 'in its own namespace',
+    );
+  });
+});

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -1218,6 +1218,60 @@ describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blo
     );
   });
 
+  // WORLDMONITOR-12A: a customer's own API key and their browser session resolve
+  // to the SAME Clerk user id, so both landed in one `user:<id>` bucket. Observed
+  // in production 2026-09-11T17:47Z: an OSINT scraper on an api_starter key spent
+  // 598 of the 600/min budget, leaving the same person's dashboard 2 successes and
+  // 22 × 429 — their country deep-dive rendered half-empty. Programmatic traffic
+  // must not be able to starve the interactive session behind the same account.
+  it('gives a principal separate API-key and interactive-session buckets (WORLDMONITOR-12A)', async () => {
+    const pipelineHandler = makeProxyPipelineHandler();
+    const incrementedKeys = new Set<string>();
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      for (const command of commands) {
+        if (String(command[0]).toUpperCase() === 'INCR') {
+          incrementedKeys.add(String(command[1]));
+        }
+      }
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    }) as typeof fetch;
+
+    const mod = await importFreshRateLimitModule();
+    const req = makeRequest({ 'x-real-ip': '203.0.113.21' });
+    const principalUserId = 'api-customer';
+
+    // Drain the whole per-minute budget through the API key, exactly as the
+    // scraper did.
+    for (let i = 0; i < 600; i++) {
+      assert.equal(
+        await mod.checkRateLimit(req, {}, { principalUserId, principalScope: 'api_key' }),
+        null,
+      );
+    }
+    assert.equal(
+      (await mod.checkRateLimit(req, {}, { principalUserId, principalScope: 'api_key' }))?.status,
+      429,
+      'API-key traffic must still be capped — separation must not become an exemption',
+    );
+
+    // The same human's dashboard must survive their own scraper.
+    assert.equal(
+      await mod.checkRateLimit(req, {}, { principalUserId }),
+      null,
+      'the interactive session must not inherit the API key\'s exhausted bucket',
+    );
+
+    assert.ok(
+      incrementedKeys.has(`rl:fw:apikey-user:${principalUserId}`),
+      'API-key traffic must use its own namespace',
+    );
+    assert.ok(
+      incrementedKeys.has(`rl:fw:user:${principalUserId}`),
+      'session traffic must keep the established user: namespace so live buckets are not reset',
+    );
+  });
+
   it('degrades instead of creating a permanent counter when EXPIRE NX is unsupported', async () => {
     const pipelineHandler = makeProxyPipelineHandler({ expireNxUnsupported: true });
     globalThis.fetch = (async (_url: string, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

A paying API customer could lock themselves out of their own dashboard. Their API key and their browser session both resolve to the same Clerk user id, and the global limiter keyed on exactly that — so both credentials drew from one 600/min sliding window.

This is not hypothetical. On 2026-09-11 at 17:47 UTC, for one `api_starter` account:

| Source | Credential | Result in that minute |
|---|---|---|
| OSINT scraper | user API key | 598 × 200 |
| Dashboard (Firefox) | Clerk JWT | 2 × 200, 22 × 429 |

598 + 2 is exactly the 600 budget. The scraper consumed it, and the same person's country deep-dive rendered with food stocks, the five-factor scorecard, tariff trends, national debt, demographics, country vulnerabilities and the defense industrial base all missing. The user sees a half-empty page with no explanation.

`principalScope` now namespaces the bucket by credential — `apikey-user:<id>` for a validated user API key, `user:<id>` for an interactive session. The default stays `session`, so live session buckets keep their existing key and are not reset by the rollout.

## The tradeoff, stated plainly

This separates namespaces; it does not exempt anyone. Each scope is still capped at the same per-minute limit. The deliberate consequence is that the aggregate a single account can spend across both credentials doubles, from 600/min to 600 per credential.

That is the intended meter. Programmatic use is supposed to be bounded by the plan's own `apiRateLimit` and daily allowance, which the API-key layer already applies — but only when `API_RATE_LIMIT_ENFORCE` is on. While it is not enforcing, `governedByApiKeyLayer` stays false and API-key traffic falls through to this global bucket, which is how it reached the dashboard's in the first place.

So there are two levers, and this PR only pulls the safe one. Turning on the API-key layer is the durable fix and a config/billing decision I deliberately have not made here.

## Why two tests

They cover two separable failures, and the second is not redundant:

- The limiter must give the two credentials independent buckets.
- The gateway must actually tell the limiter which credential was used.

Deleting both `principalScope` arguments from `gateway.ts` leaves the limiter suite fully green. A module-only test cannot see the wiring regress, so the gateway test asserts the invariant that any limiter call naming a principal also names its scope — which also catches a future third call site that forgets it.

## Validation

Written test-first. The reproduction failed in the right way before the fix: after draining the budget through the API key, the interactive session inherited the exhausted bucket and got a 429 instead of passing.

- Reproduction test: red before, green after.
- Rate-limit suite: 61 pass. With the sibling API-key, user-prefs and 511 suites: 92 pass.
- Gateway suites (pro-fresh-cache, cdn-origin-policy, rpc-no-store-contract): 29 pass.
- Lint clean on all four changed files; no new typecheck errors.

Mutation-tested, three guards, each independently load-bearing:

| Mutation | Reds |
|---|---|
| Drop the gateway wiring | both wiring tests |
| Hardcode the scope to `'session'` | the branch test only |
| Drop the namespace split | the limiter test only |

The negative assertion matters as much as the positive one: the test still requires API-key traffic to hit 429 at 600, so the separation can never quietly become an exemption.

## Related

- Sentry: WORLDMONITOR-12A
- Evidence: Axiom `wm_api_usage`, 2026-09-11T17:44–17:50Z, principal `user_3Ip8…`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
