### PR TITLE
fix(tests): align Telegram API-key rate-limit namespace

### DIFF
--- a/server/__tests__/gateway-telegram-feed-policy.test.ts
+++ b/server/__tests__/gateway-telegram-feed-policy.test.ts
@@ -109,7 +109,7 @@ for(const [name,headers,session] of [
     expect(response.headers.get('Cache-Control')).toMatch(/private/);
     expect(response.headers.get('CDN-Cache-Control')).toBeNull();
     expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
-    expect(endpointKeys()[0]).toContain(name==='paid user key'?':user:paid-account:':`:ip:${IP}:`);
+    expect(endpointKeys()[0]).toContain(name==='paid user key'?':apikey-user:paid-account:':`:ip:${IP}:`);
   });
 }
 for(const headers of [{},{'X-Api-Key':'invalid-key'}]) {
@@ -145,7 +145,7 @@ test('verified keys share a paid account identity across keys and IPs',async()=>
   await request(PATH,{'X-Api-Key':'wm_'+'b'.repeat(40),'x-real-ip':'192.0.2.29'},false);
   expect(endpointKeys()).toHaveLength(2);
   expect(new Set(endpointKeys()).size).toBe(1);
-  expect(endpointKeys()[0]).toContain(':user:paid-account:');
+  expect(endpointKeys()[0]).toContain(':apikey-user:paid-account:');
 });
 test('a session key header preserves the same IP identity as session cookies',async()=>{
   const token=(await issueSessionToken()).token;


### PR DESCRIPTION
## Summary

Restores the Telegram policy test suite after #8049 introduced two expectations for the old paid-user bucket namespace. API-key requests deliberately use `apikey-user:` since #8060; the tests now verify that namespace while retaining the shared-account, session/IP, cap, and cache assertions. Production behavior is unchanged.

Related: #8049, #8060. The failure was reproduced on current main before the edit.

## Validation

- Telegram policy test: 2 failed / 10 passed before; 12/12 passed after.
- `npm run test:convex`: 2,059/2,059 passed across 103 files.
- Rate-limit, API-key and gateway principal-scope tests: 83/83 passed.
- Policy audit passed; exact-head sequential code review found no actionable issues.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes only two test expectations. Verify required PR CI and the next main `convex-tests` run before considering the post-merge failure cleared.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--6-000000)
