### PR TITLE
fix(seo): link Crunchbase and Wikidata company identities

### DIFF
--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -187,6 +187,7 @@
       "disambiguatingDescription": "World Monitor is the open-source real-time global intelligence dashboard published at www.worldmonitor.app by founder Elie Habib since 2026, catalogued on Wikidata as Q141237754 and developed in the open at github.com/koala73/worldmonitor under AGPL-3.0. It is unaffiliated with the similarly named worldmonitor.io, world-monitor.app, and world-monitor.com, with any \"World Monitor Pro\" repository outside github.com/koala73/worldmonitor, and with unrelated mobile applications published under the same name.",
       "sameAs": [
         "https://www.crunchbase.com/organization/world-monitor",
+        "https://www.wikidata.org/wiki/Q141437464",
         "https://github.com/koala73/worldmonitor",
         "https://www.npmjs.com/package/worldmonitor",
         "https://rubygems.org/gems/worldmonitor",

--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -186,6 +186,7 @@
       "description": "Open-source real-time global intelligence platform aggregating conflicts, military movements, markets, infrastructure, and geopolitical data.",
       "disambiguatingDescription": "World Monitor is the open-source real-time global intelligence dashboard published at www.worldmonitor.app by founder Elie Habib since 2026, catalogued on Wikidata as Q141237754 and developed in the open at github.com/koala73/worldmonitor under AGPL-3.0. It is unaffiliated with the similarly named worldmonitor.io, world-monitor.app, and world-monitor.com, with any \"World Monitor Pro\" repository outside github.com/koala73/worldmonitor, and with unrelated mobile applications published under the same name.",
       "sameAs": [
+        "https://www.crunchbase.com/organization/world-monitor",
         "https://github.com/koala73/worldmonitor",
         "https://www.npmjs.com/package/worldmonitor",
         "https://rubygems.org/gems/worldmonitor",

--- a/tests/brand-identity-page.test.mjs
+++ b/tests/brand-identity-page.test.mjs
@@ -106,6 +106,7 @@ describe('Organization JSON-LD NAP alignment', () => {
     const [org] = organizationBlocks(read('pro-test/welcome.html'));
     for (const edge of [
       'https://www.crunchbase.com/organization/world-monitor',
+      'https://www.wikidata.org/wiki/Q141437464',
       'https://rubygems.org/gems/worldmonitor',
       'https://pypi.org/project/worldmonitor-sdk/',
       'https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go',

--- a/tests/brand-identity-page.test.mjs
+++ b/tests/brand-identity-page.test.mjs
@@ -102,9 +102,10 @@ describe('Organization JSON-LD NAP alignment', () => {
     assert.doesNotMatch(read('pro-test/prerender.mjs'), /Organization JSON-LD|ORGANIZATION_JSONLD/);
   });
 
-  it('links owned registry packages, never the foreign PyPI name or the product item', () => {
+  it('links the organization profile and owned packages, never foreign identities', () => {
     const [org] = organizationBlocks(read('pro-test/welcome.html'));
     for (const edge of [
+      'https://www.crunchbase.com/organization/world-monitor',
       'https://rubygems.org/gems/worldmonitor',
       'https://pypi.org/project/worldmonitor-sdk/',
       'https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go',


### PR DESCRIPTION
## Summary

Crawlers can now connect World Monitor's canonical publisher organization to its [Crunchbase profile](https://www.crunchbase.com/organization/world-monitor) and [Wikidata company item Q141437464](https://www.wikidata.org/wiki/Q141437464). The company item is typed as a company and links the official website; software item Q141237754 stays on SoftwareApplication.sameAs.

Related: #7373

## Validation

- Existing brand identity test failed for the missing Crunchbase and company Wikidata URLs in separate red/green runs before the change; all 8 tests pass after it.
- Welcome production build passed. Its generated Organization JSON-LD contains both organization URLs.
- All 15 schema graph contract tests pass with `WM_EXPECT_BUILT_OUTPUT=1`, with no skips.
- Inline correctness, test, maintainability, standards, and agent-access review found no actionable issues. No visible UI change.

## Post-Deploy Monitoring & Validation

After an authorized deployment, the PR owner should inspect homepage JSON-LD once: `#organization.sameAs` must contain the Crunchbase organization URL and Q141437464, and the product Wikidata URL must remain on `#software`. Revert this addition if the destination resolves to a different entity. Search engine ingestion is not verified by these checks; no additional runtime monitoring is required for this static metadata change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
