### PR TITLE
test(e2e): record browser loss during map budget cold loads

### DIFF
--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -2,6 +2,7 @@ import { writeFile } from 'node:fs/promises';
 
 import { expect, test, type Page, type TestInfo } from '@playwright/test';
 
+import { attachBrowserLossDiagnostics, pageBrowserLossEvents } from './browser-loss-diagnostics';
 import { waitForDomQuiescence, type DomQuiescenceResult } from './helpers/dom-quiescence';
 
 /**
@@ -551,6 +552,10 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
           timezoneId: 'UTC',
         });
         const page = await context.newPage();
+        const lossWatch = attachBrowserLossDiagnostics(
+          pageBrowserLossEvents(page),
+          `map-overlay-marker-budget cold-load-${attempt + 1}`,
+        );
         try {
           const load = await loadColdDashboard(page);
           const firstPaint = await readDashboardMetrics(page);
@@ -573,6 +578,7 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
             console.warn(`[map-budget] cold load ${sample.coldLoad} did not produce a settled sample: ${JSON.stringify(sample.quiescence)}`);
           }
         } finally {
+          lossWatch.dispose();
           await context.close();
         }
       }


### PR DESCRIPTION
## Summary

Record renderer crashes, browser disconnects, and context closes for each map-budget cold load so browser lifecycle failures remain distinguishable from metric assertions.

The existing shared browser-loss helper is attached and disposed around each fresh context. No production code, renderer ceiling, retry setting, or wait budget changes.

## Validation

- `npm exec -- biome check e2e/map-overlay-marker-budget.spec.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `node --import tsx --test tests/e2e-browser-loss-diagnostics.test.mts`

The focused Playwright test could not start because the configured webServer reported port 4173 as already used.

Refs #7837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved diagnostics for dashboard cold-load scenarios.
  - Browser-loss events are now captured and cleaned up reliably during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->