### PR TITLE
fix(mnd): preserve proxy failure phase and status

### DIFF
--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -183,6 +183,15 @@ function resolveProxyStringConnect() {
   return cfg.tls ? `https://${base}` : base;
 }
 
+function recordProxyFailure(error, stage, httpStatus = null, proxyConnectStatus = null) {
+  try {
+    Object.defineProperty(error, 'proxyFailure', {
+      value: { stage, httpStatus, proxyConnectStatus }, configurable: true,
+    });
+  } catch { /* Frozen errors and primitive abort reasons keep their original identity. */ }
+  return error;
+}
+
 function proxyConnectTunnel(targetHostname, proxyConfig, { timeoutMs = 20_000, targetPort = 443, signal } = {}) {
   return new Promise((resolve, reject) => {
     if (signal && signal.aborted) {
@@ -192,12 +201,14 @@ function proxyConnectTunnel(targetHostname, proxyConfig, { timeoutMs = 20_000, t
     let proxySock;
     let settled = false;
     let onAbort = null;
+    let stage = 'proxy_connection';
+    let proxyConnectStatus = null;
     const cleanup = () => {
       clearTimeout(timer);
       if (signal && onAbort) signal.removeEventListener('abort', onAbort);
     };
     const resolveOnce = (val) => { if (settled) return; settled = true; cleanup(); resolve(val); };
-    const rejectOnce = (err) => { if (settled) return; settled = true; cleanup(); reject(err); };
+    const rejectOnce = (err) => { if (settled) return; settled = true; cleanup(); reject(recordProxyFailure(err, stage, null, proxyConnectStatus)); };
 
     const timer = setTimeout(() => {
       if (proxySock) proxySock.destroy();
@@ -215,6 +226,7 @@ function proxyConnectTunnel(targetHostname, proxyConfig, { timeoutMs = 20_000, t
     const onError = (e) => rejectOnce(e);
 
     const connectCb = () => {
+      stage = 'proxy_connect';
       const authHeader = proxyConfig.auth
         ? `\r\nProxy-Authorization: Basic ${Buffer.from(proxyConfig.auth).toString('base64')}`
         : '';
@@ -228,6 +240,8 @@ function proxyConnectTunnel(targetHostname, proxyConfig, { timeoutMs = 20_000, t
         if (!buf.includes('\r\n\r\n')) return;
         proxySock.removeListener('data', onData);
         const statusLine = buf.split('\r\n')[0];
+        const status = Number(/^HTTP\/1\.[01] (\d{3})(?:\s|$)/.exec(statusLine)?.[1]);
+        proxyConnectStatus = status >= 100 && status <= 599 ? status : null;
         if (!statusLine.startsWith('HTTP/1.1 200') && !statusLine.startsWith('HTTP/1.0 200')) {
           proxySock.destroy();
           return rejectOnce(
@@ -242,6 +256,7 @@ function proxyConnectTunnel(targetHostname, proxyConfig, { timeoutMs = 20_000, t
           );
         }
         proxySock.pause();
+        stage = 'target_tls';
 
         const tlsSocket = tls.connect(
           { socket: proxySock, servername: targetHostname, ALPNProtocols: ['http/1.1'] },
@@ -311,6 +326,8 @@ function proxyFetch(url, proxyConfig, {
     return new Promise((resolve, reject) => {
       let settled = false;
       let onAbort = null;
+      let stage = 'response_headers';
+      let httpStatus = null;
       const cleanup = () => {
         clearTimeout(timer);
         if (signal && onAbort) signal.removeEventListener('abort', onAbort);
@@ -318,7 +335,7 @@ function proxyFetch(url, proxyConfig, {
       // Both terminal paths destroy the TLS tunnel (mirrors the original
       // behavior where success + failure both released the socket).
       const resolveOnce = (v) => { if (settled) return; settled = true; cleanup(); destroy(); resolve(v); };
-      const rejectOnce = (e) => { if (settled) return; settled = true; cleanup(); destroy(); reject(e); };
+      const rejectOnce = (e) => { if (settled) return; settled = true; cleanup(); destroy(); reject(recordProxyFailure(e, stage, httpStatus)); };
 
       const timer = setTimeout(() => rejectOnce(new Error('proxy fetch timeout')), timeoutMs);
 
@@ -344,6 +361,9 @@ function proxyFetch(url, proxyConfig, {
         headers: reqHeaders,
         createConnection: () => tlsSocket,
       }, (resp) => {
+        stage = 'response_body';
+        httpStatus = Number.isInteger(resp.statusCode) && resp.statusCode >= 100 && resp.statusCode <= 599
+          ? resp.statusCode : null;
         let stream = resp;
         const enc = (resp.headers['content-encoding'] || '').trim().toLowerCase();
         if (enc === 'gzip') stream = resp.pipe(zlib.createGunzip());

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -1685,7 +1685,23 @@ async function fetchBoundedTextWithStatus(fetchFn, url, sourceContract, diagnost
   if (!isAllowedSourceUrl(url, sourceContract)) {
     throw new Error('UNSAFE_SOURCE_URL');
   }
-  const response = await fetchFn(url, boundedHtmlRequestInit(sourceContract));
+  let response;
+  try {
+    response = await fetchFn(url, boundedHtmlRequestInit(sourceContract));
+  } catch (error) {
+    if (diagnostic?.transport === 'proxy') {
+      const details = error?.proxyFailure;
+      diagnostic.stage = ['proxy_connection', 'proxy_connect', 'target_tls', 'response_headers', 'response_body']
+        .includes(details?.stage) ? details.stage : 'unknown';
+      diagnostic.httpStatus = diagnostic.stage === 'response_body'
+        && Number.isInteger(details?.httpStatus) && details.httpStatus >= 100 && details.httpStatus <= 599
+        ? details.httpStatus : null;
+      diagnostic.proxyConnectStatus = ['proxy_connect', 'target_tls'].includes(diagnostic.stage)
+        && Number.isInteger(details?.proxyConnectStatus) && details.proxyConnectStatus >= 100 && details.proxyConnectStatus <= 599
+        ? details.proxyConnectStatus : null;
+    }
+    throw error;
+  }
   if (diagnostic) {
     diagnostic.httpStatus = response.status;
     diagnostic.stage = response.ok ? 'response_body' : 'response_headers';

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -3378,6 +3378,41 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.deepEqual(mnd.errorCodes, ['SOURCE_ERROR']);
     assert.equal(mnd.requestDiagnostics.filter(row => row.purpose === 'detail').length,
       MND_MAX_DETAIL_REQUESTS_PER_RUN);
+    for (const diagnostic of mnd.requestDiagnostics.filter(row => row.purpose === 'detail')) {
+      assert.equal(diagnostic.stage, 'response_body');
+      assert.equal(diagnostic.httpStatus, 200);
+      assert.equal(diagnostic.proxyConnectStatus, null);
+    }
+  });
+
+  it('keeps unknown MND proxy failures unknown and excludes untrusted diagnostic fields', async () => {
+    const secret = 'proxy-user:proxy-secret@proxy.test';
+    for (const details of [undefined, {
+      stage: secret, httpStatus: 999, proxyConnectStatus: '407', message: secret,
+    }, {
+      stage: 'proxy_connect', httpStatus: 407, proxyConnectStatus: 407, message: secret,
+    }]) {
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        now: Date.parse(retrievedAt), proxyUrl: '', mndProxyUrl: `https://${secret}`,
+        sleepFn: async () => {},
+        fetchFn: async (input: string | URL | Request) => {
+          if (String(input).includes('mod.go.jp')) return new Response(usableJapanEnglishIndex);
+          throw new TypeError('fetch failed');
+        },
+        proxyRequestFn: async () => {
+          throw Object.assign(new Error(secret), { proxyFailure: details });
+        },
+      });
+      const mnd = snapshot.sources.find(source => source.id === 'taiwan-mnd');
+      const diagnostic = mnd.requestDiagnostics.find(row => row.transport === 'proxy');
+      assert.equal(diagnostic.stage, details?.stage === 'proxy_connect' ? 'proxy_connect' : 'unknown');
+      assert.equal(diagnostic.httpStatus, null);
+      assert.equal(diagnostic.proxyConnectStatus, details?.stage === 'proxy_connect' ? 407 : null);
+      assert.equal(diagnostic.errorCode, 'SOURCE_ERROR');
+      assert.equal(mnd.requestCount, 2);
+      assert.equal(mnd.lastSuccessAt, null);
+      assert.equal(JSON.stringify(snapshot).includes('proxy-secret'), false);
+    }
   });
 
   it('recovers MND header failures and keeps repeated unusable coverage actionable', async () => {
@@ -3681,8 +3716,10 @@ describe('quantified cross-Strait activity (#5575)', () => {
       assert.deepEqual(mnd?.requestDiagnostics?.filter(row => row.path.endsWith('/90000'))
         .map(({ elapsedMs, ...failure }) => failure), failures.map((failure, index) => ({
         path: '/en/News/PLAAct/90000', purpose: 'detail', attempt: index + 1,
-        stage: failure === 'timeout' ? 'response_headers' : 'parse',
+        stage: failure === 'timeout'
+          ? (index === 1 && failures[0] === 'timeout' ? 'unknown' : 'response_headers') : 'parse',
         httpStatus: failure === 'timeout' ? null : 200,
+        ...(failure === 'timeout' && index === 1 && failures[0] === 'timeout' ? { proxyConnectStatus: null } : {}),
         errorCode: failure === 'timeout' ? 'TIMEOUT' : 'MND_PUBLICATION_METADATA_MISSING',
         ...(index === 1 && failures[0] === 'timeout' ? { transport: 'proxy' } : {}),
       })));

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -1,13 +1,16 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import { createRequire } from 'node:module';
-import { Readable } from 'node:stream';
+import net from 'node:net';
+import tls from 'node:tls';
+import { PassThrough, Readable } from 'node:stream';
 import { describe, it } from 'node:test';
 
 const {
   _readBoundedResponseStream,
   parseProxyConfig,
   parseProxyConfigForAttempt,
+  proxyConnectTunnel,
   proxyFetch,
   resolveProxyString,
   resolveProxyStringForAttempt,
@@ -31,6 +34,91 @@ function proxyFetchHarness(response, { maxResponseBytes = Infinity } = {}) {
 }
 
 describe('proxy utilities', () => {
+  for (const stage of ['proxy_connection', 'proxy_connect', 'target_tls']) {
+    it(`preserves the error and reports the observed ${stage} failure`, async (t) => {
+      const failure = Object.assign(new Error('fixture connection reset'), { code: 'ECONNRESET' });
+      const socket = Object.assign(new EventEmitter(), {
+        destroy() {}, pause() {}, resume() {},
+        write() {
+          queueMicrotask(() => socket.emit('data', Buffer.from(
+            stage === 'proxy_connect' ? 'HTTP/1.1 407 Proxy Authentication Required\r\n\r\n'
+              : 'HTTP/1.1 200 Connection established\r\n\r\n',
+          )));
+        },
+      });
+      t.mock.method(net, 'connect', (_options, onConnect) => {
+        queueMicrotask(() => stage === 'proxy_connection' ? socket.emit('error', failure) : onConnect());
+        return socket;
+      });
+      t.mock.method(tls, 'connect', () => {
+        const target = new EventEmitter();
+        queueMicrotask(() => target.emit('error', failure));
+        return target;
+      });
+      await assert.rejects(proxyConnectTunnel('origin.test', {
+        host: 'proxy.test', port: 8080, auth: 'user:secret', tls: false,
+      }), error => {
+        if (stage === 'proxy_connect') {
+          assert.equal(error.proxyConnect, true);
+          assert.equal(error.status, 407);
+        } else {
+          assert.equal(error, failure);
+          assert.equal(error.code, 'ECONNRESET');
+        }
+        assert.deepEqual(error.proxyFailure, {
+          stage, httpStatus: null,
+          proxyConnectStatus: stage === 'proxy_connection' ? null : stage === 'proxy_connect' ? 407 : 200,
+        });
+        assert.equal(Object.keys(error).includes('proxyFailure'), false);
+        return true;
+      });
+    });
+  }
+
+  for (const stage of ['response_headers', 'response_body']) {
+    it(`retains status and rejection identity for a proxy ${stage} failure`, async () => {
+      const failure = Object.assign(new Error('fixture response reset'), { code: 'ECONNRESET' });
+      let destroyed = 0;
+      await assert.rejects(proxyFetch('https://origin.test/report', { host: 'proxy.test', port: 8080 }, {
+        connectTunnel: async () => ({ socket: {}, destroy() { destroyed += 1; } }),
+        requestFn: (_options, onResponse) => {
+          const req = new EventEmitter();
+          req.end = () => {
+            if (stage === 'response_headers') queueMicrotask(() => req.emit('error', failure));
+            else {
+              const response = Object.assign(new PassThrough(), { statusCode: 200, headers: {} });
+              onResponse(response);
+              response.destroy(failure);
+            }
+          };
+          return req;
+        },
+      }), error => {
+        assert.equal(error, failure);
+        assert.equal(error.code, 'ECONNRESET');
+        assert.deepEqual(error.proxyFailure, {
+          stage, httpStatus: stage === 'response_body' ? 200 : null, proxyConnectStatus: null,
+        });
+        return true;
+      });
+      assert.equal(destroyed, 1);
+    });
+  }
+
+  it('does not replace frozen or primitive abort reasons for diagnostics', async () => {
+    for (const reason of [Object.freeze(new Error('frozen failure')), 'plain failure']) {
+      const controller = new AbortController();
+      await assert.rejects(proxyFetch('https://origin.test/report', { host: 'proxy.test', port: 8080 }, {
+        signal: controller.signal,
+        connectTunnel: async () => ({ socket: {}, destroy() {} }),
+        requestFn: () => Object.assign(new EventEmitter(), { end() { controller.abort(reason); } }),
+      }), error => {
+        assert.equal(error, reason);
+        return true;
+      });
+    }
+  });
+
   it('applies standard ports when URL parsing normalizes them away', () => {
     assert.deepEqual(
       parseProxyConfig('https://proxy-user:proxy-secret@proxy.test:443'),


### PR DESCRIPTION
## Summary

MND request diagnostics now distinguish a proxy connection, CONNECT reply, target TLS handshake, response headers, and response body failure. Previously, the buffered proxy helper could receive HTTP 200 and then lose the status when the body reset. The adapter logged `response_headers` with `httpStatus: null`.

The helper adds non-enumerable phase/status metadata to the same error object. The adapter copies only allowlisted phases and numeric statuses, with CONNECT status separate from target HTTP status. Unknown errors remain `unknown`; immutable errors and primitive abort reasons keep their original identity. Raw errors, credentials, proxy URLs, headers, and response bodies are not added to diagnostics. Error codes, transport selection, retry counts, deadlines, and source success clocks are unchanged.

## Validation

- Seven new diagnostic assertions failed before the repair while the prior 178 checks passed. After repair, 185 focused checks pass across the MND adapter, real proxy helper, and source fallback suites.
- Another 295 affected-caller checks pass, including FRED, sanctions, PortWatch, weather, Open-Meteo, China macro, electricity, valuations, FATF, GDELT unrest, and OpenSky proxy contracts.
- Covers HTTP 200 followed by body reset, observed connection/CONNECT/TLS phases, target header failure, unknown or hostile metadata, CONNECT/origin status separation, secret exclusion, and unchanged rejection identity/code.
- Biome and all repository pre-push gates pass. Sequential ce-simplify-code and ce-code-review found no actionable findings; no external review automation was invoked.

All behavior evidence above uses controlled local fixtures. This is a diagnostic correction, not proof of live transport recovery.

## Post-deployment verification

Deployment requires separate authorization. After deployment, inspect a naturally occurring MND failure for an observed phase and separate CONNECT/target statuses. An HTTP-200 body failure should retain `response_body` and `200`; unknown errors must remain unknown. Verify request limits and source success clocks remain unchanged. Do not run a seeder or generate paid probes for this verification.
