### PR TITLE
fix(docs): make Organization article authors self-describing

### DIFF
--- a/src/config/docs-locale-seo.ts
+++ b/src/config/docs-locale-seo.ts
@@ -12,7 +12,7 @@
  * - x-default points at the English URL
  */
 
-import { ORGANIZATION_ID, PERSON_ID, WEBSITE_ID } from './schema-graph-ids';
+import { CANONICAL_ORIGIN, ORGANIZATION_ID, PERSON_ID, WEBSITE_ID } from './schema-graph-ids';
 import { DOCS_PAGE_DATES } from './docs-page-dates.generated';
 
 export const DOCS_PUBLIC_ORIGIN = 'https://www.worldmonitor.app';
@@ -347,6 +347,26 @@ const DOCS_PERSON_AUTHOR = Object.freeze({
   name: 'Elie Habib',
 });
 
+/**
+ * Same typed-stub-plus-@id shape as WORLD_MONITOR_ORG in the corpus
+ * generator. No docs page declares the Organization node — pruneDocsEntities
+ * collapses it to a reference — so a bare author `@id` cannot resolve inside
+ * the document (#8073). `sameAs` stays on the canonical welcome node.
+ */
+const DOCS_ORGANIZATION_AUTHOR = Object.freeze({
+  '@id': ORGANIZATION_ID,
+  '@type': 'Organization',
+  name: 'World Monitor',
+  url: CANONICAL_ORIGIN,
+});
+
+function isBareOrganizationAuthor(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const node = value as Record<string, unknown>;
+  if (node['@id'] !== ORGANIZATION_ID) return false;
+  return Object.keys(node).every((key) => key === '@id' || key === '@context');
+}
+
 function docsAuthorForPathname(pathname: string | undefined): Record<string, unknown> {
   // The Chinese mirror keeps its locale segment in the slug ("zh/methodology/…"),
   // and it is the same editorial work under translation, so drop the segment
@@ -354,7 +374,7 @@ function docsAuthorForPathname(pathname: string | undefined): Record<string, unk
   const slug = docsSlugForPathname(pathname)?.replace(/^zh\//, '');
   return slug?.startsWith(DOCS_PERSON_AUTHORED_SLUG_PREFIX)
     ? { ...DOCS_PERSON_AUTHOR }
-    : { '@id': ORGANIZATION_ID };
+    : { ...DOCS_ORGANIZATION_AUTHOR };
 }
 
 /**
@@ -472,7 +492,11 @@ function withDocsArticleAuthor(value: unknown, pathname?: string): unknown {
     next[key] = withDocsArticleAuthor(nested, pathname);
   }
   const isArticle = hasJsonLdType(next, 'Article') || hasJsonLdType(next, 'TechArticle');
-  if (isArticle && next.author == null) {
+  // Prune collapses every `#organization` body to `{ @id }` before this
+  // runs, including an author we injected on a previous rewrite. A bare
+  // reference is the defect (#8073); replace it the same way as a missing
+  // author. Named upstream bylines and Person authors are not bare refs.
+  if (isArticle && (next.author == null || isBareOrganizationAuthor(next.author))) {
     next.author = docsAuthorForPathname(pathname);
   }
   return next;

--- a/tests/docs-locale-seo.test.mts
+++ b/tests/docs-locale-seo.test.mts
@@ -18,6 +18,12 @@ import {
 } from '../src/config/docs-locale-seo.ts';
 
 const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const ORGANIZATION_AUTHOR = {
+  '@id': 'https://www.worldmonitor.app/#organization',
+  '@type': 'Organization',
+  name: 'World Monitor',
+  url: 'https://www.worldmonitor.app/',
+};
 
 describe('docs locale SEO path gating', () => {
   it('accepts document paths and rejects Mintlify assets', () => {
@@ -239,7 +245,7 @@ describe('docs entity-graph rewrite (#7459d)', () => {
       .find((block) => Array.isArray(block['@graph']))?.['@graph'] as Record<string, unknown>[];
     const article = graph.find((node) => Array.isArray(node['@type']));
     assert.ok(article, 'the Article node must survive the rewrite');
-    assert.deepEqual(article.author, { '@id': 'https://www.worldmonitor.app/#organization' });
+    assert.deepEqual(article.author, ORGANIZATION_AUTHOR);
     assert.deepEqual(article.publisher, { '@id': 'https://www.worldmonitor.app/#organization' });
     assert.equal(article.dateModified, '2026-08-30T00:00:00Z');
     assert.equal(article.datePublished, DOCS_PAGE_DATES.about.datePublished);
@@ -251,7 +257,7 @@ describe('docs entity-graph rewrite (#7459d)', () => {
       .find((block) => Array.isArray(block['@graph']))?.['@graph'] as Record<string, unknown>[];
     assert.deepEqual(
       graph.find((node) => node['@type'] === 'TechArticle')?.author,
-      { '@id': 'https://www.worldmonitor.app/#organization' },
+      ORGANIZATION_AUTHOR,
     );
 
     const byline = articleSeed.replace(
@@ -264,6 +270,18 @@ describe('docs entity-graph rewrite (#7459d)', () => {
       bylineGraph.find((node) => Array.isArray(node['@type']))?.author,
       { '@type': 'Person', name: 'A Named Author' },
       'an upstream byline must win over the Organization fallback',
+    );
+
+    const stub = articleSeed.replace(
+      '"publisher"',
+      '"author":{"@id":"https://www.worldmonitor.app/#organization"},"publisher"',
+    );
+    const stubGraph = jsonLdBlocks(rewriteDocsLocaleHtml(stub, '/docs/about'))
+      .find((block) => Array.isArray(block['@graph']))?.['@graph'] as Record<string, unknown>[];
+    assert.deepEqual(
+      stubGraph.find((node) => Array.isArray(node['@type']))?.author,
+      ORGANIZATION_AUTHOR,
+      'a bare Organization author stub must be expanded on the first rewrite',
     );
   });
 
@@ -309,8 +327,14 @@ describe('docs entity-graph rewrite (#7459d)', () => {
       '/docs/methodology-overview',
       '/docs/api-reference/methodology/foo',
     ]) {
-      assert.deepEqual(authorFor(pathname), ORGANIZATION, pathname);
+      assert.deepEqual(authorFor(pathname), ORGANIZATION_AUTHOR, pathname);
     }
+  });
+
+  it('keeps a self-describing Organization author across a second rewrite (#8073)', () => {
+    const html = rewriteDocsLocaleHtml(articleSeed, '/docs/about');
+    assert.deepEqual(authorFor('/docs/about', html), ORGANIZATION_AUTHOR);
+    assert.equal(rewriteDocsLocaleHtml(html, '/docs/about'), html, 'rewriting is idempotent');
   });
 
   // Live Mintlify ships a bare WebPage with no Article at all, so INJECTION —
@@ -335,7 +359,7 @@ describe('docs entity-graph rewrite (#7459d)', () => {
       .flatMap((block) => (Array.isArray(block['@graph']) ? block['@graph'] : [block])) as Record<string, unknown>[];
     assert.deepEqual(
       aboutGraph.find((node) => Array.isArray(node['@type']))?.author,
-      ORGANIZATION,
+      ORGANIZATION_AUTHOR,
     );
   });
 
@@ -502,7 +526,7 @@ describe('docs article injection for bare WebPage output', () => {
     assert.ok(article, 'a bare WebPage must gain an Article node');
     assert.equal(article?.dateModified, DOCS_PAGE_DATES['architecture'].dateModified);
     assert.deepEqual(article?.publisher, { '@id': ORG_ID });
-    assert.deepEqual(article?.author, { '@id': ORG_ID });
+    assert.deepEqual(article?.author, ORGANIZATION_AUTHOR);
     assert.equal(article?.datePublished, DOCS_PAGE_DATES['architecture'].datePublished);
   });
 
@@ -532,7 +556,7 @@ describe('docs article injection for bare WebPage output', () => {
     assert.ok(article, 'the upstream Article must survive');
     assert.equal(article?.dateModified, DOCS_PAGE_DATES['about'].dateModified);
     assert.equal(article?.datePublished, DOCS_PAGE_DATES['about'].datePublished);
-    assert.deepEqual(article?.author, { '@id': ORG_ID });
+    assert.deepEqual(article?.author, ORGANIZATION_AUTHOR);
   });
 
   it('preserves upstream dates and leaves unknown slugs untouched', () => {
@@ -574,7 +598,7 @@ describe('docs article injection for bare WebPage output', () => {
     assert.equal(articles.length, 1, 'the complete document must contain at most one Article');
     assert.equal(articles[0]?.dateModified, DOCS_PAGE_DATES.about.dateModified);
     assert.equal(articles[0]?.datePublished, DOCS_PAGE_DATES.about.datePublished);
-    assert.deepEqual(articles[0]?.author, { '@id': ORG_ID });
+    assert.deepEqual(articles[0]?.author, ORGANIZATION_AUTHOR);
     assert.deepEqual(
       nodes.find((node) => node['@type'] === 'WebPage')?.speakable,
       { '@type': 'SpeakableSpecification', cssSelector: ['h1'] },

--- a/tests/middleware-docs-locale-seo.test.mts
+++ b/tests/middleware-docs-locale-seo.test.mts
@@ -41,7 +41,12 @@ describe('middleware docs locale SEO proxy', () => {
         const graph = JSON.parse(html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)![1])['@graph'];
         assert.deepEqual(graph[0], { '@id': id });
         assert.deepEqual(graph[1].publisher, { '@id': id });
-        assert.deepEqual(graph[1].author, { '@id': id });
+        assert.deepEqual(graph[1].author, {
+          '@id': id,
+          '@type': 'Organization',
+          name: 'World Monitor',
+          url: 'https://www.worldmonitor.app/',
+        });
         assert.deepEqual(graph[1].provider, otherOrganization);
       }
     } finally {

--- a/tests/schema-graph-contract.test.mts
+++ b/tests/schema-graph-contract.test.mts
@@ -162,6 +162,56 @@ function declarationsOf(html: string, id: string): Record<string, any>[] {
   return found;
 }
 
+function assertSelfDescribingAuthor(path: string, author: Record<string, unknown> | undefined): void {
+  assert.ok(author, `${path}: must carry an author`);
+  assert.ok(
+    author['@id'] === ORGANIZATION_ID || author['@id'] === PERSON_ID,
+    `${path}: author must reference the canonical Organization or Person, got ${JSON.stringify(author['@id'])}`,
+  );
+  // A bare `@id` is an unresolvable stub for the naive extractors this
+  // signal is for: no generated page declares the canonical node, and
+  // parsers resolve `@id` within one document (#7459b, #8073).
+  assert.ok(
+    typeof author['@type'] === 'string' && typeof author.name === 'string',
+    `${path}: author reference must carry @type and name so it resolves in-document`,
+  );
+  if (author['@id'] === ORGANIZATION_ID) {
+    assert.deepEqual(
+      author,
+      WORLD_MONITOR_ORG,
+      `${path}: Organization author must be the typed WORLD_MONITOR_ORG stub`,
+    );
+  }
+}
+
+/**
+ * Docs middleware output for every dated slug, both upstream shapes.
+ * Shared by the body-consistency test and the author guard so a new docs
+ * page cannot join one population and skip the other (#8073).
+ */
+let docsMiddlewareDocumentsMemo: Map<string, string> | null = null;
+function docsMiddlewareDocuments(): Map<string, string> {
+  docsMiddlewareDocumentsMemo ??= (() => {
+    const documents = new Map<string, string>();
+    for (const slug of Object.keys(DOCS_PAGE_DATES)) {
+      for (const type of ['WebPage', ['Article', 'TechArticle']]) {
+        const html = `<html><head><script type="application/ld+json">${JSON.stringify({
+          '@context': 'https://schema.org', '@type': type, name: slug, headline: slug,
+          url: `https://www.worldmonitor.app/docs/${slug}`,
+        })}</script></head><body></body></html>`;
+        const rewritten = rewriteDocsLocaleHtml(
+          rewriteDocsLocaleHtml(html, `/docs/${slug}`),
+          `/docs/${slug}`,
+        );
+        assert.equal(collectNodesOfType(rewritten, 'Article').length, 1, `${slug} must emit an Article`);
+        documents.set(`docs/${slug} (${JSON.stringify(type)} middleware output)`, rewritten);
+      }
+    }
+    return documents;
+  })();
+  return docsMiddlewareDocumentsMemo;
+}
+
 /**
  * Every HTML document that could carry JSON-LD: the committed entry points
  * plus anything generated under public/ (both the crawlable corpus and the
@@ -345,18 +395,7 @@ describe('canonical schema graph', () => {
       '@graph': [{ '@type': 'Organization', '@id': id, ...properties, logo: { '@type': 'ImageObject', url: logo } }],
     })}</script></head><body></body></html>`;
     documents.set('docs/about (middleware output)', rewriteDocsLocaleHtml(docsHtml, '/docs/about'));
-    // Exercise both upstream shapes for every docs slug, including localized pages.
-    for (const slug of Object.keys(DOCS_PAGE_DATES)) {
-      for (const type of ['WebPage', ['Article', 'TechArticle']]) {
-        const html = `<html><head><script type="application/ld+json">${JSON.stringify({
-          '@context': 'https://schema.org', '@type': type, name: slug, headline: slug,
-          url: `https://www.worldmonitor.app/docs/${slug}`,
-        })}</script></head><body></body></html>`;
-        const rewritten = rewriteDocsLocaleHtml(html, `/docs/${slug}`);
-        assert.equal(collectNodesOfType(rewritten, 'Article').length, 1, `${slug} must emit an Article`);
-        documents.set(`docs/${slug} (${JSON.stringify(type)} middleware output)`, rewritten);
-      }
-    }
+    for (const [path, html] of docsMiddlewareDocuments()) documents.set(path, html);
     for (const [path, html] of documents) {
       const articles = ['Article', 'TechArticle', 'BlogPosting', 'NewsArticle']
         .flatMap((type) => collectNodesOfType(html, type));
@@ -473,22 +512,28 @@ describe('canonical schema graph', () => {
       }
       for (const body of bodies) {
         checked += 1;
-        const author = body.author as Record<string, unknown> | undefined;
-        assert.ok(author, `${path}: ${JSON.stringify(body['@type'])} must carry an author`);
-        assert.ok(
-          author['@id'] === ORGANIZATION_ID || author['@id'] === PERSON_ID,
-          `${path}: author must reference the canonical Organization or Person, got ${JSON.stringify(author['@id'])}`,
-        );
-        // A bare `@id` is an unresolvable stub for the naive extractors this
-        // signal is for: no generated page declares the canonical node, and
-        // parsers resolve `@id` within one document (#7459b).
-        assert.ok(
-          typeof author['@type'] === 'string' && typeof author.name === 'string',
-          `${path}: author reference must carry @type and name so it resolves in-document`,
-        );
+        assertSelfDescribingAuthor(`${path}: ${JSON.stringify(body['@type'])}`, body.author);
       }
     }
     assert.ok(checked > 200, `expected the whole generated corpus to be checked, saw ${checked} bodies`);
+  });
+
+  // #8073: the #7980 author guard discovered its population from the corpus
+  // generator, so 465 docs Articles shipped a bare `#organization` reference
+  // the guard could not see. The docs family is synthesized through the real
+  // rewrite, the same way the date and body-consistency tests already do.
+  it('attributes every docs Article to a self-describing canonical author (#8073)', () => {
+    const documents = docsMiddlewareDocuments();
+    assert.equal(documents.size, Object.keys(DOCS_PAGE_DATES).length * 2);
+
+    let checked = 0;
+    for (const [path, html] of documents) {
+      const articles = collectNodesOfType(html, 'Article');
+      assert.equal(articles.length, 1, `${path}: expected one Article`);
+      checked += 1;
+      assertSelfDescribingAuthor(path, articles[0].author);
+    }
+    assert.equal(checked, documents.size, 'every synthesized docs document must contribute an Article author');
   });
 
   it('serves every variant dashboard identically to browsers and AI crawlers', () => {


### PR DESCRIPTION
## Summary

A crawler that resolved `author` on a typical docs Article landed on `#organization` and found only `{ "@id" }`. Person-authored methodology pages already shipped a typed stub; Organization-authored pages did not. Those 465 pages now emit the same in-document Organization stub the generated corpus uses (`@type`, `name`, `url`). Publisher stays a bare reference.

The corpus author guard still could not see docs, which is how this shipped. It now synthesizes every dated docs slug through the real rewrite (including a second pass, so prune cannot collapse the stub again) and asserts the same author shape.

Fixes #8073.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: docs JSON-LD rewrite (`src/config/docs-locale-seo.ts`) and schema-graph contract tests

## Checklist

- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] No API keys or secrets committed
- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [x] Documentation Alignment Checklist: N/A (no methodology/API claim text changed)

## Test plan

- `tests/docs-locale-seo.test.mts` — Organization author is typed; Person and named bylines unchanged; first-rewrite expansion of a bare `{ "@id" }` stub; second rewrite is idempotent.
- `tests/schema-graph-contract.test.mts` — every `DOCS_PAGE_DATES` slug × both upstream shapes carries a self-describing author; Organization authors match `WORLD_MONITOR_ORG`; body-consistency still agrees across surfaces.
- Pre-push ran the changed tests (53 pass) plus the edge-function gate (277 pass).

## Post-Deploy Monitoring & Validation

After production deploy, fetch three Organization-authored docs pages and one methodology page and resolve JSON-LD `author` in-document:

- `/docs/documentation`
- `/docs/api-reference/economicservice/getenergyprices`
- `/docs/usage-auth`
- `/docs/methodology/cii-risk-scores` (control — must stay Person)

Healthy: Organization authors have `@id`, `@type: Organization`, `name: World Monitor`, `url: https://www.worldmonitor.app/`. Methodology author stays Person with name Elie Habib. Failure: author is only `{ "@id": "...#organization" }` or a second Organization body with divergent `sameAs`. Rollback: revert this PR. Window: first crawl after deploy; owner: the merging engineer.

## Code review

Receipt: `status: complete`, run `20260912-174233-7bd69461`, artifact `/tmp/compound-engineering-501/ce-code-review/20260912-174233-7bd69461`. Correctness, testing, and project-standards. One testing finding applied (second rewrite in the docs population + first-rewrite stub expansion). Actionable findings: none.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Grok](https://img.shields.io/badge/Grok_4.6-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Documentation article metadata now includes complete organization author details, including the organization name and canonical URL.
  - Incomplete organization author references are automatically expanded to consistent structured data.
  - Repeated metadata processing preserves complete author information without unnecessary changes.

- **Tests**
  - Added coverage for complete author attribution across documentation articles and repeated metadata processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->