### PR TITLE
fix(hydration): arm viewport triggers after initial fan-out

### DIFF
--- a/e2e/dashboard-news-request-budget.spec.ts
+++ b/e2e/dashboard-news-request-budget.spec.ts
@@ -1179,6 +1179,10 @@ test.describe('dashboard container scroll hydration (#5876)', () => {
         return target instanceof HTMLElement && target.dataset.deferredPanel !== 'true';
       });
       expect(
+        await lcpMarkCount(page, VIEWPORT_HYDRATION_MARK),
+        'the App viewport handler must stay dormant while the slow tier is pending',
+      ).toBe(dashboardScroll.hydrationMarksBefore);
+      expect(
         stablecoinRequests,
         'the mounted panel callback must remain gated while slow-tier readiness is pending',
       ).toEqual([]);

--- a/e2e/dashboard-news-request-budget.spec.ts
+++ b/e2e/dashboard-news-request-budget.spec.ts
@@ -860,7 +860,7 @@ type DashboardScrollResult = {
 const VIEWPORT_HYDRATION_MARK = 'wm:hydration:viewport-trigger';
 const INITIAL_FANOUT_COMPLETE_MARK = 'wm:data:initial-fanout-complete';
 
-async function seedScrollableDashboard(page: Page): Promise<void> {
+async function seedScrollableDashboard(page: Page, panelOrder = SCROLL_HYDRATION_PANEL_ORDER): Promise<void> {
   await seedFreshAnonymousFullVariant(page, {
     stablecoins: { name: 'Stablecoins', enabled: true, priority: 1 },
   });
@@ -870,7 +870,7 @@ async function seedScrollableDashboard(page: Page): Promise<void> {
     localStorage.setItem('worldmonitor-panel-prune-v1', 'done');
     localStorage.setItem('worldmonitor-layout-reset-v2.5', 'done');
     localStorage.setItem('panel-order', JSON.stringify(panelOrder));
-  }, SCROLL_HYDRATION_PANEL_ORDER);
+  }, panelOrder);
 }
 
 async function installStablecoinContract(page: Page): Promise<string[]> {
@@ -1067,6 +1067,56 @@ async function installDelayedSlowBootstrap(page: Page): Promise<{
 }
 
 test.describe('dashboard container scroll hydration (#5876)', () => {
+  test('scroll during initial fan-out hydrates an already-mounted panel without another gesture', async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const first = [
+      'live-news', 'intel', 'gdelt-intel', 'live-webcams', 'insights',
+      'threat-timeline', 'strategic-posture', 'stablecoins', 'forecast',
+    ];
+    const order = [...first, ...SCROLL_HYDRATION_PANEL_ORDER.filter((key) => !first.includes(key))];
+    await seedScrollableDashboard(page, order);
+    const stablecoinRequests = await installStablecoinContract(page);
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    await page.route(DIGEST_GLOB, async (route) => {
+      await pending;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: digestBody(HEALTHY_DIGEST_CATEGORIES),
+      });
+    });
+    const slowBootstrap = await installDelayedSlowBootstrap(page);
+    try {
+      const navigation = page.goto('/', { waitUntil: 'domcontentloaded' });
+      await slowBootstrap.waitUntilRequested();
+      await page.waitForSelector('[data-panel="stablecoins"]');
+      // Keep this fixture to already-mounted panels: a deferred neighbor's
+      // mount callback would independently prime data and mask the lost scroll.
+      await page.addStyleTag({ content: '[data-deferred-panel="true"] { display: none !important; }' });
+      slowBootstrap.release();
+      await navigation;
+      await waitForLcpMark(page, 'wm:data:initial-fanout-start');
+      const panel = page.locator('[data-panel="stablecoins"]');
+      await expect(panel).not.toHaveAttribute('data-deferred-panel', 'true');
+      const initial = await readScrollMetrics(page);
+      expect(initial.targetTop).toBeGreaterThan(initial.viewportHeight + 400);
+      expect(stablecoinRequests).toHaveLength(0);
+      expect(await lcpMarkCount(page, INITIAL_FANOUT_COMPLETE_MARK)).toBe(0);
+      await scrollDashboardAndCollect(page);
+      expect(stablecoinRequests).toHaveLength(0);
+      release();
+      await waitForLcpMark(page, INITIAL_FANOUT_COMPLETE_MARK);
+      await expect.poll(() => stablecoinRequests.length).toBe(1);
+      await expect(panel.locator('.stable-health')).toContainText('HEALTHY');
+      expect(await lcpMarkCount(page, VIEWPORT_HYDRATION_MARK)).toBe(0);
+      await page.screenshot({ path: testInfo.outputPath('catchup-desktop.png') });
+    } finally {
+      release();
+      slowBootstrap.release();
+    }
+  });
+
   for (const viewport of [
     // From SPLIT_LAYOUT_MIN_WIDTH (900, src/app/split-layout.ts — #6417) the
     // split layout makes .panels-grid the scroll owner; below it the stacked
@@ -1076,7 +1126,7 @@ test.describe('dashboard container scroll hydration (#5876)', () => {
     { label: 'mobile', width: 390, height: 844, scrollOwner: 'main-content' },
     { label: 'ultra-wide', width: 1720, height: 720, scrollOwner: 'panels-grid' },
   ]) {
-    test(`${viewport.label} container scroll hydrates a panel-specific data path`, async ({ page }) => {
+    test(`${viewport.label} container scroll hydrates a panel-specific data path`, async ({ page }, testInfo) => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await seedScrollableDashboard(page);
       const stablecoinRequests = await installStablecoinContract(page);
@@ -1138,6 +1188,7 @@ test.describe('dashboard container scroll hydration (#5876)', () => {
       ).toBe(1);
       await expect(stablecoins.locator('.stable-health')).toContainText('HEALTHY');
       expect(stablecoinRequests).toHaveLength(1);
+      await page.screenshot({ path: testInfo.outputPath(`hydrated-${viewport.label}.png`) });
     });
   }
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -366,6 +366,8 @@ export class App {
   private visiblePanelPrimeRaf: number | null = null;
   private viewportHydrationReady = false;
   private viewportHydrationReadyAt = 0;
+  /** Scroll/resize register at readiness; marks/primes arm only after fan-out. */
+  private viewportTriggersArmed = false;
   private followedCountriesCapDropToastTimer: number | null = null;
   private bootstrapHydrationState: BootstrapHydrationState = getBootstrapHydrationState();
   private cachedModeBannerEl: HTMLElement | null = null;
@@ -387,6 +389,10 @@ export class App {
   };
   private readonly handleViewportPrime = (event?: Event): void => {
     if (!this.viewportHydrationReady || this.state.isDestroyed) return;
+    // Early scrolls are covered by the initial fan-out scan. Arming earlier lets
+    // layout thrash from that scroll schedule wm:hydration:viewport-trigger and
+    // flake the #5876 early-scroll regression (Expected 0, Received 1).
+    if (!this.viewportTriggersArmed) return;
     if (
       event &&
       this.viewportHydrationReadyAt > 0 &&
@@ -2929,15 +2935,11 @@ export class App {
     // (3.5 s browser / 8.5 s desktop). (#4512)
     await slowTierReady;
     if (this.state.isDestroyed) return;
-    this.viewportHydrationReadyAt = typeof performance !== 'undefined' &&
-      typeof performance.now === 'function'
-      ? performance.now()
-      : Date.now();
+    // Open readiness so deferred panel mounts can call primeVisiblePanelData,
+    // but keep scroll/resize triggers disarmed until the fan-out finishes.
+    // Scrolls before readiness (and layout thrash during fan-out after an early
+    // scroll) are covered by the fan-out's current-viewport scan. (#5876)
     this.viewportHydrationReady = true;
-    // Register viewport triggers only after the slow bootstrap tier settles.
-    // Scrolls before this point are covered by the initial fan-out below, which
-    // scans the current viewport after readiness. Registering earlier lets a
-    // captured descendant scroll consume hydration keys before they arrive.
     window.addEventListener('scroll', this.handleViewportPrime, {
       passive: true,
       capture: true,
@@ -2959,6 +2961,14 @@ export class App {
       this.primeVisiblePanelData(),
     ]);
     markLcpDebug('wm:data:initial-fanout-complete');
+    if (this.state.isDestroyed) return;
+    // Stamp + arm only after fan-out so an early scroll cannot schedule or
+    // replay a viewport-trigger mark across readiness. (#5876)
+    this.viewportHydrationReadyAt = typeof performance !== 'undefined' &&
+      typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+    this.viewportTriggersArmed = true;
     if (import.meta.env.VITE_E2E === '1') {
       document.documentElement.dataset.wmInitialDataReady = 'true';
     }
@@ -3500,6 +3510,7 @@ export class App {
     this.pendingPreferenceHandoffGeneration = undefined;
     this.viewportHydrationReady = false;
     this.viewportHydrationReadyAt = 0;
+    this.viewportTriggersArmed = false;
     cancelBootstrapSlowTier();
     window.removeEventListener('scroll', this.handleViewportPrime, { capture: true });
     window.removeEventListener('resize', this.handleViewportPrime);

--- a/src/App.ts
+++ b/src/App.ts
@@ -389,9 +389,8 @@ export class App {
   };
   private readonly handleViewportPrime = (event?: Event): void => {
     if (!this.viewportHydrationReady || this.state.isDestroyed) return;
-    // Early scrolls are covered by the initial fan-out scan. Arming earlier lets
-    // layout thrash from that scroll schedule wm:hydration:viewport-trigger and
-    // flake the #5876 early-scroll regression (Expected 0, Received 1).
+    // The catch-up scan after fan-out covers early viewport changes without
+    // replaying their scroll events as viewport-trigger marks. (#5876)
     if (!this.viewportTriggersArmed) return;
     if (
       event &&
@@ -2969,6 +2968,9 @@ export class App {
       ? performance.now()
       : Date.now();
     this.viewportTriggersArmed = true;
+    // The viewport can move after the initial synchronous geometry scan while
+    // other fan-out requests are pending. Hydrate its current position once.
+    void this.primeVisiblePanelData();
     if (import.meta.env.VITE_E2E === '1') {
       document.documentElement.dataset.wmInitialDataReady = 'true';
     }

--- a/tests/app-destroy-lifecycle.test.mjs
+++ b/tests/app-destroy-lifecycle.test.mjs
@@ -97,21 +97,27 @@ describe('App.destroy lifecycle cleanup contract', () => {
     );
 
     const slowTierAwait = appSrc.indexOf('await slowTierReady;');
-    const readyTimestamp = appSrc.indexOf('this.viewportHydrationReadyAt = typeof performance');
-    const readyFlag = appSrc.indexOf('this.viewportHydrationReady = true;', readyTimestamp);
+    const readyFlag = appSrc.indexOf('this.viewportHydrationReady = true;', slowTierAwait);
     const scrollRegistration = appSrc.indexOf("window.addEventListener('scroll', this.handleViewportPrime");
+    const fanoutComplete = appSrc.indexOf("markLcpDebug('wm:data:initial-fanout-complete');", scrollRegistration);
+    const readyTimestamp = appSrc.indexOf('this.viewportHydrationReadyAt = typeof performance', fanoutComplete);
+    const armedFlag = appSrc.indexOf('this.viewportTriggersArmed = true;', readyTimestamp);
     assert.notEqual(slowTierAwait, -1, 'could not locate the slow-tier readiness checkpoint');
     assert.ok(
       scrollRegistration > slowTierAwait,
       'captured descendant scrolls must not trigger hydration before the slow tier settles',
     );
     assert.ok(
-      readyTimestamp > slowTierAwait && readyTimestamp < scrollRegistration,
-      'viewport hydration must stamp the readiness time before registering scroll listeners',
+      readyFlag > slowTierAwait && readyFlag < scrollRegistration,
+      'viewport hydration readiness must open before registering scroll listeners',
     );
     assert.ok(
-      readyFlag > readyTimestamp && readyFlag < scrollRegistration,
-      'viewport hydration readiness must open after the readiness timestamp is captured',
+      fanoutComplete > scrollRegistration,
+      'scroll listeners register before the initial fan-out completes',
+    );
+    assert.ok(
+      readyTimestamp > fanoutComplete && armedFlag > readyTimestamp,
+      'viewport triggers must stamp readiness and arm only after the initial fan-out',
     );
   });
 
@@ -128,14 +134,16 @@ describe('App.destroy lifecycle cleanup contract', () => {
       'repeated scrolls in one frame must share one hydration callback',
     );
     assert.match(handler, /if \(!this\.viewportHydrationReady \|\| this\.state\.isDestroyed\) return;/);
+    assert.match(handler, /if \(!this\.viewportTriggersArmed\) return;/);
     assert.match(handler, /event\?\.type === 'scroll'/);
     assert.match(handler, /event\.target instanceof Element/);
     assert.match(handler, /!event\.target\.matches\('\.main-content, \.panels-grid'\)/);
+    const armedGuard = handler.indexOf('if (!this.viewportTriggersArmed) return;');
     const staleEventGuard = handler.indexOf('event.timeStamp < this.viewportHydrationReadyAt');
     const rafSchedule = handler.indexOf('this.visiblePanelPrimeRaf = window.requestAnimationFrame(');
     assert.ok(
-      staleEventGuard >= 0 && staleEventGuard < rafSchedule,
-      'scroll events created before slow-tier readiness must not replay viewport hydration afterward',
+      armedGuard >= 0 && armedGuard < staleEventGuard && staleEventGuard < rafSchedule,
+      'scroll events must stay disarmed through fan-out and ignore pre-arm timestamps afterward',
     );
     assert.match(handler, /this\.visiblePanelPrimeRaf = window\.requestAnimationFrame\(/);
     assert.match(handler, /this\.visiblePanelPrimeRaf = null;/);
@@ -150,8 +158,8 @@ describe('App.destroy lifecycle cleanup contract', () => {
     );
     assert.match(
       body,
-      /this\.viewportHydrationReady = false;\s*this\.viewportHydrationReadyAt = 0;/,
-      'destroy() must reset the viewport hydration readiness timestamp',
+      /this\.viewportHydrationReady = false;\s*this\.viewportHydrationReadyAt = 0;\s*this\.viewportTriggersArmed = false;/,
+      'destroy() must reset viewport hydration readiness and arming',
     );
 
     const afterPanelMounted = methodBody(panelLayoutSrc, 'private afterPanelMounted(key: string, panel: Panel): void');


### PR DESCRIPTION
## Summary

Keep viewport scroll/resize hydration triggers disarmed until the initial data fan-out finishes. An early scroll can mount a panel while bootstrap is pending; the initial scan hydrates it without replaying an early viewport trigger. A second scan when triggers arm catches scrolls or resizes made while other initial requests are pending, so already-mounted panels do not need another gesture. Existing priming guards prevent duplicate requests and preserve retry backoff.

This preserves the #5876 follow-up previously included in #8007 and separates it from that PR's billing changes. It is based directly on main.

## Validation

- All 14 Chromium news request-budget and viewport hydration tests pass.
- The new regression failed before the fix with no Stablecoins request after initial fan-out; it now hydrates after one scroll, without another gesture or a replayed viewport-trigger mark.
- Nine lifecycle checks, TypeScript, import-boundary lint, and `git diff --check` pass.
- Tested commit: `e90e1d5d0`.

Stablecoin and slow-bootstrap responses are controlled fixtures. The new desktop regression hides deferred panel placeholders to isolate already-mounted panels and prevent neighboring mount callbacks from masking the missed scroll. The mobile screenshot exercises normal container scroll hydration. This proves browser behavior, not live provider freshness; other screenshot content is outside the assertions. No deployment was performed.

![Desktop: synthetic Stablecoins hydrated after a scroll during initial fan-out at e90e1d5d0](https://github.com/user-attachments/assets/b6d52c62-abdb-430c-803a-6255d95b71ec)

![Mobile: synthetic Stablecoins hydrated after container scroll at e90e1d5d0](https://github.com/user-attachments/assets/fcee0d4c-5793-4e28-860c-fa4775d0e38d)