### PR TITLE
fix(seo): quote the forecast accuracy score in prose

### DIFF
--- a/.github/workflows/crawlable-pulse-refresh.yml
+++ b/.github/workflows/crawlable-pulse-refresh.yml
@@ -76,7 +76,7 @@ jobs:
               --base main \
               --head "$branch" \
               --title "chore(corpus): refresh crawlable live pulse ${period}" \
-              --body "Weekly crawlable live-pulse refresh. Rebuilds the crawlable corpus, root sitemap, and the homepage welcome-teaser strip (#7608)."
+              --body "Weekly crawlable live-pulse refresh. Rebuilds the crawlable corpus, root sitemap, llms-full forecast-accuracy section, and the homepage welcome-teaser strip (#7608, #8070)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -134,8 +134,13 @@ jobs:
           # publishing headlines and scores this freeze has already superseded —
           # the drift that produced #7608 — and red the unit gate on this PR.
           npm run teasers:welcome
+          # The Forecast accuracy section in llms-full is derived from this
+          # snapshot (#8070). Skipping the rebuild would leave the corpus quoting
+          # last week's Brier after /accuracy/ had already moved.
+          npm run build:llms-full
           node --import tsx --test --test-concurrency=1 \
             tests/accuracy-corpus.test.mjs \
+            tests/seo-geo-residue.test.mjs \
             tests/crawlable-corpus.test.mjs \
             tests/crawlable-developments.test.mjs \
             tests/crawlable-live-tools.test.mjs \
@@ -163,7 +168,7 @@ jobs:
           git switch -c "$BRANCH_NAME"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "$snapshot_path" public/sitemap.xml public/sitemap-main.xml pro-test/src/generated/teasers.json pro-test/welcome.html pro-test/index.html
+          git add "$snapshot_path" public/sitemap.xml public/sitemap-main.xml public/llms-full.txt pro-test/src/generated/teasers.json pro-test/welcome.html pro-test/index.html
           git commit -m "chore(corpus): refresh crawlable live pulse ${snapshot_date}"
           # Route lastmod dates come from committed material sources.
           npm run build:sitemap
@@ -177,4 +182,4 @@ jobs:
             --base main \
             --head "$BRANCH_NAME" \
             --title "chore(corpus): refresh crawlable live pulse ${snapshot_date}" \
-            --body "Weekly crawlable live-pulse refresh. Rebuilds the crawlable corpus, root sitemap, and the homepage welcome-teaser strip (#7608)."
+            --body "Weekly crawlable live-pulse refresh. Rebuilds the crawlable corpus, root sitemap, llms-full forecast-accuracy section, and the homepage welcome-teaser strip (#7608, #8070)."

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -41,6 +41,7 @@ The project is built with TypeScript, Vite, MapLibre GL JS, deck.gl, D3.js, and 
 - [Comparisons](#corpus-comparisons)
 - [Glossary](#corpus-glossary)
 - [Monitored chokepoints](#corpus-monitored-chokepoints)
+- [Forecast accuracy](#corpus-forecast-accuracy)
 - [Chokepoint methodology](#corpus-chokepoint-methodology)
 - [Start here](#corpus-start-here)
 - [What we track](#corpus-what-we-track)
@@ -425,7 +426,7 @@ Native desktop app built with Tauri (Rust + Node.js sidecar). The sidecar mirror
 <a id="corpus-generated-corpus"></a>
 ## Generated corpus
 
-The sections below are produced by `npm run build:llms-full` from the source catalog, comparison-page registry, glossary terms, chokepoint methodology, published chokepoint explainers, the Country Resilience Index methodology, the corrections log, and the current published ranking snapshot.
+The sections below are produced by `npm run build:llms-full` from the source catalog, comparison-page registry, glossary terms, chokepoint methodology, published chokepoint explainers, the forecast accuracy snapshot, the Country Resilience Index methodology, the corrections log, and the current published ranking snapshot.
 
 <a id="corpus-source-provider-directory"></a>
 ## Source provider directory
@@ -721,6 +722,17 @@ The Kerch Strait connects the Black Sea to the Sea of Azov and is the only sea r
 ### Indian Ocean ↔ Java Sea
 
 The Lombok Strait, between Bali and Lombok, is a deep-water alternative to the Malacca–Singapore route. It is favoured by the largest, deepest-draft bulk carriers and serves as a relief valve when Malacca is congested or disrupted.
+
+<a id="corpus-forecast-accuracy"></a>
+## Forecast accuracy
+
+The standing forecast-resolution record is published at https://www.worldmonitor.app/accuracy/.
+
+Over the current 180-day window, World Monitor's headline cohort scores a Brier of 0.118 across 180 scored forecasts, against 0.25 for answering 0.5 to everything.
+
+Captured 2026-09-10.
+
+This page does not publish confidence intervals; each figure is published with the number of forecasts behind it instead. It does not score the 24-hour, 7-day and 30-day projections shown in the product. It publishes aggregates only — no individual forecasts, resolution evidence, judge inputs or archive locations.
 
 <a id="corpus-chokepoint-methodology"></a>
 ## Chokepoint methodology

--- a/scripts/build-accuracy-page.mjs
+++ b/scripts/build-accuracy-page.mjs
@@ -7,7 +7,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 /** Bump when the page copy changes so its lastmod advances without touching every sibling. */
-export const ACCURACY_CONTENT_VERSION = '2026-09-10';
+export const ACCURACY_CONTENT_VERSION = '2026-09-12';
 
 export const ACCURACY_PAGE_PATH = '/accuracy/';
 
@@ -311,6 +311,46 @@ function excludedCohortPhrase(skill) {
   return origins.length > 0 ? origins.join(', ') : 'none';
 }
 
+function headlineResultSentence(scorecard) {
+  const skill = isPlainObject(scorecard?.skill) ? scorecard.skill : {};
+  if (!isFiniteNumber(skill.brier) || !isFiniteNumber(skill.count) || skill.count <= 0) return '';
+  const windowDays = isFiniteNumber(scorecard.rollingWindowDays) ? scorecard.rollingWindowDays : null;
+  const windowPhrase = windowDays
+    ? `Over the current ${formatCount(windowDays)}-day window`
+    : 'Over the current rolling window';
+  return `${windowPhrase}, World Monitor's headline cohort scores a Brier of ${formatScore(skill.brier)} across ${formatCount(skill.count)} scored forecasts, against 0.25 for answering 0.5 to everything.`;
+}
+
+const ACCURACY_NEGATIVE_SCOPE = 'This page does not publish confidence intervals; each figure is published with the number of forecasts behind it instead. It does not score the 24-hour, 7-day and 30-day projections shown in the product. It publishes aggregates only — no individual forecasts, resolution evidence, judge inputs or archive locations.';
+
+export function renderAccuracyLlmsSection(section) {
+  const state = classifyAccuracyState(section);
+  const page = new URL(ACCURACY_PAGE_PATH, WORLD_MONITOR_ORG.url).href;
+  const paragraphs = [`The standing forecast-resolution record is published at ${page}.`];
+  const result = state.scorecard ? headlineResultSentence(state.scorecard) : '';
+  if (result) {
+    paragraphs.push(result);
+    if (state.capturedAt) {
+      const vintage = `Captured ${state.capturedAt}.`;
+      if (state.availability === 'capture-failed') {
+        paragraphs.push(`${vintage} The latest capture failed; these are the last successful figures.`);
+      } else if (state.freshness === 'stale') {
+        paragraphs.push(`${vintage} The record is past the ${SCORECARD_STALE_AFTER_HOURS}-hour freshness threshold.`);
+      } else {
+        paragraphs.push(vintage);
+      }
+    }
+  } else if (state.availability === 'capture-failed' && !state.scorecard) {
+    paragraphs.push('The latest capture failed, so no figures are published.');
+  } else if (state.availability === 'missing') {
+    paragraphs.push('No scorecard has been captured for this page yet.');
+  } else if (state.coverage === 'insufficient') {
+    paragraphs.push('The headline cohort currently has no scored forecast in this window, so it carries no Brier score.');
+  }
+  paragraphs.push(ACCURACY_NEGATIVE_SCOPE);
+  return `## Forecast accuracy\n\n${paragraphs.join('\n\n')}\n`;
+}
+
 function headlineTiles(scorecard, escapeHtml) {
   const skill = isPlainObject(scorecard.skill) ? scorecard.skill : {};
   const skillCount = isFiniteNumber(skill.count) ? skill.count : 0;
@@ -337,9 +377,16 @@ function headlineTiles(scorecard, escapeHtml) {
       `of ${formatCount(totals?.resolved ?? 0)} resolved`,
     ],
   ];
+  // A space between </strong> and <small> is load-bearing: naive tag-strippers
+  // that do not insert whitespace otherwise glue "0.118" to "180 scored forecasts".
   return `      <section class="grid" aria-label="Headline forecast accuracy metrics">
-${tiles.map(([label, value, note]) => `        <div class="metric"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong><small>${escapeHtml(note)}</small></div>`).join('\n')}
+${tiles.map(([label, value, note]) => `        <div class="metric"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong> <small>${escapeHtml(note)}</small></div>`).join('\n')}
       </section>`;
+}
+
+function headlineResultParagraph(scorecard, escapeHtml) {
+  const sentence = headlineResultSentence(scorecard);
+  return sentence ? `      <p data-accuracy-result>${escapeHtml(sentence)}</p>\n` : '';
 }
 
 const RECORD_FACT_LABELS = Object.freeze({
@@ -536,7 +583,7 @@ ${provenanceLine(state, dataset, snapshotPath, escapeHtml)}`;
   return `${heading}
       <p class="lede">World Monitor scores every forecast it publishes once the outcome is knowable, over a rolling ${escapeHtml(formatCount(scorecard.rollingWindowDays))}-day window. This is the standing record: the scores, the calibration, the sample sizes, and the parts that are not measurable yet.</p>
 ${recordStatus(state, escapeHtml)}
-${state.coverage === 'insufficient' ? '' : `${headlineTiles(scorecard, escapeHtml)}\n`}      <p><strong>Lower Brier is better.</strong> A Brier score is the mean squared error of a probability forecast, so 0 is perfect and answering 0.5 to everything scores 0.25. Log score is harsher on confident mistakes, and lower is better there too.</p>
+${state.coverage === 'insufficient' ? '' : `${headlineTiles(scorecard, escapeHtml)}\n${headlineResultParagraph(scorecard, escapeHtml)}`}      <p><strong>Lower Brier is better.</strong> A Brier score is the mean squared error of a probability forecast, so 0 is perfect and answering 0.5 to everything scores 0.25. Log score is harsher on confident mistakes, and lower is better there too.</p>
 ${cohortSection(scorecard.skill, escapeHtml)}
       <h2>Resolution ledger</h2>
 ${totalsTable(scorecard.totals, escapeHtml)}

--- a/scripts/build-llms-full.mjs
+++ b/scripts/build-llms-full.mjs
@@ -6,9 +6,9 @@
  *     ahead of `## Live Instances` on every run.
  *   - public/llms-full.txt keeps its hand-authored brief above `## Generated
  *     corpus`; the comparisons index, glossary bodies, chokepoint
- *     methodology, published chokepoint explainers, CRI methodology, the
- *     corrections log, and the current ranking snapshot are inlined below
- *     that heading.
+ *     methodology, published chokepoint explainers, the forecast accuracy
+ *     record, CRI methodology, the corrections log, and the current ranking
+ *     snapshot are inlined below that heading.
  *
  * Usage:
  *   npm run build:llms-full          # rewrite whichever file is stale
@@ -21,7 +21,8 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { GLOSSARY_TERMS } from '../blog-site/src/data/glossary.ts';
 import { COMPARISON_MATRIX_COLUMNS, comparisonDiscoveryEntries } from './build-comparison-pages.mjs';
-import { resolveLatestResilienceSnapshotPath, slugify } from './build-crawlable-corpus.mjs';
+import { renderAccuracyLlmsSection } from './build-accuracy-page.mjs';
+import { resolveLatestLivePulseSnapshotPath, resolveLatestResilienceSnapshotPath, slugify } from './build-crawlable-corpus.mjs';
 import { CHOKEPOINT_CONTENT } from './chokepoint-page-content.mjs';
 import { SITE_ORIGIN } from './discover-content-corpus-pages.mjs';
 import { buildSourceCatalog, buildSourcePages } from './crawlable-sources-page.mjs';
@@ -193,6 +194,12 @@ function renderChokepointBlurbs() {
   return lines.join('\n');
 }
 
+function renderAccuracyFromSnapshot(rootDir) {
+  const snapshotPath = resolveLatestLivePulseSnapshotPath(rootDir);
+  const snapshot = JSON.parse(read(rootDir, snapshotPath));
+  return renderAccuracyLlmsSection(snapshot.forecastScorecard ?? null).trim();
+}
+
 function renderSnapshotTable(rootDir) {
   const snapshotPath = resolveLatestResilienceSnapshotPath(rootDir);
   const snapshot = JSON.parse(read(rootDir, snapshotPath));
@@ -289,7 +296,7 @@ export function buildLlmsFullText({ rootDir = ROOT } = {}) {
   const introduction = [
     LLMS_FULL_GENERATED_HEADING,
     '',
-    'The sections below are produced by `npm run build:llms-full` from the source catalog, comparison-page registry, glossary terms, chokepoint methodology, published chokepoint explainers, the Country Resilience Index methodology, the corrections log, and the current published ranking snapshot.',
+    'The sections below are produced by `npm run build:llms-full` from the source catalog, comparison-page registry, glossary terms, chokepoint methodology, published chokepoint explainers, the forecast accuracy snapshot, the Country Resilience Index methodology, the corrections log, and the current published ranking snapshot.',
     '',
     renderSourceDirectory(rootDir),
     '',
@@ -302,6 +309,7 @@ export function buildLlmsFullText({ rootDir = ROOT } = {}) {
   return withCorpusNavigation([
     { title: 'World Monitor', text: prefix },
     { title: 'Generated corpus', text: introduction },
+    { title: 'Forecast accuracy', text: renderAccuracyFromSnapshot(rootDir) },
     { title: 'Chokepoint methodology', text: `## Chokepoint methodology\n\n${stripMdx(read(rootDir, 'docs/methodology/chokepoints.mdx'))}` },
     { title: 'Chokepoint explainers', text: '## Chokepoint explainers' },
     ...CHOKEPOINT_BLOGS.map((relativePath) => {

--- a/tests/accuracy-corpus.test.mjs
+++ b/tests/accuracy-corpus.test.mjs
@@ -14,6 +14,7 @@ import {
   accuracyDatasetDownload,
   classifyAccuracyState,
   renderAccuracyPage,
+  renderAccuracyLlmsSection,
   selectDeclaredScorecardFields,
   writeAccuracySection,
 } from '../scripts/build-accuracy-page.mjs';
@@ -522,6 +523,75 @@ describe('accuracy page honesty rules', () => {
     assert.ok(headline > 0, 'the headline-cohort Brier must be rendered');
     assert.ok(rule > 0, 'the page must state the direction of the scale');
     assert.ok(Math.abs(rule - headline) < 700, `the scale direction must sit beside the number (gap ${Math.abs(rule - headline)})`);
+  });
+
+  it('states the headline Brier in a sentence, not only in a metric tile', () => {
+    const { html } = renderState(LIVE_SECTION);
+    const result = html.match(/<p data-accuracy-result>([\s\S]*?)<\/p>/);
+    assert.ok(result, 'the headline result must be a sentence an extractor can lift, not a tile');
+    const sentence = stripTags(result[1]);
+    assert.match(sentence, /180-day window/);
+    assert.match(sentence, /Brier of 0\.118/);
+    assert.match(sentence, /180 scored forecasts/);
+    assert.match(sentence, /0\.25/);
+    assert.match(sentence, /0\.5 to everything/);
+    assert.doesNotMatch(result[0], /class="metric"/);
+    const insufficient = renderState(sectionWith({
+      skill: { count: 0, excludedScored: 310, excludedOrigins: ['bet_engine', 'state_derived'] },
+    }));
+    assert.doesNotMatch(insufficient.html, /data-accuracy-result/, 'a collapsed cohort has no result sentence');
+  });
+
+  it('separates metric values from their qualifiers so naive tag-stripping cannot glue them', () => {
+    const { html } = renderState(LIVE_SECTION);
+    const naive = html.replace(/<[^>]+>/g, '');
+    assert.doesNotMatch(naive, /0\.118180/);
+    assert.doesNotMatch(naive, /0\.375180/);
+    assert.doesNotMatch(naive, /0\.192490/);
+    assert.doesNotMatch(naive, /490of 772/);
+    assert.match(naive, /0\.118\s+180 scored forecasts/);
+    assert.match(naive, /490\s+of 772/);
+  });
+
+  it('renders the llms-full accuracy section from the same classifier the page uses', () => {
+    const measurable = renderAccuracyLlmsSection(LIVE_SECTION);
+    assert.match(measurable, /^## Forecast accuracy$/m);
+    assert.match(measurable, /Brier of 0\.118/);
+    assert.match(measurable, /180 scored forecasts/);
+    assert.match(measurable, /180-day window/);
+    assert.match(measurable, /Captured 2026-09-10/);
+    assert.match(measurable, /does not publish/);
+    assert.doesNotMatch(measurable, /issue #\d+/);
+
+    const insufficient = renderAccuracyLlmsSection(sectionWith({
+      skill: { count: 0, excludedScored: 310, excludedOrigins: ['bet_engine', 'state_derived'] },
+    }));
+    assert.match(insufficient, /headline cohort currently has no scored forecast/);
+    assert.doesNotMatch(insufficient, /Brier of 0\.118/);
+
+    const failed = renderAccuracyLlmsSection({
+      attemptedAt: '2026-09-10',
+      capturedAt: null,
+      generatedAt: null,
+      scorecard: null,
+      failureCode: 'http-error',
+    });
+    assert.match(failed, /latest capture failed, so no figures are published/);
+    assert.doesNotMatch(failed, /no scored forecast in this window/);
+
+    const missing = renderAccuracyLlmsSection(null);
+    assert.match(missing, /No scorecard has been captured for this page yet/);
+
+    const retained = renderAccuracyLlmsSection({
+      attemptedAt: '2026-09-17',
+      attemptedAtMs: Date.parse('2026-09-17T21:05:00Z'),
+      capturedAt: '2026-09-10',
+      generatedAt: LIVE_SCORECARD.generatedAt,
+      scorecard: LIVE_SCORECARD,
+      failureCode: 'http-error',
+    });
+    assert.match(retained, /Brier of 0\.118/);
+    assert.match(retained, /The latest capture failed; these are the last successful figures/);
   });
 
   it('omits empty calibration buckets and states the omission with their labels', () => {

--- a/tests/accuracy-corpus.test.mjs
+++ b/tests/accuracy-corpus.test.mjs
@@ -544,7 +544,11 @@ describe('accuracy page honesty rules', () => {
 
   it('separates metric values from their qualifiers so naive tag-stripping cannot glue them', () => {
     const { html } = renderState(LIVE_SECTION);
-    const naive = html.replace(/<[^>]+>/g, '');
+    assert.match(html, /<\/strong> <small>/);
+    assert.doesNotMatch(html, /<\/strong><small>/);
+    // Drop tags by splitting, not by replace-as-sanitizer: CodeQL treats
+    // .replace(/<[^>]+>/g, '') as incomplete HTML sanitization.
+    const naive = html.split(/<[^>]*>/).join('');
     assert.doesNotMatch(naive, /0\.118180/);
     assert.doesNotMatch(naive, /0\.375180/);
     assert.doesNotMatch(naive, /0\.192490/);

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -740,8 +740,8 @@ describe('CI workflow coverage', () => {
     const openPrStep = workflowStepBlock(pulseWorkflow, 'Open the weekly pulse PR');
     assert.match(
       openPrStep,
-      /git\s+add\s+"\$snapshot_path"\s+public\/sitemap\.xml\s+public\/sitemap-main\.xml\s+pro-test\/src\/generated\/teasers\.json\s+pro-test\/welcome\.html\s+pro-test\/index\.html/,
-      'weekly pulse PRs must include the sitemap and both shared software dates',
+      /git\s+add\s+"\$snapshot_path"\s+public\/sitemap\.xml\s+public\/sitemap-main\.xml\s+public\/llms-full\.txt\s+pro-test\/src\/generated\/teasers\.json\s+pro-test\/welcome\.html\s+pro-test\/index\.html/,
+      'weekly pulse PRs must include the sitemap, llms-full corpus, and both shared software dates',
     );
     assert.match(
       openPrStep,

--- a/tests/cloudflare-cache-rule.test.mjs
+++ b/tests/cloudflare-cache-rule.test.mjs
@@ -214,6 +214,10 @@ describe('cloudflare corpus cache rule', () => {
 
     // Positive controls: the parsers must actually be seeing the new shapes.
     assert.ok(advertised.nested.has('blog') && advertised.nested.has('docs'), 'vercel.json must advertise /blog and /docs');
+    assert.ok(
+      advertised.nested.has('accuracy') && claimed.nested.has('accuracy'),
+      '/accuracy/ shipped with the origin CDN header; the Cloudflare rule must claim it too (#8070)',
+    );
     assert.ok(advertised.files.has('llms.txt'), 'vercel.json must advertise /llms.txt');
     assert.ok(claimed.nested.get('docs')?.exact.length, 'the rule must carve an exact path out of /docs');
 

--- a/tests/seo-geo-residue.test.mjs
+++ b/tests/seo-geo-residue.test.mjs
@@ -81,6 +81,31 @@ describe('GEO residue #7463', () => {
     assert.match(committed, /product-facts\.json.*capabilities\.localeCodes/);
   });
 
+  it('llms-full inlines the generated forecast-accuracy record, not only an index link', () => {
+    const generated = buildLlmsFullText({ rootDir: repoRoot });
+    const snapshot = readJson(resolveLatestLivePulseSnapshotPath(repoRoot));
+    const skill = snapshot.forecastScorecard?.scorecard?.skill;
+    const section = generated.split(/^## Forecast accuracy$/m)[1]?.split(/^## /m)[0] ?? '';
+    assert.match(generated, /^## Forecast accuracy$/m);
+    assert.match(section, /does not publish/i);
+    assert.match(section, /https:\/\/www\.worldmonitor\.app\/accuracy\//);
+    assert.ok(
+      Number.isFinite(skill?.brier) && skill.count > 0,
+      'the committed pulse snapshot must carry a measurable headline cohort so this section cannot be a hardcoded stub',
+    );
+    assert.match(section, new RegExp(`Brier of ${Number(skill.brier).toFixed(3)}`));
+    assert.match(section, new RegExp(`${Number(skill.count).toLocaleString('en-US')} scored forecasts`));
+    assert.match(
+      section,
+      new RegExp(`${Number(snapshot.forecastScorecard.scorecard.rollingWindowDays).toLocaleString('en-US')}-day window`),
+    );
+    assert.doesNotMatch(
+      section,
+      /issue #\d+/,
+      'the corpus section must state the negative scope without a tracker-only sentence',
+    );
+  });
+
   // "Usable" was previously read as "not redacted", and the URL this pinned —
   // https://api.worldmonitor.app/resilience/v1/get-runtime-manifest — 404s: the
   // route is /api/resilience/v1/..., and the link had been published without the
@@ -250,6 +275,13 @@ describe('GEO residue #7463', () => {
     const workflow = read('.github/workflows/resilience-snapshot-refresh.yml');
     assert.match(workflow, /npm run build:llms-full/);
     assert.match(workflow, /git add "\$snapshot_path" public\/sitemap\.xml public\/sitemap-main\.xml public\/llms-full\.txt/);
+  });
+
+  it('regenerates llms-full when the weekly pulse snapshot refreshes', () => {
+    const workflow = read('.github/workflows/crawlable-pulse-refresh.yml');
+    assert.match(workflow, /npm run build:llms-full/);
+    assert.match(workflow, /git add "\$snapshot_path" public\/sitemap\.xml public\/sitemap-main\.xml public\/llms-full\.txt/);
+    assert.match(workflow, /tests\/seo-geo-residue\.test\.mjs/);
   });
 });
 


### PR DESCRIPTION
## Summary

`/accuracy/` now states the headline Brier in a sentence an extractor can lift, and `/llms-full.txt` carries the same generated numbers. Asking "how accurate is World Monitor" no longer has to infer the score from a metric tile.

Naive tag-strippers no longer glue `0.118` to `180`. The weekly pulse job rebuilds `llms-full.txt` from the new snapshot so the corpus cannot keep last week's score.

Fixes #8070

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: crawlable `/accuracy/` page, `llms-full.txt`, Cloudflare corpus cache rule, weekly pulse refresh

## Intent

Issue #8070: the calibration page was already excellent, but the headline score was not quotable, naive extractors corrupted the tiles, `llms-full.txt` had zero hits for accuracy/Brier, and the edge cache bypassed the route.

## Validation Matrix

| Claim | Proof |
| --- | --- |
| Headline Brier appears in a sentence, not only a tile | `tests/accuracy-corpus.test.mjs` — `data-accuracy-result` must contain `Brier of 0.118` / `180 scored forecasts` / `180-day window`; collapsed cohort omits the sentence |
| Naive tag-stripping cannot glue tile values to qualifiers | Same file — strip tags with no inserted whitespace; reject `0.118180` and `490of 772` |
| `llms-full` Forecast accuracy section is generated from the live pulse snapshot | `tests/seo-geo-residue.test.mjs` pins Brier, n, and window days from `forecastScorecard.skill`; `renderAccuracyLlmsSection` unit tests cover measurable, insufficient, missing, failed, and retained-failure |
| Cloudflare generated rule claims `/accuracy/` | `tests/cloudflare-cache-rule.test.mjs` — advertised and claimed nested families include `accuracy` (`CONTENT_CORPUS_PREFIXES` already listed it) |
| Live zone matches the generated rule | `node scripts/cloudflare-cache-rule.mjs --apply` then `--check` (ruleset 65 -> 66, current at position 10 of 11). Production `GET /accuracy/` with `Accept: text/html`: MISS then HIT (`cf-cache-status: HIT`, `age: 1+`) |
| Weekly pulse cannot leave the corpus stale | `.github/workflows/crawlable-pulse-refresh.yml` runs `npm run build:llms-full` and stages `public/llms-full.txt`; pinned in `tests/seo-geo-residue.test.mjs` and `tests/ci-workflow-coverage.test.mts` |

Focused suites: `tests/accuracy-corpus.test.mjs`, `tests/seo-geo-residue.test.mjs`, `tests/cloudflare-cache-rule.test.mjs`, `tests/ci-workflow-coverage.test.mts` (173 passing together with related files in that run).

## Review Gates

Code review: `status: complete`, `run_id: 20260912-155156-96377fc2`, `artifact_path: /tmp/compound-engineering-501/ce-code-review/20260912-155156-96377fc2/report.json`.

Personas: correctness, testing, project-standards, agent-native. Adversarial peer not selected.

Applied before ship: capture-failed vs empty-cohort branch order; vintage/status sentence in the corpus section; pulse-refresh rebuild of `llms-full`; unit tests for sad paths.

## Documentation

N/A for methodology/API claim-ledger. The generated corpus is the documentation surface.

## Screenshots / UI Evidence

The `/accuracy/` page is build-time static HTML, not the Vite dashboard. Local tests assert the sentence and tile markup. Production cache eligibility was verified on `https://www.worldmonitor.app/accuracy/` after the Cloudflare rule apply (HIT on the same colo after the first MISS). A post-deploy screenshot of the new sentence belongs on the next corpus deploy, not this diff.

## Residual Findings

- Naive strippers can still concatenate the **label** onto the value (`headline cohort0.118`). The issue asked for value/qualifier separation; the new sentence is the extractable claim.
- The sentence says "headline cohort" without restating the excluded origins. That matches the issue's requested wording; `/accuracy/` still explains the exclusion in the following section.
- Cloudflare `--apply` already landed in the live zone. This PR keeps the generator, tests, and weekly rebuild in git so the next route family cannot skip the same step.

## Post-Deploy Monitoring & Validation

- **Window:** first production deploy after merge, then the next weekly pulse PR.
- **Healthy:** `GET https://www.worldmonitor.app/accuracy/` returns `cf-cache-status: HIT` on a second browser-like GET; `<main>` contains a sentence with `Brier of` and the current n; `GET /llms-full.txt` contains `## Forecast accuracy` and the same Brier.
- **Failure:** `cf-cache-status: DYNAMIC` on `/accuracy/` (rule drifted — `node scripts/cloudflare-cache-rule.mjs --check`); `llms-full.txt` Brier disagrees with `/accuracy/` after a pulse refresh (workflow skipped `build:llms-full`).
- **Logs/search:** Cloudflare cache-rule audit for `www_corpus_html_origin_cache`; Vercel deploy for `public/llms-full.txt` and `scripts/build-accuracy-page.mjs`.
- **Rollback:** revert this PR; the live Cloudflare rule can be rolled back from the zone ruleset history (version 65).

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

N/A — this PR does not publish methodology/API documentation claims.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
